### PR TITLE
fix(sessions): Clean old expired sessions

### DIFF
--- a/dojo/db_migrations/0222_clean_old_sessions.py
+++ b/dojo/db_migrations/0222_clean_old_sessions.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dojo', '0221_system_settings_disclaimer_notif'),
+        ('sessions', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunSQL("DELETE FROM django_session WHERE expire_date < NOW();"),
+    ]

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1149,6 +1149,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "dojo.tasks.evaluate_pro_proposition",
         "schedule": timedelta(hours=8),
     },
+    "clear_sessions": {
+        "task": "dojo.tasks.clear_sessions",
+        "schedule": crontab(hour=0, minute=0, day_of_week=0),
+    },
     # 'jira_status_reconciliation': {
     #     'task': 'dojo.tasks.jira_status_reconciliation_task',
     #     'schedule': timedelta(hours=12),

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -5,6 +5,7 @@ from auditlog.models import LogEntry
 from celery.utils.log import get_task_logger
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
+from django.core.management import call_command
 from django.db.models import Count, Prefetch
 from django.urls import reverse
 from django.utils import timezone
@@ -216,3 +217,8 @@ def evaluate_pro_proposition(*args, **kwargs):
     # Update the announcement
     announcement.message = f'Only professionals have {object_count:,} Findings and Endpoints in their systems... <a href="https://www.defectdojo.com/pricing" target="_blank">Get DefectDojo Pro</a> today!'
     announcement.save()
+
+
+@app.task
+def clear_sessions(*args, **kwargs):
+    call_command("clearsessions")


### PR DESCRIPTION
I witnessed a situation when session table `django_session` increased to a size of 3.43GB with 10M tuples. It was the largest table in the whole DefectDojo.

After investigation, I found out that until the user does not log out proactively, the session is not removed even if it is expired:

> Clearing the session store[¶](https://docs.djangoproject.com/en/5.1/topics/http/sessions/#clearing-the-session-store)
> ... If you’re using the database backend, the django_session database table will grow. ...
> ... If the user logs out manually, Django deletes the row. **But if the user does not log out, the row never gets deleted**. ...
> **Django does not provide automatic purging of expired sessions**. Therefore, it’s your job to purge expired sessions on a regular basis. Django provides a clean-up management command for this purpose: [clearsessions](https://docs.djangoproject.com/en/5.1/ref/django-admin/#django-admin-clearsessions). It’s recommended to call this command on a regular basis, for example as a daily **cron job.**
> ...
https://docs.djangoproject.com/en/5.1/topics/http/sessions/#clearing-the-session-store

As soon I ran `./manage.py clearsessions`, the number of tuples jumped from 10M to 44.

So Inspired by [one blog](https://hodovi.cc/blog/simple-django-user-session-clearing-using-celery/), I implemented weekly clean-up.

_Why "dirty SQL" migration if you already added cronjob?_

Great question. When I ran `clearsessions`, it killed my Pod on OOM (multiple times with a gradual increase of memory limit). When I disabled the limiter for memory, Pod was willing to consume 9GB of memory and it was running over 3 hours. This procedure is not possible to execute in a regular migration Job. The reason for the long and memory-consuming procedure is the current implementation of `clearsessions`:

https://github.com/django/django/blob/0bac41fc7e4a842e8d20319cba31cc645501c245/django/contrib/sessions/management/commands/clearsessions.py#L16

https://github.com/django/django/blob/0bac41fc7e4a842e8d20319cba31cc645501c245/django/contrib/sessions/backends/db.py#L192

Not sure what is the real reason why `....filter(...).delete()` consumes that much memory and takes that much time (fetching all data before removal? or many SQL logs?) but as soon as I performed raw cleanup (used in migration) on the same dataset (restored from backups) removal jumped for 3 hours to 2 or 3 minutes.