### PR TITLE
Fix aria-label in search box

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -126,7 +126,7 @@
                                 <div class="custom-search-form">
                                     <form id="custom_search_form" role="search" method="get" action="{% url 'simple_search' %}">
                                         <div class="input-group">
-                                            <input id="simple_search" label="simple_search" aria_label="simple_search" type="text" name="query" class="form-control"
+                                            <input id="simple_search" label="simple_search" aria-label="simple_search" type="text" name="query" class="form-control"
                                                 placeholder="{% trans "Search" %}..." value="{{clean_query}}">
                                             <span class="input-group-btn">
                                                 <button id="simple_search_submit" class="btn btn-primary" type="submit" aria-label="Search">


### PR DESCRIPTION
**Description**

The "Search" text area has no labels corresponding to it. 
![image](https://github.com/user-attachments/assets/c93a16c5-2422-4912-8ad0-7e6ba20a2239)

**Accessibility Issue**

[Impact on users] If a form control does not have a properly associated text label, the function or purpose of that form control may not be presented to screen reader users. Form labels also provide visible descriptions and larger clickable targets for form control.

[Steps to reproduce] While using the WAVE addon for FireFox, run it on the page and you will get this error.

**Remediation**

The aria-label had a typo which was fixed.

