### PR TITLE
Duplicate Delete Errors: Inline import history + tags (B)

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -14,11 +14,6 @@ from dojo.importers.options import ImporterOptions
 from dojo.models import (
     # Import History States
     IMPORT_ACTIONS,
-    IMPORT_CLOSED_FINDING,
-    IMPORT_CREATED_FINDING,
-    IMPORT_REACTIVATED_FINDING,
-    IMPORT_UNTOUCHED_FINDING,
-    # Finding Severities
     SEVERITIES,
     BurpRawRequestResponse,
     Endpoint,
@@ -740,5 +735,3 @@ class BaseImporter(ImporterOptions):
             url=reverse("view_test", args=(test.id,)),
             url_api=reverse("test-detail", args=(test.id,)),
         )
-
-

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -317,32 +317,38 @@ class BaseImporter(ImporterOptions):
         self,
     ) -> Test_Import:
         """Creates a record of the import or reimport operation that has occurred."""
-        if settings.TRACK_IMPORT_HISTORY:
-            # Quick fail check to determine if we even wanted this
-            # Create a dictionary to stuff into the test import object
-            import_settings = {}
-            import_settings["active"] = self.active
-            import_settings["verified"] = self.verified
-            import_settings["minimum_severity"] = self.minimum_severity
-            import_settings["close_old_findings"] = self.close_old_findings_toggle
-            import_settings["push_to_jira"] = self.push_to_jira
-            import_settings["tags"] = self.tags
-            # Add the list of endpoints that were added exclusively at import time
-            if len(self.endpoints_to_add) > 0:
-                import_settings["endpoints"] = [str(endpoint) for endpoint in self.endpoints_to_add]
-            # Create the test import object
-            return Test_Import.objects.create(
-                test=self.test,
-                import_settings=import_settings,
-                version=self.version,
-                branch_tag=self.branch_tag,
-                build_id=self.build_id,
-                commit_hash=self.commit_hash,
-                type=self.import_type,
-            )
-        return None
+        if settings.TRACK_IMPORT_HISTORY is False:
+            return None
 
-    def create_import_history_record(self, test_import, finding, action):
+        # Quick fail check to determine if we even wanted this
+        # Create a dictionary to stuff into the test import object
+        import_settings = {}
+        import_settings["active"] = self.active
+        import_settings["verified"] = self.verified
+        import_settings["minimum_severity"] = self.minimum_severity
+        import_settings["close_old_findings"] = self.close_old_findings_toggle
+        import_settings["push_to_jira"] = self.push_to_jira
+        import_settings["tags"] = self.tags
+        # Add the list of endpoints that were added exclusively at import time
+        if len(self.endpoints_to_add) > 0:
+            import_settings["endpoints"] = [str(endpoint) for endpoint in self.endpoints_to_add]
+        # Create the test import object
+        return Test_Import.objects.create(
+            test=self.test,
+            import_settings=import_settings,
+            version=self.version,
+            branch_tag=self.branch_tag,
+            build_id=self.build_id,
+            commit_hash=self.commit_hash,
+            type=self.import_type,
+        )
+
+    def create_import_history_record(
+        self,
+        test_import,
+        finding,
+        action,
+    ) -> None:
         if settings.TRACK_IMPORT_HISTORY is False or test_import is None:
             return
 
@@ -358,7 +364,14 @@ class BaseImporter(ImporterOptions):
                 action=action,
         )
 
-    def finalize_import_history(self, test_import, new_findings, closed_findings, reactivated_findings, untouched_findings):
+    def finalize_import_history(
+        self,
+        test_import,
+        new_findings,
+        closed_findings,
+        reactivated_findings,
+        untouched_findings,
+    ) -> Test_Import:
         if settings.TRACK_IMPORT_HISTORY is False or test_import is None:
             return None
 

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -80,6 +80,9 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
             api_scan_configuration=self.api_scan_configuration,
             tags=self.tags,
         )
+
+        # Initialize the import history object, each finding will be added to this object
+        self.test_import_history = self.initialize_import_history()
         return self.test
 
     def process_scan(
@@ -104,8 +107,6 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         self.verify_tool_configuration_from_engagement()
         # Fetch the parser based upon the string version of the scan type
         parser = self.get_parser()
-        # Initialize the import history object, each finding will be added to this object
-        self.test_import_history = self.initialize_import_history()
         # Get the findings from the parser based on what methods the parser supplies
         # This could either mean traditional file parsing, or API pull parsing
         self.parsed_findings = self.parse_findings(scan, parser)


### PR DESCRIPTION
**Description**
Fixes and see: #6217

This PR replaces the bulk creation of the import history at the end of the (re)import with inline statements to create these records one by one. This prevents `IntegrityErrors` from happening during race conditions with the background duplicate delete job.

**Test results**
Manual testing only as creating a unit test / integration test is not feasible within a reasonable timeframe.
