### PR TITLE
Jira Epic Mapping: Support for the removal of `Epic Name` custom fields

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -677,10 +677,26 @@ def add_issues_to_epic(jira, obj, epic_id, issue_keys, ignore_epics=True):
     try:
         return jira.add_issues_to_epic(epic_id=epic_id, issue_keys=issue_keys, ignore_epics=ignore_epics)
     except JIRAError as e:
-        logger.error("error adding issues %s to epic %s for %s", issue_keys, epic_id, obj.id)
-        logger.exception(e)
-        log_jira_alert(e.text, obj)
-        return False
+        """
+        We must try to accommodate the following:
+
+        The request contains a next-gen issue. This operation can't add next-gen issues to epics.
+        To add a next-gen issue to an epic, use the Edit issue operation and set the parent property
+        (i.e., '"parent":{"key":"PROJ-123"}' where "PROJ-123" has an issue type at level one of the issue type hierarchy).
+        See <a href="https://developer.atlassian.com/cloud/jira/platform/rest/v2/"> developer.atlassian.com </a> for more details.
+        """
+        try:
+            if "The request contains a next-gen issue." in str(e):
+                # Attempt to update the issue manually
+                for issue_key in issue_keys:
+                    issue = jira.issue(issue_key)
+                    epic = jira.issue(epic_id)
+                    issue.update(parent={"key": epic.key})
+        except JIRAError as e:
+            logger.error("error adding issues %s to epic %s for %s", issue_keys, epic_id, obj.id)
+            logger.exception(e)
+            log_jira_alert(e.text, obj)
+            return False
 
 
 # we need two separate celery tasks due to the decorators we're using to map to/from ids
@@ -1284,13 +1300,12 @@ def update_epic(engagement, **kwargs):
             if not epic_name:
                 epic_name = engagement.name
 
-            epic_priority = kwargs.get("epic_priority")
-
             jira_issue_update_kwargs = {
                 "summary": epic_name,
                 "description": epic_name,
-                "priority": {"name": epic_priority},
             }
+            if (epic_priority := kwargs.get("epic_priority")) is not None:
+                jira_issue_update_kwargs["priority"] = {"name": epic_priority}
             issue.update(**jira_issue_update_kwargs)
             return True
         except JIRAError as e:
@@ -1319,6 +1334,7 @@ def add_epic(engagement, **kwargs):
     jira_instance = get_jira_instance(engagement)
     if jira_project.enable_engagement_epic_mapping:
         epic_name = kwargs.get("epic_name")
+        epic_issue_type_name = getattr(jira_project, "epic_issue_type_name", "Epic")
         if not epic_name:
             epic_name = engagement.name
         issue_dict = {
@@ -1328,14 +1344,16 @@ def add_epic(engagement, **kwargs):
             "summary": epic_name,
             "description": epic_name,
             "issuetype": {
-                "name": getattr(jira_project, "epic_issue_type_name", "Epic"),
+                "name": epic_issue_type_name,
             },
-            get_epic_name_field_name(jira_instance): epic_name,
         }
         if kwargs.get("epic_priority"):
             issue_dict["priority"] = {"name": kwargs.get("epic_priority")}
         try:
             jira = get_jira_connection(jira_instance)
+            # Determine if we should add the epic name or not
+            if (epic_name_field := get_epic_name_field_name(jira_instance)) in get_issuetype_fields(jira, jira_project.project_key, epic_issue_type_name):
+                issue_dict[epic_name_field] = epic_name
             logger.debug("add_epic: %s", issue_dict)
             new_issue = jira.create_issue(fields=issue_dict)
             j_issue = JIRA_Issue(

--- a/unittests/vcr/jira/JIRAConfigEngagementEpicTest.test_add_engagement_with_jira_project_and_epic_mapping.yaml
+++ b/unittests/vcr/jira/JIRAConfigEngagementEpicTest.test_add_engagement_with_jira_project_and_epic_mapping.yaml
@@ -1,34 +1,112 @@
 interactions:
 - request:
-    body: '{}'
+    body: '{"description": "Event engagement_added has occurred.", "title": "Engagement
+      created for &quot;Python How-to&quot;: new engagement", "user": null, "url_ui":
+      "http://localhost:8080/engagement/7", "url_api": "http://localhost:8080/api/v2/engagements/7/",
+      "product_type": {"name": "books", "id": 1, "url_ui": "http://localhost:8080/product/type/1",
+      "url_api": "http://localhost:8080/api/v2/product_types/1/"}, "product": {"name":
+      "Python How-to", "id": 1, "url_ui": "http://localhost:8080/product/1", "url_api":
+      "http://localhost:8080/api/v2/products/1/"}, "engagement": {"name": "new engagement",
+      "id": 7, "url_ui": "http://localhost:8080/engagement/7", "url_api": "http://localhost:8080/api/v2/engagements/7/"}}'
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '710'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.42.3
+      X-DefectDojo-Event:
+      - engagement_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"710\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"engagement_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
+        \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
+        \"172.18.0.2:48456\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \ \"data\": \"{\\\"description\\\": \\\"Event engagement_added has occurred.\\\",
+        \\\"title\\\": \\\"Engagement created for &quot;Python How-to&quot;: new engagement\\\",
+        \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/7\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/7/\\\", \\\"product_type\\\":
+        {\\\"name\\\": \\\"books\\\", \\\"id\\\": 1, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/1\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/1/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Python How-to\\\", \\\"id\\\": 1, \\\"url_ui\\\": \\\"http://localhost:8080/product/1\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/1/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"new engagement\\\", \\\"id\\\": 7, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/7\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/7/\\\"}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        engagement_added has occurred.\",\n    \"engagement\": {\n      \"id\": 7,\n
+        \     \"name\": \"new engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/7/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/7\"\n    },\n    \"product\":
+        {\n      \"id\": 1,\n      \"name\": \"Python How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/1/\",\n      \"url_ui\": \"http://localhost:8080/product/1\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 1,\n      \"name\": \"books\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/1/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/1\"\n    },\n    \"title\": \"Engagement
+        created for &quot;Python How-to&quot;: new engagement\",\n    \"url_api\":
+        \"http://localhost:8080/api/v2/engagements/7/\",\n    \"url_ui\": \"http://localhost:8080/engagement/7\",\n
+        \   \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 29 Jan 2025 20:45:18 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
-      Content-Length:
-      - '2'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.28.1
+      - python-requests/2.32.3
     method: GET
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA1SPTUvEMBCG/0uuttlJ0ibd3EQPKrIK2z2JSNokWEmT0qTCsux/N8XFj9vwzvPM
-        y5xQp6I5zA5J9J7SFOVmo401fdLhI2CVnIpxUB57k1CBPs0ch+AzTAAIBgzlfnf9vL97an+3u2Xs
-        8oTkywoVUMBrgbSZXDiOxqf2OJl84MaFRWepWwanvxUks0ChvoS3Kq0gBUpLaEoiWmgkCElrDABX
-        mYTsRzPn3nYY/7HbFkAyLhnBgm9/2H689zZkkFdEWGatZaKhlANrAKpaUU56BZr3QlQGGP9bkNza
-        8DDMCq3vWLW49Bh6tcYn5C4TMv7tsEfn8xcAAAD//wMAlf3vZFoBAAA=
+        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bqkS2mXN5ngFJ1Cu5eJSJpcMJompUkHY+y7m+DQ+aa+HXe/
+        //2OO6CWe9gMBjH0GkLv2WwmQYEI0r25jAfDvdfcZhYCmiCpfW/4/h98DcNOC5Dg31dg+iXYAMNf
+        lyydVWYEK+B3yR0MXjsbYYIxyXCGp/X68rFePTTf0/XYtbFC7ClBEzzBz9EJvXH7Ll7Z7PtkWxo3
+        yhhqR23kZwSxGMjL8tS84iGBOc6LKSbTvGoIZZSweZVhjC9whGPexz/A0OjuB7tocsJowUiVUUK/
+        WNHdWOUiqIqCAJRz0koQVAgOwElbSUUWJVeERoFqC8jPBMEkw60eeHohKD6acOcET+0DMqcKgX3Z
+        1Oh4ftjW2TS5vm/Q8QMAAP//AwDv8BdOIAIAAA==
     headers:
+      Atl-Request-Id:
+      - 0142053b-a7dc-4dfd-b59f-77a77e6ddd88
       Atl-Traceid:
-      - b0cc01e650d9c110
+      - 0142053ba7dc4dfdb59f77a77e6ddd88
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -36,20 +114,19 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 18 Aug 2022 22:36:31 GMT
-      Expect-Ct:
-      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/atlassian-proxy",
-        max-age=86400
+      - Wed, 29 Jan 2025 20:45:18 GMT
       Nel:
-      - '{"report_to": "endpoint-1", "max_age": 600, "include_subdomains": true, "failure_fraction":
-        0.001}'
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
       Report-To:
-      - '{"group": "endpoint-1", "max_age": 600, "endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}],
-        "include_subdomains": true}'
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
       Server:
-      - globaledge-envoy
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=170,atl-edge-internal;dur=16,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
-      - max-age=63072000; preload
+      - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Transfer-Encoding:
@@ -57,64 +134,62 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Aaccountid:
-      - 5fa43d1b8405b10077912260
+      - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - bbf8bde8-75c1-4c79-b8df-4c3ed40008f4
+      - fdc0e3fa7a97f7656746ccc3405af67e
       X-Content-Type-Options:
       - nosniff
-      X-Envoy-Upstream-Service-Time:
-      - '204'
       X-Xss-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
-      Content-Length:
-      - '2'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.28.1
+      - python-requests/2.32.3
     method: GET
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+xWS08bMRD+K9EeOEVsEiKKIkUIlR5QEapE6KVCldmdJSZee/EjjyL+e2f2ZQcq
-        uqEtvbCn9Xge34xnPvshgnXBZBpNokKrO0isifr+d/LtwStwYxzYTQGkYkBkKJtbW5hJHKeQoUGq
-        7tQ+s4IZw5ncl2BjDcbGrODxKK69xsMBfuiCk9NmsYANri5mny5nuJIsB1xeSW4tOqCAbMks01da
-        IKqHaHy0Hh/tGN9JvgRtmPhe+YqXHFYxJdRCqzeGg/HgA8Ycjdej8b+Ncmz4D5ianAmBAYeH6+Hh
-        WwRcNxEPRuuD0VtEzCHlLo8e+2EfUX+9opNaD2UvjcJeokUKJtG8sFxJlJ70ylz7vZQby2ViewWH
-        BHoq662UXuyTdaIkdtaOKF4ogwfYFuJgeLRViLbJZ8wscOWk1UwawSykF1s7xt1Y+ptkTBjo+4HM
-        OIiUZqP+wbkwLs+Z3tCvhnvHNaCi1Q7NTDKHnNEOAUNzYzWXtxRgYyzkJKmtH1twl7WkGdBGox/N
-        mTmFjDlhvzLhoEWnCtCMSk+ni4dro2t0VzAN0m7Dqg2e4SqLJ7gsc2+g1Q48si+VoAFW7++Kqz2o
-        ThXz2gEyL/TgzkjWm1WaFcDQthPGa+Q8IdQK0lLpfVheGInK8AzzKm2xwhwrqZP55hyWgFgHj3Ta
-        icoLJbFPyln5fScyrRn1OseTRhNvH55/4NQ3wEcvbBog0OvYARFLU4oEFE9DrpYQ/aIrKDNmLUvm
-        eecZe5pZYB+kFkh9aiehapXalnW31FpiqC6MTuPX6Ia0UIsCXmiVamJo1zsAe17kV43en714amti
-        kc8V+arMrpDnqAA8LwRH3vdn/P5A+psB/98DqWSqLVbuMtDPL/PQhR+P00Da9GCoudOYNBcoXdav
-        pNTA/umdWkk99HNcQ9or71ZPq1sOmLOKqFeAhd3vqNJVXPBkAfo4cZpeFDWdnKXTPTNXq0t3Q1dQ
-        9fiYEk+FYlNJatMSKE7uVDoh9u4d6M20c32J+ktiR6S3EqBbdZ0BHdaxtQ7ouxG15I2CnwAAAP//
-        vJhNT8MwDIb/ytQzayjrLkhoJxCHceU2oQ6FNtO2Vk0H5dD/jh0n/UqHWlJxdRPniev4daINbuHD
-        xRl5i/ZHziRHBd7ojH9QlW5qGEyafYjyFU4UmcdEop9neB4pv+vgtH028XkS5UIPbpKsPXQK+o2W
-        8N/FO8tFmoui17Vf21k9uiOD2tbWwXqYEcLaYG2ABNfmHwD+oxDS2izAXzK+gRSnKOaS4QxpnAgw
-        JCJOwLsvP7Hk6R0/kxFXUDoLwXCDVb3yPLA2qcG8c8ZczYNJ+tMFfTHtt0JdOaOG86BCRnY5t+mX
-        gQydIdezQVopulU2g7r2qh1KffskuqH/ZypAqXm/yCI9qdeHN2hrg3BcBYvOWIRosqcuRn72XQrp
-        xznn5yTNoA75B5FH93Gy5KDHS/0aQFPomgerNcXuEQYtsD/w6tuWhTZQ9q7WbazKx2jPqZcesaOe
-        2tjdmPbW6mbIYHj1dzcNDvxbRo6YvMTwa4vNRL0dunFW2JLuqh8AAAD//wMA4ncFkysWAAA=
+        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
+        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
+        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
+        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
+        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
+        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
+        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
+        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
+        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
+        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
+        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
+        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
+        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
+        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
+        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
+        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
+        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
+        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
+        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
+        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
     headers:
+      Atl-Request-Id:
+      - 1f2a65fd-a609-4604-a5b0-57706c020c82
       Atl-Traceid:
-      - 48d321396cda1bba
+      - 1f2a65fda6094604a5b057706c020c82
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -122,69 +197,70 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 18 Aug 2022 22:36:32 GMT
-      Expect-Ct:
-      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/atlassian-proxy",
-        max-age=86400
+      - Wed, 29 Jan 2025 20:45:18 GMT
       Nel:
-      - '{"report_to": "endpoint-1", "max_age": 600, "include_subdomains": true, "failure_fraction":
-        0.001}'
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
       Report-To:
-      - '{"group": "endpoint-1", "max_age": 600, "endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}],
-        "include_subdomains": true}'
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
       Server:
-      - globaledge-envoy
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=288,atl-edge-internal;dur=15,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
-      - max-age=63072000; preload
+      - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Transfer-Encoding:
       - chunked
       Vary:
       - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
       X-Aaccountid:
-      - 5fa43d1b8405b10077912260
+      - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 846df59e-5d73-438d-9345-a85e12ec5b55
+      - a2c7004340d79a5385a3da9a87056ab4
       X-Content-Type-Options:
       - nosniff
-      X-Envoy-Upstream-Service-Time:
-      - '247'
       X-Xss-Protection:
       - 1; mode=block
     status:
       code: 200
       message: OK
 - request:
-    body: '{}'
+    body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
-      Content-Length:
-      - '2'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.28.1
+      - python-requests/2.32.3
     method: GET
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA1SPTUvEMBCG/8tcbbPTpE1qbqIHFVmF7Z5kkbRJsJI2pUmFZdn/boqLH7fhneeZ
-        lzlBq4LZzw4kvMc4BbnZaGNNF7X/8ERFp0Lo1UhGEyGDTzOH3o8JLhALggTz3fbmZXf/3Pxut8vQ
-        pgnk6wplmOEhA20m54+DGWNznEw6cOv8opPULr3T3wrIJFCsLuGdiitIkdIc67wQDdYShaQVQcSr
-        RGLyg5lTb9MP/9jrBlEyLhklnFc/bDc8jNYnkJeFsMxay0RNKUdWI5aVorzoFGreCVEaZPxvQXRr
-        w2M/K1jfsWpx8cl3ao1P4C4TmPFtv4Pz+QsAAP//AwAW6AtAWgEAAA==
+        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpc19ItbzLBKTqFdi+KSJpcMJompUkHY+y7m6Cw+aa+HXe/
+        //2OO5CWe9wOhjDyFkLv2WwmUaEI0r27jAfDvdfcZhYDmRCpfW/4/h98jcNOC5ToP9Zo+hXagMNf
+        l6ycVWZEK/B3yR0OXjsbYaAUMprRab25fKzXD81puhm7NlaEPSdoQif0JTqxN27fxSubfZ9sK+NG
+        GUPtqI38ihAWA3lVfTeveEhgTvNySmGaLxooWAFsvsgopRc0wjHv4x9waHT3g102ObCiZLDMoDqx
+        oruxykVQlSUgVnNoJYpCCI7IoV1IBcuKKyiiQLUl5meCYJLhVg88vRAVH024c4Kn9oGY74qgfd3W
+        5Hh+2JOzaXJ935DjJwAAAP//AwCGwdS4IAIAAA==
     headers:
+      Atl-Request-Id:
+      - a128a453-82a5-46fe-a051-0d622a2f0da1
       Atl-Traceid:
-      - 1403d316903ec3d1
+      - a128a45382a546fea0510d622a2f0da1
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -192,20 +268,19 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 18 Aug 2022 22:36:32 GMT
-      Expect-Ct:
-      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/atlassian-proxy",
-        max-age=86400
+      - Wed, 29 Jan 2025 20:45:19 GMT
       Nel:
-      - '{"report_to": "endpoint-1", "max_age": 600, "include_subdomains": true, "failure_fraction":
-        0.001}'
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
       Report-To:
-      - '{"group": "endpoint-1", "max_age": 600, "endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}],
-        "include_subdomains": true}'
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
       Server:
-      - globaledge-envoy
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=162,atl-edge-internal;dur=14,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
-      - max-age=63072000; preload
+      - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Transfer-Encoding:
@@ -213,13 +288,98 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Aaccountid:
-      - 5fa43d1b8405b10077912260
+      - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 651b707d-2b09-4d87-9c46-1b43505ab6e0
+      - 4c5701eb45fee93086d2d076d9db96b1
       X-Content-Type-Options:
       - nosniff
-      X-Envoy-Upstream-Service-Time:
-      - '123'
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Epic&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xWW0/bMBT+K1aeS0JLxVClaZqASWwTmsTlZULIbU5bg2NnttMmQ/3vO6e5OKVs
+        S9nGXshTfHIu37G/88UPAeQpV3EwClKj72DibNDzr6OvD95BWJuBK1IgFwtyira5c6kdRVEMUwyI
+        9Z0OuZPcWsFVqMBFBqyLeCqiQVRljfr7+GAKQUnrxT0UuDq/PL24xJXiCeDySgnnMAEV5AvuuLky
+        ElE9BMOjfHi0Y/1MiQUYy+VtmStaCFhG1FADrfrQ3x/uv8Gag2E+GP7bKu+s+A5vbcKlxIL9w7x/
+        +BIF87riwSA/GLxExQRikSXBqtfmEfHrGUxqMjzNpRjsxIjUCa3Q+p6NxYxlFgyzTpuCuTl3TAHE
+        ljnNxsDGRt+DYrFeqpAdG+AOYjYu2EdhOLvQU7fkBtgeOjClHcNGHNOGxSDBQUjVJ1ohM7t0IRI+
+        AxtRhPV92AhSMQntYubJf4oWXGXKGa6sJFDnG19sNnbc3gejKZcWesFcgOFmMi8+wwIQTL/nZ3cq
+        QMY0RtULjpDNkoSbgl4NfMuEAXR0JsNMdjKHhNMXAofh1hmhCJstrIOELFX0qsF7UVnqWa49EBi3
+        JzDlmXTXXGbQANYpAqZTIiIgD1xw06ZHJ2TeuwXOGz28M7Kxy9KzRNiO7YTxBmVISr2EeO30yt8O
+        /P0tS1d06BOdpFqBon9O+9SroK1j58ZwopbAA8cQH9+mQSup58GxN9Y8aPl1JELA45gqAdUzkOgF
+        BE+QgzrbOMwurW3PWjuFb+SkZa07aXt2baWeu0q6O01d7dsCWZs8wC+NUwnOB+0AbHtTnzVxf3b3
+        qKJJPD6V2lYNFW2ASFIpUFb9kb5eVf5mwf93VSmVKUPVTda/zVskTL+/4xSX8cFaZcK0yIUNZwZA
+        zXWKbA/vUKNHs/ke6eee5GOgTsuYM0y/ruhHijSVrW8BjXZtwdtpvFZ0I8ivcYtKc5fWHmsvbXAp
+        OI0YtHN69B9EzipnL75t112g9yoN/rX6pkZoI9yjW87POmu8N3StsrWFrXGrla0xbDVQKug2/icA
+        P1PZhP4BAAD//7xYwW6DMAz9lx16XLaWHhHabZOYVKm79kAZAlQGGxBVPfTfZ8cJOINJlKAea7Dz
+        Yr/afuDZAis/d5DrIDkYsjzNILo9y1/JiCeoxgnJcAO7Xg7sEKmBuXaGuVkGJjUUG+g7NRkNdeMM
+        1VsGKjDSxhlWZwPScwa5XQzkgKKhshmo24frAXcv/k90g35PKoyMHW9aB4tKbEI3zZy8PHUuZuR4
+        f0ZOSC+Njxxk3qDt/du3sSurOTdz2gzXYx2thxySweDVz6HfyrbC9R9lz8Qydkx4fnwSFEg0MoXS
+        tsGPTOqLP/nyY5IBMEdtG8XZF0qXWflg/iwnzNrn5YW/SrmxvKfdg24QV9+XXq4jiWbWk/kz/MzK
+        6gq/QdkqJd+X1wrgUmKtywUQ/pTUQSzrGvKiVczbp79qsuq8l8cPkLO7CJ/5ONy5uSGLdlVAQTD4
+        pSyK1Sy6dGlGwCmI/mlJxq8FFh2MNyODMXVU6A1uWcTDBUWLjkUimgT1fqD3bV/prFuzQZ0DN/LD
+        9RcAAP//AwBwEqjntBYAAA==
+    headers:
+      Atl-Request-Id:
+      - 73c8b0f9-1d75-4368-acd7-aa0789b267cf
+      Atl-Traceid:
+      - 73c8b0f91d754368acd7aa0789b267cf
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 29 Jan 2025 20:45:19 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=297,atl-edge-internal;dur=15,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Arequestid:
+      - ad710f2110169e1ee2d8b1c8c01707f3
+      X-Content-Type-Options:
+      - nosniff
       X-Xss-Protection:
       - 1; mode=block
     status:
@@ -230,7 +390,7 @@ interactions:
       "new engagement", "issuetype": {"name": "Epic"}, "customfield_10011": "new engagement"}}'
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -242,34 +402,35 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.28.1
+      - python-requests/2.32.3
     method: POST
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"11823","key":"NTEST-1485","self":"https://defectdojo.atlassian.net/rest/api/2/issue/11823"}'
+      string: '{"id":"16611","key":"NTEST-1828","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16611"}'
     headers:
+      Atl-Request-Id:
+      - e5d301a0-db46-476e-a680-b2b0eb8a1db6
       Atl-Traceid:
-      - 20f9e5df98a5a95a
+      - e5d301a0db46476ea680b2b0eb8a1db6
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 18 Aug 2022 22:36:33 GMT
-      Expect-Ct:
-      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/atlassian-proxy",
-        max-age=86400
+      - Wed, 29 Jan 2025 20:45:20 GMT
       Nel:
-      - '{"report_to": "endpoint-1", "max_age": 600, "include_subdomains": true, "failure_fraction":
-        0.001}'
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
       Report-To:
-      - '{"group": "endpoint-1", "max_age": 600, "endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}],
-        "include_subdomains": true}'
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
       Server:
-      - globaledge-envoy
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=750,atl-edge-internal;dur=13,atl-edge-upstream;dur=737,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
-      - max-age=63072000; preload
+      - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Transfer-Encoding:
@@ -277,71 +438,70 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Aaccountid:
-      - 5fa43d1b8405b10077912260
+      - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - dfe58a94-2020-4ddf-b61e-62b2adce0472
+      - 4476e86ab623cefcadc29c6eea3b1844
       X-Content-Type-Options:
       - nosniff
-      X-Envoy-Upstream-Service-Time:
-      - '646'
       X-Xss-Protection:
       - 1; mode=block
     status:
       code: 201
       message: Created
 - request:
-    body: '{}'
+    body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
-      Content-Length:
-      - '2'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.28.1
+      - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1485
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1828
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xX224bNxD9FYKvlbQ3WZYFBEFqK4VbxzFsOX0oCoPaHa0YccktybWkuv73Dvem
-        WJfAVtG8aTnkXM+cGT1RWOVMJnRENcgENCQfOYjEdCTLwHRMPIeMdVQOmlmupOlAwm0GlnXiOZMp
-        CJV2HkEblEFyC7kGA9LWd+PCWJXNnMKHwPcDv6fhrwKMnaxzuNEstjwG2qHc2Q+CYRjhhwExw8+5
-        tbkZeV4CM4htor6qHrOCGcOZ7EmwHlqyHsu5F3rcmAK8RsEC1vj+ejK+m3SD/vAEj0oXDB09UYO+
-        FSZmFlKl11UMCX7hi9APw64/7AZnE98fRYNRFPWiQfSTH/q+c9IZseh4qeZIJ917D1NRaSzDrj8S
-        MLHmuUscnn4gU56SwoAmmEK9JnbOLJEAiSFWkSmQqVYLkCRRS9kj5xowhoRM1+RXrhm5UzO7ZBpI
-        Fy8QqSxxZSNKkwQEWOg567GS91q8JgqesRSM516YTRzGg5zHPfOYojYHF1Q1xhNXw2JqmVnQ0YwJ
-        Ax0654gfHc/XV/AIaDJ47lDLEWA5goWOZCFEh26hJfIPCYJGkGv1FT0+siD16/3l+AZEm+juJbcW
-        FRja2nZI/q28a+qcu/B5lguODidtBtgjs0xjvksU9oer/vCN7haSu0Zj4qHS5T1yWHoloJpIakHg
-        9/1TdCPsr8L+/2vlveF/wzuTMSHQYDBYBYMfYXDVWIzCVRT+CIsZNlCR0efnXTiGDRxnfPWlokIs
-        8h9/YtHTVEOKnbmDdXRHiaJq9r0gD08PCYaHBGe7yitmq06XSi9KEqejblDTmcuK5nHlx9POmcMq
-        BmzmqhDJBTe5YOsa0Xi8ZBanQ8Wqb+++irM3LO1V6rTrrfLnuSpcvkpXf3cHXKZ0ZHXhbKNS+wXL
-        5jqszkZFgXt5POydnfoNj2+n7RDNhC3NbAvagm8Log0xcaW5XR+Zm+a558bZsTxdK+F4UIH3JVN/
-        qgBd015Ey6ROwfGTg+52aIMDMbt+3y9AANO80LlwjLgtHLrMzJlx8+KKy8VHJ7mA3O0gMm5AVkJv
-        WcraE6nkGGcZmwq4BWYq4Or6F725uv/l8vrh6vJ8fH03fhjf3n6+RfPYfQZTgxcmcyA3yNLSEmeX
-        cEOUFGuCHc+FU+rGazlDbzRkmKFyCJvevs4PsOOo/w/3/aGZjehWv2PyUy6ZwLJiXTZ96GTbZ/UG
-        Vee+bA2B3jU0ghVOcfY3t4vc9fUroF4tO0eCsHrcTseX+8nbcLlB3c8sXuDK2MCuUV7ZOq+3sv/k
-        cLPaeWFtJGyGuYSlQ6ISSl9X3kxFAd1UI6m1Dk4UuVBVsVWW41IrbV2F79X0ZXLQEAGZIuAyR/m7
-        uDlEOUHwmtfhkfmp9JTd9Ll01dUW+xfhxzARbfCb2qBwD+qR5Wg6X3VLuui6RWP7Rv9brFvc8xcl
-        d7tZsn315EAq/IOClnAMxEVFsvsvHpqg/qEJ6rcTlFnL4nmZ/91Bvl18U2QZc6jdUzo3lJQ+smCO
-        ed6zOHaD8DJ5dzJj/SgJpsO+fzJFd09Pz4IwHLj+aS+hhe9cw79yXHxIErSBoKaVD/8CAAD//+xY
-        TU+DQBT8NT3uuoBgPRhtUj0bDx56W2GtmJYlC7QmDf/d2Q/WFoMxxigHEg7Lx76dPPLmzTyNgTjh
-        cyP3vCqpVLpCv5asJvuConrMZxTl0smmOAiDcxEwEYXZZZJGaXwRpPM4yxhPngMxv86uTJRZtJiF
-        d7jsPrLlhUsdIfZRRZuK7JERElJAzGjZPG3gOZAyUnJe6Yxhfw5dnqM9YLm8JwktC42/L3/Hj7iv
-        n8ePuK+/x44YDJRZHetawNLUAGjvVaLjWzup66mGR7Bq07LYCq0An982SsInrEA86ctH4WkXiLe+
-        kvU5zgO77qFEKVUtJir4h58+UcFfIJ6oYJAKvHwAxLWtuIMeILk1Q1xZc0hp9lkhsSEbyoZsKPM2
-        tP/C6zJR7HIlCytwnIRt3BzU3n4LqdzaCIdu6cjuBwR3NMI96+LCt/G3B1E1Gx346GxjGFS9qC2O
-        nax/bwxhg/mgOAs29VEav+UnH1IZF6OP9EBO0YYncN0Gk562bd8BAAD//wMAWs/2JHYXAAA=
+        H4sIAAAAAAAAA7xX23LbNhD9FQxfK4kXXaxoptNpHaWT1nE8tpw+dDoeiFxRiECABUBd4vrfuyBI
+        ypbEtlameROxwF7Pnl09erDNqUi8iadAJKAgeceAJ7ojaAa6o+MlZLQjc1DUMCl0BxJmMjC0Ey+p
+        SIHLtLMGpVEGyS3kCjQIU92NC21ktrAKH8IgCIOegj8L0Ga2y+FG0diwGLyOx6z9cDQKQ/zQwBf4
+        uTQm1xPfT2ABsUnkZ9mjhlOtGRU9AcZHS8anOfMjn2ldgF8rWMEO31/PpnezbjiOxnhUuqC9yaOn
+        0bdCx9RAKtXOxZDgF76IgmjYDcJu9GYWhZPBcBIFvf5w9B36HVgnrRGDjpdqznTSvvdRn9NYhl19
+        JKBjxXKbODz9kcxZSgoNimAK1Y6YJTVEACSaGEnmQOZKrkCQRG5Ej1wqwBgSMt+RX5ii5E4uzIYq
+        IF28QIQ0xJaNSEUS4GCgZ63HUtwr/l+iYBlNQfv2hd7HoX3IWdzT6xS1Wbigqime2BoWc0P1ypss
+        KNfQ8ZYM8aPi5e4K1oAmw6eOZxgCLEeweBNRcN7xDtDSD2pBruRndOzMvFevT2f9GVb2QdwLZgwq
+        0F5j2wL21/KurlJro2RZzhk6nDSB0jU1VGFaS7ANxtvB+JXuFoLZfqL8weny1ww2fombOpJKEAaD
+        4ALdiAbbaPD/WvlBsy/wvc4o52gwHG3D0bcwuK0t9qNtP/oWFjPskyLznp6O4Ri24TSqBQu2/eSo
+        EKv/+x/HN/v1TZqmClJs2aMmwAAkLxwLnDY3bBOM2gQXLYKoVTBuE7w59tOxpzvdSLUqB4U36Yb4
+        SQ3OD8e7r29cx+p7HvedOmXbsvx5KQubuNBy82/2gInUmxhVAJYPlZpPWHHbnFUsjiRbmD4IxjXT
+        HwbdENGhoA0SUQOJXDGpmNmdmYL6ud//CsKulDA8cPB+SdkfHOQrYux7x9CPGtxyOgdLbSfAHbXB
+        z1LFaQHCz0uoWj3sgHO5Oc58OLZ5W1Jtx8oVE6t3VvIWcruqiHjX0K5eyk0pa06EFFMceXTO4Rao
+        tu30iKB1v7ybq/uf318/XL2/nF7fTR+mt7cfb9E89qLGxOGF2RLIDbK8MMTaJUwTKfiOIGMwbpXa
+        KVyO2hsFGeavnNW6d4o5QmwaL/iLBYFafJl4bvJhjbFI+855wQhYrpQJyg8vVYtWVYCyPzh6V33b
+        +qe4ItS3i9y2Zhvew/Cixrvbic6EqHvcTNeXa8zrULvH5E80XuFmWYOyVu5sXVbL21c5XG+AflQZ
+        ieplQECJRMmlunbezHkB3VTR3d7BmSRvpSu2zHLcfYU53RbDNvIYNuTxTxV/mU50jYBIEaKZHRnH
+        OptGPYRgmxe4MP+72jA6M9VOT9mYH8sYLEyQDxDJFHPa5HFfZhSeaCAMy0uX225JP11bscMbg+fJ
+        NPjPYlXOgscTytrm56CZbQeCoO1F0DCbhrhwNH/6YtugDdoGbdA4Q42h8bIsjOvy50RxCBddZBm1
+        nXGipnb6SXVmJf8GAAD//+xYPW/CMBD9K10Yk4YkNGFAFKFW6sDSoQObYzttpJBE+aBFKP+9z3Zw
+        IYpRVVWIAYnBxPbdceTevXcC3eaEUtFxX9hswrwwCKNx4HCPTh06nbjxdByLf1Yfgoczx6Aqk3TB
+        GHygcFBFbPd4FAiqStg6y6Zl0rmNwpTHxJ0Do/M5egdhY99/CGgYTLxpRKPAgfuY8DikczaTVkbe
+        YuQ+46PuWRuSdRmzLPWospvK+kQiLNcGbWR20UQpVA8yZRWEVCJRuJ9AMiToPFguV5ZjF5kArz4z
+        v/6I+9T++iPuS4NrjxiIxJKqSMmu6y5LvPp3KxLHDaWJLKAawkXxWIVna/QXHHxqyhziZQ2koR8/
+        lSakKXZ16QoPnf4ebkm+qRn4Jj7raz7b39ANp+RFXtb8hi+Xe5Nu+HKJiG/4MoAvfRjQ9EuzE0T9
+        rmpvL2Zo3dqBw7wmUAPOgBUjzzLikklaOu4w8hl5mIk4C0AY3HD0T+5teKYbnqZ0PNsmZZ4pTqce
+        saabQquvv8pevlEW9odlB/d/gN+jAfr9wS7kMPl65VWTCsNHvqUOK+tFreLY5vX/jXiUMW0UvqD+
+        33IpY6Wyb9WQSYhD4VIHchqtexJud0Gmp23bbwAAAP//AwA6zCNv9BgAAA==
     headers:
+      Atl-Request-Id:
+      - fc062cd3-da38-4d95-8b00-ecc24bb3dcb2
       Atl-Traceid:
-      - dd000025791e2419
+      - fc062cd3da384d958b00ecc24bb3dcb2
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -349,20 +509,19 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 18 Aug 2022 22:36:33 GMT
-      Expect-Ct:
-      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/atlassian-proxy",
-        max-age=86400
+      - Wed, 29 Jan 2025 20:45:20 GMT
       Nel:
-      - '{"report_to": "endpoint-1", "max_age": 600, "include_subdomains": true, "failure_fraction":
-        0.001}'
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
       Report-To:
-      - '{"group": "endpoint-1", "max_age": 600, "endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}],
-        "include_subdomains": true}'
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
       Server:
-      - globaledge-envoy
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=271,atl-edge-internal;dur=14,atl-edge-upstream;dur=258,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
-      - max-age=63072000; preload
+      - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Transfer-Encoding:
@@ -370,13 +529,11 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Aaccountid:
-      - 5fa43d1b8405b10077912260
+      - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 4ccb1d1f-ed6a-4e7a-be67-7c9bed4b8dca
+      - 446c00b1e72bcc391857513273a2fa6a
       X-Content-Type-Options:
       - nosniff
-      X-Envoy-Upstream-Service-Time:
-      - '274'
       X-Xss-Protection:
       - 1; mode=block
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_creation.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_creation.yaml
@@ -19,17 +19,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1nZb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwCbz0/NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4DTnDNLFsvhm
-        ZXdjlA1gRouFFIA5KklncxSZUpkCqdhyli9qVWTICgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAOhBbeiACAAA=
+        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bqka+iWN6ngFJ1Cu5eJSJpcMJompUkHY+y7m+DQ+aa+HXe/
+        //2OO6CWe9gMBjH0GkLv2WwmQYEI0r25jAfDvdfcZhYCmiCpfW/4/h98DcNOC5Dg31dg+gpsgOGv
+        SypnlRnBCvhdcgeD185GmGBMMpzhab2+fKxXD833dD12bawQe0rQBE/wc3RCb9y+i1c2+z7ZKuNG
+        GUPtqI38jCAWA3lZnppXPCQwxzmdYjLNFw0pWEHYfJFhjC9whGPexz/A0OjuB7tscsIKygjNCkq+
+        WNHdWOUiqCglAOWctBJEIQQH4KRdSEWWJVekiALVUsjPBMEkw60eeHohKD6acOcET+0DMqcKgX3Z
+        1Oh4ftjW2TS5vm/Q8QMAAP//AwAhfxRWIAIAAA==
     headers:
       Atl-Request-Id:
-      - ad0b1495-8283-47ea-af20-cece1e560387
+      - a416e98b-18d8-450f-852c-5a7cdd05e165
       Atl-Traceid:
-      - ad0b1495828347eaaf20cece1e560387
+      - a416e98b18d8450f852c5a7cdd05e165
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -37,7 +37,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:20 GMT
+      - Wed, 29 Jan 2025 20:45:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +47,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=165,atl-edge-internal;dur=17,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=147,atl-edge-internal;dur=18,atl-edge-upstream;dur=130,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -59,7 +59,94 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 769698bf4fd3ab037cc03f3174493ceb
+      - 308663ded5c76f207008e263d9d9948f
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Epic&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xWW0/bMBT+K1aeS0JLxVClaZqASWwTmsTlZULIbU5bg2NnttMmQ/3vO6e5OKVs
+        S9nGXshTfHIu37G/88UPAeQpV3EwClKj72DibNDzr6OvD95BWJuBK1IgFwtyira5c6kdRVEMUwyI
+        9Z0OuZPcWsFVqMBFBqyLeCqiQVRljfr7+GAKQUnrxT0UuDq/PL24xJXiCeDySgnnMAEV5AvuuLky
+        ElE9BMOjfHi0Y/1MiQUYy+VtmStaCFhG1FADrfrQ3x/uv8Gag2E+GP7bKu+s+A5vbcKlxIL9w7x/
+        +BIF87riwSA/GLxExQRikSXBqtfmEfHrGUxqMjzNpRjsxIjUCa3Q+p6NxYxlFgyzTpuCuTl3TAHE
+        ljnNxsDGRt+DYrFeqpAdG+AOYjYu2EdhOLvQU7fkBtgeOjClHcNGHNOGxSDBQUjVJ1ohM7t0IRI+
+        AxtRhPV92AhSMQntYubJf4oWXGXKGa6sJFDnG19sNnbc3gejKZcWesFcgOFmMi8+wwIQTL/nZ3cq
+        QMY0RtULjpDNkoSbgl4NfMuEAXR0JsNMdjKHhNMXAofh1hmhCJstrIOELFX0qsF7UVnqWa49EBi3
+        JzDlmXTXXGbQANYpAqZTIiIgD1xw06ZHJ2TeuwXOGz28M7Kxy9KzRNiO7YTxBmVISr2EeO30yt8O
+        /P0tS1d06BOdpFqBon9O+9SroK1j58ZwopbAA8cQH9+mQSup58GxN9Y8aPl1JELA45gqAdUzkOgF
+        BE+QgzrbOMwurW3PWjuFb+SkZa07aXt2baWeu0q6O01d7dsCWZs8wC+NUwnOB+0AbHtTnzVxf3b3
+        qKJJPD6V2lYNFW2ASFIpUFb9kb5eVf5mwf93VSmVKUPVTda/zVskTL+/4xSX8cFaZcK0yIUNZwZA
+        zXWKbA/vUKNHs/ke6eee5GOgTsuYM0y/ruhHijSVrW8BjXZtwdtpvFZ0I8ivcYtKc5fWHmsvbXAp
+        OI0YtHN69B9EzipnL75t112g9yoN/rX6pkZoI9yjW87POmu8N3StsrWFrXGrla0xbDVQKug2/icA
+        P1PZhP4BAAD//7xYwW6DMAz9lx16XLaWHhHabZOYVKm79kAZAlQGGxBVPfTfZ8cJOINJlKAea7Dz
+        Yr/afuDZAis/d5DrIDkYsjzNILo9y1/JiCeoxgnJcAO7Xg7sEKmBuXaGuVkGJjUUG+g7NRkNdeMM
+        1VsGKjDSxhlWZwPScwa5XQzkgKKhshmo24frAXcv/k90g35PKoyMHW9aB4tKbEI3zZy8PHUuZuR4
+        f0ZOSC+Njxxk3qDt/du3sSurOTdz2gzXYx2thxySweDVz6HfyrbC9R9lz8Qydkx4fnwSFEg0MoXS
+        tsGPTOqLP/nyY5IBMEdtG8XZF0qXWflg/iwnzNrn5YW/SrmxvKfdg24QV9+XXq4jiWbWk/kz/MzK
+        6gq/QdkqJd+X1wrgUmKtywUQ/pTUQSzrGvKiVczbp79qsuq8l8cPkLO7CJ/5ONy5uSGLdlVAQTD4
+        pSyK1Sy6dGlGwCmI/mlJxq8FFh2MNyODMXVU6A1uWcTDBUWLjkUimgT1fqD3bV/prFuzQZ0DN/LD
+        9RcAAP//AwBwEqjntBYAAA==
+    headers:
+      Atl-Request-Id:
+      - 369f45ce-734a-4a76-8264-4f6e40681459
+      Atl-Traceid:
+      - 369f45ce734a4a7682644f6e40681459
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 29 Jan 2025 20:45:15 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=279,atl-edge-internal;dur=14,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Arequestid:
+      - 9a47223711d986c096a708b4d5d8fd13
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -90,18 +177,18 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16078","key":"NTEST-1594","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16078"}'
+      string: '{"id":"16610","key":"NTEST-1827","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16610"}'
     headers:
       Atl-Request-Id:
-      - 6e92d4a7-a838-4be0-8752-5957888cb29d
+      - 05bc7a5a-49d2-4e5d-a335-da7fd0a8cd07
       Atl-Traceid:
-      - 6e92d4a7a8384be087525957888cb29d
+      - 05bc7a5a49d24e5da335da7fd0a8cd07
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:21 GMT
+      - Wed, 29 Jan 2025 20:45:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -111,7 +198,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=726,atl-edge-internal;dur=15,atl-edge-upstream;dur=712,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=811,atl-edge-internal;dur=15,atl-edge-upstream;dur=797,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -123,7 +210,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 05a2df9725b31c24c5dd4b7622e319c0
+      - a127865b86cdb4616e34c4e57c1539cb
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -147,45 +234,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1594
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1827
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xX227jNhD9FUKvta2LL/EaKIo28RbbptnAcbYPRRHQ0ljmmiJVkvKlaf69Q1GS
-        E9sqNll03ywOOTOcOecM/ejBLqci8SaeApGAguQ9A57ojqAZ6I6OV5DRjsxBUcOk0B1ImMnA0E68
-        oiIFLtPOBpRGGyQzyBVoEKbaGxfayGxpHT6EQRAGPQV/FaDNfJ/DraKxYTF4HY/Z+OEouBjjhwa+
-        xM+VMbme+H4CS4hNIj/LHjWcas2o6AkwPkYyPs2ZH/lM6wL82sEa9nj+Zj69m3fD4bsBLpUpaG/y
-        6GnMrdAxNZBKtXd3SPALT0RBNOwGYTcM5lEwCYeTKOyNRsF3mHdgk7RBDCZeunljkva8j/6cx/La
-        1UcCOlYst4XD1R/JgqWk0KAIllDtiVlRQwRAoomRZAFkoeQaBEnkVvTIpQK8Q0IWe/ILU5TcyaXZ
-        UgWkixuIkIbYthGpSAIcDPRs9FiKe8W/5BYsoylo357Qh3toH3IW9/QmRW8WLuhqiiu2h8XCUL32
-        JkvKNXS8FUP8qHi1v4YNYMjwqeMZhgDLESzeRBScd7wjtPSDNkNYG3IlP2PGb2xIdfp8O56B6HC7
-        e8GMQQfaa2JbJP9a7tVVze31WZZzhgknTQXohhqqsN4lCgfj3WD8ynQLwSzRKH9wvvwNg61fAqq+
-        SWUIg0FwgWlEg100+H+j/KDZ3/C9zijnGDAc7cLRtwi4qyP2o10/+hYRMyRQkXlPT6dwjGo4Ltnu
-        k5NCbPIff57u7Nc7aZoqSJGyJyTAPCUvnAqcR/+wzTBqM1y0GKJWw7jN8O40T6eebnUr1bocFN6k
-        G1aSaSuvWOyu9HiyZvmARdUrWfDkiumc033FGlzeUoMTyCn36xnu5sJhEvjOnbL8LX9eysKWvkz1
-        d7vAROpNjCpsbHRqPiE0LIurajiZbZkV0Xhcz4rjsrVJWdRI2bGhAVWumFTM7N9Ygvq43/8Kya+c
-        MFxwPHgp+r85blQK2vdOORI1yD82NKDldAFWHM/wxmrK2dMhAtjbA+dye1r0cGxLtqLazqRrJtbv
-        reUKcvvOEXENshJ629LWrAgppjgv6YLDDKh2wFXVL+/2+v7nDzcP1x8upzd304fpbPZxhuGRyBpr
-        hhvmKyC3OAmEITYuYZpIwfcEVYVx69SO8HJO3yrIsHTloNe9c+oSIuO84B8WBHm2mXhubGJ7sT8H
-        2r2QE+xUygTlx5uqV1pV4pIaHLOrvm3rU3xf1LuL3PK6DeqDqHkWuQfVG9HpDjcT+OUb6HWAPcDx
-        Jxqv8Vla47F27mJdVi+/r0q4fj76URUkqh8MAkokSi7VjctmwQvopgpFrUlwLsmVdM2WWY4PZ2HO
-        A3/YphvDRjf+q+Mvy7kFWCMIQaSI0syOnFO3bTQN2xIJwy/zHEZvLLjzU9LzY3kTCxYUBMQzxco2
-        1Tw0G41naIQ389LVrlvKTNeK4fGOwfOSGvxzsi6HgR1Ox1vbRnDQZhg0c/P4RCNtGuLC6fz5jW2z
-        Omib1UETkxpD41XZGMf153JxDBpdZBm1/HjR1n8BAAD//+xYPW/CMBD9K10Yk5okNGFAFKFW6sDS
-        oQObYzttJJpE+aCtEP+9z3bi0ihGFaoQAxKDcXznu0vu7r0zr1V2wLw88WXKMjenjMmu+8RnE+5H
-        YRSPQyJ8NiVsOvGS6TiRL9ccwg1HjoGbppsF57gDGYR04l/3B4YgvaSuo9BbxV24yFB1TMp08C8Q
-        aCKUj4PgLmRROPGnMYtDgusTKpKIzflMaRn5i5H3iJ+Wc95p1kbMcfRW5TaV84FAOJ4LjMndook3
-        4E6IlFNQWslAQT4Fv0jRgrBcrhziFpmsYn0Yf/kW93nA5Vvc5xGXbjGKEtdYuW0zS3z6NyuaJA1j
-        qUqgGixHY1ld0tZoNDj40JQ5mM4axYa9/WSa5LF4alJX3tCy+OHeFNhaQmDDtIHBtKUo8rIW1zJy
-        vg/mWkbOYfG1jAyUkX4ZsIHMwCAwA1DgzqtOyp0cuLVrAkvymoIWkAH1NgxGbHWJeMMFzsY6idUB
-        K0YznvUlbODNtz4wqE5k27TMMw3r9BZv2lm2/vuX6G3z+v/GK1qZUYqbQL9fcsUju4kOUkCbvOuW
-        bX852QA197/t9IKI089nUTUbqfjAWcUAy3pRa8flqEqyROm62f8t7P2SbgWUtfv9/hsAAP//AwAA
-        yG5wOhkAAA==
+        H4sIAAAAAAAAA7xXbW/bNhD+K4S+zrZerDiJgWLYUnfolqVB4rQfhiGgpbPMmiI1kortZfnvO4qS
+        3NjS0KRYv1k88l6fe+786MG2oCL1pp4CkYKC9B0DnuqBoDnogU5WkNOBLEBRw6TQA0iZycHQQbKi
+        IgMus8EDKI0ySG+gUKBBmPpuUmoj86VVeB8GQRiMFPxVgjbzXQHXiiaGJeANPGbth5NJGOCHBr7E
+        z5UxhZ76fgpLSEwqP8sRNZxqzagYCTA+WjI+LZgf+UzrEvxGwRp2+P5qPrudD8Oz6BSPKhe0N330
+        NPpW6oQayKTauRhS/MIXURCdDINwGJ3Po3Aan0zDyeg0jH5Av63ayohBxys1r3TSvvdRn9NYhV1/
+        pKATxQqbODz9iSxYRkoNimAK1Y6YFTVEAKSaGEkWQBZKrkGQVG7EiFwowBhSstiRX5mi5FYuzYYq
+        IEO8QIQ0xJaNSEVS4GBgZK0nUtwp/jVRsJxmoH37Qu/j0D4ULBnphwy1Wbigqhme2BqWC0P12psu
+        Kdcw8FYM8aOS1e4SHgBNhk8DzzAEWIFg8aai5HzgHaBlHDSCQsnP6Ngr816/7s76F1jZB3EnmDGo
+        QHutbQvY36q7uk6tjZLlBWfocNoGSh+ooQrTWoEtPtvGZy90txTM9hPl906X/8Bg41e4aSKpBWEQ
+        BxbcUbyN4v/Xyo+a/Q1vdE45R4PhZBtOvofBbWNxHG3H0fewmGOflLn39HQMx7APp1EjWLLtR0eF
+        WP0//jy+OW5u0ixTkGHLHjUBBiB56Vig29xJn2DSJzjtEUS9grM+wfmxn4493elGqnU1KLzpMMRP
+        anB+ON59eeM6Vt/zuO/UKduW1c8LWdrEhZabP9kDJjJvalQJWD5Uaj5ixW1z1rE4kuxh+nEcN0x/
+        GHRLRIeCPkhELSQKxaRiZvfKFDTP/fE3EHathOGBg/dzyv7dQb4mxrF3DP2oxS2nC7DU1gHuqA9+
+        liq6BQg/L6Vqfb/gpeXTQ/mZzdqKajtULplYv7OSt1DYRUUku5Z09UpuKll7IqSY4cCjCw43QLVt
+        pkeErPvlXV/e/fL+6v7y/cXs6nZ2P7u5+XCD5rETNaYNL8xXQK6R44Uh1i5hmkjBdwT5gnGr1M7g
+        atBeK8gxe9Wk1qMu3gixZbzgHxYEaqmmnpt7WGEs0b5vnvEBFitjgvLDS/WaVae/6g6O3tXftvoZ
+        LgjN7bKwjdmH9nhy3qDdbUSvBKh73M7W50vMyzC7R+TPNFnjXtlAslHubF3Uq9s3Odzsf35UG4ma
+        VUDAxiJRcqmunDcWnMNM0d3ewbkkb6UrtswL3HyF6W6Kk5Y6/quwh49aWnmezg3AGkEIIkOU5nZm
+        HD9tO/UQhX0cFoZfpzmMXplwp6dqzw9VJBYsyAmIZ2rbvsnmvtgo7GgjjMzLVtthRUHDuMPD+Mtc
+        G/x3sa7mwWOHsr4ZGvQJ4nbwHb5o2U1DUjqq777YN2yDvmEbtDaf0cMheqgxNFlVVasgqMs8p7Y/
+        ustqh6BULy3mvwAAAP//7FhNb4JAEP0rvXiEroAFDsYa0yY9eOmhB2/LLlQSBMKHrTH8975lYWsJ
+        a5qmMR5MPKzs7sw4Mm/em55TAeYWlDHReF/4fMZtz/WCqUtCm/mE+TMr8qeR+HPVIXg4cwziMk6W
+        nMMHKgjlxA+PJ4GgvISts6S6zXtookLbY+JOT+ycEE2E8qnjPLjMc2e2H7DAJXAf0TDy2ILPWysT
+        ezmxnvGR94wdTbuMGYZ8VJp1aXwgEYZlgj1yM6+DBOIHmTJySkuRKNyPoRxitCAsV2uDmHkqUGxI
+        0K8/4iHDv/6Ihwrh2iMGKPG4zBN66NrMCq/+3ZpGUc1Y3BZQBf0i6ayEtA0aDQ4+1UUGDbMB2LDt
+        d6UJhYpdVbrCQyfDx3uTo2sJjo7WOorWDjdU2ynCPCuq8IYvl3uTbvhyiYhv+DKCL0MYUAxMERZE
+        /S5r7yhGad2awGFWUcgCMmJFx8GIDpeINQ5wOuFJdCzZ0XI09cuGN3TkzdZuKFYXpvu4yFLJ3OQj
+        XnfDaPn1V9nLdtLCsV92cP8H+D2Zo9/3dqGL6edrWNaJMHziuxVkRbWsZBz7rPq/SY80pozC15aW
+        b1mrZ1uJ38hZk1CJwqUK5Ge01o9wuwttepqm+QIAAP//AwA6/KnH+xgAAA==
     headers:
       Atl-Request-Id:
-      - e5e5c14b-a836-4cc1-9a3b-5934dac285ac
+      - 71ee13bb-d170-48a6-906c-72016de1bb34
       Atl-Traceid:
-      - e5e5c14ba8364cc19a3b5934dac285ac
+      - 71ee13bbd17048a6906c72016de1bb34
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -193,7 +279,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:22 GMT
+      - Wed, 29 Jan 2025 20:45:17 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -203,7 +289,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=431,atl-edge-internal;dur=13,atl-edge-upstream;dur=418,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=249,atl-edge-internal;dur=14,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -215,7 +301,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 206c2fe40afcc4f1bc2298436d4073ea
+      - 99e237ceb0c6f5fc7a7b096b25effccd
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_enabled_create_epic_and_push_findings.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_enabled_create_epic_and_push_findings.yaml
@@ -19,17 +19,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2bpvvIDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04qJtgRuFn2
-        8/qxfCC18LjtDeHkLYTO8+m0QYUyNO7dpSIY4b0WNrUYyIQ02ndG7P/Bl9jvtMQG/ccaTbdCG7D/
-        65KVs8oMaCX+LrnD3mtnI5wBZCmkkJSby8dy/VD9TDdDW8eK8OcRmsAEXqITO+P2bbyy2nejbWXc
-        0MRQPWjTfEUIjwE6n5+aVyKMIAVaJJAlsKwo5SznLIoBLiDCMe/jH7CvdHvOZlBR4FnBc5bSgn6z
-        sr2xykWQZbOFFIAFKpnlcxRMKaZAKrrMi0WtZgzpTAE9EwQzGm51L8YXohKDCXdOirF9IOZUEbSv
-        25Iczw97cnacXN9X5PgJAAD//wMAVZhjdyACAAA=
+        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1tKZN5ngFJ1CuxdFJE0uWE2T0qSDMfbdTXDofFPfjrvf
+        /37H7UkjPG4GQzh5DaH3fDZTqFEG5d5cJoIR3rfCZhYDmRDV+t6I3T/4CodtK1Ghf1+h6ZdoAw5/
+        XbJ0VpsRrcTfJbc4+NbZCFMAmkEG02p98VCt7uvv6XrsmlgR/pSgCUzgOTqxN27XxSvrXZ9sS+NG
+        FUPN2Br1GSE8BlhZHpuXIiSQASumQKdsUdOc55TPFxkAnEGEY97HP+BQt90P9rxmlOcFhyKDkn2x
+        sru22kVQFwVFLOe0UShzKQWioM1CaXpeCk3zKNBNgexEEEwy3LSDSC9ELUYTbp0Uqb0n5lgRtC+b
+        ihxOD3t0Nk2u7mpy+AAAAP//AwDjs6gYIAIAAA==
     headers:
       Atl-Request-Id:
-      - cf32c567-6ff5-41f4-ba07-35ef62cc163f
+      - dc2fdac2-6ca6-4d66-a1fa-7b7a8151f2c8
       Atl-Traceid:
-      - cf32c5676ff541f4ba0735ef62cc163f
+      - dc2fdac26ca64d66a1fa7b7a8151f2c8
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -37,7 +37,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:34 GMT
+      - Wed, 29 Jan 2025 20:45:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +47,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=144,atl-edge-internal;dur=15,atl-edge-upstream;dur=130,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=228,atl-edge-internal;dur=29,atl-edge-upstream;dur=200,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -59,7 +59,94 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - e95e0cabf3fed24c769d00719e17d11f
+      - 18474af2b7f4a69211e1b5cfeeef83a6
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Epic&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xWW0/bMBT+K1aeS0JLxVClaZqASWwTmsTlZULIbU5bg2NnttMmQ/3vO6e5OKVs
+        S9nGXshTfHIu37G/88UPAeQpV3EwClKj72DibNDzr6OvD95BWJuBK1IgFwtyira5c6kdRVEMUwyI
+        9Z0OuZPcWsFVqMBFBqyLeCqiQVRljfr7+GAKQUnrxT0UuDq/PL24xJXiCeDySgnnMAEV5AvuuLky
+        ElE9BMOjfHi0Y/1MiQUYy+VtmStaCFhG1FADrfrQ3x/uv8Gag2E+GP7bKu+s+A5vbcKlxIL9w7x/
+        +BIF87riwSA/GLxExQRikSXBqtfmEfHrGUxqMjzNpRjsxIjUCa3Q+p6NxYxlFgyzTpuCuTl3TAHE
+        ljnNxsDGRt+DYrFeqpAdG+AOYjYu2EdhOLvQU7fkBtgeOjClHcNGHNOGxSDBQUjVJ1ohM7t0IRI+
+        AxtRhPV92AhSMQntYubJf4oWXGXKGa6sJFDnG19sNnbc3gejKZcWesFcgOFmMi8+wwIQTL/nZ3cq
+        QMY0RtULjpDNkoSbgl4NfMuEAXR0JsNMdjKHhNMXAofh1hmhCJstrIOELFX0qsF7UVnqWa49EBi3
+        JzDlmXTXXGbQANYpAqZTIiIgD1xw06ZHJ2TeuwXOGz28M7Kxy9KzRNiO7YTxBmVISr2EeO30yt8O
+        /P0tS1d06BOdpFqBon9O+9SroK1j58ZwopbAA8cQH9+mQSup58GxN9Y8aPl1JELA45gqAdUzkOgF
+        BE+QgzrbOMwurW3PWjuFb+SkZa07aXt2baWeu0q6O01d7dsCWZs8wC+NUwnOB+0AbHtTnzVxf3b3
+        qKJJPD6V2lYNFW2ASFIpUFb9kb5eVf5mwf93VSmVKUPVTda/zVskTL+/4xSX8cFaZcK0yIUNZwZA
+        zXWKbA/vUKNHs/ke6eee5GOgTsuYM0y/ruhHijSVrW8BjXZtwdtpvFZ0I8ivcYtKc5fWHmsvbXAp
+        OI0YtHN69B9EzipnL75t112g9yoN/rX6pkZoI9yjW87POmu8N3StsrWFrXGrla0xbDVQKug2/icA
+        P1PZhP4BAAD//7xYwW6DMAz9lx16XLaWHhHabZOYVKm79kAZAlQGGxBVPfTfZ8cJOINJlKAea7Dz
+        Yr/afuDZAis/d5DrIDkYsjzNILo9y1/JiCeoxgnJcAO7Xg7sEKmBuXaGuVkGJjUUG+g7NRkNdeMM
+        1VsGKjDSxhlWZwPScwa5XQzkgKKhshmo24frAXcv/k90g35PKoyMHW9aB4tKbEI3zZy8PHUuZuR4
+        f0ZOSC+Njxxk3qDt/du3sSurOTdz2gzXYx2thxySweDVz6HfyrbC9R9lz8Qydkx4fnwSFEg0MoXS
+        tsGPTOqLP/nyY5IBMEdtG8XZF0qXWflg/iwnzNrn5YW/SrmxvKfdg24QV9+XXq4jiWbWk/kz/MzK
+        6gq/QdkqJd+X1wrgUmKtywUQ/pTUQSzrGvKiVczbp79qsuq8l8cPkLO7CJ/5ONy5uSGLdlVAQTD4
+        pSyK1Sy6dGlGwCmI/mlJxq8FFh2MNyODMXVU6A1uWcTDBUWLjkUimgT1fqD3bV/prFuzQZ0DN/LD
+        9RcAAP//AwBwEqjntBYAAA==
+    headers:
+      Atl-Request-Id:
+      - b87ab541-9873-4bcb-b4d0-171962f3a902
+      Atl-Traceid:
+      - b87ab54198734bcbb4d0171962f3a902
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 29 Jan 2025 20:45:05 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=362,atl-edge-internal;dur=15,atl-edge-upstream;dur=348,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Arequestid:
+      - 123eca3c50496b773a888435b9d54f08
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -90,18 +177,18 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16083","key":"NTEST-1599","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16083"}'
+      string: '{"id":"16607","key":"NTEST-1824","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16607"}'
     headers:
       Atl-Request-Id:
-      - 81ac8855-a328-4d48-99e2-b6881fa538c0
+      - 35a69b3f-045c-438b-bf97-7d1ae935c2bb
       Atl-Traceid:
-      - 81ac8855a3284d4899e2b6881fa538c0
+      - 35a69b3f045c438bbf977d1ae935c2bb
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:35 GMT
+      - Wed, 29 Jan 2025 20:45:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -111,7 +198,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=747,atl-edge-internal;dur=13,atl-edge-upstream;dur=734,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=884,atl-edge-internal;dur=13,atl-edge-upstream;dur=871,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -123,7 +210,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 55e6aabba5a96be9ab92e89700460e32
+      - 8d6e3026c6ae2627c31fe90f2e23886b
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -147,45 +234,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1599
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1824
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xXbXPiNhD+Kxp/LeAXICHMdDptjutcm+YyCbl+6HQywl5sHbLkSnKAS/Pfu7Js
-        kwDuXOj0vmHtal+ffVY8ebApqEi8qadAJKAgec+AJ7onaA66p+MMctqTBShqmBS6BwkzORjaizMq
-        UuAy7T2C0iiD5BYKBRqEqXXjUhuZL63BhzAIwmCg4K8StJlvC7hRNDYsBq/nMes/PAsmQ/zQwJf4
-        mRlT6KnvJ7CE2CTysxxQw6nWjIqBAOOjJ+PTgvmRz7QuwW8MrGCL96/ns7t5PxxfXOBRFYL2pk+e
-        xthKHVMDqVRbl0OCX3gjCqJxPwj7YTCPgmk4ng7Hg2A4+Q7jDmyQ1onBwCszJwZp7/toz1ms0q4/
-        EtCxYoUtHJ7+SBYsJaUGRbCEaktMRg0RAIkmRpIFkIWSKxAkkWsxIJcKMIeELLbkF6YouZNLs6YK
-        SB8ViJCG2LYRqUgCHAwMrPdYinvFvyYLltMUtG9v6F0e2oeCxQP9mKI1Cxc0NcMT28NyYaheedMl
-        5Rp6XsYQPyrOtlfwCOgyfO55hiHACgSLNxUl5z1vDy3DoBEUSn7GwE6se337eNVfYGWXxL1gxqAB
-        7bW+LWB/rXR1XVqbJcsLzjDgpE2UPlJDFZa1AttoshlN3hhuKZidJ8ofnC3/kcHar3DTZFILwmAU
-        nGMY0WgTjf5fLz9o9gW+1znlHB2GZ5vw7Fs43DQeh9FmGH0LjznOSZl7z8+HcAy7cBo1giXbfHJU
-        iN3/489DzWGjSdNUQYojezAEmIDkpWOB4+7GXYKzLsF5hyDqFEy6BBeHcTr2dKdrqVbVovCm/bCm
-        TNsSxWKX0tPBmR0UrLbOZMmTd0wXnG7rccLjNTW4gRxzv3303V7YbQLfmVN2sKufl7K0pa9C/d0e
-        MJF6U6NK6xuNmk+IGTvedTUczR7dFaPB2XnU7Ir9srVUti/oAlXUgqpQTCpmtieWoLnu2814KuXX
-        RhgeuAF5Tfq/uaGpqXXoHQ5P1CJ/X9CCltMFWNY8MjeWbI7eDhHAXkLV6mELnMv1YeXDia1bRrVd
-        TFdMrN5byTso7GNHxA3SKvytK1l7IqSY4dKkCw63QLVDr6p/eTdX9z9/uH64+nA5u76bPcxubz/e
-        onucZo2FQ4V5BuQG94QwxPolTBMp+JYg5zBujdo9Xi3rGwU51q/a9npwjHtCHDsv+JsFQSG+TD23
-        O7HH2KTd7L3iFGxXygTl+0r1U62uczUfHKOrv23/U3xkNNplYYe7C+/nkxbv7lV1IkTd5XY/v34I
-        vQ21O0z+ROMVvk0bUDbGna/L+vn3nwJu3pB+VDuJmueEgAqJkkt17aJZ8BL6qUJmawOcS/JOumbL
-        vMDXszDH0T9uyePfGrt/qSWW1+VcA6wQhCBSRGlu987h1a5ZDbtYLAy/znIYnVhwZ6caz49VJhYs
-        yAqIZ4qVbau5azYKj4wRZual2aZfcU3f9m1fY/Sy1gb/oayqjWA31L5q1x4etTtyTxB03QhaftMQ
-        l47sjyt2Leyga2EHbTDUGBpnVWPcrL+ki3006TLPqZ2Ppq3/AAAA///sWD1vwjAQ/StdGJOaJDRh
-        QBShVurA0qEDm2M7bSSaRPmgrRD/vc924pYoRhWqEAMSg7F957Ode/eeD69VlsG8PPEyJczNKWOy
-        9D7x2YT7URjF45AIn00Jm068ZDpO5OWaSVjhyDQI1HSz4BxrIIOQTvzr/lcgSC/p6ygxV+cuXGSo
-        miZtOnIYCBQRysdBcBeyKJz405jFIcHyCRVJxOZ8pryM/MXIe8RP2znvNGtPzHF0V+U2lfOBg3A8
-        FwyUu0UTbyCgcFJOQWklDwr2KdRHihKE5nLlELfIJIr1Sf7lR9xXCZcfcV9lXHrEACWuCXNbZpb4
-        9G9WNEkaxlKVQDU0kCa0GtLWKDSY+NCUOXTQGmDD3n4yTapcjJrUlSu0Un64NgW2khDYiG1giG1/
-        wJSdUhR5WYsrvpzvS7riyzkivuLLAL70YcAwMENQEPWrzr2dfI5r2wQL5jWFLCADXqxUy4pLNo1J
-        vGHks1IxG32WgDA4QMyWewO+zcI3rE5k27TMM03rdBdv2gdt/fcvp7fN6/97Y9HOjFOsBPn9kisd
-        2T3r4EvXIe+6ZltfTg5APf7fdn4hxOnns6iajXT8a7NKAZb1otYbl+9VUiXKrZv+Q2PvwLo1UNHu
-        9/tvAAAA//8DAEVZg+E/GQAA
+        H4sIAAAAAAAAA7xXbW/bNhD+K4S+zrZeLLuOgWHYUnfolqZB4nQfhiGgpbPEmiI1kortZfnvO+rN
+        iy0NjYv1m8Uj7/W5585PDuxyKmJn7igQMSiI3zHgsR4ImoEe6CiFjA5kDooaJoUeQMxMBoYOopSK
+        BLhMBo+gNMogvoVcgQZh6rtRoY3M1lbhg+95vjdS8GcB2iz3OdwoGhkWgTNwmLXvT6feG/zQwNf4
+        mRqT67nrxrCGyMTysxxRw6nWjIqRAOOiJePSnLmBy7QuwG0UbGCP76+Xi7vl0J8FIR6VLmhn/uRo
+        9K3QETWQSLWvYojxC18EXjAZev4wuFgG/jyczL3pKBwH36HfnnXSGjHoeKnmTCftexf1VRrLsOuP
+        GHSkWG4Th6c/khVLSKFBEUyh2hOTUkMEQKyJkWQFZKXkBgSJ5VaMyKUCjCEmqz35hSlK7uTabKkC
+        MsQLREhDbNmIVCQGDgZG1nokxb3iXxIFy2gC2rUv9CEO7ULOopF+TFCbhQuqWuCJrWGxMlRvnPma
+        cg0DJ2WIHxWl+yt4BDTpPw8cwxBgOYLFmYuC84FzhJax1whyJT+jY2fmvX7dnfV/YeUQxL1gxqAC
+        7bS2LWB/Le/qOrU2SpblnKHDcRsofaSGKkxrCbZwtgtnr3S3EMz2E+UPlS73kcHWLXHTRFILfC8s
+        8R6EOwT5/2rlB83+gu91RjlHg/5050+/hcFdY3Ec7MbBt7CYYZ8UmfP8fApHvw+nQSNYs92nigqx
+        +r//cXpz3NykSaIgwZY9aQIMQPKiYoFuc5M+wbRP8KZHEPQKZn2Ci1M/K/asTrdSbcpB4cyHPn5S
+        g/Oj4t3XN27F6gcedyt1yrZl+fNSFjZxvuXm3+wBE4kzN6oALB8qNZ+w4rY561gqkuxk+snoYhY2
+        TH8cdEtEx4I+SAQtJHLFpGJmf2YKmufu+CsIu1bC8KCC90vK/lBBvibGsXMK/aDF7bGghRynK7Cc
+        14F6SxWdr32En4N9sD9NuT+zCUuptvPkionNOyt5C7ndUUS0b/lWp3JbytoTIcUCZx1dcbgFqm0f
+        PSFaq1/OzdX9z++vH67eXy6u7xYPi9vbj7doHptQY8bwwjIFcoP0LgyxdgnTRAq+J0gVjFuldvyW
+        M/ZGQYaJK4e0HnVRho/d4nh/M89T6/HcqUYeFherc2iZF1SAdUqYoPz4Ur1h1QkuG4Ojd/W3LXyC
+        u0Fzu8htT3YDfTryw0kD9GoZOhOb1eN2rL7cX14H1wMYf6LRBlfKBo2N8srWZb21fZXDzernBrWR
+        oNkCBGwtEiWX6rryZsULGCaKWoTWDi4leSurYsssx6VXmG7YT/pYY9Kyxn9V/GU6twAbBCGIBFGa
+        2XFxqravSf0+R3z/yzT7wZkJr/SU7fmxjMSCBekA8Uwxs202D8VGYUcbYWROku6GJckMfVu44yth
+        X4zttLTJNviXY1MOiadTM17fYA3boXf8omU2DVFR0Xz3xb5B6/UNWq+1+YIfjlFCjaFRWpatxKAu
+        sozaBumuqx2AUp1TzX8AAAD//+xYPW+DMBD9K10yQh0gBYYojaJW6pClQ4dsxoYGiQDiI20U8d/7
+        bBM3jXBUVVWUIRKDwfbdcXDv3rPgU8C5GWVMNN0XPp1wN/CDaOyT2GUhYeHEScJxIr6uXgQPZ5ZB
+        WKbZnHP4QAmhnvju8SgQ1JewdZZQy7zHNkpULhN7DqTOi9FFKB973oPPAn/ihhGLfAL3CY2TgM34
+        VFoZufOR84xL7bM2NO8zZlnqUW23tfWBRFiODebI7bKNMggfZMoqKa1ForA/hWpI0YMwXCwtYpe5
+        gLFTcn79EZ+y++uP+FQdXHvEwB6e1mVGd32fWeDXv1vSJGkZS2UBNdAuisoq5Fqh02DhU1sV0C8r
+        gA1bf1eaUKeY1aUrPPQSfLg5eaae4JkoracpbRWXRdXENxi53A9zg5FLRHyDkQEYOYUBE8v0NAPT
+        hAWv866Kci+O0foxQSRFQ6ELyIB5EwcjJlwizjDAmUQnMb6AkaOZuKWAkMEJ1zihWV2cb9OqyBVz
+        U4942x9Eq9tfZa/YKAv7w7CH+z/g8tEZ+v3BLoQx/XyN6zYTho98S0VWNfNGxbEtmv875VHGtFH4
+        WtP6rZCCVmr8Tp0zCZkoXOpAfkbr/Ai33yDT03XdFwAAAP//AwCr0ocf9xgAAA==
     headers:
       Atl-Request-Id:
-      - 4fd4aa1a-2618-4cf5-aaab-156783d4ab8f
+      - 3d4d84c7-56aa-4efc-9c2c-49e5c17f852b
       Atl-Traceid:
-      - 4fd4aa1a26184cf5aaab156783d4ab8f
+      - 3d4d84c756aa4efc9c2c49e5c17f852b
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -193,7 +279,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:35 GMT
+      - Wed, 29 Jan 2025 20:45:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -203,7 +289,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=305,atl-edge-internal;dur=14,atl-edge-upstream;dur=292,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=260,atl-edge-internal;dur=19,atl-edge-upstream;dur=241,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -215,7 +301,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - d28683dfb7669434b9a9dcd3ce8099aa
+      - b21a099f1b3c205cf3170a7d4e62a792
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -243,17 +329,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2bNvvIDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04qJtgRuFn2
-        8/qxfCC18LjtDeHkLYTO8+m0QYUyNO7dpSIY4b0WNrUYyIQ02ndG7P/Bl9jvtMQG/ccaTbdCG7D/
-        65KVs8oMaCX+LrnD3mtnI5wBZCmkkJSby8dy/VD9TDdDW8eK8OcRmsAEXqITO+P2bbyy2nejbWXc
-        0MRQPWjTfEUIjwE6n5+aVyKMIAXKEsgSWFaU8iLnRRQDXECEY97HP2Bf6faczaCiwDPGc5YuGPtm
-        ZXtjlYtgkc0WUgAyVDLL5ygKpQoFUtFlzha1mhVIZwromSCY0XCrezG+EJUYTLhzUoztAzGniqB9
-        3ZbkeH7Yk7Pj5Pq+IsdPAAAA//8DAHOVr/UgAgAA
+        H4sIAAAAAAAAA5yQ30vDMBDH/5e8unVJf9AubzLBKTqFdi8TkTS5YDRNSpMOytj/boJD55v6dtx9
+        vvc57oBa5mA7aETRq/e9o4uFAAncC/tmE+Y1c04xkxjwaIaEcr1m0z/4Goa94iDAva9B9yswHoa/
+        LllZI/UIhsPvknsYnLImwARjkuAEz+vN5WO9fmi+p5uxa0OF6FOEZniGn4MTem2nLlzZTH20rbQd
+        RQi1o9LiM4JoCKRleWpeMR/BFKfFHJN5WjUkpzmhWZVgjC9wgEPehT/A0KjuB7tsUkLzguIyyarq
+        i+XdjZE2gLIoCECZkVYAzzlnAIy0lZBkWTJJ8iCQbQHpmcDraLhVA4svBMlG7e8sZ7F9QPpUITAv
+        2xodzw/bWRMn1/cNOn4AAAD//wMA82+DqSACAAA=
     headers:
       Atl-Request-Id:
-      - 18ba0aaa-972e-4fa9-9889-5204fc86b4d7
+      - 3dbaf052-0574-4271-99d0-0ec013e2c8dc
       Atl-Traceid:
-      - 18ba0aaa972e4fa998895204fc86b4d7
+      - 3dbaf0520574427199d00ec013e2c8dc
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -261,7 +347,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:35 GMT
+      - Wed, 29 Jan 2025 20:45:07 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -271,7 +357,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=172,atl-edge-internal;dur=15,atl-edge-upstream;dur=158,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=152,atl-edge-internal;dur=13,atl-edge-upstream;dur=139,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -283,7 +369,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 78545f24694651553f3ddac549fc9365
+      - cd80cd9f60d98728446e60efee24320f
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -334,9 +420,9 @@ interactions:
         Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
     headers:
       Atl-Request-Id:
-      - 537c7e6d-0b1e-4846-ba06-78bbc186c3a9
+      - 9ed7915e-d5aa-4323-a982-c6d13885ecce
       Atl-Traceid:
-      - 537c7e6d0b1e4846ba0678bbc186c3a9
+      - 9ed7915ed5aa4323a982c6d13885ecce
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -344,7 +430,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:36 GMT
+      - Wed, 29 Jan 2025 20:45:07 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -354,7 +440,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=304,atl-edge-internal;dur=13,atl-edge-upstream;dur=293,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=270,atl-edge-internal;dur=15,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -369,7 +455,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 925dbceca6905cd0c0cb09d08883e87f
+      - 95c3692dea6dac5b3ca1f5b2a5424029
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -380,11 +466,11 @@ interactions:
 - request:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
-      [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/242]\n\n*Defect
-      Dojo link:* http://localhost:8080/finding/242 (242)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/232]\n\n*Defect
+      Dojo link:* http://localhost:8080/finding/232 (232)\n\n*Severity:* Low\n\n\n*Due
+      Date:* May 29, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
-      / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+      / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
       cookie has been set without the secure flag, which means that the cookie can\nbe
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
@@ -411,18 +497,18 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16084","key":"NTEST-1600","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16084"}'
+      string: '{"id":"16608","key":"NTEST-1825","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16608"}'
     headers:
       Atl-Request-Id:
-      - 73ad8331-fceb-4ba1-adde-c4cea47b3908
+      - 77d664d0-36fc-4d13-ad09-dfc1fc543df8
       Atl-Traceid:
-      - 73ad8331fceb4ba1addec4cea47b3908
+      - 77d664d036fc4d13ad09dfc1fc543df8
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:36 GMT
+      - Wed, 29 Jan 2025 20:45:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -432,7 +518,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=540,atl-edge-internal;dur=13,atl-edge-upstream;dur=527,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=643,atl-edge-internal;dur=16,atl-edge-upstream;dur=628,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -444,7 +530,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 5f537c59b9296df8a23ae8d4973bc3b3
+      - a782d3a8371f1e6328f557ca39f53571
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -468,53 +554,53 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1600
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1825
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvdhxXAHDkMXO1i3LgsRpgGZBwEhnmTVFaiQV22v733ek
-        XtwmUYtkWFEgtXi89+ce3nsPNgUVqRd7CkQKCtJjBjzVPUFz0D2dLCGnPVmAooZJoXuQMpODob1k
-        SUUGXGa9e1AaZZCeQ6FAgzD13aTURuYLa/A2DIIwGCj4uwRt5tsCzhRNDEvA63nM+g/HwWSEHxr4
-        Aj+XxhQ69v0UFpCYVL6TA2o41ZpRMRBgfPRkfFowP/KZ1iX4jYEVbFH/dD67mPfxLMAjF4L24vee
-        xthKnVADmVTbKocUv1AjCqL9fhD2w2AeBXG4Hw/Hg0k4/gHjtjacE4OBOzMvDNLq+2gviNq0648U
-        dKJYYQuHp4dE55TzHkmZNkwkhhQMEiByQdZSrQZWO5HiUvFnRlEKZttF+S29p4Yq/57B2ndh7QKs
-        RWEwDCc/afYP/Jhj28scvVpYoMs51Svbq/LO2F/xgnINPa9SfI15Od2et2QIHJUstydwDxhr8LHn
-        GYbIKhAlXixKzNF7AJNh0AgKJd9hRi8seK3tyu0a2JTbfnwCkl1Wl4IZgwa01/q2SP3d3dVyYdZU
-        WbxqlhecYcDpg8yxHw5lo8lmNHlmuF/oTJNJ25dRcIBhRKNNNPp/vVTdd1hEh+F4E46/hcNN43EY
-        bYbRt/BYA/zjx8dwDLtwGjWCBdu8qTgQu3998/jmsLlJs0xBhnzz1SHYbwSYmeRlxQtPXx13CQ46
-        BFGnYNIlePU4nIo2q1NLSu6F8OJ+WHOlbYliSRX5+0dndlCw2nopS55OmS443dbjhMdravDpqSj7
-        +aNfPQi7J8CvzCk72O7nkSxt6V2oV/aAicyLjSqtbzRq3iBm7HjX1VCAyVr+eOqR2D8ImkfiYdla
-        Knso6AJV1IKqUEwqZrYvLEGj7tsn8RlvBctpBtq3GroxwvCAy/VA32c7sjyR64ZUR97jsYlazHN6
-        B5YWnxgMyyZPliHsQmg4sfVYUj0rWHLCxOrYSqZQ2O1FJA2CHK7WTtaeCClmuLzQOw7nQHWFSlX/
-        8s5OLn95fXp78vpodnoxu52dn/95jvnhlGosCF6YL4GcIf8LQ6xfwjSRgm8Jcgnj1igxkvzGFCVn
-        CnIkE1JqRNzgKU4JcZy84AMLgkIexF71JmLvsPi7mfqMK7ANGROUP7xU7151eR3uOUZXf9u+ZgLa
-        22Vhh7YLx+Nw2OC4WpNeCL1KuX13P99snofGHdx+pskKl80Gco3xytdRvc/9p4CbpdBvdrOoWRME
-        WKgnkkt1WkVzx0voZwoZa7cSSTKVVbNlXuA6LMzToN/vIoX9lhS+1PHPy/mX2P3bmzPDYS8m129p
-        EcbkSMoVA3LFDHKsIReQlArIMafZB1sdLA6XCeVLqU08CSaBv2AiRSL0o1F04wxOXfEwr3eSWFjF
-        e+SrmuQ7/PO9U7/Apc9yEKohW9RBTksgU8wHD/+gWxIGPWLB2CZxdDVD0TX+1x+HIxep7WOyhkHO
-        jIKBVJmPMKa2tQw3Ngt/H68OlibnLu7Kzhtr51KshFx/WqQzJdMSd4CZyHCwc2yTP8caW5+uQhgv
-        +VWu+0Z2VKmoDUQ3xCfXa4AVsgC01jq0dhf8oVN8e3hGLhIqOu7bPdR/NWzz+SSDi602kGvMIC0k
-        Q5jtxe7c9cbWKqdMaGZggEjEUunlnaQq7brxyP50hzBr+ZAk8l8AAAD//+xZbWvbMBD+K6JQaKF2
-        ncRpkkHpQulgH8pGCyuUQpBluTFLZOOXumXrf99zkqK5XtyNMko/FPLBsaTT3eXuuecuOpCAuiyS
-        UrFSVqyxUVUBFksTWQki64A1y1Qs2VpyVWKRmx1WAsy9UZFkXAjgqozZXcpZjVQRxUMOYMI+paSh
-        B35Lo3P8yre6qSSFrpZSUWQx7uRm6DlhETQhs8D/WKqSrFjrMywrCK05VksCSwD1d6kOSDEITytm
-        OAjjq4Y/kIks51q7ukRMM65YS0F0jEqufHamSrLZWWh8cKPICXQb+QgaWA3LjYoksKzhoK2atmxu
-        WX+BLETdgcvIehsuTdP4WcPLXOcD0k/e+/ky17GMSxaQubB3L3gF0hXVCKnF3per+eVX7/LcQ4nW
-        WeouybOikgXlwR6P16naZ3v7PxEoqyr7gDD8k92MXYnvlrc+hBuEbYSrCmC6Jl5EBLtbHQHuLISO
-        inYWgr4TgWMZ+kfSnGr7xj7WEfTx4sApAx9zsaT8tqW3Xb27GF7W6zWncrXzN6QmrxP5zIoX1jYi
-        ISfINyK8n+PjcTyaTqbRYBLIkZgFYjYeJrNBcoR73Cbc8Mw2SSExj2PcgfqGYhc/fGwpAkAhWc+2
-        wyZXfNRPvU3DlG3JQgmKx+NBGB5NxHQyHs0iEU0CXJ9wmUzFSXyspeyO5rvDT/iYc96aKwuvnmde
-        lX5deg0c4Q19gmw/r6NVKshTXs55SY7CeV1BQBDxeIqk8HNFPu+21m9f425v/vY17vb2b11jYFRs
-        2lRLAk8R+uAwSVILkeoEIjw3baRBuGvQQGw8q4ssl4fXwB6x/J1pNFvCqktdusFO1LYzx7APV8O+
-        djJ07WRh8f0dRl4tYN5h5DU0foeRLTDShYE+phY6Qub4Csy5NUn5g4bg9jmAJlnF7Qi/K6WXefXi
-        Ut/gJxhuR75eZtZrWS9lcyZ3FkZ9J0aO5El1lxaZMizPvIpr+/+R+fov3rvLqv832TTCnFDchDbt
-        W6anPJthKlLAqPxj82jry4sV0P+1HW7kHuys+f2FLOsVCW4Zq+czRTWvjOE0JaYZDpnu3j89PHxy
-        2h7Q2j4+Pv4CAAD//wMAYqPKDa4cAAA=
+        H4sIAAAAAAAAA7xW+2/bNhD+Vwj9tGWy9fCjjoBh6BJ365ZlQeK0QLMioKWzxJoiVZKK7aX533fU
+        y20SdUiGFQVSk8d7f/fpbh3YFlQkTuQoEAkoSF4x4Il2Bc1BuzrOIKeuLEBRw6TQLiTM5GCoG2dU
+        pMBl6t6A0iiD5BwKBRqEad7GpTYyX1mD14HvB/5QwccStFnsCjhTNDYsBsd1mPUfTKf+DA8a+AqP
+        mTGFjjwvgRXEJpEf5JAaTrVmVAwFGA89GY8WzAs9pnUJXmtgDTvUP13MLxaDYBZO8KoKQTvRraMx
+        tlLH1EAq1a7OIcETaoR+OBn4wSA8XIRBNJ5E/mw4Dg5/wLh9G6R1YjDwyswzg7T6Htrzwy7t5pCA
+        jhUrbOHw9iXROeXcJQnThonYkIJBDESuyEaq9dBqx1JcKv7EKErBbLsov6Y31FDl3TDYeFVY+wAb
+        UeCPgtlPmv0NP+bY9jJHrxYW6HJB9dr2qlwa+ytaUa7BdWrF15hXpes6GUPgqDjbncANYKz+nesY
+        hsgqECVOJErM0bkHk5HfCgolP2BGzyx4o12Vu2pgW257+Awk+6wuBTMGDWin822R+nv1VsuV2VBl
+        8apZXnCGASf3Msd+VCgbz7bj2RPD/Upn2ky6voz9FxhGON6G4//XS939CovoMJhug+m3cLhtPY7C
+        7Sj8Fh4bgN/dPYRj0IfTsBWs2PZNzYHY/av3D1+O2pc0TRWkyDcPhgATkLysx/9xd5M+wbRP8KJH
+        EPYKZn2Cw4dx1rRZ31pSqr4QTjQI8EgNfjhqwn364NZ0vidwrzan7FhWP49kaQsXWFJ+ay+YSJ3I
+        qBKwfWjUvMGO2+FsclGAodrpf4zi/WnYUvz9pDsiui/og0TYQaJQTCpmds8sQavujZ/G9CynKWjP
+        aujWCMMLLjdDfZPuqe5EblpKHDsPQR92iOV0CZbUHoG15YJHyxD04SuY2XpkVM8LFp8wsX5lJcdQ
+        2N1DxLuOTnUmN5WsuxFSzHH1oEsO50C1HZNbBGP9yzk7ufzl9en1yeuj+enF/Hp+fv7nOeaHM6ax
+        IPhgkQE5Q/YWhli/hGkiBd8RZALGrVFiJPmNKUrOFORIBaTUiLjhY4wQ4DA4/ifm+2q1jJz6i4a9
+        w+LvJ+KLScc2pExQfv9Rszk15a1wzzG65mz7mgroXpeFHbk+HAeTFy2O6yXnmdCrlbuv5pd7ydPQ
+        uIfbzzRe46rYQq41Xvs6arax/xRwu9J57WYVth95ARbqseRSndbRLHkJg1TR3T7AhSTHsm62zAtc
+        ZoV5HPSTPlKYdKTwtY5/Wc6/xP7fwYIZDgcRuXpHiyAiR1KuGZC3zGSyNOQC4lIBecVp+slWB4vD
+        ZUx5JrWJZv7M91ZMJEiEXjgK31cGj6viYV4fJLGwig7Iv2qS7/DP95X6Ba5sloNQDdmiCfK4BHKM
+        +eDlH3RHwkOXWDB2SRy9naPoCv8bTINxFantY7yBYc6MgqFUqYcwpra1DPctC38Pnw4zk/Mq7trO
+        G2vnUqyF3HxepDMlkxK/4HOR4mDn2CZvgTW2PqsKYbzkV7kZGNlTpaIxEL4nHrnaAKyRBaCz1qO1
+        f+CNKsV3L8/IRUxFz3u7RXqHfpfPZxlc7LSBXGMGSSEZwuwgqu6r3tha5ZQJzQwMEYlYKp0tJVVJ
+        34sH9o/3CLOWX5K4BhKyLlkCCKLBkE2DKoO0qGtkrRBZLtlkLM5IDlRoFNL6RSz/AQAA///sWV1L
+        40AU/StBEBRMTNvUtgviFnFhH2QXhRVEKNPJxAbTSciHtbj973vuzDgbs4m7yCJ9KPgQMzP3K3PP
+        PfdWSYC7d3IuHMY5cFWEzmPMnAqpwvN1BmDCPilx4+iTejWLLvGV71VLSAbdLISkm+UwKzdFxwiP
+        YAm5BfbmxDJK86U646Q5oTXDakFgCaB+EPKIDIPwuHRQK6okdFiyYmty0cmYsq4qcKcdJp2agej3
+        pEg850IW5LP1UMfgTlIQSBvFCBYYC4sXE0lgUSFArZbWfK55f4UsRN1ByMh7c11Wq5WXrliRqXxA
+        +oknL1tk6i5DyQwyZ0b3jJVlHs8rXKnZwbeb6fV39/rSRYlWWWqVZGleipzy4ICFy1geOgeHP3FR
+        kjL9hGv4J7sZ2hLfLG9dCNcL6ghXon9/UMTruaVEdpHVwBLJxoLfdcLvYhm+ZRnq6ymy1b6xi9X6
+        1hjEmPEF5bcpvfXq3cTwolouGZWrvb8hNUWdyGeav7O2EQk5Q74R4f0ang7DwXg0nvdGvhjwic8n
+        w3406UUn0GM3QcMb2wRdiWkYQgfqG4pduP5cMwSAQrLebGZ1rnion2qbginTUAUCFI+FvSA4GfHx
+        aDiYzPl85EN9xEQ05mfhqZKyP5ju97/gT59zl0waeHVd/arwqsJdIRBu3yPI9rJqnsScIuVmjBUU
+        KJxXFQQEEY/nSAovkxTzZmO8/RY3O+vtt7jZmW+7xcCoMC6yhK0NCTzH1QeHiaKK81glEOG5biM1
+        wt2CBmLjRZWnmTi+BcTwxe9Mo8kQVm3qkgYzD2tnjkEXrgZd7WRg28nmgsXu3AD/Dl8+7Cbt8OUj
+        LN7hSwu+NGHAEjLLV2D1vc69Zxphm2cfCtOSmQF8U0on8+rEpU5K1m9Hvq55kN/FQQkQWhd863Jj
+        YdB1YmBJnpCPcZ5KzfL0q7Ayv/7of/8leo9p+f8mm1qYFQpNaNN+pGrKowZfeiChTX5+eTT15d0G
+        qF/Kjl/kHu0t2dOVKKqEBNecVfOZvJyW2nGa8dIMh1y3718f7r86bQ4oazebzS8AAAD//wMATn/G
+        nGwcAAA=
     headers:
       Atl-Request-Id:
-      - 35e52e6c-ed75-4f23-8ca3-7e161a79ca9c
+      - bd1888e8-37a6-4dbe-a30e-345772f7ac9e
       Atl-Traceid:
-      - 35e52e6ced754f238ca37e161a79ca9c
+      - bd1888e837a64dbea30e345772f7ac9e
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -522,7 +608,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:37 GMT
+      - Wed, 29 Jan 2025 20:45:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -532,7 +618,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=283,atl-edge-internal;dur=15,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=378,atl-edge-internal;dur=14,atl-edge-upstream;dur=364,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -544,7 +630,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - a2bdf888f262427122a515c798491bdd
+      - 6d194404d9abd49996e32a1c3405dbb9
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -568,53 +654,53 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16084
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16608
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvdhxXAHD0MXu1i3LgsRJgWZFwEhnmTVFqiQV22vz33ek
-        XtzGUYdkWFEgtXi89+ce3kcPNgUVqRd7CkQKCtJXDHiqe4LmoHs6WUJOe7IARQ2TQvcgZSYHQ3vJ
-        kooMuMx6d6A0yiA9h0KBBmHqu0mpjcwX1uBNGARhMFDwoQRt5tsCzhRNDEvA63nM+g/HwWSEHxr4
-        Aj+XxhQ69v0UFpCYVL6XA2o41ZpRMRBgfPRkfFowP/KZ1iX4jYEVbFH/dD67mPfxLMAjF4L24o+e
-        xthKnVADmVTbKocUv1AjCqLDfhD2w2AeBXF4GA/Hg0k4/gHjtjacE4OBOzPPDNLq+2gviNq0648U
-        dKJYYQuHpy+JzinnPZIybZhIDCkYJEDkgqylWg2sdiLFpeJPjKIUzLaL8ht6Rw1V/h2Dte/C2gVY
-        i8JgGE5+0uxv+DHHtpc5erWwQJdzqle2V+Wtsb/iBeUael6l+Brzcro9b8kQOCpZbk/gDjDW4L7n
-        GYbIKhAlXixKzNF7AJNh0AgKJd9jRs8seK3tyu0a2JTbfnwGkl1Wl4IZgwa01/q2SP3d3dVyYdZU
-        WbxqlhecYcDpg8yxHw5lo8lmNHliuF/pTJNJ25dRcIRhRKNNNPp/vVTdd1hEh+F4E46/hcNN43EY
-        bYbRt/BYA/z+fh+OYRdOo0awYJurigOx+9fv9m8Om5s0yxRkyDd7Q4AJSF5W4/+4u8MuwbhLcNQh
-        iDoFky7Bi/04K9qsTi0puRfCi/thzZW2JYolVUof987soGC19VKWPJ0yXXC6rccJj9fU4NNTUfbT
-        R796EHZPgF+ZU3aw3c9jWdrSu1Df2AMmMi82qrS+0ai5QszY8a6roQCTtfzx2CNxeBQ0j8TDsrVU
-        9lDQBaqoBVWhmFTMbJ9Zgkbdt0/iE94KltMMtG81dGOE4QGX64G+y3ZkeSLXDamOvP2xiVrMc3oL
-        lhYfGQzLJo+WIexCaDix9VhSPStYcsLE6pWVTKGw24tIGgQ5XK2drD0RUsxweaG3HM6B6gqVqv7l
-        nZ1c/vL69Obk9fHs9GJ2Mzs///Mc88Mp1VgQvDBfAjlD/heGWL+EaSIF3xLkEsatUWIk+Y0pSs4U
-        5EgmpNSIuMFjnBLiOHnBJxYEhTyKvepNxN5h8Xcz9QVXYBsyJih/eKneveryOtxzjK7+tn3NBLS3
-        y8IObReOx+GwwXG1Jj0TepVy++5+udk8DY07uP1MkxUumw3kGuOVr+N6n/tPATdLod/sZlGzJgiw
-        UE8kl+q0iuaWl9DPFDLWbiWSZCqrZsu8wHVYmMdBf9iSwtca+1CpJYwvy/mX2P07mDPD4SAm129p
-        EcbkWMoVA/KGGeRYQy4gKRWQV5xmn2x1sDhcJpQvpTbxJJgE/oKJFInQj0bRO2dw6oqHeb2XxMIq
-        PiD/qkm+wz/fO/ULXPosB6EaskUd5LQEMsVE8fAPuiVh0CMWjG0Sx29mKLrG//rjcOQitX1M1jDI
-        mVEwkCrzEcbUtpbhxmbh7+PVwdLk3MVd2bmydi7FSsj150U6UzItcQeYiQwHO8c2+XMsvvXpKoTx
-        kl/lum9kR5WK2kD0jvjkeg2wQhaA1lqH1u6CP3SKb1+ekYuEio77dg/1XwzbfD7L4GKrDeQaM0gL
-        yRBmB7E7d72xtcopE5oZGCASsVR6eSupSrtu7Nmf7hBmLb8kifwHAAD//+xZbUvjQBD+K4sgKJiY
-        tqltD8Qr4sF9kDsUThChbJKNDdduQl6Mcud/v2d2t3sx1/UOOcQPgh9qsjtvnXnmmalKJKAui4SQ
-        rBI1a01W1YDFSmdWisw6YO0yi5dsLbis8JLrE0YC3L2RkWA8joGrImF3GWcNSiUuHwoAE85JKTQ9
-        8DsWneNbvlVDJRl0tRSSMotxKzfHzAmPYAm5Bf7HMpnm5VrdYXlJaM3xtiKwBFB/F/KADIPwrGaa
-        gzC+avkDucgKrqxrKuQ045J1DMTEKMXKZ2eyIp+thzoGN5KCQNooRrDAWFhtTCSBVYMAbbW043PH
-        +wtUIfoOQkbem3Rp29bPW14Vqh5QfuLeL5aFymUoWUDmwuhe8BqkK2qQUou9L1fzy6/e5bmHFq2q
-        1Cop8rIWJdXBHk/Wmdxne/s/kSirOv+ANPyT3Yxti++3NxftGYRd6KtLYLoiXkQE+0dddDdwvQgt
-        R+3fsCxDfUmKU20/6GIdgYsXB1YnYszjJdW3ab3d7t0H96pZrzm1q52/ITVFnchnXr6wtxEJOUG9
-        EeH9nByPk9F0Mo0Gk0CM4lkQz8bDdDZIj6DHHoKGZ44JSol5kkAH+huaXfLwsWMIAIVkPTsO61rx
-        0T/VMQVTZiQLBSgeTwZheDSJp5PxaBbF0SSA+pSLdBqfJMdKyu5ovjv8hD99z1tzaeDV8/Sjym8q
-        r0UgvKFPkO0XTbTKYoqUV3BeUaBwX3UQEER8PEVR+IWkmPdH67dvcX82f/sW92f7t24xMCrRY6oh
-        gadIfXCYNG3iOFMFRHiux0iNcNeggTh41pR5IQ6vgT3x8nel0W4Jb23pkgazUdvOHEMXroaucTK0
-        42Rp8P0dRl4tYd5h5DUsfoeRLTDShwEXUwstIbN8Be7c6qL8QUtw8zmAJXnNzQq/L8VFyQIXLgXD
-        7QDn2gcFTgeclM161r/h4nIj5wtL8oS8y8pcapanHyWN+f1I//sv0bvL6/+32dTCrFBowpj2LVdb
-        ns0yFSWgTf6x+Wj6y4sNUL+1HW7kHuys+f2FqJoVCe44q/YzZT2vteO0JaYdDrlunz+9PHxy21xQ
-        1j4+Pv4CAAD//wMAkplGsa4cAAA=
+        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZlsvdhxHAHD0CXuli3LgsRJgWZFQEtniTVFqiQV20vz33eU
+        LLlxog7JsKJAavF47889vHsHVgUViRM5CkQCCpK3DHiiXUFz0K6OM8ipKwtQ1DAptAsJMzkY6sYZ
+        FSlwmbp3oDTKILmAQoEGYTZ341Ibmc+twdvA9wO/r+BTCdpM1wWcKxobFoPjOsz6D0Yjf4wfGvgc
+        PzNjCh15XgJziE0iP8o+NZxqzajoCzAeejIeLZgXekzrErzGwALWqH82nVxOe8E43MejKgTtRPeO
+        xthKHVMDqVTrOocEv1Aj9MP9nh/0wsNpGETD/cgf94fB4Q8Yt2+DtE4MBl6ZeWWQVt9De37Ypr35
+        SEDHihW2cHj6huiccu6ShGnDRGxIwSAGIudkKdWib7VjKa4Uf2EUpWC2XZTf0jtqqPLuGCy9Kqxt
+        gBtR4A+C8U+a/Q0/5tj2MkevFhbockr1wvaqnBn7K5pTrsF1asUTzKvSdZ2MIXBUnK1P4Q4wVv/B
+        dQxDZBWIEicSJebo7MBk4DeCQsmPmNErC77RrspdNbApt/34AiTbrK4EMwYNaKf1bZH6e3VXy7lZ
+        UmXxqllecIYBJzuZYz8qlA3Hq+H4heF+pTNNJm1fhv4BhhEOV+Hw//VSd7/CIjoMRqtg9C0crhqP
+        g3A1CL+Fxw3AHx6ewjHowmnYJRg0gjlbXdfkiLC4+YAwSVMFKfLNkyHABCQv6/F/3up+l2DUJTjo
+        EISdgnGX4PBpnDVt1qeWlKoXwol6AX5Sgw9HTbgvH9yazrcE7tXmlB3L6ueRLG3hAkvK7+wBE6kT
+        GVUCtg+NmmvsuB3OTS4KMFQ7/c9RvD8KG4rfTbolol1BFyTCFhKFYlIxs35lCRp1b/gypmc5TUF7
+        VkM3RhgecLns67t0S3WnctlQ4tB5CvqwhTCnM7CkZtG7+553AS/owlcwtvXIqJ4ULD5lYvHWSo6h
+        sLuHiNctnepMLitZeyKkmODqQWccLoBqOyb3CMb6l3N+evXLydnt6cnR5Oxycju5uPjzAvPDGdNY
+        ELwwzYCcI3sLQ6xfwjSRgq8JMgHj1igxkvzGFCXnCnKkAlJqRFz/OUYIcBgc/zPzfTWfRU79omHv
+        sPjbiXg06diGlAnKdy9tNqdNeSvcc4yuIQvsayqgvV0WduS6cBzsHzQ4rpecV0KvVm5fzcd7ycvQ
+        uIXbzzRe4KrYQK4xXvs62mxj/yngZqXzms0qbB55ARbqseRSndXRzHgJvVTR9TbAqSTHsm62zAtc
+        ZoV5HvT7LSl8rbG7Si1hPC7nX2L7b2/KDIe9iNy8p0UQkSMpFwzIO2YyWRpyCXGpgLzlNP1sq4PF
+        4TKmPJPaRGN/7HtzJhIkQi8chB8qg8dV8TCvj5JYWEV75F81yXf45/tK/RJXNstBqIZssQnyuARy
+        jIni4R90TcJDl1gwtkkcvZug6Ab/642CYRWp7WO8hH7OjIK+VKmHMKa2tQz3LQt/D6/2M5PzKu7a
+        zrW1cyUWQi6/LNK5kkmJL/hEpDjYObbJm2Lxrc+qQhgv+VUue0Z2VKnYGAg/EI/cLAEWyALQWuvQ
+        2l7wBpXi+zfn5DKmouO+3SK9Q7/N54sMLtfaQK4xg6SQDGG2F1XnVW9srXLKhGYG+ohELJXOZpKq
+        pOvGE/vHW4RZy29IXAMJWZfMAATRYMhygyqDtKhrZM0RWS5ZZizOSA5UaBTS+kYs/wEAAP//7Flt
+        S+NAEP4rQRAUTEzb1LYH4hXx4D7IHQoniFC2ycYGk92QF2vx+t99Zjfdi7HrHXKIH4R+SJvNvGXm
+        mWemSgLcvRFz7rAwBK7yyLlPmFOjVMJilQOYcE4IZBy9Uq9l0Tne8q0aCcmgqwUXlFkOM3IlJkZ4
+        BEvILbA3JxGxLDL1jCMLQmuGuyWBJYD6josDMgzCk8pBr6jTyGHpkq3IRSdnyrq6RE47TDgtAzHv
+        CZ56zpkoyWfjoY7BjaAgkDaKESxoLCw3JpLAskaAtlra8rnl/QWqEH0HISPvm3RZLpeeXLIyV/WA
+        8uMPXr7IVS5DyQwyZ43uGauqIpnXSKnZ3o+r6eVP9/LcRYtWVWqU5LKoeEF1sMeiLBH7zt7+byRK
+        WskvSMOX7GZoWny3vdloTy+w3TDUlDCxwmB/pxjZ48veGRgi2bnh2+itb1iGekmKU20/aGMdvo3V
+        +sYYxJiFC6rvLTy9C+5lnWWM2tXO35Caok7kUxZv7G1EQk5Qb0R4v0fHw2gwHo3nvZHPB+HEDyfD
+        fjzpxUfQYw5BwyvHOKXENIqgA/0NzS5afW0ZAkAhWa8Os7pWPPRPdUzBVDNQBRwUj0W9IDgahePR
+        cDCZh/ORD/Ux4/E4PImOlZTdwXS3/w0f/ZybMdHAq+vqn0qvLt0lAuH2PYJsL6/naRJSpNycsZIC
+        hedVBwFBxOUpisLLBcW8Oxh/fIu7k/XHt7g7mX90iwFFUVLmKVs1JPAUqQ8OE8d1GCaqgAjP9Rip
+        gewaNBAHz+pC5vzwGtgTLv5UGm2GcNeULmlo9mHbmWNgw9XANk4GZpwsGnz/hJF3S5hPGHkPiz9h
+        ZAuMdGHAxtQCQ8gMX4E7t7ooH2mF3Vz7sERWrFnAd6VYmZcVl2yLH7+/HfmszMzqmZWy2TjowPbE
+        wJA8Lu6TQgrN8vRPUd38+6O//lP0ZKYlPG4uG7h/Ay63/rg63Mg92MnYwwUv65QEt3SrdUlRTStt
+        x72s/t+GVQszQqEL4+IvqbZNagG31jte2uGQSmPIc2v7z8xtHlDhWa/XTwAAAP//AwCKUuOjbBwA
+        AA==
     headers:
       Atl-Request-Id:
-      - cc775fb0-3f66-47cb-8ec9-ae93f20b3486
+      - 0f5b7b79-1cd3-4b6d-bf34-0a0e87a8f0c5
       Atl-Traceid:
-      - cc775fb03f6647cb8ec9ae93f20b3486
+      - 0f5b7b791cd34b6dbf340a0e87a8f0c5
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -622,7 +708,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:37 GMT
+      - Wed, 29 Jan 2025 20:45:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -632,7 +718,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=268,atl-edge-internal;dur=14,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=247,atl-edge-internal;dur=13,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -644,7 +730,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - e524439e1a7c2af3b7de1348526f4ee0
+      - 697fb4618e6c4d62015bdd36a63d4548
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -653,7 +739,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"issues": ["16084"]}'
+    body: '{"issues": ["16608"]}'
     headers:
       Accept:
       - application/json,*/*;q=0.9
@@ -670,21 +756,21 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/16083/issue
+    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/16607/issue
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 3b990d3b-59fe-4d1f-8d58-518c8e72adc6
+      - 4d8d8178-6de0-4e14-85a2-f909d716eb0f
       Atl-Traceid:
-      - 3b990d3b59fe4d1f8d58518c8e72adc6
+      - 4d8d81786de04e1485a2f909d716eb0f
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:38 GMT
+      - Wed, 29 Jan 2025 20:45:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -694,7 +780,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=475,atl-edge-internal;dur=12,atl-edge-upstream;dur=462,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=565,atl-edge-internal;dur=15,atl-edge-upstream;dur=551,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -704,7 +790,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - cdc7ff8ecfb25b053782770721534ea3
+      - 025a1155b4e5baa6fb4758386409ef52
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -732,17 +818,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2bfmzLDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCANd7gdNGHkzfvesdmsRYnCt/bdJtxr7pziJjHoyYS0yvWa7//BVzjslMAW3ccadb9C43H4
-        65KVNVKPaAT+LrnDwSlrApwCpAkkMK02l4/V+qH+mW7GrgkVYc8RmsAEXoITe233Xbiy3vfRttJ2
-        bEOoGZVuvyKEhQCdz0/NK+4jSIEWU0insKwpZXnG8iAGuIAAh7wLf8ChVt05m0JNgaUFyxZJXtJv
-        VnQ3RtoA5mm5EBywQCnSbI48lzKXICRdZsWikWWOtJRAzwReR8OtGnh8IUo+an9nBY/tA9GniqB5
-        3VbkeH7YkzVxcn1fk+MnAAAA//8DAOboofMgAgAA
+        H4sIAAAAAAAAA5yQ30vDMBDH/5e8unVJf9AubzLBKTqFdi8TkTS5YDRNSpMOytj/boJD55v6dtx9
+        vvc57oBa5mA7aETRq/e9o4uFAAncC/tmE+Y1c04xkxjwaIaEcr1m0z/4Goa94iDAva9B9yswHoa/
+        LllZI/UIhsPvknsYnLImwARjkuAEz+vN5WO9fmi+p5uxa0OF6FOEZniGn4MTem2nLlzZTH20rbQd
+        RQi1o9LiM4JoCKRleWpeMR/BFKfFHJN5WjUkpzmhWZVgjC9wgEPehT/A0KjuB7tsUkLzIixM8qz6
+        Ynl3Y6QNoCwKAlBmpBXAc84ZACNtJSRZlkySPAhkW0B6JvA6Gm7VwOILQbJR+zvLWWwfkD5VCMzL
+        tkbH88N21sTJ9X2Djh8AAAD//wMAgMpZMSACAAA=
     headers:
       Atl-Request-Id:
-      - 8d0c70f8-0a2e-4736-91e9-121d55a86699
+      - d752dd56-7df1-4465-a712-0e3c8eba73cb
       Atl-Traceid:
-      - 8d0c70f80a2e473691e9121d55a86699
+      - d752dd567df14465a7120e3c8eba73cb
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -750,7 +836,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:38 GMT
+      - Wed, 29 Jan 2025 20:45:10 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -760,7 +846,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=159,atl-edge-internal;dur=15,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=182,atl-edge-internal;dur=14,atl-edge-upstream;dur=169,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -772,7 +858,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 5f6c2fb5aaf4ecec9f224eafe697b533
+      - 820dc70ae834b2bdda75d5ebd71e7c56
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -823,9 +909,9 @@ interactions:
         Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
     headers:
       Atl-Request-Id:
-      - f723eba0-d9db-4625-b8c6-c6b59f3d45c5
+      - e7295481-3fe6-463d-9954-d68587c44c11
       Atl-Traceid:
-      - f723eba0d9db4625b8c6c6b59f3d45c5
+      - e72954813fe6463d9954d68587c44c11
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -833,7 +919,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:38 GMT
+      - Wed, 29 Jan 2025 20:45:10 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -843,7 +929,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=310,atl-edge-internal;dur=17,atl-edge-upstream;dur=293,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=255,atl-edge-internal;dur=17,atl-edge-upstream;dur=238,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -858,7 +944,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - b4ed380b258248c60d5856fbfdc325d6
+      - 646b22644e43607aaf975a6bd07be075
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -869,11 +955,11 @@ interactions:
 - request:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
-      [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/243]\n\n*Defect
-      Dojo link:* http://localhost:8080/finding/243 (243)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/233]\n\n*Defect
+      Dojo link:* http://localhost:8080/finding/233 (233)\n\n*Severity:* Low\n\n\n*Due
+      Date:* May 29, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
-      / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+      / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
       cookie has been set without the secure flag, which means that the cookie can\nbe
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
@@ -900,18 +986,18 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16085","key":"NTEST-1601","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16085"}'
+      string: '{"id":"16609","key":"NTEST-1826","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16609"}'
     headers:
       Atl-Request-Id:
-      - b60554b4-448a-46a1-88df-cb7fa0ccdedc
+      - 02ef8b2c-291a-465c-9a3b-f2f2109609c7
       Atl-Traceid:
-      - b60554b4448a46a188dfcb7fa0ccdedc
+      - 02ef8b2c291a465c9a3bf2f2109609c7
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:39 GMT
+      - Wed, 29 Jan 2025 20:45:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -921,7 +1007,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=798,atl-edge-internal;dur=12,atl-edge-upstream;dur=785,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=778,atl-edge-internal;dur=12,atl-edge-upstream;dur=766,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -933,7 +1019,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 1bd187e9b37f649272ef4658b8a37b6a
+      - e82e2ff5a18a14506c7e6f3ac6c6353d
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -957,53 +1043,53 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1601
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1826
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxtXvpCiTRNjJaNjTFEC0iXIWSS09S3jp3ZDm3H5b/vOGnS
-        SyH3CqZdVYLYx+f98ePz6MAqoyJ2QkeBiEFBfMyAx7olaAq6paM5pLQlM1DUMCl0C2JmUjC0Fc2p
-        SIDLpPUASqMM4gvIFGgQZnM2yrWR6cwavPM9z/c6Cv7OQZvpOoNzRSPDInBaDrP+/YE37ONCA5/h
-        cm5MpkPXjWEGkYnlR9mhhlOtGRUdAcZFT8alGXMDl2mdg1sZWMAa9c+m48m0jXs+bhUhaCd8dDTG
-        luuIGkikWpc5xLhCjcAL+m3Pb/veNPBCvx92DzqDwf4PGLdng7RODAZemHlnkFbfRXteUKe9WcSg
-        I8UyWzjcPSQ6pZy3SMy0YSIyJGMQAZEzspRq0bHakRSXir8xilww2y7K7+gDNVS5DwyWbhHWNsCN
-        yPe6/vAnzf6BH1Nse56iVwsLdDmlemF7ld8b+xXOKNfQckrFE8yr0G05c4bAUdF8fQoPgLF6Ty3H
-        MERWhihxQpFjjs4OTLpeJciU/IgZvbPgG+2i3EUDq3LbxWcg2WZ1KZgxaEA7tW+L1N+Ls1rOzJIq
-        i1fN0owzDDjeyRz7UaCsN1z1hm8M9wudqTKp+9Lz9jGMoLcKev+vl7L7BRbRoT9Y+YNv4XBVeewG
-        q27wLTxuAP709BKOfhNOgyZBtxLM2OqqJEeExc0twiRJFCTIN1+9BP1KgJlJnpe88PrRQZNgv0EQ
-        NAqGTYKDl+GUtFnuWlIqXggnbPu4pAYfjpJw335xSzrfErhbmlP2WhafRzK3hfMtKV/bDSYSJzQq
-        B2wfGjVX2HF7OcvgCnvWvmJRWcfHF3s2VlTWc5nzeMR0xul6c7ktJBRgspY/Xnskuv2D6pHYLVtN
-        ZbuCJlAFNagyxaRiZv3OIlbqbu9tbwVLaQLatRq6MsJwg8tlRz8kW7I8lcuKVHvOy2sT1JeA03uw
-        tGjxvzsRNEHXb0KoP7T1mFM9zlh0ysTi2EpGkNnpRURVz4pOLgtZvSOkGOPwQu85XADVJQ7U5ss5
-        P7385eTs7vTkaHw2Gd+NLy7+vMD88JZqLAgemM6BnCP/C0OsX8I0kYKvCXIJ49YoMZL8xhQl5wpS
-        JBOSa8Rs5zVO8fE6Od4n5nmZnIVO+SZi77D42zv1jCuwDQkTlO8e2sxem/IWqOYYXUU32NdEQH06
-        z+ylbcJxr9uvcFyOSe+EXqlcv7vPJ5u3oXELt59ptMBhs4JcZbz0dbSZ5/5TwNVQ6FazWVCNCQIs
-        1CPJpToro7nnObQThRyxHYkkGcmy2TLNcBwW5nXQ95tIoV+Twpc6/rycf4ntb2/KDIe9kNx8oFkQ
-        kiMpFwzINTPIaoZMIMoVkGNOk0+2OlgcLiPK51KbcOgNPXfGRIxU6ga97m1hcFQUD/P6KImFVbhH
-        vqpJvsM/3xfqExz6LAehGrLFJshRDmSE+eDmH3RNfK9FLBjrJI6uxyi6wX/tgd8rIrV9jJbQSZlR
-        0JEqcRHG1LaW4cRm4e/i0c7cpLyIu7RzZe1cioWQy8+LdK5knOMMMBYJXuwU2+ROscbWZ1EhjJf8
-        KpdtIxuqlG0MBLfEJTdLgAWyANTWGrS2B9xuofjh8JxMIioazts51D0o+/D8tzdZawOpxgziTDKE
-        2V5Y7Be9sbVKKROaGeggErFUen4vqYqbTrywP9oizFo+JJH8FwAA///sWVFr2zAQ/iuiUGihdp3E
-        aZJB6ULpYA9lo4UVSiHIttyYxbKx7Lpl63/fd5KipV7cjTJKHwp5cCLp7nS+++67iw4koC6LhJBM
-        iZq1NqpqwKIykZUisg5Yu8ziJcsFlwqL3OywEnDdGxkJxuMYuCoSdpdx1iBV4uqhBDBhn5TCFGR/
-        w6JzvOVb3VSSQVdLISmyGHdyC/ScuBEsoWuB/7FMpkWV6zOsqAitOVYVgSWA+ruQB2QYhGc1M1Wf
-        8VXLH+iKrOTaukYhphmXbMNAdIxSrHx2JhXd2d3Q+OBGkhNIG/kIFlgL1dpEEqgaOGirpRt33rj9
-        BbIQdQcuo9vbcGnb1i9arkqdD0g/ce+Xy1LHMpQsIHNhdS94DZoTNQipxd6Xq/nlV+/y3EOJ1lnq
-        lJRFVYuK8mCPJ3km99ne/k8EyqouPiAM/2Q3Y1fiu+WtD+EGYd+Co7sEfXUFsNecjjhZZ2voqGhn
-        IXAyugt9LCNwLEO/PU22tm/s48WBM+ZJte5iNl4Aj5eU/KYiqCbPOZWrnb8hNXmdyGdRvbC2EQk5
-        Qb4RZf6cHI+T0XQyjQaTQIziWRDPxsN0NkiPoMdtgoZntgkKiXmSQAfqG4pd8vBxwxAACsl6th02
-        ueKjfuptGqZsSxYKUDyeDMLwaBJPJ+PRLIqjSQD1KRfpND5JjrWU3dF8d/gJH3POy7m08Op55ifl
-        N8pr4Qhv6BNk+2UTrbKYPOWVnCtyFM7rCgKCiMdTJIVfSvJ5t7V++xZ3e/O3b3G3t3/rFgOKEtMY
-        WhJ4itAHh0nTJo4znUCE56YRNUB2DRqIjWdNVZTi8BoQEy9/ZxrNlrDqUpc02InaduYY9uFq2NdO
-        hn0zitBhd2WB/x1fXi2S3vHlNSx+x5ct+NKFAUfIHH+B1bcm937QENw+B1BY1NyO8LtSeplXLy71
-        UrLhduTrmwcFfRyUAGHrQtDHQUd9J0aO5Al5l1WFNETO/JQ09v8j8/WfvFfkRsKP9aOF+xfA78Zf
-        X4druQc7Ob+/EKpZkeAN3XpcUtXz2thxV9T/b0ZrhDmh0IV28Vuhp03rMSpNiWmGQyqdIU+tHT4x
-        1x7Q7nl8fPwFAAD//wMA+gwBq64cAAA=
+        H4sIAAAAAAAAA7xWbU/jRhD+Kyt/aqkTvyTkgqWqopBraSlFEA7pKEKLPbGXrHd9u2uS9O7+e2f9
+        Fg7wVVD1dBKX3dl5f+bxfHRgXVCROJGjQCSgIHnLgCfaFTQH7eo4g5y6sgBFDZNCu5Awk4OhbpxR
+        kQKXqXsPSqMMkjMoFGgQpnkbl9rIfGEN3gS+H/hDBR9K0Ga+KeBU0diwGBzXYdZ/MJn4e3jQwBd4
+        zIwpdOR5CSwgNom8k0NqONWaUTEUYDz0ZDxaMC/0mNYleK2BJWxQ/2Q+O58Pgmk4wasqBO1EHx2N
+        sZU6pgZSqTZ1DgmeUCP0w92BHwzCvXkYROPdKAiGk9HuDxi3b4O0TgwGXpl5ZZBW30N7ftil3RwS
+        0LFihS0c3u4TnVPOXZIwbZiIDSkYxEDkgqykWg6tdizFheIvjKIUzLaL8ht6Tw1V3j2DlVeFtQ2w
+        EQX+KJj+pNnf8GOObS9z9GphgS7nVC9tr8pbY39FC8o1uE6teIR5VbqukzEEjoqzzTHcA8bqf3Yd
+        wxBZBaLEiUSJOTqPYDLyW0Gh5B1m9MqCN9pVuasGtuW2hwcg2WZ1IZgxaEA7nW+L1N+rt1ouzIoq
+        i1fN8oIzDDh5lDn2o0LZeLoeT18Y7lc602bS9WXsv8EwwvE6HP+/XuruV1hEh8FkHUy+hcN163EU
+        rkfht/DYAPzz56dwDPpwGraCBVu/qzkQu391/fTlqH1J01RBinzzZAgwAcnLevyfd7fbJ5j0Cd70
+        CMJewbRPsPc0zpo261tLStUXwokGAR6pwQ9HTbgvH9yazrcE7tXmlB3L6ueBLG3hAkvKl/aCidSJ
+        jCoB24dGzTvsuB3OJhcFGKqd/ucoPhyPW4p/nHRHRI8FfZAIO0gUiknFzOaVJWjVvfHLmJ7lNAXt
+        WQ3dGmF4weVqqO/TLdUdy1VLiWPnKejDDrGc3oIltWdgbbng2TIEffgKprYeGdWzgsXHTCzfWskh
+        FHb3EPGmo1OdyVUl626EFDNcPegthzOg2o7JRwRj/cs5Pb745ejk5vjoYHZyPruZnZ39eYb54Yxp
+        LAg+mGdATpG9hSHWL2GaSME3BJmAcWuUGEl+Y4qSUwU5UgEpNSJu+BwjBDgMjv+J+b5a3EVO/UXD
+        3mHxtxPxxaRjG1ImKH/8qNmcmvJWuOcYXXO2fU0FdK/Lwo5cH45Ho6DFcb3kvBJ6tXL31fxyL3kZ
+        Grdw+5nGS1wVW8i1xmtfB8029p8Cblc6r92swvYjL8BCPZZcqpM6mltewiBVdLMNcC7JoaybLfMC
+        l1lhngf9bkcKX2vsY6WOML4s519i+29nzgyHnYhcvadFGJEDKZcMyCUzmSwNOYe4VEDecpp+stXB
+        4nAZU55JbaKpP/W9BRMJEqEXjkbXlcHDqniY150kFlbRDvlXTfId/vm+Uj/Hlc1yEKohWzRBHpZA
+        DjFRvPyDbki45xILxi6Jg8sZiq7wv8EkGFeR2j7GKxjmzCgYSpV6CGNqW8tw37Lw9/DpMDM5r+Ku
+        7byzdi7EUsjVwyKdKpmU+AWfiRQHO8c2eXMsvvVZVQjjJb/K1cDInioVjYHwmnjkagWwRBaAzlqP
+        1vaBN6oU3++fkvOYip73dov09vwunwcZnG+0gVxjBkkhGcJsJ6ruq97YWuWUCc0MDBGJWCqd3Uqq
+        kr4XT+wfbhFmLe+TuAYSsi65BRBEgyGrBlUGaVHXyFogslyyylickRyo0Cik9YtY/gMAAP//7Flt
+        S+NAEP4rQRAUTEzb9NoeiFfEg/sgdyicIELZbjY2mGxCXqzF63+/Z3bjXhq73iGH+KHQD2mzmbfM
+        PPPMVEmAu7dyLhzGOXBVhM5DzJwapcKLVQ5gwjkpkXH0Sr2WRRd4y3dqJCSDrhdCUmY5zMjNMDHC
+        I1hCboG9ObGMsiJVzzhZQWjNcLcksARQ3wt5RIZBeFw56BV1EjosWbIVuejkTFlXl8hph0mnZSDm
+        PSkSzzmXJflsPNQxuJUUBNJGMYIFjYXls4kksKwRoK2WtnxueX+JKkTfQcjI+yZdlsully1Zmat6
+        QPmJRy9f5CqXoWQGmbNG94xVVRHPa6TU7OD79fTqh3t14aJFqyo1SvKsqERBdXDAwjSWh87B4S8k
+        SlJln5GGL9nN0LT4bnuz0Z5eYLthqClhYoXB/l4xsqeXvdO3sdjAMMzuE4ZlqJekONX2gzbW4dtY
+        rW90bnTrLpjjBTC+oOLXHaGs05RRu9r7G1JT1Il8ZsUbexuRkFPUGxHeb+HJMByMR+N5b+SLAZ/4
+        fDLsR5NeRCsOcwgaXjkmKCWmYQgd6G9oduHqS8sQAArJenWY1bXioX+qYwqmmoEqEKB4LOwFwacR
+        H4+Gg8mcz0c+1EdMRGN+Gp4oKfuD6X7/Kz76OTdlsoFX19U/lV5duksEwu17BNleXs+TmFOk3Jyx
+        kgKF51UHAUHE5RmKwsslxbw7GH98i7uT9ce3uDuZf3SLAUVhXOYJWzUk8AypDw4TRTXnsSogwnM9
+        RmoguwENxMHzushycXwD7OGLP5VGmyHcNaVLGpp92HbmGNhwNbCNk4EZJ4sG33cw8m4Js4OR97B4
+        ByNbYKQLAzamFhhCZvgL3LnTRflEK+zm2oclWcWaBXxXio2S+TZc8vvbAc62D/KtDlgpm41qEoRs
+        vTGw3jAkT8iHuMikJnL6p7Bu/v3RX/8pelmqJTw9XzZw/wZcbv1xdfws92gvZY+XoqwTEtzSrdYl
+        RTWttB0PWfX/NqxamBEKXRgXf2Zq26QWcGu946UdDqk0hmxa298wt3lAhWe9Xv8GAAD//wMA3LOe
+        qmwcAAA=
     headers:
       Atl-Request-Id:
-      - 8327f36e-ae57-4b74-9f11-389bdeed0e8e
+      - 1a809b0b-bf28-4392-94a0-d0a6dec81d9a
       Atl-Traceid:
-      - 8327f36eae574b749f11389bdeed0e8e
+      - 1a809b0bbf28439294a0d0a6dec81d9a
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -1011,7 +1097,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:40 GMT
+      - Wed, 29 Jan 2025 20:45:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1021,7 +1107,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=308,atl-edge-internal;dur=14,atl-edge-upstream;dur=294,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=276,atl-edge-internal;dur=15,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1033,7 +1119,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - c26821749be615c24813df157fd1d96f
+      - 9fb4fed285f3e04d08489bccc85ade8d
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1057,53 +1143,53 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16085
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16609
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeeSxYaSqoiS0tJRGEFhp6QqZmZuJNx571vaQpLv8917P
-        KwthtoKqq0gwftz3ucf3kwObjIrYCR0FIgYF8QkDHuuOoCnojo6WkNKOzEBRw6TQHYiZScHQTrSk
-        IgEuk849KI1nEF9ApkCDMNXdKNdGpgur8Nb3PN/rKfiYgzbzbQYzRSPDInA6DrP2/ZE3HuJCA1/g
-        cmlMpkPXjWEBkYnlB9mjhlOtGRU9AcZFS8alGXMDl2mdg1srWMEW5c/n08t5F/d83Cpc0E74ydHo
-        W64jaiCRalvGEOMKJQIvGHY9v+t788AL/WHYP+yNRm9+QL8966Q1YtDxQs0rnbTyLurzgibsahGD
-        jhTLbOJw94jolHLeITHThonIkIxBBEQuyFqqVc9KR1JcKf5CL3LBbLkov6X31FDl3jNYu4VbOwer
-        I9/r++OfNPsbfkyx7HmKVi0s0OSc6pWtVX5n7Fe4oFxDxykFTzGuQrbjLBkCR0XL7RncA/rqPXQc
-        wxBZGaLECUWOMTpPYNL36oNMyQ8Y0SsTXkkX6S4KWKfbLr4AyS6qK8GMQQXaaWxbpP5e3NVyYdZU
-        WbxqlmacocPxk8ixHgXKBuPNYPxCd79SmTqSpi4D7w26EQw2weD/tVJWv8AiGvRHG3/0LQxuaov9
-        YNMPvoXFCuAPD/tw9NtwGtQHC7a5LjkQq3/zfv9mv75Jk0RBgnyz1wQYgOR52f7Pmxu2HYzaDt60
-        HAStB+O2g8N9P0vaLHctKRUvhBN2/YorbUkUi8qQPu3t2UbBbOulzHk8YTrjdFu1E26vqcGnp6Ts
-        l7d++SDsngC3VKdsYxefxzK3qS9cfWs3mEic0Kjc2kal5hoxY9u7yoYCDNbyx3OPRH94WD8ST9PW
-        UNnTgzZQBQ2oMsWkYmb7yhTU4u7gZW8FS2kC2rUSulbCcIPLdU/fJzuyPJPrmlQHzn7bBA3mOb0D
-        S4vPNIZlk2fT4Lch1B/bfCypnmYsOmNidWJPJpDZ6UVENYIKXK2Ls2ZHSDHF4YXecbgAqktUqurL
-        mZ1d/XJ6fnt2ejw9v5zeTi8u/rzA+LBLNSYEL8yXQGbI/8IQa5cwTaTgW4JcwrhVSowkvzFFyUxB
-        imRCco2I6z3HKT62k+N9Zp6XyUXolG8i1g6Tv+upR1yBZUiYoPzppWr2qtJb4J6jd9Xa1jUR0NzO
-        M9u0bTge9Ic1jssx6ZXQK4Wbd/fxZPMyNO7g9jONVjhs1pCrlZe2jqt57j85XA+Fbj2bBfWYIMBC
-        PZJcqvPSmzueQzdRyFi7kUiSiSyLLdMMx2Fhngf9sCGFrxX2qVBDGI/T+ZfY/Q7mzHA4CMnNO5oF
-        ITmWcsWAvGUGOdaQS4hyBeSE0+SzzQ4mh8uI8qXUJhx7Y89dMBEjEbrBoP++UDgpkodxfZDEwio8
-        IP8qSb7DP98X4pc49FkOQjFki8rJSQ5kgoHi5h90S3yvQywYmyCO307x6Ab/dUf+oPDU1jFaQy9l
-        RkFPqsRFGFNbWoYTm4W/i1d7S5Pywu9Sz7XVcyVWQq6/TNJMyTjHGWAqEmzsFMvkzjH51maRIfSX
-        /CrXXSNbspRVCoL3xCU3a4AVsgA02lqkdhfcfiH47mhGLiMqWu7bOdQ9LOvw+HdwudUGUo0RxJlk
-        CLODsNgvamNzlVImNDPQQyRiqvTyTlIVt93Y0z/ZIcxqPiKR/AcAAP//7Flda9swFP0rolBooXad
-        xGmSQelC6WAPZaOFFUohyLbcmCWy8UfdsvW/71xJ0Vwv6kYZpQ+FPDiWdL9y77nnKiqRgLosEkKy
-        StSsNVlVAxYrnVkpMuuAtcssXrK14LLCItc7jAS4eyMjwXgcA1dFwu4yzhqUSlw+FAAm7JNSaHrg
-        dyw6x698q4ZKMuhqKSRlFuNWbo6ZEx7BEnIL/I9lMs3LtTrD8pLQmmO1IrAEUH8X8oAMg/CsZpqD
-        ML5q+QO5yAqurGsq5DTjknUMxMQoxcpnZ7Iin62HOgY3koJA2ihGsMBYWG1MJIFVgwBttbTjc8f7
-        C1Qh+g5CRt6bdGnb1s9bXhWqHlB+4t4vloXKZShZQObC6F7wGqQrapBSi70vV/PLr97luYcWrarU
-        KinyshYl1cEeT9aZ3Gd7+z+RKKs6/4A0/JPdjG2L77c3F+0ZhK4FS24JE+sSYK8YGTHE3tbAxYND
-        y1H7JyzLUD+S4lTbN7pYR+DixYHViRjzeEn1bVpvt3v3wb1q1mtO7Wrnb0hNUSfymZcv7G1EQk5Q
-        b0R4PyfH42Q0nUyjwSQQo3gWxLPxMJ0N0iPosZug4ZltglJiniTQgf6GZpc8fOwYAkAhWc+Ow7pW
-        fPRPtU3BlBnJQgGKx5NBGB5N4ulkPJpFcTQJoD7lIp3GJ8mxkrI7mu8OP+Gjz3lrLg28ep5+VflN
-        5bUIhDf0CbL9oolWWUyR8grOKwoUzqsOAoKIx1MUhV9Iinl/tH77Fvdn87dvcX+2f+sWA4oSPaYa
-        EniK1AeHSdMmjjNVQITneozUQHYNGoiNZ02ZF+LwGtgTL39XGt0tYdWWLmkwN2rbmWPowtXQNU6G
-        dpwsDb6/w8irJcw7jLyGxe8wsgVG+jDgYmqhJWSWr8CdW12UP+gS3DwHsCSvubnC70txUbLAhUvB
-        cDvAue6DAqcDTsrmopoEIVsXRs4FS/KEvMvKXGqWp18ljfn/SH/9l+jd5fX/u9nUwqxQaMKY9i1X
-        tzyby1SUgDb5x+bR9JcXG6D+azvcyD3YWfP7C1E1KxLccVbdz5T1vNaO0y0x3eGQ6/b908PDJ6fN
-        AWXt4+PjLwAAAP//AwBSgNGgrhwAAA==
+        H4sIAAAAAAAAA7xWbU/jRhD+Kyt/aqkTvyTkgqWqopBraSlFEDjpKEKLPbGXrHfd3TVJyvHfO2vH
+        DhfwnaDq6SQu3tl5f+bZeXBgWVCROJGjQCSgIHnPgCfaFTQH7eo4g5y6sgBFDZNCu5Awk4OhbpxR
+        kQKXqXsPSqMMkjMoFGgQZn03LrWR+cwavAl8P/D7Cv4uQZvpqoBTRWPDYnBch1n/wWjk7+GHBj7D
+        z8yYQkeel8AMYpPIO9mnhlOtGRV9AcZDT8ajBfNCj2ldgtcYmMMK9U+mk/NpLxiHIzyqQtBO9OBo
+        jK3UMTWQSrWqc0jwCzVCP9zt+UEv3JuGQTTcjYKgPxrs/oBx+zZI68Rg4JWZNwZp9T2054dt2uuP
+        BHSsWGELh6f7ROeUc5ckTBsmYkMKBjEQOSMLqeZ9qx1LcaH4K6MoBbPtovyG3lNDlXfPYOFVYW0C
+        XIsCfxCMf9LsH/gxx7aXOXq1sECXU6rntlflrbG/ohnlGlynVjzCvCpd18kYAkfF2eoY7gFj9R9d
+        xzBEVoEocSJRYo7OFkwGfpcgaASFkneY6hs7sdau+lB1tumD/XiCnk26F4IZgwa00/q2EP69uqvl
+        zCyoskDWLC84w4CTrZJgoyr4DcfL4fiV4X6hZU0mbcOG/jsMIxwuw+H/66WGRQVSdBiMlsHoWzhc
+        Nh4H4XIQfguPa+Q/Pj6HY9iF00EjmLHlZU2O2P2ra0RDmipIkW++OgS7jQATkLyseeHlq6MuwbsO
+        QdgpGHcJ9p6HU9NmfWpJqXohnKgX4Cc1+HDUhPv6+azpfEPgXm1O2emrfh7I0hYusKT8wR4wkTqR
+        USVgl9CoucTG2hlc56IAQ7VD/hLFh8NhQ/HbSXcRUdgS0baghUShmFTMrN5YgkbdG76O6VlOU9Ce
+        1dCNEYYHXC76+j7dMNqxXDTMN3SeYztsIczpLVjusujdfs+7gBd04SsY23pkVE8KFh8zMX9vJYdQ
+        2N1DxKuWNXUmF5WsPRFSTHD1oLcczoBqOw0PCMb6l3N6fPHL0cnN8dHB5OR8cjM5O/vzDPPDGdNY
+        ELwwzYCcIkkLQ6xfwjSRgq8IDjzj1igxkvzGFCWnCnKceFJqRFz/pcEPcBgc/xPzfTW7i5z6RcPe
+        YfE3E/HZpGMbUiYo37603pzW5a1wzzG6hiywr6mA9nZZ2JHrwvFgEDQ4rpecN0KvVm4fx8/3kteh
+        cQO3n2k8x1WxgVxjvPZ1sN7G/lPAzUrnNZtV2LzlAizUY8mlOqmjueUl9FJFV5sAp5IcyrrZMi9w
+        mRXmZdDvtqTwpcZuK7WE8Xk5/xKbfztTZjjsROTqIy3CiBxIOWdAPjCTydKQc4hLBeQ9p+knWx0s
+        Dpcx5ZnUJhr7Y9+bMZEgEXrhYHBdGTysiod53UliYRXtkK9qku/wz/eV+jmubJaDUA3ZYh3kYQnk
+        EBPFwz/oioR7LrFgbJM4+DBB0RX+1xsFwypS28d4Af2cGQV9qVIPYUxtaxmuVRb+Hl7tZybnVdy1
+        nUtr50LMhVw8LdKpkkmJD/VEpDjYObbJm2Lxrc+qQhgv+VUuekZ2VKlYGwiviUeuFgBzZAForXVo
+        bS54g0rx4/4pOY+p6Lhvl0Vvz2/zeZLB+UobyDVmkBSSIcx2ouq86o2tVU6Z0MxAH5GIpdLZraQq
+        6brxzP7hBmHW8j6JayAh65JbAEE0GLJYo8ogLeoaWTNElksWGYszkgMVGoW0vhHLfwEAAP//7Flt
+        S+NAEP4rQRAUTEzb9NoeiFfEg/sgdyicIELZbjY2mG5CXqzF63+/Z3bXvRqz3iGH+EHwQ8zuzs5M
+        Zp55ZqokwNxrORce4xy4KmLvLmVeg1Th5boAMGGflIg4+qTBlkZn+Mo3qiUkhS4XQlJkeczKzdEx
+        wiJoQmaBpHmpTPJyqc54eUlozbBaEVgCqG+FPCDFIDytPdSKJos9lq3Ymkz0Cqa0ayrEtMekt6Ug
+        +j0pssA7lRXZbC3UPriW5AS6jXwEDYyG1aOKJLBq4KBOTbds3rL+HFmIugOXkfUmXFarVZCvWFWo
+        fED6ifugWBQqlnHJDDJn5u4Zq+synTcIqdne98vpxQ//4sxHiVZZai8p8rIWJeXBHouXqdz39vZ/
+        IVCyOv+MMHzOboa2xLfLm4v29CLXgiWrhIk1GvtbxcgentfOyBLJ1kJoZbQXXCwjtCxDfT1Ftro3
+        ulhtaJWBjxlfUH538PQ2uFfNcsmoXO38DanJ60Q+8/KVtY1IyDHyjQjvt/hoGA/Go/G8NwrFgE9C
+        Phn2k0kvoRGH3YQbXtgmKCSmcYw7UN9Q7OL1ly1FACgk68WeVedKgPqptimYMn1TJEDxWNyLok8j
+        Ph4NB5M5n49CXJ8wkYz5cXykpOwOprv9r/jT5/wlkwZefV+/qoKm8ldwhN8PCLKDoplnKSdP+QVj
+        FTkK51UFAUHE4wmSIigk+bzd/75/jdsN9PvXuN2Av3eNAUVxWhUZWxsSeILQB4dJkobzVCUQ4blu
+        IzWQXYEGYuNpU+aFOLwCxPDFn0yjARBWberSDWYe1s0cIxeuRq52MnJNGCKL3aUB/g98ebNI+sCX
+        t9D4A1868KUNA5aQWb4CrW907j3QpNo8h7gwr5kZwLelOJmXE5eclKzfjXyueVDo4qAECJ0LoYuD
+        DlwnBpbkCXmXlrnULE+/ihvz64/+91+8d5fX/2+yqYVZobgJbdrPXE151OBLDyS0yg+Pj6a+vFoB
+        9UvZ4aPcg50luz8XVZOR4C1j1XymrKe1NpxmvDTDIdPt+6eH+09OmwNK281m8xsAAP//AwB8FoVT
+        bBwAAA==
     headers:
       Atl-Request-Id:
-      - 5a5e0fe9-f715-4b70-b2dc-13c9fe76cd3f
+      - 8d665a4d-ac63-432b-b5ef-bca6b1880049
       Atl-Traceid:
-      - 5a5e0fe9f7154b70b2dc13c9fe76cd3f
+      - 8d665a4dac63432bb5efbca6b1880049
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -1111,7 +1197,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:40 GMT
+      - Wed, 29 Jan 2025 20:45:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1121,7 +1207,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=270,atl-edge-internal;dur=14,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=290,atl-edge-internal;dur=14,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1133,7 +1219,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - aa8de8f48550350c210f0edb3b2cec44
+      - ccf764aeb6daa09afe8d5e767a89806c
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1142,7 +1228,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"issues": ["16085"]}'
+    body: '{"issues": ["16609"]}'
     headers:
       Accept:
       - application/json,*/*;q=0.9
@@ -1159,21 +1245,21 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/16083/issue
+    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/16607/issue
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 1df7a1d0-005f-40e7-a3c4-69ec938ecb4e
+      - f775a80a-f906-49d9-87a2-4e95b9927b64
       Atl-Traceid:
-      - 1df7a1d0005f40e7a3c469ec938ecb4e
+      - f775a80af90649d987a24e95b9927b64
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:41 GMT
+      - Wed, 29 Jan 2025 20:45:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1183,7 +1269,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=470,atl-edge-internal;dur=15,atl-edge-upstream;dur=454,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=461,atl-edge-internal;dur=15,atl-edge-upstream;dur=444,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1193,7 +1279,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 95c3f0f1637d7fca3cb0f89edbd4d866
+      - d1b63777dda0ac9ac859eccdef696c77
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1203,14 +1289,14 @@ interactions:
       message: No Content
 - request:
     body: '{"description": "Event test_added has occurred.", "title": "Test created
-      for Security How-to: weekly engagement: ZAP Scan", "user": null, "url_ui": "http://localhost:8080/test/93",
-      "url_api": "http://localhost:8080/api/v2/tests/93/", "product_type": {"name":
+      for Security How-to: weekly engagement: ZAP Scan", "user": null, "url_ui": "http://localhost:8080/test/90",
+      "url_api": "http://localhost:8080/api/v2/tests/90/", "product_type": {"name":
       "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2", "url_api":
       "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name": "Security
       How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api": "http://localhost:8080/api/v2/products/2/"},
       "engagement": {"name": "weekly engagement", "id": 3, "url_ui": "http://localhost:8080/engagement/3",
       "url_api": "http://localhost:8080/api/v2/engagements/3/"}, "test": {"title":
-      null, "id": 93, "url_ui": "http://localhost:8080/test/93", "url_api": "http://localhost:8080/api/v2/tests/93/"}}'
+      null, "id": 90, "url_ui": "http://localhost:8080/test/90", "url_api": "http://localhost:8080/api/v2/tests/90/"}}'
     headers:
       Accept:
       - application/json
@@ -1225,7 +1311,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.42.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1239,13 +1325,13 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"828\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:56242\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:48442\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: weekly engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\":
-        \\\"http://localhost:8080/test/93\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/93/\\\",
+        \\\"http://localhost:8080/test/90\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/90/\\\",
         \\\"product_type\\\": {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\":
         \\\"http://localhost:8080/product/type/2\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"},
         \\\"product\\\": {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\":
@@ -1253,8 +1339,8 @@ interactions:
         \\\"engagement\\\": {\\\"name\\\": \\\"weekly engagement\\\", \\\"id\\\":
         3, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/3\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/engagements/3/\\\"}, \\\"test\\\": {\\\"title\\\":
-        null, \\\"id\\\": 93, \\\"url_ui\\\": \\\"http://localhost:8080/test/93\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/93/\\\"}}\",\n  \"files\":
+        null, \\\"id\\\": 90, \\\"url_ui\\\": \\\"http://localhost:8080/test/90\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/90/\\\"}}\",\n  \"files\":
         {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event test_added
         has occurred.\",\n    \"engagement\": {\n      \"id\": 3,\n      \"name\":
         \"weekly engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/3/\",\n
@@ -1264,10 +1350,10 @@ interactions:
         \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
         \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
         \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
-        93,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/93/\",\n
-        \     \"url_ui\": \"http://localhost:8080/test/93\"\n    },\n    \"title\":
+        90,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/90/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/90\"\n    },\n    \"title\":
         \"Test created for Security How-to: weekly engagement: ZAP Scan\",\n    \"url_api\":
-        \"http://localhost:8080/api/v2/tests/93/\",\n    \"url_ui\": \"http://localhost:8080/test/93\",\n
+        \"http://localhost:8080/api/v2/tests/90/\",\n    \"url_ui\": \"http://localhost:8080/test/90\",\n
         \   \"user\": null\n  }\n}\n"
     headers:
       Access-Control-Allow-Credentials:
@@ -1277,7 +1363,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:15:41 GMT
+      - Wed, 29 Jan 2025 20:45:13 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1303,17 +1389,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TtfvIDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC18LjtDeHkLYTO88mkQYUyNO7dZSIY4b0WNrMYyIg02ndG7P/Bl9jvtMQG/ccaTbdCG7D/
-        65KVs8oMaCX+LrnD3mtnI0wBaAYZjMvN5WO5fqh+ppuhrWNF+HOCRjCCl+jEzrh9G6+s9l2yrYwb
-        mhiqB22arwjhMcDm81PzSoQEMmDFGOgYlhVjPJ/yPIoBLiDCMe/jH7CvdHvOUqgYcFoktgD6zcr2
-        xioXwZzOFlIAFqgknc5R5ErlCqRiy2mxqNUsRzZTwM4EwSTDre5FeiEqMZhw56RI7QMxp4qgfd2W
-        5Hh+2JOzaXJ9X5HjJwAAAP//AwBnGWXmIAIAAA==
+        H4sIAAAAAAAAA5yQUUvDMBDHv0te3boka+mWN6ngFJ1Cu5eJSJpcMJompUkHY+y7m+Bg8019O+5+
+        //sdd0At97AZDGLoPYTes9lMggIRpPtwGQ+Ge6+5zSwENEFS+97w/T/4GoadFiDBf67A9BXYAMNf
+        l1TOKjOCFfC75A4Gr52NMMGYZDjD03p9/VyvnprzdD12bawQe0nQBE/wa3RCb9y+i1c2+z7ZKuNG
+        GUPtqI38jiAWA7QsT80bHhJIMS2mmEzpoiE5ywmbLzKM8RWOcMz7+AcYGt39YJcNJSwvGJlnBT2z
+        oruzykVQFQUBKOeklSByITgAJ+1CKrIsuSJ5FKi2AHohCCYZ7vXA0wtB8dGEByd4ah+QOVUI7Num
+        RsfLw7bOpsntY4OOXwAAAP//AwBukVcqIAIAAA==
     headers:
       Atl-Request-Id:
-      - a6ccec44-fb6c-447a-9667-0063b8584791
+      - 63c87549-8e2c-4cbf-8ecf-d90285decde7
       Atl-Traceid:
-      - a6ccec44fb6c447a96670063b8584791
+      - 63c875498e2c4cbf8ecfd90285decde7
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -1321,7 +1407,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:41 GMT
+      - Wed, 29 Jan 2025 20:45:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1331,7 +1417,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=161,atl-edge-internal;dur=19,atl-edge-upstream;dur=141,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=167,atl-edge-internal;dur=15,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1343,7 +1429,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - fb437c4f1514de63a4c0cae70893f4ef
+      - 33a508a0dfc8263889715abe736ba6b0
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1367,63 +1453,63 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/NTEST-1599/issue
+    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/NTEST-1824/issue
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xXWW/jNhD+K4Rea1uHj3UEFMU28RZp03ThONuHoghoaSxzLYkCScV2g/z3zlCH
-        HcdewGm6b+IMOfPNPXpyYFPwPHZCR0dLyHgn5xlop+Now5X5aJzQ6zgZ30xBl6nRTjjEs5GGp04Y
-        dByhdYnXw7+edoJkAYobIXPdeQSl8QPiKRQKNOSmZkAsTAaGd6IlzxNIZdJRkMegIP4kII0JgSBh
-        /sgbDwgOpAs8Lo0pdOi6MSwgMrH8KnvcpFxrwfNeDsZFLcbliUjB9Xuea/G5jZAVbFHG7WxyN+si
-        zUPSotIWPpHBptQRN5BIta1wxXjCF4EXDLue3/W9WeCF/jDsj3pjf/SD51sZVonZFmDFnAW0EG5Q
-        gaT3Lsrzgtb0+hCDjpQoyHFI/ch0xtO0w2KhjcgjwwoBETC5YGupVj16Hcn8XqVnoihzQeHi6QN/
-        5Bh891HA2rWwdgBrlu/1/fFPWvwDP2YYyjJDrZQ4qHLG9YriVc4NfYULnmroONXDa7TLvu04S4FZ
-        oqLl9gYeAbF6zx2n4JgEhrzYxr5/GLbhxcXZ6bDzsk0FkrkX9zLLuCINa4BVumWQJzyBjJDYMsCs
-        eGNgq8c2qpQnLwN5XqB2Dv6ZRyusl/0sIeGVrss6ff8T4KYG3CYVgyYGOayRFMlUqtsKzTwtoZso
-        vt3LAMmupPNM8VRCKmHeiqZ57lLAzvCVyDB+2qUXuhEikFClak8/kvNqsL836Wud2Xee37ucbYPY
-        D9RhOc9FwkoNimmDPmdmyQ3LAWLNjGRzYHMlV5CzWK7zHrtUgMGJ2XzLfhWKszu5MGusGtbFCyyX
-        hlFnZVKxGFIwcGY7eOG51g7tQiGil36bIIWy7qDMD6vaf6Y8MAJnSmFLOy+xdzkao7I7RSWantmK
-        fEAv9b2GUSj5FYG+MQ716+NR2OspO6Puc2EMCqDpU7+eof2/2bu6djVZLbIiFQg4Puhv6GbbKwbj
-        zWB8Jtxv9N/Gkrb7DrwPCCMYbILB/6ul6vF24qBCf7TxR99D4abR2A82/eB7aKzHGGXrYTr6p/I0
-        aBgLsflSbTq0Cv39+ma/ucmTREGCJfyqJNAAmZZVVziubniKMTrF+HCCEZxkjE8xLl7jrJajikqr
-        h136nLDr45Eb3CbfOjarSb1b09xKnKKytJ+XsiTH+dSr/ySCyBMnNKqEpn2TNCWiyp1Pr2iEDK/q
-        pSzT+EroIsUBVpUykhGW+YI5Q+Vde6Nqu87xVXD4wWtWwUO3ta3skNEmFbXWZuOxy8k77Dvt+kvC
-        25WnbnJHt5xv7kB23hPGCpg9PgTtqLx8yS5KVaRA3Bg3/51XDz3QVs97bQm04b911u1tCalcvxx1
-        N5KWHjs9BmTWoSFtcad8DtT/j3QAaptHE8E/VYr+mPyx5Jom7Y3IV5+IcwUF/SblUZOuNonXltdS
-        cplPcAvg8xSmwHVVAqr+cj7f3P9yfftwc305ub2bPEym0z+maB+2I40OwQuzJbDPdhNnN/8CAAD/
-        /+xYa0/bSBT9KyOkSoCw47zIQ6raCKh2P6BFTbtIQIUm43Hs1p6xPPa6kfjxPXdsnODGdLUrVXxA
-        REDsmTv3ee65g3NZZJhWyAmAZhSTUCImln1cZTIBalr6Ytx94NkHbhx4D5HnpXoyP6ioAGIH52/B
-        4wkoIgzrSPG4vageJWv32sSLoV39neK6Bmt6XF2khE77C3biTqeTx4J95ff/g98LnaSocUX3AnuS
-        ftyg33OBbW/qarfjps6e+vlObX+OP0V5LI/n7PaGp/05O9P6WyTZdZQD6XO2lKIAV/4Q8/UDuQ1e
-        i7XgcahNPp96U68XRMpHM+kNRoMvVuC59SoM/qoZ5dv8mP1yJzvEryO7fQkaTOCEbYCRWsnzQrJz
-        eAAPL/mG9b0TRlnaGHF2fYFXt/jjnPZHVlMKsCilm0R5Jl2drXvIb04xj8BZqS56WOqGeRJbvSs5
-        f5Ocz+qbwuyw46SrTPsFWNBFA/K9T4gKnWk9BH3ZH7p0ct3hpbQWMPjCeuz2p5bRsWu7oDe0G28W
-        V2wpuOpYT0y8Nxs29uxYsNyYXCYGFvipxiRhjuf2uY0N+SrhkTIR5h+kKFxlwpXmmd+14if559sM
-        I8kLJqpEAhxjJMM0ZmTOyjqrcuClqTIrQGadsDKMRMgSyZWpxjlaUUuAuXcKUx0XAoCLSe6fiLMC
-        NSSyTUqTHSBDyYqkuDsaXSLKa3t5Rgpdh1JRZjHeyNUqJ4ugCZkFBswiFegssXtoIASMc7w1hKJA
-        cMyUJ6QYhGNgrJgQ43HJN2QiS7nVrjDIacYV21Ew5NAwdtmFMmRzY2HlgztFTqDTyEfQoNbQPKpI
-        Ak0BB+3VdMfmHes/ogrRkOAysr5Ol7IsXV1yk9p6QPnJ724apjaXccg9ZN7XZ9/zHNRvVSCl7g//
-        ul4sr5zlpYPebau0OSTVWS4zqoND7ieROmKHRw9IlDjXc6QhQWOrvXXxu3EXWR93EgGa5J5wPgLN
-        PEM3sOyW+Gp7S9chXteLUUPj2zsatWwULRvbv7CLr3hdo4PXnPmkz7fbACLERWgZp+0llEXrnQF7
-        S1F/Be0UJuLrFSn9D12S6Mw7FChNGX/6b8f+cDqZrvoTTw7FzBOz8SCY9YNTnNMswgnPLJOUQwvf
-        xxnolGib/ub9jiJAIJL17A1CVVwuOrFdZnGtnmJHEmSR+/3R6HQippPxcLYSq4mH4wMug6l457+1
-        Ut4MF28GH/Cp9jkJVzUeO071yLiFcUo4whm4hPFuWqziSJCnnJRzQ47CfttyEBX8e4YqclNFPm/f
-        Rrx8jdvXGS9f4/Z1yEvXmIbAarqu6eQZUh+kJwgKISJbQNQAqtm9QrwbOzQeXBSZTmXvBlgkwm2l
-        0XUc3jalSyfUd5D7OeioC6FHXTxz1AymWd0QXmHktyXMK4z8Do3/PYz8AAAA//8aHC6mSzGCXgzA
-        u5voEiYY7Rmgd9IhmbIaNG8AZSMmykFzm+im4GqiGeAsl3C1HA2MsJd8OFtqSD4DAAAA//9C1YGz
-        CQf3MpqEMS4dxvBGX2peWWZRfh6kYQcRSimFTqxDuMSEXll+CfWGkyGGwQ0F2gTs14Xlg8eL4KOV
-        +bkQJ1fDmND6hWwHgBch6MPMRV1UgeRZ8EgPdOVFLWRgHTQaBPI6XBxVsxGKbqgGsGtBk2+0XJhh
-        qkRqeGBZmAEyBG1hhqES2QszLPXMzOCDe9SdyR1dmGE1ujADw1REAA+hgVtqTbmMLswYXZhBejzA
-        ZuGxxsLowgyibBldmDG6MAMsAW9oI9yJZ2EG+kIIcJVO4eIIqi72MCRtsQe+hRmWesamlqMLM+DS
-        pCzMAAAAAP//gpby1GkljC7MGNwLM9IGx8IMEwM9c3N4hh1t31PQvh/cCzOM8M3e4VgMgFheAVkQ
-        QM7CDGPQwgzj0YUZ6LpGF2aMLswYXZiBsyEA6smNLswA94gILszAW7SDoml0YQad584wRyMGv4vR
-        hzMGv4vRh0MGu4tBnUCaz6iOLswYssUIAAAA///CSDCjxQg9XEz3YgQAAAD//6LQxXQpRtCLAXh3
-        E10CvkphdGHGUFyYYTiACzNM6b4wI7YWAAAA//8DAAnZ2XF8QwAA
+        H4sIAAAAAAAAA7xXbW8iNxD+K9Z+LbAvkBxZqaquCVelTdMTIdcPVRWZ3QF87Nor2xugUf57Z7wv
+        EAInkab3DXvWM8/MM288ebAuuEy92DPJAnLekTwH43U8Y7m2H60XBx0v5+sxmDKzxovP8GyV5ZkX
+        Rx1PGFPi5/FfT1tFqgDNrVDSdB5BG/wB6RgKDQakrQWQCpuD5Z1kweUcMjXvaJApaEg/CchSQiBI
+        WXh+HgwJDmQzPC6sLUzs+ynMILGp+qp63GbcGMFlT4L10Yr1+Vxk4Ie9wHf4/EbJEjao43Yyupt0
+        w2F0hlezylr8RA7b0iTcwlzpTYUrxRO+iILorBuE3ehiEoXx4CwOhr1BePFDEAYBASUjdlOAU3MS
+        0EL4UQWS3vuoL4ha1+tDCibRoqDA4e1HZnKeZR2WCmOFTCwrBCTA1IytlF726HWi5L3OTkRRSkF0
+        8eyBP3Ik338UsPIdrC3AWhQG/XD4kxH/wI85UlnmaJUSB01OuFkSX+XU0q94xjMDHa96eI1+ubcd
+        byEwS3Sy2NzAIyDW4LnjFRyTwFIUW+4/vKZtcHI6bKPsUoF07vBe5jnXZGEFsMw2DOSczyEnJK4M
+        MCveSGz12LFKefKSyNOI2gb4Z54ssV52s4SUV7Yu6/T9T4CbGvCbVIwaDiSs8CpRmdK3FZppVkJ3
+        rvlmJwMUu1LeM/GphdLCvhVN89zvnxYrkSN/xqcXplEi8KJK1Z55pODVYH9v0tcFs+89v3c5uwax
+        S9R+OU/FnJUGNDMWY87sglsmAVLDrGJTYFOtliBZqlayxy41IDkpm27Yr0JzdqdmdoVVw7r4AZPK
+        MuqsTGmWQgYWTmwHLyLX+mF8KETyMm4jvKGs2yvz/aoOnykPrMCZUrjSliX2Ls8gK9tTUqLruavI
+        B4xSP2gEhVZfEegbeahfH2Zhp6dsnbqXwlpUQNOnfj1B/39z35o61OS1yItMIOB0r79hmF2vGAzX
+        g+GJcL/RfxtP2u47cD0sGqyxGf6vVqoe7yYOGgzP1+H59zC4biz2o3U/+h4W6zFG2bqfjuGxPI0a
+        wUysv1SbDq1Cf7/+st98yedzDXMs4VclgQ6orKy6wmFzZ8cE58cEH44IoqOC4THBxWuc1XJU3dLq
+        4ZY+L+6GdQslSrRIKpeeXt1RoWC0zUKVWXolTJHhEKnKCa+RW/sFeaMSq01wixvqW0dxNf23q59f
+        qdNU6u7npSqJDAf+T7oQcu7FVpeEJqnarnd4FQzOo2YV3A9b28r2BW1SUWttNh63nLzDvtOuv6S8
+        XXnqJndwy/nmDuTmPWGsgLnjQxi1s/LypbwodZEBSVNc/beU7oegLZ/3WhMoUG8ddjtrQqZWL2fd
+        jaKtx42PAbm170hb3RmfAg2AAy2A+ubBTAiP1WI4pHgsuKFReyPk8hNJrqCg/0kyaWrFVdDKydob
+        qeQI1wA+zWAM3FT1p+tf3ueb+1+ubx9uri9Ht3ejh9F4/McY/cN+ZDAg+MFkAeyzW8XZvwAAAP//
+        7FhrT9tIFP0rI6RKgLDjvMhDqtoIqHY/oEVNu0hAhSbjcezWnrE89rqR+PE9d2yc4MZ0tStVfEBE
+        QOyZ+5p7zz13SC+LDNMKSQHUjGISSszE0o+rTCaATctfjLsPPfsAjgPvIfK8LFjNDyougLND8Lfo
+        8QQVcQzrSPG4vaieJevw2sSLYV39nc51Ddr0uLpICZ72V+zMPZ1OHiv2leD/D4IvdJKixhVdDOxJ
+        +nEDf88dbHtTA41Pw3mntj/Hn6I8lsdzdnvD0/6cnWn9LZLsOsrRTXK2lKIAJ/4Q8/UDRQfBibXg
+        cahNPp96U68XRMoHwPcGw8EXK/DcBg9+fdWM0mp+zH65kx3i15HdvgTdJQzCNqBFbeR5Idk5HMXD
+        S75hg9kJo2RsnDi7vsCrW/xxTvsjaymdoyilm0R5Jl2drXtIY05HG4GbUvr3sNQN8yS2dldy/iY5
+        n9U3hRlhJ0hXmfYLsJ2LBsx7nxB80mkjBHvZH7p0ct0RpbQWMPjCeuz2p9bQsWu7oDe0G28WV2wp
+        uOpYT4y7N/Maf3Y8WG5MLhMDD/xUY2Iwx3P73J4NxSrhkTIR5hxkIkJlwpXmmd+14if559sMI8kL
+        JqpEAupi9MLUZWTOyjqrcsCiqTIrQGadsDKMRMgSyZWpxjZaUUuAu3cK0xsXAriKie2fiLMCpSKy
+        TUoTHJBByYoIuTsWXeKU1/aSjAy6DqWizGK8katVTh7BEnILTJdFKtBZYvfQ4Ae05nhrCCwB1Jgd
+        T8gwCMdgWLEtxuOSb8hFlnJrXWGQ04wrtmNgyGFh7LILZcjnxsMqBneKgkDaKEawoLbQPJpIAk2B
+        AO21dMfnHe8/ogrRdxAy8r5Ol7IsXV1yk9p6QPnJ724apjaXoeQeMu9r3fc8B71cFUip+8O/rhfL
+        K2d56aBF2yptlKQ6y2VGdXDI/SRSR+zw6AGJEud6jjQkBGxhUtPi2+2ti+CNu9j6uJMI0Cj3hPQR
+        aOYZuoGlokSW21u6lHhdL0YNj2/vaMyyx2vZ2P6FXXzF65odvEbnkz7fbgM4Oi5CSzltL6H0Wu9M
+        2FuO+ivMp/Mjwl6R0v/QJYnOvEPl0kjwp/927A+nk+mqP/HkUMw8MRsPglk/OIWeZhE0PLNMUnIt
+        fB860CnRNv3N+x1DAE0k69krhKrqXHRiu8wCXj3GjiTIIvf7o9HpREwn4+FsJVYTD+oDLoOpeOe/
+        tVLeDBdvBh/wqfY5CVc1UDtO9ci4hXFKBMIZuAT+blqs4khQpJyUc0OBwn7bi3Aq+PcM5eWmimLe
+        vo54+Ra37zNevsXt+5CXbjENgdVoX9PJM6Q+2FAQFEJEtoCoM1SDdoV4N3ZoPLgoMp3K3g2wSITb
+        SqP7OLxtSpc01JeQ+znoqAuhR133OqNmMM3qTvEKI78tYV5h5HdY/K9h5AcAAAD//xokLqZLMYJe
+        DOBq85mYYLRngN5Jh2TKatDEAZSNmCkHTW6im4KriWaAs1zC1XI0MMJe8uFsqSF8BgAAAP//QtOB
+        swkH9zKahDEuHcbwRl9qXllmUX4epGEHEUophc6sQ7jEhF5Zfgn1xn4hhsENBdoE7PCF5YPHi+Cj
+        lfm5ECdXw5jQ+oVsB4BXIejDzEVdVYHkWfBID3TpRS1kZB00GgTyOlwcVbMRim6oBrBrQbNvtFyZ
+        YalEanhgWZkBMgRtyBtU2YGTEiTKSViZYWioZ2ZsOroyY3RlBl4rR/rALbWmXEZXZoyuzCA9HmDT
+        8FhjYXRlBlG2jK7MGF2ZAZaAN7QR7hzKKzPMqLYyA9gUNDIxGV2ZgZAnfmUGAAAA//+CF/PUaSaM
+        rswY3CszsgbHygxDIz0LY4vRlRlUaOAPipUZRvhm6XCsBkCsrzAme2WGMWhlhvHoygx0XaMrM0ZX
+        ZoyuzMDVWh9dmQGt59GrAZJWZuAt80HxN7oyg86TZ5jDEYPfxejjGYPfxejjIYPdxaBOIM2nVEdX
+        ZgzRYgQAAAD//8KSYEaLEXq4mM7FCAAAAP//otjFdClG0IsBXG2+0ZUZCAm6rcygzUIJS5IXSlBx
+        hYgZUStEKF2ZEVsLAAAA//8DAB+M+iV+QwAA
     headers:
       Atl-Request-Id:
-      - b024bf78-55af-4311-9eec-06e433041949
+      - 1ab0c683-0f7f-4e43-8ad5-da93b3a539b1
       Atl-Traceid:
-      - b024bf7855af43119eec06e433041949
+      - 1ab0c6830f7f4e438ad5da93b3a539b1
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -1431,7 +1517,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:42 GMT
+      - Wed, 29 Jan 2025 20:45:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1441,7 +1527,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=409,atl-edge-internal;dur=13,atl-edge-upstream;dur=396,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=499,atl-edge-internal;dur=16,atl-edge-upstream;dur=483,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1453,7 +1539,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 988788be61269a4b2bfb9852d324f6fc
+      - f8670a958f7cb0e80a132e5b4738e9e4
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1481,17 +1567,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TpfvIDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04qJtgRuFn2
-        8/qxfCCVDLjtLBHkLcY2iMmkRo0q1v7dZzJaGYKRLnMYyYjUJrRW7v/BF9jtjMIaw8cabbtCF7H7
-        65KVd9r26BT+LrnDLhjvEkwBaAYZjIvN5WOxfih/ppu+qVJFxPMAjWAEL8mJrfX7Jl1Z7tvBtrK+
-        r1Oo6o2tvyJEpACbz0/NKxkHkAHLx0DHsCwZE3wqeBIDXECCUz6kP2BXmuacpVAyEDQXnGVswb9Z
-        1dw47RPI6WyhJGCOWtHpHCXXmmtQmi2n+aLSM45spoGdCaIdDLemk8MLUcvexjuv5NA+EHuqCLrX
-        bUGO54c9eTdMru9LcvwEAAD//wMA3LYyZyACAAA=
+        H4sIAAAAAAAAA5yQwUoDMRCG3yVX222SZtmam1SwilZhtxdFJJtMMJpNlk22UErf3QSL1pt6G2a+
+        f75h9qgVATaDRRy9xtgHPpsp0CCj8m++ENGKEIxwhYOIJkiZ0Fux+wdfw7A1EhSE9xXYfgkuwvDX
+        JUvvtB3BSfhdcgtDMN4lmGBMClzgab2+eKhX9833dD12baoQf8rQBE/wc3JCb/2uS1c2uz7bltaP
+        KoXa0Vj1GUE8BWhVHZuXImaQYlpOMZnSRUMYZ4TPFwXG+AwnOOVD+gMMjel+sOcNJZyVnLCCYfrF
+        yu7aaZ9AXZYEoJqTVoFkUgoAQdqF0uS8EpqwJNBtCfREEG023JhB5BeCFqONt16K3N4je6wQuJdN
+        jQ6nhz16lydXdw06fAAAAP//AwBRCcFyIAIAAA==
     headers:
       Atl-Request-Id:
-      - 56a92ebb-0d80-4a14-be44-24d868aa033f
+      - 841216f7-032d-4cd3-ae33-004340c3ab0d
       Atl-Traceid:
-      - 56a92ebb0d804a14be4424d868aa033f
+      - 841216f7032d4cd3ae33004340c3ab0d
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -1499,7 +1585,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:42 GMT
+      - Wed, 29 Jan 2025 20:45:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1509,7 +1595,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=164,atl-edge-internal;dur=22,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=151,atl-edge-internal;dur=14,atl-edge-upstream;dur=138,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1521,7 +1607,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - b77ef7609747894811d0ac7ba230183c
+      - 353f3bf5f2ae590f0c1aee49961249e2
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1628,9 +1714,9 @@ interactions:
         NNXWxgIAAAD//wMADdrZt2VyAAA=
     headers:
       Atl-Request-Id:
-      - e9d6aa9b-29d2-42a0-bbea-f5bfd047a96d
+      - d6ed07fd-4a02-4f87-b6aa-be078e2352fe
       Atl-Traceid:
-      - e9d6aa9b29d242a0bbeaf5bfd047a96d
+      - d6ed07fd4a024f87b6aabe078e2352fe
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -1638,7 +1724,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:42 GMT
+      - Wed, 29 Jan 2025 20:45:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1648,7 +1734,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=216,atl-edge-internal;dur=13,atl-edge-upstream;dur=203,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=240,atl-edge-internal;dur=15,atl-edge-upstream;dur=226,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1660,7 +1746,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - 29b795f14b715cfc907233c2771709e4
+      - 6d01592ec71d5dd2e52ff8c9ee34d256
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1684,57 +1770,56 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1600
+    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1825
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xXbW/jNgz+K4K/zolfkiZpgGHY2txwW68r2vT2YRgKxWYcXWTJk+QmWdf/PtIv
-        aZprNiS73TdLlEiKfPiQfvJgXXCVemPPgErBQPpOgEytr3gO1rfJAnLu6wIMd0Ir60MqXA6O+8mC
-        qwykzvxHMBZlkN5CYcCCcs3ZpLRO53NS+BCFYRR2DfxRgnXTTQE3hidOJOD5niD70SAc9XFhQc5x
-        uXCusOMgSGEOiUv1J93lTnJrBVddBS5ASy7ghQgkd/QprC0haLUsYYNKrqeTu2kH90Lcqvyw3vjJ
-        s+hgaRO8l2mzqR+S4gpvxGF81gmjThRO43AcnY17g+4oGnyDzpOOyohD7ys1x3oa107S/QD1hfH2
-        7c0iBZsYUVD0cPd7ZnMupc9SYZ1QiWOFgASYnrOVNssu3U60ujfySC9KJShnXD7wR+64CR4FrILK
-        rRcHG1EU9qLRd1b8Cd/mmPsyR6uEDTQ55XZJCStnjr7Gcy4t+F598T2+q7rrewuB6DHJYnMFj4C+
-        hs++V3DEm6MobpPf20/b2fn5KXhoolxBgXTu5L3Mc27IwgpgKTcMVMYzyMkTv0HFiYmtL1dZJZy8
-        TuRxiXoJ8A88WWKB7aKElNe2Lhr4/ieH2xoIWijGbQ4UrHAr0VKb69qbmSyhkxm+2UGAZpfae6Z8
-        GqGNcKd6014PKGFHxErkmD8b0A3bKhG4UUO1ax8peI2zH1r4VsHsec9fupwrgthN1H45z0TGSguG
-        IS2aDXML7pgCSC1zms2AzYxegmKpXqkuuzCAyUnZbMN+EoazOz13K6wa1sEDTGnHiIqZNiwFCQ6O
-        pINXkdu+wwZQiOR13Ca4Q6jbK/P9qo6eCQdOYNsoqtJWJXKXt9cDemErKIz+hK6dGPnm9ttx32GR
-        l2fcK+GoUVhva5va0M/VWdsEl94p8kIKdDjdYzQMbMUO/dG6PzrS3X9g3PYlW77th0N0I+6v4/7/
-        a6Vm9arHoMFosI4GX8PgurXYi9e9+GtYbBoX4XMfjtEhnMaHBL1WMBfrj/Xkg7D47XeESZYZyLBo
-        /7UIzloBvkzLsiaIt48ODgmGBwTxQcHokOD8c3fqcajepWGjGv+8cSfCJXc4FZ7aKOve/DKYBbU6
-        Q2VZfV7okgIXETv/ShtCZd7YmRIwfajUfcSMU3HWzlX6SL8RSR3Hp8/2yFe8bBe6lOmlsIXEJlYX
-        N0GiJlrv7eHvbBi2w99+2LZUti84BKp4C6ov1S5p1D2V9HfapdSr15x/pan7V6Tap0a5/5BtEUg+
-        A6JFwv/+uH8IutEhhEYjiseCW2o5V0It35HkEgr6NVFJm7Mqk6tKtt1RWk2wHfKZhFvgtsaBab68
-        m6v7H99fP1y9v5hc300eJre3v9zi+7BKLQYED0wXwG6qkZSRXSYs0woHROQSIUkpdeiqDd8YyJFM
-        qj5uu29xSoTl5IV/iTAs9HDs1T0Rc4fBf6mpV1yBaciE4nL/UPNj1YS3QrVE71q6wbxmOD60p8uC
-        ivZtHA+7o9GwxfFxg+7fAAAA///sWW1P20gQ/iv7pRIg7DiJQ16kqhcBVfsBHbq0RQIqtFmvsa/2
-        ruW164uOH99n1q4TTEyl+1AhHQKRyJ6dnZmdeeaZZS9v/P8SXaHTDLOuKvYn/aQFhecOtruoBYzH
-        4bxV25+jT3GRyKMFu7nm2XDBTrX+Fkt2FRdAtYKtpCjBDd8n/P6BooPgJFrwJNKmWMy8mTcIYxUA
-        Sgcjf/TVKjyzwYNff2tGabU4Yr9cyQ7w59AuX4H2EQZhGdCiMfKslOwMjuLhBd+woXfMKBlbJ06v
-        zvHqBh/OydC3ltI5ikq6aVzk0tX5/QBpzOloYzA2Sv8BRN2oSBNrd63nC+n5rL4pcOWdIF3mOijB
-        Ac7bwW7wCcGnPW2EYC/7oCun0D1RyhoFo69swG6ejIk9q7YCg7FdeL28ZCvBVY+8vbCYj1t/djxY
-        bUwhUwMPgkzHSLOjhX1uz4ZilfJYmRh8H5mIUJlorXke9Ek80X+2zTDSvGSiTiSgLkYQTB9GFqxq
-        sqoALJo6s0Jk1jGrolhELJVcmXp8IYlGA9y9VZhiuBDAVUwu32POSpSKyDcZTTJABiXrhuzuWHSB
-        U763N0Zk0FUkFWUW461erQryCJaQW+B/LFahzlO7hgYgoDXHW0NgCaDGDHVMhkE5BqS66zOeVHxD
-        LrKMW+tKg5xmXLEdAyMOCxOXnStDPrce1jG4VRQE2o1iBAsaC81PE0mhKRGgvZbu+Lzj/V+oQvQd
-        hIy8b9KlqipXV9xkth5QfvIfN4sym8vY5A4675q973gBmrMukVJ3B39eLVeXzurCQYu2Vdpukum8
-        kDnVwQEP0lgdsoPDByRKUugF0vApu5m0Lb7b3vpoz5DGlUdXN12BlvYSNhY5QN9yO+JmHVG/paSd
-        F16ro/uij214Lduwp2hJ137BPn7stcY86tpdUMdBcBHZyyTbGba3Tb9CbAoVkVCd/8ceR2TkHeqO
-        qPPH4O0kGM+ms/Vw6smxmHtiPhmF82F4gn1aIezwjJik1FgGAfZAn0PTCzZ/7BgCYCFdz47Fdc24
-        6KNWzMJVM5r5ElSPB0PfP5mK2XQynq/Feuph+5DLcCbeBW+tljfj5ZvRe/zW65yUqwZmHad+ZNzS
-        OBUC4Yxcgm43K9dJLChSTsa5oUBhve0kIIr4eoricDNFMe+O2C/f4u6M/vIt7s74L91iQFFQD4gN
-        GTxF6oPLhGEpRGwLiHC9HkhrILsGHYTgeZnrTA6uATEi2lYa3THhbVu6tENzlbafQfp9+Or3jZV+
-        312F32J43jSAV3z5bZn0ii+/w+JXfNmDL10Y8J/wF1h9X9fev3QZ3nz3sKEuePMvukbLDwAAAP//
-        gpuCs+WFs1zC2SQzwl7y4RoXMsDVFgUVCFglDOBeRpMwxqXDGN7IS80ryyzKz4M05CBCKaXQ+WEI
-        l6jQy8+FmFANY0KLezKKX6SpbX2YuTpKuYkVQanFpTkgg5HsBg+bFJU4lkDcUZZfgmesFgAAAP//
-        IsZepLFaiGFwQ4F2AbuNYfngUSfYcCpotBg0lgOyEu4QVNcaoTgXqgEcPLW1tQAAAAD//wMAm8Wf
-        eZMgAAA=
+        H4sIAAAAAAAAA7xXW3PqNhD+Kxq/1uALhEOY6XTaHE4nbZpmEnL60OlkhL0YHWTJleQATfPfu+sL
+        IQQ6Az3Nm6WVtLdvv10/ebAquEq9kWdApWAg/SRAptZXPAfr22QOOfd1AYY7oZX1IRUuB8f9ZM5V
+        BlJn/iMYizJIb6EwYEG55mxSWqfzGT34EIVhFHYN/FmCdZN1ATeGJ04k4PmeIP3RYBAOcWFBznA5
+        d66woyBIYQaJS/UX3eVOcmsFV10FLkBNLuCFCCR39CmsLSFoX1nAGh+5nozvJp1oGJ/hVmWH9UZP
+        nkUDS5vgvUybde1Iiiu8EYfxWSeMOvH5JI5G/bNROOz2o/Nv0PiQLCUlDq2vnjnW0rg2ku4H+F4Y
+        b3xvFinYxIiCooe73zObcyl9lgrrhEocKwQkwPSMLbVZdOl2otW9kUdaUSpBOePygT9yx03wKGAZ
+        VGa9GNiIorAXDb+z4i/4NsfclzlqJWygygm3C0pYOXX0NZpxacH36ouX6Fd11/fmAtFjkvn6Ch4B
+        bQ2ffa/giDdHUdwk/8PbtPVPwUMT5QoK9OZW3ss854Y0LAEWcs1AZTyDnCzxG1ScmNj6cpVVwsnr
+        RB6XqJcA/8CTBRbYNkro8VrXRQPf/2RwWwNBC8W4zYGCJW4lWmpzXVszlSV0MsPXWwjQ7KP2nimf
+        Rmgj3KnWtNeD3nGxEjnmzwZ0w7aPCNyoodq1jxS8xthfWvhWwex5z1+7nCuC2E7UbjlPRcZKC4Yh
+        LZo1c3PumAJILXOaTYFNjV6AYqleqi67MIDJSdl0zX4ShrM7PXNLrBrWwQNMaceIipk2LAUJDo6k
+        g1eR2/hhAyhE8jpuY9wh1O2U+W5VR8+EAyewbRRVaasSucvb6QG9sBUURn9B006MfHN7f9y3WOTF
+        jXslHDUK6210Uxv6uTprm+CSnyIvpECD0x1Gw8BW7NAfrvrDI839F8ZtPdnwbb9irbi/Qvr7X7XU
+        rF71GFQYDVbR4D0UrlqNvXjVi99DY9O4CJ+7cIwO4TRuBTOx+lwPOJj93/94e7LXnuRZZiDDon1T
+        BOiAlmXNA/vVnR0SDA4JPhwQxAcFw0OC87d21uNQvUvDRjX+eaNOhEvucCo8tVHWvfllMAvq5wyV
+        ZfV5oUsKXETs/BttCJV5I2dKwPTho+4zZpyKs/Glpklv/+gWDuJ2dNt1ekNEu4JDkIg3kPhazY7G
+        m1Mpe6vZSb18zdhXmnp3RYl9anO7jmwQK/kUiNT2wJq4YG8YokP4ioYUjzm31DCuhFp8IslHKOjH
+        QiXrDZ3auV5Wss2O0mqMzYxPJdwCt1QmTwjG+su7ubr/8fL64eryYnx9N34Y397+eov+YY1ZDAge
+        mMyB3VQDJSO9TFimFY53yARC0qPUX6smemMgRyqourDt7mOECIvBC/8WYWhm05FXdzTMHQb/pSJe
+        VTqmIROKy91DzW9RE94K9xKta9aU1wybf3u6LKjk9uP4vDsYfmhx/N5j6j8AAAD//+xZbWvbSBD+
+        K/ulkIRIlm05foHSmiTl7kNoOPcukKSE9UqK1Eq7QruqzrQ//p5Z6WRHtlK4DyUHISE20uzszOzM
+        M89s+rRu0+1/RFOFynJMqtIcTvpJCwrPHWx3UQsYT8N5L7c/J58Sk4YnC3Z3y/Phgp0r9TUJ2U1i
+        YlUatgpFCWb3IeWPPyg6CE6qBE9jpc1i5s28QZTIAEA4GI1Hn63CCxs8+PVFMUqrxQn76Up2hD/H
+        dvkKpI0wCMuAFo2RF2XILuAoHl7xDRvNTxklY+vE+c0lXt3hwzkb+tZSOkdRhW6WmCJ0VfE4QBpz
+        OtoEfIvSfwBRNzZZau2u9fxFev6UXyWY7k6QrgsVlOjgl+1YNviE4NOeNkKwl/2mKseonijljYLR
+        ZzZgd3tDXs+qrcBgbBfeLq/ZSnDZI2+vG+Ze68+OB6uNNmGm4UGQqwRpdrKwz+3ZUKwynkidgK0j
+        ExEqHa8VL4I+iT39F9sMI81LJupEAupigMDsoEPDqiarDGBR15kVIbNOWRUnImZZyKWuhw+SaDTA
+        3XuJGYQLAVzF3PEt4axEqYhik9McAmSQyDg6UnfHoiuc8qO97yGDbuJQUmYx3upV0pBHsITcAntj
+        iYxUkdk1NL4ArTneagJLADUmoFMyDMox3qBXlGnAeFrxDbnIcm6tKzVymnHJdgyMOSxMXXYpNfnc
+        eljH4F5SEGg3ihEsaCzU/5pICnWJAB20dMfnHe//QBWi7yBk5H2TLlVVuariOrf1gPIL/3bzOLe5
+        jE0eoPOh2fuBG1Mk6xIp9XD08Wa5unZWVw5atK3SdpNcFSYsqA6OeJAl8pgdHf9AoqRGLZCG++xm
+        0rb4bnvroz1DGjaeXLx0BVqKSthoCoC+ZWbf93uo18dm/ZZpdle0bMMeluVWhwX72IfXx269ds8n
+        XbsL6jgILmJ7FWQ7w/au6GeITaEiEqqK/9jjiIy8Q90R8f09eDsJxrPpbD2ceuFYzD0xn4yi+TA6
+        wz6tEHZ4Riyk1FgGAfZAn0PTCzbvdwwBsJCuZ4faumZc9FErZuGqGaz8EFSPB0PfP5uK2XQynq/F
+        euph+4iH0Uy8C95aLW/GyzejD/it1zkZlw3MOk79SLuldioEwhm5BN1uXq7TRFCknJxzTYHCettJ
+        QBTx9RzF4eaSYt4dkF++xd0J++Vb3J3QX7rFgKIg0XnKNw0ZPEfqg8tEUSlEYguIcL0eJ2sguwUd
+        hOBlWag8HNwCe0S8rTS6IcLbtnRph+Yi7DCD9Pvw1e8bK/12rCwanH+FkV+WMK8w8issfoWRAzDS
+        hYE+xub7e/wF7jzWRfmdrrKb7x4sUYY3/2DraumjZF4fLnmjGuD+AQAA//9CNwjXuJABTg/gbLLB
+        fYauA1dbzhinBLyRl5pXllmUnwdpyEGEUkqhs7sQLlGhl58LMaEaxoQW92SUy0gT0/owc3WUchMr
+        glKLS3NABiPZDR42KSpxLIG4oyy/hHojrRDD4IYC7coAAAAA//9KLA7LB486gQfiaiFjvaCxHJCV
+        cIegutYIxblQDeDgqa2tBQAAAP//AwDenZgOUSAAAA==
     headers:
       Atl-Request-Id:
-      - 04d520f6-2752-459b-bbcc-6de212d90a32
+      - bab75e9e-a5fe-47ea-a26d-f5ab3c9c24d4
       Atl-Traceid:
-      - 04d520f62752459bbbcc6de212d90a32
+      - bab75e9ea5fe47eaa26df5ab3c9c24d4
       Cache-Control:
       - no-cache, no-store, no-transform
       Content-Encoding:
@@ -1742,7 +1827,7 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:42 GMT
+      - Wed, 29 Jan 2025 20:45:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1752,7 +1837,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=290,atl-edge-internal;dur=22,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1"
+      - atl-edge;dur=332,atl-edge-internal;dur=12,atl-edge-upstream;dur=320,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1764,7 +1849,7 @@ interactions:
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
       X-Arequestid:
-      - a6f8d1a3f97ed13f9ab06f6304e94ca8
+      - f01a7f6b4b22ae7ed6cf29061a83ba29
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:


### PR DESCRIPTION
When attempting to create an Epic in Jira, this error was raised:
``"Field 'customfield_xyz' cannot be set. It is not on the appropriate screen, or unknown."``

The Jira integration needs a custom_field value for 'Epic Name'.  However, Jira Project settings might not actually use 'Epic Name' as a field when creating Epics.  Atlassian made a change in [*August 2023*](https://community.atlassian.com/t5/Jira-articles/Upcoming-changes-to-epic-fields-in-company-managed-projects/ba-p/1997562) which combined the 'Epic Name' and 'Epic Summary' fields.

Newer Jira Projects might not use this field when creating Epics by default, which results in this error message. It looks like they've just changed the default metadata required for Epic creation.  They've left things so that older Projects and API integrations will continue to work, but newer Projects have a different set of content required to create an issue by default.

In addition to this new change, Atlassion has also changed that way that "next-gen" issues can be added to epics, so we must support both. The error raised there is:
```
The request contains a next-gen issue. This operation can't add next-gen issues to epics.
To add a next-gen issue to an epic, use the Edit issue operation and set the parent property
(i.e., '"parent":{"key":"PROJ-123"}' where "PROJ-123" has an issue type at level one of the issue type hierarchy).
See <a href="https://developer.atlassian.com/cloud/jira/platform/rest/v2/"> developer.atlassian.com </a> for more details.
```
[sc-10058]