### PR TITLE
jira push error reasons should not be propagated to all channels

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -2983,7 +2983,7 @@ def finding_bulk_update_all(request, pid=None):
                         ) = jira_helper.can_be_pushed_to_jira(group)
                         if not can_be_pushed_to_jira:
                             error_counts[error_message] += 1
-                            jira_helper.log_jira_alert(error_message, group)
+                            jira_helper.log_jira_cannot_be_pushed_reason(error_message, group)
                         else:
                             logger.debug(
                                 "pushing to jira from finding.finding_bulk_update_all()",
@@ -3033,10 +3033,10 @@ def finding_bulk_update_all(request, pid=None):
                                 "finding already pushed as part of Finding Group"
                             )
                             error_counts[error_message] += 1
-                            jira_helper.log_jira_alert(error_message, finding)
+                            jira_helper.log_jira_cannot_be_pushed_reason(error_message, finding)
                         elif not can_be_pushed_to_jira:
                             error_counts[error_message] += 1
-                            jira_helper.log_jira_alert(error_message, finding)
+                            jira_helper.log_jira_cannot_be_pushed_reason(error_message, finding)
                         else:
                             logger.debug(
                                 "pushing to jira from finding.finding_bulk_update_all()",

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -547,6 +547,7 @@ def log_jira_cannot_be_pushed_reason(error, obj):
         obj=obj,
         alert_only=True)
 
+
 # Displays an alert for Jira notifications
 def log_jira_message(text, finding):
     create_notification(

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -513,8 +513,8 @@ def get_jira_comments(finding):
     return None
 
 
-# Logs the error to the alerts table, which appears in the notification toolbar
 def log_jira_generic_alert(title, description):
+    """Creates a notification for JIRA errors happening outside the scope of a specific (finding/group/epic) object"""
     create_notification(
         event="jira_update",
         title=title,
@@ -523,8 +523,8 @@ def log_jira_generic_alert(title, description):
         source="JIRA")
 
 
-# Logs the error to the alerts table, which appears in the notification toolbar
 def log_jira_alert(error, obj):
+    """Creates a notification for JIRA errors when handling a specific (finding/group/epic) object"""
     create_notification(
         event="jira_update",
         title="Error pushing to JIRA " + "(" + truncate_with_dots(prod_name(obj), 25) + ")",
@@ -534,6 +534,18 @@ def log_jira_alert(error, obj):
         source="Push to JIRA",
         obj=obj)
 
+
+def log_jira_cannot_be_pushed_reason(error, obj):
+    """Creates an Alert for GUI display  when handling a specific (finding/group/epic) object"""
+    create_notification(
+        event="jira_update",
+        title="Error pushing to JIRA " + "(" + truncate_with_dots(prod_name(obj), 25) + ")",
+        description=obj.__class__.__name__ + ": " + error,
+        url=obj.get_absolute_url(),
+        icon="bullseye",
+        source="Push to JIRA",
+        obj=obj,
+        alert_only=True)
 
 # Displays an alert for Jira notifications
 def log_jira_message(text, finding):
@@ -787,10 +799,12 @@ def add_jira_issue(obj, *args, **kwargs):
 
     obj_can_be_pushed_to_jira, error_message, _error_code = can_be_pushed_to_jira(obj)
     if not obj_can_be_pushed_to_jira:
+        # not sure why this check is not part of can_be_pushed_to_jira, but afraid to change it
         if isinstance(obj, Finding) and obj.duplicate and not obj.active:
             logger.warning("%s will not be pushed to JIRA as it's a duplicate finding", to_str_typed(obj))
+            log_jira_cannot_be_pushed_reason(error_message + " and findis a duplicate", obj)
         else:
-            log_jira_alert(error_message, obj)
+            log_jira_cannot_be_pushed_reason(error_message, obj)
             logger.warning("%s cannot be pushed to JIRA: %s.", to_str_typed(obj), error_message)
             logger.warning("The JIRA issue will NOT be created.")
         return False

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -54,6 +54,7 @@ def create_notification(
     no_users: bool = False,  # noqa: FBT001
     url: str | None = None,
     url_api: str | None = None,
+    alert_only: bool = False,  # noqa: FBT001
     **kwargs: dict,
 ) -> None:
     """Create an instance of a NotificationManager and dispatch the notification."""
@@ -86,6 +87,7 @@ def create_notification(
         no_users=no_users,
         url=url,
         url_api=url_api,
+        alert_only=alert_only,
         **kwargs,
     )
 
@@ -802,53 +804,9 @@ class NotificationManager(NotificationManagerHelpers):
         )
         logger.debug("process notifications for %s", notifications.user)
 
-        if self.system_settings.enable_slack_notifications and "slack" in getattr(
-            notifications,
-            event,
-            getattr(notifications, "other"),
-        ):
-            logger.debug("Sending Slack Notification")
-            self._get_manager_instance("slack").send_slack_notification(
-                event,
-                user=notifications.user,
-                **kwargs,
-            )
-
-        if self.system_settings.enable_msteams_notifications and "msteams" in getattr(
-            notifications,
-            event,
-            getattr(notifications, "other"),
-        ):
-            logger.debug("Sending MSTeams Notification")
-            self._get_manager_instance("msteams").send_msteams_notification(
-                event,
-                user=notifications.user,
-                **kwargs,
-            )
-
-        if self.system_settings.enable_mail_notifications and "mail" in getattr(
-            notifications,
-            event,
-            getattr(notifications, "other"),
-        ):
-            logger.debug("Sending Mail Notification")
-            self._get_manager_instance("mail").send_mail_notification(
-                event,
-                user=notifications.user,
-                **kwargs,
-            )
-
-        if self.system_settings.enable_webhooks_notifications and "webhooks" in getattr(
-            notifications,
-            event,
-            getattr(notifications, "other"),
-        ):
-            logger.debug("Sending Webhooks Notification")
-            self._get_manager_instance("webhooks").send_webhooks_notification(
-                event,
-                user=notifications.user,
-                **kwargs,
-            )
+        alert_only = kwargs.get("alert_only", False)
+        if alert_only:
+            logger.debug("sending alert only")
 
         if "alert" in getattr(notifications, event, getattr(notifications, "other")):
             logger.debug(f"Sending Alert to {notifications.user}")
@@ -857,6 +815,58 @@ class NotificationManager(NotificationManagerHelpers):
                 user=notifications.user,
                 **kwargs,
             )
+
+        # Some errors should not be pushed to all channels, only to alerts.
+        # For example reasons why JIRA Issues: https://github.com/DefectDojo/django-DefectDojo/issues/11575
+        if not alert_only:
+            if self.system_settings.enable_slack_notifications and "slack" in getattr(
+                notifications,
+                event,
+                getattr(notifications, "other"),
+            ):
+                logger.debug("Sending Slack Notification")
+                self._get_manager_instance("slack").send_slack_notification(
+                    event,
+                    user=notifications.user,
+                    **kwargs,
+                )
+
+            if self.system_settings.enable_msteams_notifications and "msteams" in getattr(
+                notifications,
+                event,
+                getattr(notifications, "other"),
+            ):
+                logger.debug("Sending MSTeams Notification")
+                self._get_manager_instance("msteams").send_msteams_notification(
+                    event,
+                    user=notifications.user,
+                    **kwargs,
+                )
+
+            if self.system_settings.enable_mail_notifications and "mail" in getattr(
+                notifications,
+                event,
+                getattr(notifications, "other"),
+            ):
+                logger.debug("Sending Mail Notification")
+                self._get_manager_instance("mail").send_mail_notification(
+                    event,
+                    user=notifications.user,
+                    **kwargs,
+                )
+
+            if self.system_settings.enable_webhooks_notifications and "webhooks" in getattr(
+                notifications,
+                event,
+                getattr(notifications, "other"),
+            ):
+                logger.debug("Sending Webhooks Notification")
+                self._get_manager_instance("webhooks").send_webhooks_notification(
+                    event,
+                    user=notifications.user,
+                    **kwargs,
+                )
+
 
 
 @app.task(ignore_result=True)

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -868,7 +868,6 @@ class NotificationManager(NotificationManagerHelpers):
                 )
 
 
-
 @app.task(ignore_result=True)
 def webhook_status_cleanup(*_args: list, **_kwargs: dict):
     # If some endpoint was affected by some outage (5xx, 429, Timeout) but it was clean during last 24 hours,

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -159,7 +159,7 @@
                                     {% if request.user.is_authenticated %}
                                         <li>
                                             <a href="{% url 'view_profile' %}">
-                                                <i class="fa-solid fa-user fa-fw"></i> 
+                                                <i class="fa-solid fa-user fa-fw"></i>
                                                 {{ request.user.username }}
                                             </a>
                                         </li>
@@ -438,7 +438,7 @@
                                                 </a>
                                                 <ul class="nav nav-second-level">
                                                     {% if "auth.view_user"|has_configuration_permission:request %}
-                                                        <li>    
+                                                        <li>
                                                             <a href="{% url 'users' %}">
                                                                 {% trans "Users" %}
                                                             </a>
@@ -666,7 +666,7 @@
                                             <a class="dropdown-toggle" data-toggle="dropdown" href="">
                                                 <span class="fa-solid fa-calendar-days" aria-hidden="true"></span>
                                                 <span class="hidden-xs">{% trans "Engagements" %}
-                                                    {% if product_tab.engagements > 0 %} 
+                                                    {% if product_tab.engagements > 0 %}
                                                         <span class="badge">{{ product_tab.engagements }}</span>
                                                     {% endif %}
                                                 </span>
@@ -1136,6 +1136,9 @@
                 {% endif %}
 
                 function htmlEscape(str) {
+                    if (!str) {
+                        return '';
+                    }
                     return str
                         .replace(/\n/g, " ")
                         .replace(/&/g, '&amp;')


### PR DESCRIPTION
**Description**

Historically the current notification system always propagates all messages to all channels configured for the notification type / source.
Some messages however are not relevant for all channels, for example reasons why findings cannot be pushed to JIRA.
But we do need to display these alerts in the UI because that's the only place where users can see feedback of these errors/warnings.
This PR introduces an `alert_only` flag to indicate that notifications should only be an alert.
It does reuse all the existing `NotificationManager` logic around System vs Personal notifications, templating and recipients.

This PR also fixes a bug where the "See All Alerts / Clear All Alerts" buttons where not shown due to a Javascript error.

Fixes #11575

**Test results**
Creating a unit test for this is currently not possible, unless I create a whole bunch of code to Mock more things.
I'm not sure if that's worth it for this small corner case situation.
I did test the different scenario's, and can still create JIRA issues: https://defectdojo.atlassian.net/browse/DOJOTEST-24

