### PR TITLE
Sample Data: Remove audit logs entries

### DIFF
--- a/unittests/test_sample_data.py
+++ b/unittests/test_sample_data.py
@@ -11,6 +11,7 @@ class TestSampleData(DojoTestCase):
         python3 manage.py dumpdata \
             --exclude auth.permission \
             --exclude contenttypes \
+            --exclude auditlog.logentry \
             --natural-foreign \
             --natural-primary \
             --indent 2 \


### PR DESCRIPTION
For some reason, loading sample data in a local setting does not work with `auditlog.logentry` entries, but it has been working in out unit tests. This PR will remove all `auditlog.logentry` entries from the sample data to ensure that both cases can work.

[sc-10141]