### PR TITLE
Ruff: Merge safe rules (A, FIX, PLW01)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -44,7 +44,7 @@ select = [
    "ASYNC",
    "S1", "S2", "S302", "S303", "S304", "S305", "S306", "S307", "S31", "S323", "S401", "S402", "S406", "S407", "S408", "S409", "S41", "S5", "S601", "S602", "S604", "S605", "S606", "S607", "S609", "S610", "S612", "S7",
    "FBT",
-   "A001", "A002", "A003", "A004", "A005", "A006",
+   "A",
    "COM",
    "C4",
    "T10",
@@ -70,13 +70,13 @@ select = [
    "ARG003", "ARG004", "ARG005",
    "PTH2", "PTH10", "PTH11", "PTH120", "PTH121", "PTH122", "PTH124",
    "TD001", "TD004", "TD005",
-   "FIX001", "FIX003",
+   "FIX",
    "PD",
    "PGH",
    "PLC01", "PLC0205", "PLC0208", "PLC0414", "PLC18", "PLC24", "PLC3",
    "PLE",
    "PLR01", "PLR0203", "PLR0206", "PLR04", "PLR0915", "PLR1716", "PLR172", "PLR1733", "PLR1736", "PLR6201",
-   "PLW0108", "PLW0120", "PLW0127", "PLW0129", "PLW013", "PLW017", "PLW02", "PLW04", "PLW07", "PLW1", "PLW2", "PLW3",
+   "PLW01", "PLW02", "PLW04", "PLW07", "PLW1", "PLW2", "PLW3",
    "TRY003", "TRY004", "TRY2", "TRY300", "TRY401",
    "FLY",
    "NPY",
@@ -94,6 +94,7 @@ ignore = [
     "RUF012",
     "RUF015",
     "D205",
+    "FIX002",  # TODOs need some love but we will probably not get of them
     "D211",  # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible.
     "D212",  # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible.
 ]


### PR DESCRIPTION
After many fixes, we can safely merge some rules without touching the code. I move `FIX002` so we can merge all `FIX` rules.