### PR TITLE
API Tags: Add filter for `AND` expressions

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -137,6 +137,10 @@ class CharFieldInFilter(filters.BaseInFilter, filters.CharFilter):
 
 class CharFieldFilterANDExpression(CharFieldInFilter):
     def filter(self, queryset, value):
+        # Catch the case where a value if not supplied
+        if not value:
+            return queryset
+        # Do the filtering
         objects = value.split(",")
         return (
             queryset.filter(**{f"{self.field_name}__in": objects})
@@ -1217,15 +1221,15 @@ class ApiEngagementFilter(DojoFilter):
     tags = CharFieldInFilter(
         field_name="tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags")
+        help_text="Comma separated list of exact tags (uses OR for multiple values)")
     tags__and = CharFieldFilterANDExpression(
         field_name="tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression")
     product__tags = CharFieldInFilter(
         field_name="product__tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags present on product")
-    product__tags__and = CharFieldInFilter(
+        help_text="Comma separated list of exact tags present on product (uses OR for multiple values)")
+    product__tags__and = CharFieldFilterANDExpression(
         field_name="product__tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression present on product")
 
@@ -1387,7 +1391,7 @@ class ApiProductFilter(DojoFilter):
     tags = CharFieldInFilter(
         field_name="tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags")
+        help_text="Comma separated list of exact tags (uses OR for multiple values)")
     tags__and = CharFieldFilterANDExpression(
         field_name="tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression")
@@ -1537,23 +1541,29 @@ class ApiFindingFilter(DojoFilter):
     tags = CharFieldInFilter(
         field_name="tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags")
+        help_text="Comma separated list of exact tags (uses OR for multiple values)")
     tags__and = CharFieldFilterANDExpression(
         field_name="tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression")
-    test__tags = CharFieldInFilter(field_name="test__tags__name", lookup_expr="in", help_text="Comma separated list of exact tags present on test")
-    test__tags__and = CharFieldInFilter(field_name="test__tags__name", help_text="Comma separated list of exact tags to match with an AND expression present on test")
+    test__tags = CharFieldInFilter(
+        field_name="test__tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags present on test (uses OR for multiple values)")
+    test__tags__and = CharFieldFilterANDExpression(
+        field_name="test__tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression present on test")
     test__engagement__tags = CharFieldInFilter(
         field_name="test__engagement__tags__name",
-        help_text="Comma separated list of exact tags to match with an AND expression present on engagement")
-    test__engagement__tags__and = CharFieldInFilter(
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags present on engagement (uses OR for multiple values)")
+    test__engagement__tags__and = CharFieldFilterANDExpression(
         field_name="test__engagement__tags__name",
-        help_text="Comma separated list of exact tags present on engagement")
+        help_text="Comma separated list of exact tags to match with an AND expression present on engagement")
     test__engagement__product__tags = CharFieldInFilter(
         field_name="test__engagement__product__tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags present on product")
-    test__engagement__product__tags__and = CharFieldInFilter(
+        help_text="Comma separated list of exact tags present on product (uses OR for multiple values)")
+    test__engagement__product__tags__and = CharFieldFilterANDExpression(
         field_name="test__engagement__product__tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression present on product")
     not_tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Not Tag name contains", exclude="True")
@@ -2156,7 +2166,7 @@ class ApiTemplateFindingFilter(DojoFilter):
     tags = CharFieldInFilter(
         field_name="tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags")
+        help_text="Comma separated list of exact tags (uses OR for multiple values)")
     tags__and = CharFieldFilterANDExpression(
         field_name="tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression")
@@ -2737,7 +2747,7 @@ class ApiEndpointFilter(DojoFilter):
     tags = CharFieldInFilter(
         field_name="tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags")
+        help_text="Comma separated list of exact tags (uses OR for multiple values)")
     tags__and = CharFieldFilterANDExpression(
         field_name="tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression")
@@ -2897,21 +2907,22 @@ class ApiTestFilter(DojoFilter):
     tags = CharFieldInFilter(
         field_name="tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags")
+        help_text="Comma separated list of exact tags (uses OR for multiple values)")
     tags__and = CharFieldFilterANDExpression(
         field_name="tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression")
     engagement__tags = CharFieldInFilter(
         field_name="engagement__tags__name",
-        help_text="Comma separated list of exact tags to match with an AND expression present on engagement")
-    engagement__tags__and = CharFieldInFilter(
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags present on engagement (uses OR for multiple values)")
+    engagement__tags__and = CharFieldFilterANDExpression(
         field_name="engagement__tags__name",
-        help_text="Comma separated list of exact tags present on engagement")
+        help_text="Comma separated list of exact tags to match with an AND expression present on engagement")
     engagement__product__tags = CharFieldInFilter(
         field_name="engagement__product__tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags present on product")
-    engagement__product__tags__and = CharFieldInFilter(
+        help_text="Comma separated list of exact tags present on product (uses OR for multiple values)")
+    engagement__product__tags__and = CharFieldFilterANDExpression(
         field_name="engagement__product__tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression present on product")
 
@@ -2964,7 +2975,7 @@ class ApiAppAnalysisFilter(DojoFilter):
     tags = CharFieldInFilter(
         field_name="tags__name",
         lookup_expr="in",
-        help_text="Comma separated list of exact tags")
+        help_text="Comma separated list of exact tags (uses OR for multiple values)")
     tags__and = CharFieldFilterANDExpression(
         field_name="tags__name",
         help_text="Comma separated list of exact tags to match with an AND expression")

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -12,7 +12,7 @@ from django import forms
 from django.apps import apps
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import JSONField, Q
+from django.db.models import JSONField, Q, Count
 from django.forms import HiddenInput
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -134,6 +134,15 @@ class CharFieldInFilter(filters.BaseInFilter, filters.CharFilter):
     def __init__(self, *args, **kwargs):
         super(CharFilter, self).__init__(*args, **kwargs)
 
+
+class CharFieldFilterANDExpression(CharFieldInFilter):
+    def filter(self, queryset, value):
+        objects = value.split(',')
+        return (
+            queryset.filter(**{f"{self.field_name}__in": objects})
+            .annotate(object_count=Count(self.field_name))
+            .filter(object_count=len(objects))
+        )
 
 class FindingStatusFilter(ChoiceFilter):
     def any(self, qs, name):
@@ -1204,11 +1213,20 @@ class ProductEngagementFilterWithoutObjectLookups(ProductEngagementFilterHelper,
 class ApiEngagementFilter(DojoFilter):
     product__prod_type = NumberInFilter(field_name="product__prod_type", lookup_expr="in")
     tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Tag name contains")
-    tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
-                             help_text="Comma separated list of exact tags")
-    product__tags = CharFieldInFilter(field_name="product__tags__name",
-                                            lookup_expr="in",
-                                            help_text="Comma separated list of exact tags present on product")
+    tags = CharFieldInFilter(
+        field_name="tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags")
+    tags__and = CharFieldFilterANDExpression(
+        field_name="tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression")
+    product__tags = CharFieldInFilter(
+        field_name="product__tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags present on product")
+    product__tags__and = CharFieldInFilter(
+        field_name="product__tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression present on product")
 
     not_tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Not Tag name contains", exclude="True")
     not_tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
@@ -1365,9 +1383,13 @@ class ApiProductFilter(DojoFilter):
     regulations = NumberInFilter(field_name="regulations", lookup_expr="in")
 
     tag = CharFilter(field_name="tags__name", lookup_expr="icontains", label="Tag name contains")
-    tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
-                             help_text="Comma separated list of exact tags")
-
+    tags = CharFieldInFilter(
+        field_name="tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags")
+    tags__and = CharFieldFilterANDExpression(
+        field_name="tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression")
     not_tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Not Tag name contains", exclude="True")
     not_tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
                                  help_text="Comma separated list of exact tags not present on product", exclude="True")
@@ -1511,16 +1533,28 @@ class ApiFindingFilter(DojoFilter):
     risk_acceptance = extend_schema_field(OpenApiTypes.NUMBER)(ReportRiskAcceptanceFilter())
 
     tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Tag name contains")
-    tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
-                             help_text="Comma separated list of exact tags")
+    tags = CharFieldInFilter(
+        field_name="tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags")
+    tags__and = CharFieldFilterANDExpression(
+        field_name="tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression")
     test__tags = CharFieldInFilter(field_name="test__tags__name", lookup_expr="in", help_text="Comma separated list of exact tags present on test")
-    test__engagement__tags = CharFieldInFilter(field_name="test__engagement__tags__name", lookup_expr="in",
-                                               help_text="Comma separated list of exact tags present on engagement")
+    test__tags__and = CharFieldInFilter(field_name="test__tags__name", help_text="Comma separated list of exact tags to match with an AND expression present on test")
+    test__engagement__tags = CharFieldInFilter(
+        field_name="test__engagement__tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression present on engagement")
+    test__engagement__tags__and = CharFieldInFilter(
+        field_name="test__engagement__tags__name",
+        help_text="Comma separated list of exact tags present on engagement")
     test__engagement__product__tags = CharFieldInFilter(
         field_name="test__engagement__product__tags__name",
         lookup_expr="in",
         help_text="Comma separated list of exact tags present on product")
-
+    test__engagement__product__tags__and = CharFieldInFilter(
+        field_name="test__engagement__product__tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression present on product")
     not_tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Not Tag name contains", exclude="True")
     not_tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
                                  help_text="Comma separated list of exact tags not present on model", exclude="True")
@@ -2118,9 +2152,13 @@ class TemplateFindingFilter(DojoFilter):
 
 class ApiTemplateFindingFilter(DojoFilter):
     tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Tag name contains")
-    tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
-                             help_text="Comma separated list of exact tags")
-
+    tags = CharFieldInFilter(
+        field_name="tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags")
+    tags__and = CharFieldFilterANDExpression(
+        field_name="tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression")
     not_tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Not Tag name contains", exclude="True")
     not_tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
                                  help_text="Comma separated list of exact tags not present on model", exclude="True")
@@ -2695,9 +2733,13 @@ class EndpointFilterWithoutObjectLookups(EndpointFilterHelper):
 
 class ApiEndpointFilter(DojoFilter):
     tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Tag name contains")
-    tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
-                             help_text="Comma separated list of exact tags")
-
+    tags = CharFieldInFilter(
+        field_name="tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags")
+    tags__and = CharFieldFilterANDExpression(
+        field_name="tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression")
     not_tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Not Tag name contains", exclude="True")
     not_tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
                                  help_text="Comma separated list of exact tags not present on model", exclude="True")
@@ -2851,13 +2893,26 @@ class EngagementTestFilterWithoutObjectLookups(EngagementTestFilterHelper):
 
 class ApiTestFilter(DojoFilter):
     tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Tag name contains")
-    tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
-                             help_text="Comma separated list of exact tags")
-    engagement__tags = CharFieldInFilter(field_name="engagement__tags__name", lookup_expr="in",
-                                               help_text="Comma separated list of exact tags present on engagement")
-    engagement__product__tags = CharFieldInFilter(field_name="engagement__product__tags__name",
-                                                              lookup_expr="in",
-                                                              help_text="Comma separated list of exact tags present on product")
+    tags = CharFieldInFilter(
+        field_name="tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags")
+    tags__and = CharFieldFilterANDExpression(
+        field_name="tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression")
+    engagement__tags = CharFieldInFilter(
+        field_name="engagement__tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression present on engagement")
+    engagement__tags__and = CharFieldInFilter(
+        field_name="engagement__tags__name",
+        help_text="Comma separated list of exact tags present on engagement")
+    engagement__product__tags = CharFieldInFilter(
+        field_name="engagement__product__tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags present on product")
+    engagement__product__tags__and = CharFieldInFilter(
+        field_name="engagement__product__tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression present on product")
 
     not_tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Not Tag name contains", exclude="True")
     not_tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
@@ -2905,9 +2960,13 @@ class ApiTestFilter(DojoFilter):
 
 class ApiAppAnalysisFilter(DojoFilter):
     tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Tag name contains")
-    tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
-                             help_text="Comma separated list of exact tags")
-
+    tags = CharFieldInFilter(
+        field_name="tags__name",
+        lookup_expr="in",
+        help_text="Comma separated list of exact tags")
+    tags__and = CharFieldFilterANDExpression(
+        field_name="tags__name",
+        help_text="Comma separated list of exact tags to match with an AND expression")
     not_tag = CharFilter(field_name="tags__name", lookup_expr="icontains", help_text="Not Tag name contains", exclude="True")
     not_tags = CharFieldInFilter(field_name="tags__name", lookup_expr="in",
                                  help_text="Comma separated list of exact tags not present on model", exclude="True")

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -141,7 +141,7 @@ class CharFieldFilterANDExpression(CharFieldInFilter):
         if not value:
             return queryset
         # Do the filtering
-        objects = value.split(",")
+        objects = set(value.split(","))
         return (
             queryset.filter(**{f"{self.field_name}__in": objects})
             .annotate(object_count=Count(self.field_name))

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -12,7 +12,7 @@ from django import forms
 from django.apps import apps
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import JSONField, Q, Count
+from django.db.models import Count, JSONField, Q
 from django.forms import HiddenInput
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -137,12 +137,13 @@ class CharFieldInFilter(filters.BaseInFilter, filters.CharFilter):
 
 class CharFieldFilterANDExpression(CharFieldInFilter):
     def filter(self, queryset, value):
-        objects = value.split(',')
+        objects = value.split(",")
         return (
             queryset.filter(**{f"{self.field_name}__in": objects})
             .annotate(object_count=Count(self.field_name))
             .filter(object_count=len(objects))
         )
+
 
 class FindingStatusFilter(ChoiceFilter):
     def any(self, qs, name):

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -716,8 +716,8 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         response = self.do_finding_tags_api(self.client.get, finding_id)
         return response.data
 
-    def get_finding_api_filter_tags(self, tags):
-        response = self.client.get(reverse("finding-list") + f"?tags={tags}", format="json")
+    def get_finding_api_filter_tags(self, tags, parameter="tags"):
+        response = self.client.get(reverse("finding-list") + f"?{parameter}={tags}", format="json")
         self.assertEqual(200, response.status_code, response.content[:1000])
         return response.data
 

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -58,6 +58,12 @@ class TagTests(DojoAPITestCase):
 
         response = self.get_finding_api_filter_tags("tag4")
         self.assertEqual(response["count"], 0)
+        # Test the tags__and filter for a case with no matches
+        response = self.get_finding_api_filter_tags("tag2,tag3", parameter="tags__and")
+        self.assertEqual(response["count"], 0)
+        # Test the tags__and filter for a case with one exact match
+        response = self.get_finding_api_filter_tags("tag1,tag2", parameter="tags__and")
+        self.assertEqual(response["count"], 1)
 
     def test_finding_post_tags(self):
         # create finding


### PR DESCRIPTION
When using the `tags` filter on a finding, the operation applied with multiple tags is an `OR`, but an `AND` expression would be desired. To avoid creating some breaking changes, this PR adds new filters with the filters for `*tags__and` in all the places where tag filters are currently used

[sc-10134]