### PR TITLE
feat(release): Label and group linters

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -60,3 +60,8 @@ localization:
     - any-glob-to-any-file:
       - dojo/locale/*
       - dojo/locale/**/*
+
+lint:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ruff.toml

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -41,6 +41,8 @@ categories:
     label: 'ui'
   - title: '🗣 Updates in localization'
     label: 'localization'
+  - title: '🔧 Improved code quality with linters'
+    label: 'lint'
   - title: '🧰 Maintenance'
     collapse-after: 3
     labels:


### PR DESCRIPTION
Changes in the `ruff.toml` file indicated that some improvement connected to linters was performed. Why not label these PRs and group them in release notes? It increases the readability of notes.