### PR TITLE
Duplicate Delete errors: catch IntegrityErrors (A)

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -167,7 +167,7 @@ class ImportStatisticsSerializer(serializers.Serializer):
     )
     delta = DeltaStatisticsSerializer(
         required=False,
-        help_text="Finding statistics of modifications made by the reimport. Only available when TRACK_IMPORT_HISTORY has not disabled.",
+        help_text="Finding statistics of modifications made by the reimport. Only available when TRACK_IMPORT_HISTORY has not been disabled.",
     )
     after = SeverityStatusStatisticsSerializer(
         help_text="Finding statistics as stored in Defect Dojo after the import",

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -167,7 +167,7 @@ class ImportStatisticsSerializer(serializers.Serializer):
     )
     delta = DeltaStatisticsSerializer(
         required=False,
-        help_text="Finding statistics of modifications made by the reimport. Only available when TRACK_IMPORT_HISTORY hass not disabled.",
+        help_text="Finding statistics of modifications made by the reimport. Only available when TRACK_IMPORT_HISTORY has not disabled.",
     )
     after = SeverityStatusStatisticsSerializer(
         help_text="Finding statistics as stored in Defect Dojo after the import",

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -405,7 +405,7 @@ class BaseImporter(ImporterOptions):
         """Creates an import history record, while catching any IntegrityErrors that might happen because of the background job having deleted a finding"""
         logger.debug(f"creating Test_Import_Finding_Action for finding: {test_import_finding_action.finding.id} action: {test_import_finding_action.action}")
         try:
-            Test_Import_Finding_Action.create(test_import_finding_action)
+            Test_Import_Finding_Action.objects.create(test_import_finding_action)
         except IntegrityError as e:
             # This try catch makes us look we don't know what we're doing, but in https://github.com/DefectDojo/django-DefectDojo/issues/6217 we decided that for now this is the best solution
             logger.warning("Error creating Test_Import_Finding_Action: %s", e)

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -360,7 +360,6 @@ class BaseImporter(ImporterOptions):
         )
 
         # Create a history record for each finding
-        test_import_finding_action_list = []
         for finding in closed_findings:
             self.create_import_history_record_safe(Test_Import_Finding_Action(
                 test_import=test_import,
@@ -368,13 +367,13 @@ class BaseImporter(ImporterOptions):
                 action=IMPORT_CLOSED_FINDING,
             ))
         for finding in new_findings:
-            test_import_finding_action_list.append(Test_Import_Finding_Action(
+            self.create_import_history_record_safe(Test_Import_Finding_Action(
                 test_import=test_import,
                 finding=finding,
                 action=IMPORT_CREATED_FINDING,
             ))
         for finding in reactivated_findings:
-            test_import_finding_action_list.append(Test_Import_Finding_Action(
+            self.create_import_history_record_safe(Test_Import_Finding_Action(
                 test_import=test_import,
                 finding=finding,
                 action=IMPORT_REACTIVATED_FINDING,

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -367,7 +367,6 @@ class BaseImporter(ImporterOptions):
                 finding=finding,
                 action=IMPORT_CLOSED_FINDING,
             ))
-
         for finding in new_findings:
             test_import_finding_action_list.append(Test_Import_Finding_Action(
                 test_import=test_import,
@@ -401,7 +400,10 @@ class BaseImporter(ImporterOptions):
 
         return test_import
 
-    def create_import_history_record_safe(self, test_import_finding_action):
+    def create_import_history_record_safe(
+        self,
+        test_import_finding_action,
+    ):
         """Creates an import history record, while catching any IntegrityErrors that might happen because of the background job having deleted a finding"""
         logger.debug(f"creating Test_Import_Finding_Action for finding: {test_import_finding_action.finding.id} action: {test_import_finding_action.action}")
         try:
@@ -411,7 +413,11 @@ class BaseImporter(ImporterOptions):
             logger.warning("Error creating Test_Import_Finding_Action: %s", e)
             logger.debug("Error creating Test_Import_Finding_Action, finding marked as duplicate and deleted ?")
 
-    def add_tags_safe(self, finding_or_endpoint, tag):
+    def add_tags_safe(
+        self,
+        finding_or_endpoint,
+        tag,
+    ):
         """Adds tags to a finding or endpoint, while catching any IntegrityErrors that might happen because of the background job having deleted a finding"""
         if not isinstance(finding_or_endpoint, Finding) and not isinstance(finding_or_endpoint, Endpoint):
             msg = "finding_or_endpoint must be a Finding or Endpoint object"

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -405,7 +405,7 @@ class BaseImporter(ImporterOptions):
         """Creates an import history record, while catching any IntegrityErrors that might happen because of the background job having deleted a finding"""
         logger.debug(f"creating Test_Import_Finding_Action for finding: {test_import_finding_action.finding.id} action: {test_import_finding_action.action}")
         try:
-            Test_Import_Finding_Action.objects.create(test_import_finding_action)
+            test_import_finding_action.save()
         except IntegrityError as e:
             # This try catch makes us look we don't know what we're doing, but in https://github.com/DefectDojo/django-DefectDojo/issues/6217 we decided that for now this is the best solution
             logger.warning("Error creating Test_Import_Finding_Action: %s", e)

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -32,6 +32,7 @@ from dojo.models import (
 from dojo.notifications.helper import create_notification
 from dojo.tools.factory import get_parser
 from dojo.utils import max_safe
+from django.db import IntegrityError
 
 logger = logging.getLogger(__name__)
 
@@ -357,52 +358,74 @@ class BaseImporter(ImporterOptions):
             commit_hash=self.commit_hash,
             type=self.import_type,
         )
-        # Define all of the respective import finding actions for the test import object
+
+        # Create a history record for each finding
         test_import_finding_action_list = []
         for finding in closed_findings:
-            logger.debug(f"preparing Test_Import_Finding_Action for closed finding: {finding.id}")
-            test_import_finding_action_list.append(Test_Import_Finding_Action(
+            self.create_import_history_record_safe(Test_Import_Finding_Action(
                 test_import=test_import,
                 finding=finding,
                 action=IMPORT_CLOSED_FINDING,
             ))
+
         for finding in new_findings:
-            logger.debug(f"preparing Test_Import_Finding_Action for created finding: {finding.id}")
             test_import_finding_action_list.append(Test_Import_Finding_Action(
                 test_import=test_import,
                 finding=finding,
                 action=IMPORT_CREATED_FINDING,
             ))
         for finding in reactivated_findings:
-            logger.debug(f"preparing Test_Import_Finding_Action for reactivated finding: {finding.id}")
             test_import_finding_action_list.append(Test_Import_Finding_Action(
                 test_import=test_import,
                 finding=finding,
                 action=IMPORT_REACTIVATED_FINDING,
             ))
         for finding in untouched_findings:
-            logger.debug(f"preparing Test_Import_Finding_Action for untouched finding: {finding.id}")
-            test_import_finding_action_list.append(Test_Import_Finding_Action(
+            self.create_import_history_record_safe(Test_Import_Finding_Action(
                 test_import=test_import,
                 finding=finding,
                 action=IMPORT_UNTOUCHED_FINDING,
             ))
-        # Bulk create all the defined objects
-        Test_Import_Finding_Action.objects.bulk_create(test_import_finding_action_list)
 
         # Add any tags to the findings imported if necessary
         if self.apply_tags_to_findings and self.tags:
             for finding in test_import.findings_affected.all():
                 for tag in self.tags:
-                    finding.tags.add(tag)
+                    self.add_tags_safe(finding, tag)
         # Add any tags to any endpoints of the findings imported if necessary
         if self.apply_tags_to_endpoints and self.tags:
             for finding in test_import.findings_affected.all():
                 for endpoint in finding.endpoints.all():
                     for tag in self.tags:
-                        endpoint.tags.add(tag)
+                        self.add_tags_safe(endpoint, tag)
 
         return test_import
+
+    def create_import_history_record_safe(self, test_import_finding_action):
+        """Creates an import history record, while catching any IntegrityErrors that might happen because of the background job having deleted a finding"""
+        logger.debug(f"creating Test_Import_Finding_Action for finding: {test_import_finding_action.finding.id} action: {test_import_finding_action.action}")
+        try:
+            Test_Import_Finding_Action.create(test_import_finding_action)
+        except IntegrityError as e:
+            # This try catch makes us look we don't know what we're doing, but in https://github.com/DefectDojo/django-DefectDojo/issues/6217 we decided that for now this is the best solution
+            logger.warn("Error creating Test_Import_Finding_Action: %s", e)
+            logger.debug("Error creating Test_Import_Finding_Action, finding marked as duplicate and deleted ?")
+
+    def add_tags_safe(self, finding_or_endpoint, tag):
+        """Adds tags to a finding or endpoint, while catching any IntegrityErrors that might happen because of the background job having deleted a finding"""
+        if not isinstance(finding_or_endpoint, Finding) and not isinstance(finding_or_endpoint, Endpoint):
+            msg = "finding_or_endpoint must be a Finding or Endpoint object"
+            raise TypeError(msg)
+
+        msg = "finding" if isinstance(finding_or_endpoint, Finding) else "endpoint" if isinstance(finding_or_endpoint, Endpoint) else "unknown"
+        logger.debug(f" adding tag: {tag} to " + msg + f"{finding_or_endpoint.id}")
+
+        try:
+            finding_or_endpoint.tags.add(tag)
+        except IntegrityError as e:
+            # This try catch makes us look we don't know what we're doing, but in https://github.com/DefectDojo/django-DefectDojo/issues/6217 we decided that for now this is the best solution
+            logger.warn("Error adding tag: %s", e)
+            logger.debug("Error adding tag, finding marked as duplicate and deleted ?")
 
     def construct_imported_message(
         self,

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import TemporaryUploadedFile
+from django.db import IntegrityError
 from django.urls import reverse
 from django.utils.timezone import make_aware
 
@@ -32,7 +33,6 @@ from dojo.models import (
 from dojo.notifications.helper import create_notification
 from dojo.tools.factory import get_parser
 from dojo.utils import max_safe
-from django.db import IntegrityError
 
 logger = logging.getLogger(__name__)
 
@@ -408,7 +408,7 @@ class BaseImporter(ImporterOptions):
             Test_Import_Finding_Action.create(test_import_finding_action)
         except IntegrityError as e:
             # This try catch makes us look we don't know what we're doing, but in https://github.com/DefectDojo/django-DefectDojo/issues/6217 we decided that for now this is the best solution
-            logger.warn("Error creating Test_Import_Finding_Action: %s", e)
+            logger.warning("Error creating Test_Import_Finding_Action: %s", e)
             logger.debug("Error creating Test_Import_Finding_Action, finding marked as duplicate and deleted ?")
 
     def add_tags_safe(self, finding_or_endpoint, tag):
@@ -424,7 +424,7 @@ class BaseImporter(ImporterOptions):
             finding_or_endpoint.tags.add(tag)
         except IntegrityError as e:
             # This try catch makes us look we don't know what we're doing, but in https://github.com/DefectDojo/django-DefectDojo/issues/6217 we decided that for now this is the best solution
-            logger.warn("Error adding tag: %s", e)
+            logger.warning("Error adding tag: %s", e)
             logger.debug("Error adding tag, finding marked as duplicate and deleted ?")
 
     def construct_imported_message(


### PR DESCRIPTION
**Description**
Fixes and see: #6217

This PR catches integrity errors that might happen if the background dedupe delete job deletes findings before the import process is fully completed. In the absence of transactions, for now we implement this "fix".

**Test results**
Manual testing only as creating a unit test / integration test is not feasible within a reasonable timeframe.
