### PR TITLE
Pin pyopenssl to something recent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,3 +74,4 @@ netaddr==1.3.0
 vulners==2.2.3
 fontawesomefree==6.6.0
 PyYAML==6.0.2
+pyopenssl==25.0.0


### PR DESCRIPTION
Fix #11799

For some reason pip was installing an old version of `pyopenssl`, something like `22.0.x`. With `pip freeze` I couldn't find any constraints that pointed to the need of an old version. This PR pins `pyopenssl` to `25.0.0` which also fixes #11799