### PR TITLE
fix: media-pvc template extraLabels

### DIFF
--- a/helm/defectdojo/templates/media-pvc.yaml
+++ b/helm/defectdojo/templates/media-pvc.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ include "defectdojo.chart" $ }}
-    {{- with .Values.extraLabels }}
+    {{- with $.Values.extraLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   name: {{ $fullName }}


### PR DESCRIPTION
**Description**
- Currently when trying to use media-pvc template it fails with the following error:
```
install.go:214: [debug] Original chart version: ""

Error: template: defectdojo/templates/media-pvc.yaml:13:20: executing "defectdojo/templates/media-pvc.yaml" at <.Values.extraLabels>: nil pointer evaluating interface {}.extraLabels
helm.go:84: [debug] template: defectdojo/templates/media-pvc.yaml:13:20: executing "defectdojo/templates/media-pvc.yaml" at <.Values.extraLabels>: nil pointer evaluating interface {}.extraLabels
```
The main issue is related to having in the template the following:
```yaml
{{ with .Values.django.mediaPersistentVolume }}
```

the “dot” (.) now refers to .Values.django.mediaPersistentVolume. In other words, inside that with block, writing
```yaml
{{ .Values.extraLabels }}
```
will try to look up .extraLabels inside `.Values.django.mediaPersistentVolume`, rather than at the top-level values.

You can see that its already using `{{ $.Release.Name }}` and similar in the labels block, which explicitly steps back to the “root” context using the $.  `extraLabels` is defined at the top level of the values.yaml, then is also needed to use:
```yaml
{{- with $.Values.extraLabels }}
  {{- toYaml . | nindent 4 }}
{{- end }}
```

**Test results**

```yaml
# Source: defectdojo/templates/media-pvc.yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  labels:
    defectdojo.org/component: django
    app.kubernetes.io/name: defectdojo
    app.kubernetes.io/instance: dd
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: defectdojo-1.6.170
  name: dd-django-media
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 20Gi
```

**Documentation**

Please update any documentation when needed in the [documentation folder](https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs))

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.