### PR TITLE
Added accessibility for charts

### DIFF
--- a/dojo/static/dojo/js/metrics.js
+++ b/dojo/static/dojo/js/metrics.js
@@ -738,6 +738,83 @@ function accepted_per_week_2(critical, high, medium, low) {
         options);
 }
 
+
+// This function is valid besides metrics.js also for the dashboard-metrics.html, 
+// dashboard.html, and product-metrics.html
+function updatePunchcardTable(punchcardData, ticks) {
+    let tableBody = $("#punchcard-table tbody");
+
+    const daysMap = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+    let formattedData = {};
+    
+    // No table processing in case of no data
+    if (punchcardData.length === 0 || ticks.length === 0) return; 
+
+    // Removing html elements from the ticks dates
+    let ticksMap = {};
+    ticks.forEach(entry => {
+        let weekIndex = String(entry[0]);
+        let rawHtml = entry[1]; 
+
+        // Goodbye <span> + space instead of <br/> 
+        let cleanDate = rawHtml.replace(/<\/?span[^>]*>/g, "").replace(/<br\s*\/?>/g, " ");
+        cleanDate = cleanDate.trim();
+        ticksMap[weekIndex] = cleanDate;
+    });
+
+    let minWeekOffset = ticks[0][0]; 
+    let maxWeekOffset = ticks[ticks.length - 1][0]; 
+    
+    for (let weekOffset = minWeekOffset; weekOffset <= maxWeekOffset; weekOffset++) {
+        let formattedDate = ticksMap[String(weekOffset)] || "Unknown Date";
+        let formattedWeek = `Week ${weekOffset - minWeekOffset + 1}, starting on ${formattedDate}`;
+
+        formattedData[formattedWeek] = {
+            "Monday": 0, "Tuesday": 0, "Wednesday": 0,
+            "Thursday": 0, "Friday": 0, "Saturday": 0, "Sunday": 0
+        };
+    }
+
+    // Populating week data
+    punchcardData.forEach(entry => {
+        let weekOffset = entry[0]; 
+        let day = daysMap[entry[1]];
+        let value = entry[3] || 0;
+
+        let formattedDate = ticksMap[String(weekOffset)] || "Unknown Date";
+        let formattedWeek = `Week ${weekOffset - minWeekOffset + 1}, starting on ${formattedDate}`;
+
+        if (formattedData[formattedWeek]) {
+            formattedData[formattedWeek][day] = value;
+        }
+    });
+
+    // Rendering accessibility table body
+    Object.entries(formattedData).forEach(([week, values]) => {
+        let newRow = `
+            <tr>
+                <td scope="row">${week}</td>
+                <td>${values.Monday || '0'}</td>
+                <td>${values.Tuesday || '0'}</td>
+                <td>${values.Wednesday || '0'}</td>
+                <td>${values.Thursday || '0'}</td>
+                <td>${values.Friday || '0'}</td>
+                <td>${values.Saturday || '0'}</td>
+                <td>${values.Sunday || '0'}</td>
+            </tr>
+        `;
+        tableBody.append(newRow);
+    });
+}
+
+
+
+
+
+
+
+
+
 /*
         product_metrics.html
 */

--- a/dojo/static/dojo/js/metrics.js
+++ b/dojo/static/dojo/js/metrics.js
@@ -807,14 +807,6 @@ function updatePunchcardTable(punchcardData, ticks) {
     });
 }
 
-
-
-
-
-
-
-
-
 /*
         product_metrics.html
 */

--- a/dojo/static/dojo/js/metrics.js
+++ b/dojo/static/dojo/js/metrics.js
@@ -739,7 +739,7 @@ function accepted_per_week_2(critical, high, medium, low) {
 }
 
 
-// This function is valid besides metrics.js also for the dashboard-metrics.html, 
+// This function is valid besides metrics.html also for the dashboard-metrics.html, 
 // dashboard.html, and product-metrics.html
 function updatePunchcardTable(punchcardData, ticks) {
     let tableBody = $("#punchcard-table tbody");

--- a/dojo/templates/dojo/dashboard-metrics.html
+++ b/dojo/templates/dojo/dashboard-metrics.html
@@ -229,7 +229,7 @@
                         Severity{% endblocktrans %}</div>
                     <!-- /.panel-heading -->
                     <div class="panel-body">
-                        <div aria-describedby="top-ten-description" class="graph" id="top-ten" role="img" tabindex="0"></div>
+                        <div aria-labelledby="top-ten-title" aria-describedby="top-ten-description" class="graph" id="top-ten" role="img" tabindex="0"></div>
                     </div>
                     <div class="sr-only">
                         <h3 id="top-ten-title">{% trans "Top Products By Bug Severity" %}</h3>
@@ -275,7 +275,7 @@
                 <div class="panel-heading">{% trans "Total Findings In Period By Severity" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div aria-describedby="opened-in-period-description" class="graph" id="opened_in_period" role="img"
+                    <div aria-labelledby="severity-pie-title" aria-describedby="opened-in-period-description" class="graph" id="opened_in_period" role="img"
                         tabindex="0"></div>
                 </div>
                 <div class="sr-only">
@@ -297,7 +297,7 @@
                 <div class="panel-heading">{% trans "Total Findings Risk Accepted In Period By Severity" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div aria-describedby="total-accepted-in-period-description" class="graph" id="total_accepted_in_period"
+                    <div aria-labelledby="total-accepted-severity-pie-title" aria-describedby="total-accepted-in-period-description" class="graph" id="total_accepted_in_period"
                         role="img" tabindex="0">
                     </div>
                     <div class="sr-only">
@@ -322,7 +322,8 @@
                 <div class="panel-heading">{% trans "Total Findings Closed In Period By Severity" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div aria-describedby="total-closed-in-period-description" class="graph" id="total_closed_in_period"
+                    <div
+                    aria-labelledby="total-accepted-severity-pie-title" aria-describedby="total-closed-in-period-description" class="graph" id="total_closed_in_period"
                         role="img" tabindex="0">
                     </div>
                     <div class="sr-only">
@@ -348,7 +349,8 @@
                         {% trans "Weekly activity, displayed by day, of findings reported.*" %}
                     </div>
                     <div class="panel-body">
-                        <div aria-describedby="punchcard-description" class="graph-500" id="punchcard" role="img" tabindex="0">
+                        <div
+                        aria-labelledby="punchcard-title" aria-describedby="punchcard-description" class="graph-500" id="punchcard" role="img" tabindex="0">
                         </div>
                         <div class="sr-only">
                             <h3 id="punchcard-title">{% trans "Weekly Activity of Findings Reported" %}</h3>

--- a/dojo/templates/dojo/dashboard-metrics.html
+++ b/dojo/templates/dojo/dashboard-metrics.html
@@ -58,40 +58,163 @@
                 <div class="panel-heading">{% trans "Open Bug Count by Month" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div id="opened_per_month" class="graph"></div>
+                    <div aria-describedby="opened-per-month-description" aria-labelledby="opened-per-month-title"
+                        id="opened_per_month" class="graph" role="img" tabindex="0"></div>
+                    <div class="sr-only">
+                        <h3 id="opened-per-month-title">{% trans "Open Bug Count by Month" %}</h3>
+                        <p id="opened-per-month-description">{% trans "This graph represents the number of open bugs per month
+                            categorized by severity. The x-axis represents months, and the y-axis represents the number of open
+                            bugs. The table below provides the same data in text format." %}</p>
+                        <table id="opened-per-month-table" aria-labelledby="opened-per-month-title" tabindex="0">
+                            <caption>{% trans "Open bug count breakdown" %}</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">{% trans "Month" %}</th>
+                                    <th scope="col">{% trans "Critical" %}</th>
+                                    <th scope="col">{% trans "High" %}</th>
+                                    <th scope="col">{% trans "Medium" %}</th>
+                                    <th scope="col">{% trans "Low" %}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for month in opened_per_month %}
+                                <tr>
+                                    <td>{{ month.grouped_date|date:"F Y" }}</td>
+                                    <td>{{ month.critical }}</td>
+                                    <td>{{ month.high }}</td>
+                                    <td>{{ month.medium }}</td>
+                                    <td>{{ month.low }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
                 <!-- /.panel-body -->
             </div>
             <!-- /.panel -->
         </div>
+
         <div class="col-md-6">
             <div class="panel panel-default">
                 <div class="panel-heading">{% trans "Risk Accepted Bug Count by Month" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div id="accepted_per_month" class="graph"></div>
+                    <div aria-describedby="accepted-per-month-description" aria-labelledby="accepted-per-month-title"
+                        class="graph" id="accepted_per_month" role="img" tabindex="0"></div>
+                    <div class="sr-only">
+                        <h3 id="accepted-per-month-title">{% trans "Risk Accepted Bug Count by Month" %}</h3>
+                        <p id="accepted-per-month-description">{% trans "This graph represents the number of risk accepted bugs
+                            per month, categorized by severity. The x-axis represents months and the y-axis represents the
+                            number of accepted bugs. The table below provides the same data in text format." %}</p>
+                        <table id="accepted-per-month-table" aria-labelledby="accepted-per-month-title" tabindex="0">
+                            <caption>{% trans "Risk accepted bug count breakdown" %}</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">{% trans "Month" %}</th>
+                                    <th scope="col">{% trans "Critical" %}</th>
+                                    <th scope="col">{% trans "High" %}</th>
+                                    <th scope="col">{% trans "Medium" %}</th>
+                                    <th scope="col">{% trans "Low" %}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for month in accepted_per_month %}
+                                <tr>
+                                    <td>{{ month.grouped_date|date:"F Y" }}</td>
+                                    <td>{{ month.critical }}</td>
+                                    <td>{{ month.high }}</td>
+                                    <td>{{ month.medium }}</td>
+                                    <td>{{ month.low }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
                 <!-- /.panel-body -->
             </div>
             <!-- /.panel -->
         </div>
+
         <div class="col-md-12 section-start">
             <div class="panel panel-default">
                 <div class="panel-heading">{% trans "Open Bug Count by Week" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div id="opened_per_week" class="graph"></div>
+                    <div aria-describedby="opened-per-week-description" aria-labelledby="opened-per-week-title" class="graph"
+                        id="opened_per_week" role="img" tabindex="0"></div>
+                </div>
+                <div class="sr-only">
+                    <h3 id="opened-per-week-title">{% trans "Open Bug Count by Week" %}</h3>
+                    <p id="opened-per-week-description">{% trans "This graph represents the number of open bugs per week
+                        categorized by severity. The x-axis represents weeks and the y-axis represents the number of open bugs.
+                        The table below provides the same data in text format." %}</p>
+                    <table id="opened-per-week-table" aria-labelledby="opened-per-week-title" tabindex="0">
+                        <caption>{% trans "Open Bug Count Breakdown by Week" %}</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">{% trans "Week" %}</th>
+                                <th scope="col">{% trans "Critical" %}</th>
+                                <th scope="col">{% trans "High" %}</th>
+                                <th scope="col">{% trans "Medium" %}</th>
+                                <th scope="col">{% trans "Low" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for week in opened_per_week %}
+                            <tr>
+                                <td>{{ week.grouped_date|date:"W Y" }}</td>
+                                <td>{{ week.critical }}</td>
+                                <td>{{ week.high }}</td>
+                                <td>{{ week.medium }}</td>
+                                <td>{{ week.low }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
                 <!-- /.panel-body -->
             </div>
             <!-- /.panel -->
         </div>
+
         <div class="col-md-12 section-start">
             <div class="panel panel-default">
                 <div class="panel-heading">{% trans "Risk Accepted Bug Count by Week" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div id="accepted_per_week" class="graph"></div>
+                    <div aria-describedby="accepted-per-week-description" aria-labelledby="accepted-per-week-title"
+                        class="graph" id="accepted_per_week" role="img" tabindex="0"></div>
+                    <div class="sr-only">
+                        <h3 id="accepted-per-week-title">{% trans "Risk accepted bug count by week" %}</h3>
+                        <p id="accepted-per-week-description">{% trans "This graph represents the number of risk accepted bugs
+                            per week categorized by severity. The x-axis represents weeks and the y-axis represents the number
+                            of accepted bugs. The table below provides the same data in text format." %}</p>
+                        <table id="accepted-per-week-table" aria-labelledby="accepted-per-week-title" tabindex="0">
+                            <caption>{% trans "Risk accepted bug count breakdown by week" %}</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">{% trans "Week" %}</th>
+                                    <th scope="col">{% trans "Critical" %}</th>
+                                    <th scope="col">{% trans "High" %}</th>
+                                    <th scope="col">{% trans "Medium" %}</th>
+                                    <th scope="col">{% trans "Low" %}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for week in accepted_per_week %}
+                                <tr>
+                                    <td>{{ week.grouped_date|date:"W Y" }}</td>
+                                    <td>{{ week.critical }}</td>
+                                    <td>{{ week.high }}</td>
+                                    <td>{{ week.medium }}</td>
+                                    <td>{{ week.low }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
                 <!-- /.panel-body -->
             </div>
@@ -102,49 +225,122 @@
         {% if top_ten_products %}
             <div class="col-md-12 section-start">
                 <div class="panel panel-default">
-                    <div class="panel-heading">{% blocktrans with length=top_ten_products|length %}Top {{ length }} Products By Bug Severity{% endblocktrans %}</div>
+                    <div class="panel-heading">{% blocktrans with length=top_ten_products|length %}Top {{ length }} Products By Bug
+                        Severity{% endblocktrans %}</div>
                     <!-- /.panel-heading -->
                     <div class="panel-body">
-                        <div id="top-ten" class="graph"></div>
+                        <div aria-describedby="top-ten-description" class="graph" id="top-ten" role="img" tabindex="0"></div>
+                    </div>
+                    <div class="sr-only">
+                        <h3 id="top-ten-title">{% trans "Top Products By Bug Severity" %}</h3>
+                        <p id="top-ten-description">
+                            {% blocktrans %}
+                            This bar chart represents the number of bugs categorized by severity for the top {{ length }} products.
+                            The x-axiscrepresents different products, and the y-axis represents the count of bugs for each severity. 
+                            The following table represents the same data in text format.
+                            {% endblocktrans %}
+                        </p>
+                        <table id="top-ten-table" aria-labelledby="top-ten-title" tabindex="0">
+                            <caption>{% trans "Bug count by severity for top products" %}</caption>
+                            <thead>
+                                <tr>
+                                    <th>{% trans "Product" %}</th>
+                                    <th>{% trans "Critical" %}</th>
+                                    <th>{% trans "High" %}</th>
+                                    <th>{% trans "Medium" %}</th>
+                                    <th>{% trans "Low" %}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for product in top_ten_products %}
+                                <tr>
+                                    <td scope="row">{{ product.name }}</td>
+                                    <td scope="row">{{ product.critical|default_if_none:0 }}</td>
+                                    <td scope="row">{{ product.high|default_if_none:0 }}</td>
+                                    <td scope="row">{{ product.medium|default_if_none:0 }}</td>
+                                    <td scope="row">{{ product.low|default_if_none:0 }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
                     </div>
                     <!-- /.panel-body -->
                 </div>
                 <!-- /.panel -->
             </div>
         {% endif %}
+
         <div class="col-md-4 section-start">
             <div class="panel panel-default">
                 <div class="panel-heading">{% trans "Total Findings In Period By Severity" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div id="opened_in_period" class="graph"></div>
+                    <div aria-describedby="opened-in-period-description" class="graph" id="opened_in_period" role="img"
+                        tabindex="0"></div>
+                </div>
+                <div class="sr-only">
+                    <h3 id="severity-pie-title">{% trans "Total findings in period by severity" %}</h3>
+                    <p id="severity-pie-description">{% blocktrans with critical=in_period_counts.critical|default_if_none:0 high=in_period_counts.high|default_if_none:0 medium=in_period_counts.medium|default_if_none:0 low=in_period_counts.low|default_if_none:0 %}
+                        This pie chart represents the total number of findings categorized by severity. The following 
+                        findings are included: {{ critical }} critical, {{ high }} high, {{ medium }}
+                        medium, and {{ low }} low severity findings.
+                        {% endblocktrans %}
+                    </p>
                 </div>
                 <!-- /.panel-body -->
             </div>
             <!-- /.panel -->
         </div>
+
         <div class="col-md-4">
             <div class="panel panel-default">
                 <div class="panel-heading">{% trans "Total Findings Risk Accepted In Period By Severity" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div id="total_accepted_in_period" class="graph"></div>
+                    <div aria-describedby="total-accepted-in-period-description" class="graph" id="total_accepted_in_period"
+                        role="img" tabindex="0">
+                    </div>
+                    <div class="sr-only">
+                        <h3 id="total-accepted-severity-pie-title">{% trans "Total risk accepted findings in period by severity"
+                            %}</h3>
+                        <p id="total-accepted-in-period-description">
+                            {% blocktrans with critical=accepted_in_period_counts.critical|default_if_none:0 high=accepted_in_period_counts.high|default_if_none:0 medium=accepted_in_period_counts.medium|default_if_none:0 low=accepted_in_period_counts.low|default_if_none:0 %}
+                            This pie chart represents the total number of risk-accepted findings categorized by severity. The
+                            following findings are included: {{ critical }} critical, {{ high }} high, {{ medium }} medium 
+                            and {{ low }} low severity findings.
+                            {%endblocktrans %}
+                        </p>
+                    </div>
                 </div>
                 <!-- /.panel-body -->
             </div>
             <!-- /.panel -->
         </div>
+
         <div class="col-md-4">
             <div class="panel panel-default">
                 <div class="panel-heading">{% trans "Total Findings Closed In Period By Severity" %}</div>
                 <!-- /.panel-heading -->
                 <div class="panel-body">
-                    <div id="total_closed_in_period" class="graph"></div>
+                    <div aria-describedby="total-closed-in-period-description" class="graph" id="total_closed_in_period"
+                        role="img" tabindex="0">
+                    </div>
+                    <div class="sr-only">
+                        <h3 id="total-accepted-severity-pie-title">{% trans "Total closed in period by severity" %}</h3>
+                        <p id="total-accepted-in-period-description">
+                            {% blocktrans with critical=closed_in_period_counts.critical|default_if_none:0 high=closed_in_period_counts.high|default_if_none:0 medium=closed_in_period_counts.medium|default_if_none:0 low=closed_in_period_counts.low|default_if_none:0 %}
+                            This pie chart represents the total number of closed findings categorized by severity. The following
+                            findings are included: {{ critical }} critical, {{ high }} high {{ medium }} medium 
+                            and {{ low }} low severity findings.
+                            {% endblocktrans %}
+                        </p>
+                    </div>
                 </div>
                 <!-- /.panel-body -->
             </div>
             <!-- /.panel -->
         </div>
+
         {% if punchcard %}
             <div class="col-lg-12 section-start">
                 <div class="panel panel-default">
@@ -152,9 +348,47 @@
                         {% trans "Weekly activity, displayed by day, of findings reported.*" %}
                     </div>
                     <div class="panel-body">
-                        <div class="graph-500" id="punchcard"></div>
+                        <div aria-describedby="punchcard-description" class="graph-500" id="punchcard" role="img" tabindex="0">
+                        </div>
+                        <div class="sr-only">
+                            <h3 id="punchcard-title">{% trans "Weekly Activity of Findings Reported" %}</h3>
+                            <p id="punchcard-description">
+                                {% trans "This chart represents the weekly activity of findings reported, categorized by day of the
+                                week. The x-axis represents the days of the week, while the y-axis represents the corresponding week 
+                                number. The size of each data point indicates the number of findings reported on that particular day.
+                                The table below provides the same data in text format." %}
+                            </p>
+                            <table class="sr-only" id="punchcard-table" aria-labelledby="punchcard-table-caption" tabindex="0">
+                                <caption id="punchcard-table-caption">Weekly findings activity Breakdown</caption>
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Week</th>
+                                        <th scope="col">Monday</th>
+                                        <th scope="col">Tuesday</th>
+                                        <th scope="col">Wednesday</th>
+                                        <th scope="col">Thursday</th>
+                                        <th scope="col">Friday</th>
+                                        <th scope="col">Saturday</th>
+                                        <th scope="col">Sunday</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for week, values in punchcard.items %}
+                                    <tr>
+                                        <td scope="row">{{ week }}</td>
+                                        <td scope="row">{{ values.Sunday|default:"0" }}</td>
+                                        <td scope="row">{{ values.Monday|default:"0" }}</td>
+                                        <td scope="row">{{ values.Tuesday|default:"0" }}</td>
+                                        <td scope="row">{{ values.Wednesday|default:"0" }}</td>
+                                        <td scope="row">{{ values.Thursday|default:"0" }}</td>
+                                        <td scope="row">{{ values.Friday|default:"0" }}</td>
+                                        <td scope="row">{{ values.Saturday|default:"0" }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
                         <p class="text-center text-muted small"><br/>{% trans "Week begins on date displayed." %}</p>
-
                         <p>
                             <br/>
                             <span class="text-muted small">{% trans "* Weeks are only displayed if findings are available." %}</span>
@@ -169,20 +403,20 @@
 {% block postscript %}
     {{ block.super }}
     <!-- Flot Charts JavaScript -->
-    <script src="{% static "flot/excanvas.min.js" %}"></script>
-    <script src="{% static "flot/jquery.flot.js" %}"></script>
-    <script src="{% static "flot/jquery.flot.pie.js" %}"></script>
-    <script src="{% static "flot/jquery.flot.time.js" %}"></script>
-    <script src="{% static "jquery.flot.tooltip/js/jquery.flot.tooltip.min.js" %}"></script>
-    <script src="{% static "flot/jquery.flot.stack.js" %}"></script>
-    <script src="{% static "flot/jquery.flot.resize.js" %}"></script>
+    <script src="{% static 'flot/excanvas.min.js' %}"></script>
+    <script src="{% static 'flot/jquery.flot.js' %}"></script>
+    <script src="{% static 'flot/jquery.flot.pie.js' %}"></script>
+    <script src="{% static 'flot/jquery.flot.time.js' %}"></script>
+    <script src="{% static 'jquery.flot.tooltip/js/jquery.flot.tooltip.min.js' %}"></script>
+    <script src="{% static 'flot/jquery.flot.stack.js' %}"></script>
+    <script src="{% static 'flot/jquery.flot.resize.js' %}"></script>
     {% if punchcard %}
-        <script src="{% static "JUMFlot/javascripts/JUMFlot.min.js" %}"></script>
-        <script src="{% static "JUMFlot/javascripts/jquery.flot.mouse.js" %}"></script>
-        <script src="{% static "JUMFlot/javascripts/jquery.flot.bubbles.js" %}"></script>
+        <script src="{% static 'JUMFlot/javascripts/JUMFlot.min.js' %}"></script>
+        <script src="{% static 'JUMFlot/javascripts/jquery.flot.mouse.js' %}"></script>
+        <script src="{% static 'JUMFlot/javascripts/jquery.flot.bubbles.js' %}"></script>
     {% endif %}
     {% block metrics %}
-        <script src="{% static "dojo/js/metrics.js" %}"></script>
+        <script src="{% static 'dojo/js/metrics.js' %}"></script>
     {% endblock metrics %}
     <script>
         $(function () {
@@ -289,7 +523,10 @@
 
             {%  if punchcard %}
 
-                punchcard("#punchcard", {{ punchcard|safe }}, {{ ticks|safe }});
+                let punchcardData = {{ punchcard|safe }};
+                let ticksData = {{ ticks|safe }}
+                punchcard("#punchcard", punchcardData, ticksData);
+                updatePunchcardTable(punchcardData, ticksData);
 
             {%  endif %}
 

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -368,9 +368,9 @@
 
             {% if punchcard %}
                 let punchcardData = {{ punchcard|safe }};
-                let ticks = {{ ticks|safe }};
-                punchcard("#punchcard", punchcardData, ticks);
-                updatePunchcardTable(punchcardData, ticks);
+                let ticksData = {{ ticks|safe }};
+                punchcard("#punchcard", punchcardData, ticksData);
+                updatePunchcardTable(punchcardData, ticksData);
             {% endif %}
         });
 

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -117,12 +117,24 @@
             {% block historical_finding_severity %}
                 <div class="col-lg-6">
                     <div class="panel panel-default">
-                        <div class="panel-heading">
+                        <div class="panel-heading" id="homepage_pie_chart_heading">
                             {% trans "Historical Finding Severity" %}
                         </div>
                         <!-- /.panel-heading -->
                         <div class="panel-body">
-                            <div class="chart" id="homepage_pie_chart"></div>
+                            <p id="chart-description" class="sr-only">
+                                This pie chart represents findings categorized by severity: 
+                                critical ({{critical}}), high ({{high}}), medium ({{medium}}), 
+                                low ({{low}}), and informational ({{info}}).
+                            </p>
+                            <div 
+                                aria-describedby="chart-description"
+                                aria-labelledby="homepage_pie_chart_heading"
+                                class="chart" 
+                                id="homepage_pie_chart" 
+                                role="img"
+                                tabindex="0" >
+                            </div>
                         </div>
                         <!-- /.panel-body -->
                     </div>
@@ -132,12 +144,44 @@
             {% block reported_finding_severity_by_month %}
                 <div class="col-lg-6">
                     <div class="panel panel-default">
-                        <div class="panel-heading">
+                        <div class="panel-heading" id="severity-chart-heading">
                             {% trans "Reported Finding Severity by Month" %}
                         </div>
+                        <p id="severity-chart-description" class="sr-only">
+                            This severity trend chart shows monthly data for findings categorized by severity:
+                            critical, high, medium, and low. The table below the chart provides the data in text format.
+                        </p>
                         <!-- /.panel-heading -->
                         <div class="panel-body">
-                            <div class="chart" id="homepage_severity_plot"></div>
+                            <div class="chart" id="homepage_severity_plot" aria-describedby="severity-chart-description"
+                                aria-labelledby="severity-chart-heading" role="img" tabindex="0">
+                            </div>
+                            <div class="sr-only">
+                                <h3 id="severity-table-title">{% trans "Reported finding severity breakdown by month" %}</h3>
+                                <table id="severity-table" aria-labelledby="severity-table-title" tabindex="0">
+                                    <caption>{% trans "Reported finding severity breakdown" %}</caption>
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">{% trans "Month" %}</th>
+                                            <th scope="col">{% trans "Critical" %}</th>
+                                            <th scope="col">{% trans "High" %}</th>
+                                            <th scope="col">{% trans "Medium" %}</th>
+                                            <th scope="col">{% trans "Low" %}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for month in by_month %}
+                                        <tr>
+                                            <td>{{ month.y|slice:"5:" }} {{ month.y|slice:":4" }}</td>
+                                            <td>{{ month.a|default_if_none:0 }}</td>
+                                            <td>{{ month.b|default_if_none:0 }}</td>
+                                            <td>{{ month.c|default_if_none:0 }}</td>
+                                            <td>{{ month.d|default_if_none:0 }}</td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
                         <!-- /.panel-body -->
                     </div>
@@ -233,11 +277,46 @@
             {% if punchcard %}
                 <div class="col-lg-12">
                     <div class="panel panel-default">
-                        <div class="panel-heading">
+                        <div class="panel-heading" id="punchcard-heading">
                             {% trans "Weekly activity, displayed by day, of findings you reported." %}*
                         </div>
                         <div class="panel-body">
-                            <div class="chart" id="punchcard"></div>
+                            <p id="punchcard-description" class="sr-only">
+                                This punchcard chart represents findings distribution over time by week.
+                                The table below the chart provides the data in text format.
+                            </p>
+                            <div class="chart" id="punchcard" role="img" aria-labelledby="punchcard-heading"
+                                aria-describedby="punchcard-description">
+                            </div>
+                            <table class="sr-only" id="punchcard-table" aria-labelledby="punchcard-table-caption" tabindex="0">
+                                <caption id="punchcard-table-caption">Weekly findings activity breakdown</caption>
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Week</th>
+                                        <th scope="col">Monday</th>
+                                        <th scope="col">Tuesday</th>
+                                        <th scope="col">Wednesday</th>
+                                        <th scope="col">Thursday</th>
+                                        <th scope="col">Friday</th>
+                                        <th scope="col">Saturday</th>
+                                        <th scope="col">Sunday</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for week, values in punchcard.items %}
+                                    <tr>
+                                        <td scope="row">{{ week }}</td>
+                                        <td>{{ values.Sunday|default:"0" }}</td>
+                                        <td>{{ values.Monday|default:"0" }}</td>
+                                        <td>{{ values.Tuesday|default:"0" }}</td>
+                                        <td>{{ values.Wednesday|default:"0" }}</td>
+                                        <td>{{ values.Thursday|default:"0" }}</td>
+                                        <td>{{ values.Friday|default:"0" }}</td>
+                                        <td>{{ values.Saturday|default:"0" }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
                             <p class="text-center text-muted small">{% trans "Week begins on date displayed." %}</p>
                             <p>
                                 <br/>
@@ -288,7 +367,10 @@
             homepage_severity_plot(critical, high, medium, low);
 
             {% if punchcard %}
-                punchcard("#punchcard", {{ punchcard|safe }}, {{ ticks|safe }});
+                let punchcardData = {{ punchcard|safe }};
+                let ticks = {{ ticks|safe }};
+                punchcard("#punchcard", punchcardData, ticks);
+                updatePunchcardTable(punchcardData, ticks);
             {% endif %}
         });
 

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -110,6 +110,10 @@
     *border-left-color: #ffffff;
     }
 
+    h3 {
+        margin-bottom: 10px; 
+    }
+
     #opened_per_month_2, #active_per_month, #accepted_per_month_2, #opened_per_week_2, #accepted_per_week_2 {height: 300px}
 {% endblock %}
 {% block content %}
@@ -163,7 +167,7 @@
                     {% for c_prod in critical_prods %}
                         <div class='col-md-4' align="center">
                             <h3>{{ c_prod.name }} </h3>
-                            <div aria-labelledby="gauge-description-{{ c_prod.id }}" style="display:inline-block;" class="gaugeloop 200x160px"
+                            <div aria-label="Health gauge for {{ c_prod.name }}" aria-describedby="gauge-description-{{ c_prod.id }}" style="display:inline-block;" class="gaugeloop 200x160px"
                                 name="{{ c_prod.name }}" id="{{ c_prod.name }}{{ c_prod.id }}" role="img" start="{{ c_prod.calc_health }}"
                                 tabindex="0">
                             </div>

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -223,7 +223,7 @@
                             <div class="panel-heading">{% trans "Open Bug Count by Month" %}</div>
                             <!-- /.panel-heading -->
                             <div class="panel-body">
-                                <div aria-describedby="opened_per_month_2-description" id="opened_per_month_2" role="img" tabindex="0">
+                                <div aria-describedby="opened_per_month_2-description" aria-labelledby="opened-per-month-title" id="opened_per_month_2" role="img" tabindex="0">
                                 </div>
                                 <div class="sr-only">
                                     <h3 id="opened-per-month-title">{% trans "Open bug count by month" %}</h3>
@@ -269,6 +269,7 @@
                             <!-- /.panel-heading -->
                             <div class="panel-body">
                                 <div
+                                aria-labelledby="active-per-month-title"
                                 aria-describedby="active-per-month-description"
                                 id="active_per_month"
                                 role="img"
@@ -320,11 +321,12 @@
                             <!-- /.panel-heading -->
                             <div class="panel-body">
                                 <div
+                                aria-labelledby="accepted-per-month-title"
                                 aria-describedby="accepted-per-month-description"
                                 id="accepted_per_month_2"
                                 role="img"
                                 tabindex="0">
-                                ></div>
+                                </div>
                                 <div class="sr-only">
                                     <h3 id="accepted-per-month-title">{% trans "Risk accepted bug count by month" %}</h3>
                                     <p id="accepted-per-month-description">
@@ -371,11 +373,12 @@
                             <!-- /.panel-heading -->
                             <div class="panel-body">
                                 <div
+                                aria-labelledby="opened-per-week-title"
                                 aria-describedby="opened-per-week-description"
                                 id="opened_per_week_2"
                                 role="img"
                                 tabindex="0">
-                                ></div>
+                                </div>
                                 <div class="sr-only">
                                     <h3 id="opened-per-week-title">{% trans "Open bug count by week" %}</h3>
                                     <p id="opened-per-week-description">
@@ -420,6 +423,7 @@
                             <!-- /.panel-heading -->
                             <div class="panel-body">
                                 <div
+                                aria-labelledby="accepted-per-week-title"
                                 aria-describedby="accepted-per-week-description"
                                 id="accepted_per_week_2"
                                 role="img"

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -162,10 +162,16 @@
                 <div class="row">
                     {% for c_prod in critical_prods %}
                         <div class='col-md-4' align="center">
-                            <div><b>{{ c_prod.name }} </b><br><br></div>
-                            <div style="display:inline-block;" class="gaugeloop" name="{{ c_prod.name }}"
-                                 id="{{ c_prod.name }}{{ c_prod.id }}" class="200x160px"
-                                 start="{{ c_prod.calc_health }}"></div>
+                            <h3>{{ c_prod.name }} </h3>
+                            <div aria-labelledby="gauge-description-{{ c_prod.id }}" style="display:inline-block;" class="gaugeloop 200x160px"
+                                name="{{ c_prod.name }}" id="{{ c_prod.name }}{{ c_prod.id }}" role="img" start="{{ c_prod.calc_health }}"
+                                tabindex="0">
+                            </div>
+                            <p id="gauge-description-{{ c_prod.id }}" class="sr-only">
+                                {% blocktrans with name=c_prod.name health=c_prod.calc_health %}
+                                The security health score for {{ name }} is {{ health }} percent.
+                                {% endblocktrans %}
+                            </p>
                             <div>
                                 {% if c_prod.critical_present and c_prod.high_present %}
                                     <p>{% blocktranslate with name=c_prod.name%}{{ name }} is affected by <b>both</b> critical and
@@ -213,11 +219,43 @@
                             <div class="panel-heading">{% trans "Open Bug Count by Month" %}</div>
                             <!-- /.panel-heading -->
                             <div class="panel-body">
-                                <div id="opened_per_month_2"></div>
-                            </div>
-                            <!-- /.panel-body -->
+                                <div aria-describedby="opened_per_month_2-description" id="opened_per_month_2" role="img" tabindex="0">
+                                </div>
+                                <div class="sr-only">
+                                    <h3 id="opened-per-month-title">{% trans "Open bug count by month" %}</h3>
+                                    <p id="opened-per-month-description">
+                                        {% trans "This line chart represents the number of open bugs over time, categorized by severity.
+                                        The x-axis represents months, while the y-axis represents the number of open bugs.
+                                        The table below provides the same data in text format." %}
+                                    </p>
+                                    <table id="opened-per-month-table" aria-labelledby="opened-per-month-title" tabindex="0">
+                                        <caption>{% trans "Open bug count breakdown" %}</caption>
+                                        <thead>
+                                            <tr>
+                                                <th scope="col">{% trans "Month" %}</th>
+                                                <th scope="col">{% trans "Critical" %}</th>
+                                                <th scope="col">{% trans "High" %}</th>
+                                                <th scope="col">{% trans "Medium" %}</th>
+                                                <th scope="col">{% trans "Low" %}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for month in opened_per_month %}
+                                            <tr>
+                                                <td scope="row">{{ month.grouped_date|date:"F Y" }}</td>
+                                                <td>{{ month.critical|default:"0" }}</td>
+                                                <td>{{ month.high|default:"0" }}</td>
+                                                <td>{{ month.medium|default:"0" }}</td>
+                                                <td>{{ month.low|default:"0" }}</td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>                    
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.panel-body -->
+                    </div>
+                    <!-- /.panel -->
                     </div>
                 {% endif %}
                 {% if active_per_month %}
@@ -226,7 +264,43 @@
                             <div class="panel-heading">{% trans "Active Bug Count by Month" %}</div>
                             <!-- /.panel-heading -->
                             <div class="panel-body">
-                                <div id="active_per_month"></div>
+                                <div
+                                aria-describedby="active-per-month-description"
+                                id="active_per_month"
+                                role="img"
+                                tabindex="0">
+                            </div>
+                            <div class="sr-only">
+                                <h3 id="active-per-month-title">{% trans "Active Bug Count by Month" %}</h3>
+                                <p id="active-per-month-description">
+                                    {% trans "This graph represents the number of active bugs per month categorized by severity.
+                                    The x-axis represents months, and the y-axis represents the number of active bugs.
+                                    The table below provides the same data in text format." %}
+                                </p>
+                                <table id="active-per-month-table" aria-labelledby="active-per-month-title" tabindex="0">
+                                    <caption>{% trans "Active bug count breakdown" %}</caption>
+                                    <thead>
+                                        <tr>
+                                            <th scope="col">{% trans "Month" %}</th>
+                                            <th scope="col">{% trans "Critical" %}</th>
+                                            <th scope="col">{% trans "High" %}</th>
+                                            <th scope="col">{% trans "Medium" %}</th>
+                                            <th scope="col">{% trans "Low" %}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for month in active_per_month %}
+                                        <tr>
+                                            <td>{{ month.grouped_date|date:"F Y" }}</td> 
+                                            <td>{{ month.critical|default:"0" }}</td>
+                                            <td>{{ month.high|default:"0" }}</td>
+                                            <td>{{ month.medium|default:"0" }}</td>
+                                            <td>{{ month.low|default:"0" }}</td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
                             </div>
                             <!-- /.panel-body -->
                         </div>
@@ -241,7 +315,43 @@
                             </div>
                             <!-- /.panel-heading -->
                             <div class="panel-body">
-                                <div id="accepted_per_month_2"></div>
+                                <div
+                                aria-describedby="accepted-per-month-description"
+                                id="accepted_per_month_2"
+                                role="img"
+                                tabindex="0">
+                                ></div>
+                                <div class="sr-only">
+                                    <h3 id="accepted-per-month-title">{% trans "Risk accepted bug count by month" %}</h3>
+                                    <p id="accepted-per-month-description">
+                                        {% trans "This graph represents the number of risk accepted bugs per month categorized by severity.
+                                        The x-axis represents months, and the y-axis represents the number of risk-accepted bugs.
+                                        The table below provides the same data in text format." %}
+                                    </p>
+                                    <table id="accepted-per-month-table" aria-labelledby="accepted-per-month-title" tabindex="0">
+                                        <caption>{% trans "Risk Accepted Bug Count Breakdown" %}</caption>
+                                        <thead>
+                                            <tr>
+                                                <th scope="col">{% trans "Month" %}</th>
+                                                <th scope="col">{% trans "Critical" %}</th>
+                                                <th scope="col">{% trans "High" %}</th>
+                                                <th scope="col">{% trans "Medium" %}</th>
+                                                <th scope="col">{% trans "Low" %}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for month in accepted_per_month %}
+                                            <tr>
+                                                <td>{{ month.grouped_date|date:"F Y" }}</td> 
+                                                <td>{{ month.critical|default:"0" }}</td>
+                                                <td>{{ month.high|default:"0" }}</td>
+                                                <td>{{ month.medium|default:"0" }}</td>
+                                                <td>{{ month.low|default:"0" }}</td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
                             </div>
                             <!-- /.panel-body -->
                         </div>
@@ -256,7 +366,43 @@
                             </div>
                             <!-- /.panel-heading -->
                             <div class="panel-body">
-                                <div id="opened_per_week_2"></div>
+                                <div
+                                aria-describedby="opened-per-week-description"
+                                id="opened_per_week_2"
+                                role="img"
+                                tabindex="0">
+                                ></div>
+                                <div class="sr-only">
+                                    <h3 id="opened-per-week-title">{% trans "Open bug count by week" %}</h3>
+                                    <p id="opened-per-week-description">
+                                        {% trans "This graph represents the number of open bugs per week categorized by severity.
+                                        The x-axis represents weeks, and the y-axis represents the number of open bugs.
+                                        The table below provides the same data in text format." %}
+                                    </p>
+                                    <table id="opened-per-week-table" aria-labelledby="opened-per-week-title" tabindex="0">
+                                        <caption>{% trans "Open bug count breakdown by week" %}</caption>
+                                        <thead>
+                                            <tr>
+                                                <th scope="col">{% trans "Week" %}</th>
+                                                <th scope="col">{% trans "Critical" %}</th>
+                                                <th scope="col">{% trans "High" %}</th>
+                                                <th scope="col">{% trans "Medium" %}</th>
+                                                <th scope="col">{% trans "Low" %}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for week in opened_per_week %}
+                                            <tr>
+                                                <td>{{ week.grouped_date|date:"W Y" }}</td> 
+                                                <td>{{ week.critical|default:"0" }}</td>
+                                                <td>{{ week.high|default:"0" }}</td>
+                                                <td>{{ week.medium|default:"0" }}</td>
+                                                <td>{{ week.low|default:"0" }}</td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
                             </div>
                             <!-- /.panel-body -->
                         </div>
@@ -269,7 +415,43 @@
                             </div>
                             <!-- /.panel-heading -->
                             <div class="panel-body">
-                                <div id="accepted_per_week_2"></div>
+                                <div
+                                aria-describedby="accepted-per-week-description"
+                                id="accepted_per_week_2"
+                                role="img"
+                                tabindex="0"
+                                ></div>
+                                <div class="sr-only">
+                                    <h3 id="accepted-per-week-title">{% trans "Risk Accepted Bug Count by Week" %}</h3>
+                                    <p id="accepted-per-week-description">
+                                        {% trans "This graph represents the number of risk-accepted bugs per week categorized by severity.
+                                        The x-axis represents weeks, and the y-axis represents the number of accepted bugs.
+                                        The table below provides the same data in text format." %}
+                                    </p>
+                                    <table id="accepted-per-week-table" aria-labelledby="accepted-per-week-title" tabindex="0">
+                                        <caption>{% trans "Risk Accepted Bug Count Breakdown by Week" %}</caption>
+                                        <thead>
+                                            <tr>
+                                                <th scope="col">{% trans "Week" %}</th>
+                                                <th scope="col">{% trans "Critical" %}</th>
+                                                <th scope="col">{% trans "High" %}</th>
+                                                <th scope="col">{% trans "Medium" %}</th>
+                                                <th scope="col">{% trans "Low" %}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for week in accepted_per_week %}
+                                            <tr>
+                                                <td>{{ week.grouped_date|date:"W Y" }}</td> 
+                                                <td>{{ week.critical|default:"0" }}</td>
+                                                <td>{{ week.high|default:"0" }}</td>
+                                                <td>{{ week.medium|default:"0" }}</td>
+                                                <td>{{ week.low|default:"0" }}</td>
+                                            </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
                             </div>
                             <!-- /.panel-body -->
                         </div>

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -33,9 +33,6 @@
                     </ul>
                 </div>
               </h3>
-
-
-
             </div>
         </div>
         <div id="the-filters" class="is-filters panel-body collapse">
@@ -47,22 +44,38 @@
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa-solid fa-crosshairs fa-2x"></i>
+                                <i class="fa-solid fa-crosshairs fa-2x" aria-hidden="true"></i>
 
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">{{ verified_objs }}</span>
-                                    <span><a
-                                            href="{% url 'product_verified_findings' prod.id %}?test__engagement__product={{ prod.id }}"
-                                            title="Findings that are open/active and verified">Verified
-                                        {{ view }}{{ verified_objs|pluralize }} <i
-                                                class="fa-solid fa-circle-right"></i></a>
+                                    <span>
+                                        <a href="{% url 'product_verified_findings' prod.id %}?test__engagement__product={{ prod.id }}"
+                                            title="Findings that are open/active and verified">
+                                        Verified {{ view }}{{ verified_objs|pluralize}} <i class="fa-solid fa-circle-right" aria-hidden="true"></i></a>
                                     </span>
                                 </div>
                             </div>
                         </div>
                     </div>
+                    <h3 id="verified-objects-title" class="sr-only">Verified {{ view }}{{ view|pluralize }} overview</h3>
                     <div class="panel-body">
-                        <div id="verified_objs" class="graph"></div>
+                        <div id="verified_objs"
+                             class="graph" 
+                             role="img"
+                             aria-labelledby="verified-objects-title"
+                             aria-describedby="verified-objects-description"
+                             tabindex="0"
+                             >
+                        </div>
+                        <p id="verified-objects-description" class="sr-only">
+                            This graph displays the number of verified {{ view|lower }}{{ view|pluralize }} by severity.
+                            There are {{ verified_objs }} verified findings since {{ start_date|date:"D., M. d, Y" }}:
+                            {{ verified_objs_by_severity.Critical }} critical,
+                            {{ verified_objs_by_severity.High }} high,
+                            {{ verified_objs_by_severity.Medium }} medium,
+                            {{ verified_objs_by_severity.Low }} low and
+                            {{ verified_objs_by_severity.Info }} informational.
+                        </p>                                               
                     </div>
                     <div class="panel-footer">
                         <i title="Since {{ start_date }}."
@@ -76,53 +89,89 @@
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa-solid fa-bug fa-2x"></i>
+                                <i class="fa-solid fa-bug fa-2x" aria-hidden="true"></i>
 
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">{{ open_objs }}</span>
-                                    <span><a href="{% url 'product_open_findings' prod.id %}?test__engagement__product={{ prod.id }}"
-                                        title="Findings that are open/active, but not (yet) verified">Open
-                                        {{ view }}{{ open_objs|pluralize }} <i
-                                                class="fa-solid fa-circle-right"></i></a>
+                                    <span>
+                                        <a href="{% url 'product_open_findings' prod.id %}?test__engagement__product={{ prod.id }}"
+                                            title="Findings that are open/active, but not (yet) verified">
+                                            Open {{ view }}{{ open_objs|pluralize }}
+                                            <i class="fa-solid fa-circle-right" aria-hidden="true"></i>
+                                        </a>
                                     </span>
                                 </div>
                             </div>
                         </div>
                     </div>
+                    <h3 id="open-objects-title" class="sr-only">Open {{ view }}{{ view|pluralize }} overview</h3>
                     <div class="panel-body">
-                        <div id="open_objs" class="graph"></div>
+                        <div 
+                        aria-labelledby="open-objects-title"
+                        aria-describedby="open-objects-description"
+                        id="open_objs"
+                        class="graph"
+                        role="img"
+                        tabindex="0"
+                        ></div>
+                        <p id="open-objects-description" class="sr-only">
+                            This graph displays the number of open {{ view|lower }}{{ view|pluralize }} by severity.
+                            There are {{ open_objs }} open findings since {{ start_date|date:"D., M. d, Y" }}:
+                            {{ open_objs_by_severity.Critical }} critical,
+                            {{ open_objs_by_severity.High }} high,
+                            {{ open_objs_by_severity.Medium }} medium,
+                            {{ open_objs_by_severity.Low }} low, and
+                            {{ open_objs_by_severity.Info }} informational.
+                        </p>   
                     </div>
                     <div class="panel-footer">
                         <i title="Opened since {{ start_date }}"
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Opened since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
             </div>
+
             <div class="col-md-3">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa-solid fa-check fa-2x"></i>
-
+                                <i class="fa-solid fa-check fa-2x" aria-hidden="true"></i>
                                 <div class="pull-right text-right">
                                     <span class="fa-2x">{{ accepted_objs }}</span>
                                     <span><a
                                             href="{% url 'accepted_findings' %}?test__engagement__product={{ prod.id }}"
                                             title="Findings that have been accepted in a risk acceptance.">Risk Accepted
-                                    {{ view }}s <i class="fa-solid fa-circle-right"></i></a>
+                                    {{ view }}s <i class="fa-solid fa-circle-right" aria-hidden="true"></i></a>
                                 </span>
                                 </div>
                             </div>
                         </div>
                     </div>
+                    <h3 id="accepted-objects-title" class="sr-only">Risk Accepted {{ view|lower }}{{ view|pluralize }} overview</h3>
                     <div class="panel-body">
-                        <div id="accepted_objs" class="graph"></div>
+                        <div 
+                        aria-describedby="accepted-objects-description"
+                        aria-labelledby="accepted-objects-title"
+                        class="graph"
+                        id="accepted_objs"
+                        role="img"
+                        tabindex="0"
+                       ></div>
+                       <p id="accepted-objects-description" class="sr-only">
+                        This graph displays the number of risk accepted {{ view|lower }}{{ view|pluralize }} by severity.
+                        There are {{ accepted_objs }} risk accepted {{view|lower}}{{ view|pluralize }} since {{ start_date|date:"D., M. d, Y" }}:
+                        {{ accepted_objs_by_severity.Critical }} critical,
+                        {{ accepted_objs_by_severity.High }} high,
+                        {{ accepted_objs_by_severity.Medium }} medium,
+                        {{ accepted_objs_by_severity.Low }} low, and
+                        {{ accepted_objs_by_severity.Info }} informational.
+                    </p>  
                     </div>
                     <div class="panel-footer">
                         <i title="Accepted since {{ start_date }}"
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Risk Accepted since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
@@ -132,25 +181,42 @@
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa-solid fa-fire-extinguisher fa-2x"></i>
+                                <i class="fa-solid fa-fire-extinguisher fa-2x" aria-hidden="true"></i>
 
                                 <div class="text-right pull-right">
                                     <span class="fa-2x">{{ closed_objs }}</span>
                                     <span><a href="{% url 'closed_findings' %}?test__engagement__product={{ prod.id }}"
                                              title="Findings that are closed and mitigated.">Closed
                                         {{ view }}{{ closed_objs|pluralize }} <i
-                                                class="fa-solid fa-circle-right"></i></a>
+                                                class="fa-solid fa-circle-right" aria-hidden="true"></i></a>
                                     </span>
                                 </div>
                             </div>
                         </div>
                     </div>
+                    <h3 id="closed-objects-title" class="sr-only">Closed {{ view|lower }}{{ view|pluralize }} overview</h3>
                     <div class="panel-body">
-                        <div id="closed_objs" class="graph"></div>
+                        <div
+                        aria-describedby="closed-objects-description"
+                        aria-labelledby="closed-objects-title"
+                        class="graph" 
+                        id="closed_objs"
+                        role="img"
+                        tabindex="0"
+                        ></div>
+                        <p id="closed-objects-description" class="sr-only">
+                            This graph displays the number of closed {{ view|lower }}{{ view|pluralize }} by severity.
+                            There are {{ closed_objs }} closed {{ view|lower }}{{ view|pluralize }} since {{ start_date|date:"D., M. d, Y" }}:
+                            {{ closed_objs_by_severity.Critical }} critical,
+                            {{ closed_objs_by_severity.High }} high,
+                            {{ closed_objs_by_severity.Medium }} medium,
+                            {{ closed_objs_by_severity.Low }} low, and
+                            {{ closed_objs_by_severity.Info }} informational.
+                        </p>   
                     </div>
                     <div class="panel-footer">
                         <i title="Closed since {{ start_date }}"
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Closed since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
@@ -160,25 +226,41 @@
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa-solid fa-fire-extinguisher fa-2x"></i>
-
+                                <i class="fa-solid fa-fire-extinguisher fa-2x" aria-hidden="true"></i>
                                 <div class="text-right pull-right">
                                     <span class="fa-2x">{{ false_positive_objs }}</span>
                                     <span><a href="{% url 'product_false_positive_findings' prod.id %}?test__engagement__product={{ prod.id }}"
                                              title="Findings that are marked as false postive.">False-postive
                                         {{ view }}{{ false_positive_objs|pluralize }} <i
-                                                class="fa-solid fa-circle-right"></i></a>
+                                                class="fa-solid fa-circle-right" aria-hidden="true"></i></a>
                                     </span>
                                 </div>
                             </div>
                         </div>
                     </div>
+                    <h3 id="false-positive-objects-title" class="sr-only">False positive {{ view }}{{ view|pluralize }} overview</h3>
                     <div class="panel-body">
-                        <div id="false_positive_objs" class="graph"></div>
+                        <div
+                        aria-describedby="false-positive-objects-description"
+                        aria-labelledby="false-positive-objects-title"
+                        class="graph"
+                        id="false_positive_objs"
+                        role="img"
+                        tabindex="0">
+                    </div>
+                    <p id="false-positive-objects-description" class="sr-only">
+                        This graph displays the number of false positive {{ view|lower }}{{ view|pluralize }} by severity.
+                        There are {{ false_positive_objs }} false positive {{ view|lower }}{{ view|pluralize }} since {{ start_date|date:"D., M. d, Y" }}:
+                        {{ false_positive_objs_by_severity.Critical }} critical,
+                        {{ false_positive_objs_by_severity.High }} high,
+                        {{ false_positive_objs_by_severity.Medium }} medium,
+                        {{ false_positive_objs_by_severity.Low }} low, and
+                        {{ false_positive_objs_by_severity.Info }} informational.
+                    </p>   
                     </div>
                     <div class="panel-footer">
                         <i title="Flagged since {{ start_date }}"
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Flagged since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
@@ -188,26 +270,42 @@
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa-solid fa-fire-extinguisher fa-2x"></i>
-
+                                <i class="fa-solid fa-fire-extinguisher fa-2x" aria-hidden="true"></i>
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">{{ out_of_scope_objs }}</span>
                                     <span><a
                                             href="{% url 'product_out_of_scope_findings' prod.id %}?test__engagement__product={{ prod.id }}"
                                             title="Findings that are marked as out of scope.">Out Of Scope
                                         {{ view }}{{ out_of_scope_objs|pluralize }} <i
-                                                class="fa-solid fa-circle-right"></i></a>
+                                                class="fa-solid fa-circle-right" aria-hidden="true"></i></a>
                                     </span>
                                 </div>
                             </div>
                         </div>
                     </div>
+                    <h3 id="out-of-scope-objects-title" class="sr-only">Out of Scope {{ view }}{{ view|pluralize }} overview</h3>
                     <div class="panel-body">
-                        <div id="out_of_scope_objs" class="graph"></div>
+                        <div
+                        aria-describedby="out-of-scope-objects-description"
+                        aria-labelledby="out-of-scope-objects-title"
+                        class="graph"
+                        id="out_of_scope_objs"
+                        role="img"
+                        tabindex="0">
+                    </div>
+                    <p id="out-of-scope-objects-description" class="sr-only">
+                        This graph displays the number of out of scope {{ view|lower }}{{ view|pluralize }} by severity.
+                        There are {{ out_of_scope_objs }} out of scope {{ view|lower }}{{ view|pluralize }} since {{ start_date|date:"D., M. d, Y" }}:
+                        {{ out_of_scope_objs_by_severity.Critical }} Critical,
+                        {{ out_of_scope_objs_by_severity.High }} high,
+                        {{ out_of_scope_objs_by_severity.Medium }} medium,
+                        {{ out_of_scope_objs_by_severity.Low }} low, and
+                        {{ out_of_scope_objs_by_severity.Info }} informational.
+                    </p>   
                     </div>
                     <div class="panel-footer">
                         <i title="Since {{ start_date }}."
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Since {{ start_date|date:"D., M. d, Y" }}.</small>
                     </div>
                 </div>
@@ -217,25 +315,42 @@
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa-solid fa-bullseye fa-2x"></i>
+                                <i class="fa-solid fa-bullseye fa-2x" aria-hidden="true"></i>
 
                                 <div class="text-right pull-right">
                                     <span class="fa-2x">{{ all_objs }}</span>
                                     <span><a href="{% url 'product_all_findings' prod.id %}?test__engagement__product={{ prod.id }}"
                                             title="All findings.">Total
                                         {{ view }}{{ all_objs|pluralize }} <i
-                                                class="fa-solid fa-circle-right"></i></a>
+                                                class="fa-solid fa-circle-right" aria-hidden="true"></i></a>
                                     </span>
                                 </div>
                             </div>
                         </div>
                     </div>
+                    <h3 id="all-objects-title" class="sr-only">Total {{ view }}{{ view|pluralize }} overview</h3>
                     <div class="panel-body">
-                        <div id="all_objs" class="graph"></div>
+                        <div
+                        aria-describedby="all-objects-description"
+                        aria-labelledby="all-objects-title"
+                        class="graph"
+                        id="all_objs"
+                        role="img"
+                        tabindex="0">
+                    </div>
+                    <p id="all-objects-description" class="sr-only">
+                        This graph displays the number of all {{ view|lower }}{{ view|pluralize }} by severity.
+                        There are {{ all_objs }} {{ view|lower }}{{ view|pluralize }} since {{ start_date|date:"D., M. d, Y" }}:
+                        {{ all_objs_by_severity.Critical }} Critical,
+                        {{ all_objs_by_severity.High }} High,
+                        {{ all_objs_by_severity.Medium }} Medium,
+                        {{ all_objs_by_severity.Low }} Low, and
+                        {{ all_objs_by_severity.Info }} Informational.
+                    </p> 
                     </div>
                     <div class="panel-footer">
                         <i title="Since {{ start_date }}"
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
@@ -245,25 +360,41 @@
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa-solid fa-bug fa-2x"></i>
+                                <i class="fa-solid fa-bug fa-2x" aria-hidden="true"></i>
 
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">{{ inactive_objs }}</span>
                                     <span><a href="{% url 'product_inactive_findings' prod.id %}?test__engagement__product={{ prod.id }}"
-                                             title="Findings that are not active but not mitigated for some reason">Inactive
-                                        {{ view }}{{ inactive_objs|pluralize }} <i
-                                                class="fa-solid fa-circle-right"></i></a>
+                                            title="Findings that are not active but not mitigated for some reason">Inactive
+                                            {{ view }}{{ view|pluralize }} <i class="fa-solid fa-circle-right"  aria-hidden="true"></i></a>
                                     </span>
                                 </div>
-                            </div>
+                                </div>
                         </div>
                     </div>
+                    <h3 id="inactive-objects-title" class="sr-only">Inactive {{ view }}{{ view|pluralize }} overview</h3>
                     <div class="panel-body">
-                        <div id="inactive_objs" class="graph"></div>
+                        <div
+                        aria-describedby="inactive-objects-description"
+                        aria-labelledby="inactive-objects-title"
+                        class="graph" 
+                        id="inactive_objs"
+                        role="img"
+                        tabindex="0"
+                        ></div>
+                        <p id="inactive-objects-description" class="sr-only">
+                            This graph displays the number of inactive {{ view|lower }}{{ view|pluralize }} by severity.
+                            There are following inactive {{ view|lower }}{{ view|pluralize }} since {{ start_date|date:"D., M. d, Y" }}:
+                            {{ inactive_objs_by_severity.Critical }} Critical,
+                            {{ inactive_objs_by_severity.High }} High,
+                            {{ inactive_objs_by_severity.Medium }} Medium,
+                            {{ inactive_objs_by_severity.Low }} Low, and
+                            {{ inactive_objs_by_severity.Info }} Informational.
+                        </p> 
                     </div>
                     <div class="panel-footer">
                         <i title="Ingested since {{ start_date }}"
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Ingested since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
@@ -294,99 +425,303 @@
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         Open Day to Day by Severity
-                        <i title="Days are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                        <i title="Days are only displayed if findings are available." class="text-info fa-solid fa-circle-info"
+                            aria-hidden="true"></i>
                     </div>
                     <div class="panel-body text-center">
                         <div id="id_open_findings_burndown_loader" class="graph-loader">
                             <p><i class="fas fa-spinner fa-spin fa-2x"></i></p>
                             <p>Loading Finding Burndown Metrics...</p>
                         </div>
-                        <div id="open_findings_burndown" class="graph"></div>
+                        <h3 id="open-findings-title" class="sr-only">
+                            Open findings burndown overview
+                        </h3>
+                        <div aria-describedby="open-findings-description" aria-labelledby="open-findings-title"
+                            class="graph" id="open_findings_burndown" role="img" tabindex="0"></div>
+                        <div id="open-findings-description" class="sr-only">
+                            <p>
+                                This burndown chart represents the number of open findings over time, categorized by severity.
+                                The x-axis represents days, while the y-axis represents the number of findings.
+                                Each severity level is color-coded: critical (red), high (orange), medium (yellow),
+                                low (green), and informational (blue).
+                            </p>
+                        </div>
+                        <table id="open-findings-table" class="sr-only" tabindex="0" aria-labelledby="open-findings-table-caption">
+                            <caption id="open-findings-table-caption">Open findings burndown overview</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">Date</th>
+                                    <th scope="col">Critical</th>
+                                    <th scope="col">High</th>
+                                    <th scope="col">Medium</th>
+                                    <th scope="col">Low</th>
+                                    <th scope="col">Informational</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            </tbody>
+                        </table>
                     </div>
                     <div class="panel-footer">
-                        <i class="text-info fa-solid fa-circle-info"></i>
+                        <i class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Days are only displayed if findings are available.</small>
                     </div>
                 </div>
             </div>
+            
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         Open, Closed, and Risk Accepted Week to Week
-                        <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                        <i title="Weeks are only displayed if findings are available." class="text-info fa-solid fa-circle-info"
+                            aria-hidden="true"></i>
                     </div>
                     <div class="panel-body">
-                        <div id="open_close_weekly" class="graph"></div>
+                        <h3 id="open-closed-weekly-title" class="sr-only">Open, Closed, and Risk Accepted Findings Week to Week Overview</h3>
+                        <div aria-describedby="open-closed-weekly-description" aria-labelledby="open-closed-weekly-title"
+                            class="graph" id="open_close_weekly" role="img" tabindex="0">
+                        </div>
+                        <div id="open-closed-weekly-description" class="sr-only">
+                            <p>
+                                This chart shows the weekly count of open, closed, and risk-accepted findings.
+                                The x-axis represents the weeks, while the y-axis represents the number of findings.
+                                Opened findings are shown in red. Closed findings are shown in orange.
+                                Risk accepted findings are shown in purple. The table below provides the same data in text format.
+                            </p>
+                        </div>
+                        <table id="open-closed-weekly-table" aria-labelledby="open-closed-weekly-table-caption" class="sr-only"
+                            tabindex="0">
+                            <caption id="open-closed-weekly-table-caption">Weekly findings breakdown</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">Week</th>
+                                    <th scope="col">Open Findings</th>
+                                    <th scope="col">Closed Findings</th>
+                                    <th scope="col">Risk Accepted Findings</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for week, values in open_close_weekly.items %}
+                                <tr>
+                                    <td>{{ values.week|safe }}</td>
+                                    <td>{{ values.open }}</td>
+                                    <td>{{ values.closed }}</td>
+                                    <td>{{ values.accepted }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+            
                     </div>
                     <div class="panel-footer">
                         <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                            class="text-info fa-solid fa-circle-info"></i>
                         <small>Weeks are only displayed if findings are available.</small>
                     </div>
                 </div>
             </div>
+
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         Week to Week by Severity
-                        <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                        <i title="Weeks are only displayed if findings are available." class="text-info fa-solid fa-circle-info"
+                            aria-hidden="true"></i>
                     </div>
                     <div class="panel-body">
-                        <div id="severity_weekly" class="graph"></div>
+                        <h3 id="severity-weekly-title" class="sr-only">Weekly Findings by Severity Overview</h3>
+                        <div aria-describedby="severity-weekly-description" aria-labelledby="severity-weekly-title" class="graph"
+                            id="severity_weekly" role="img" tabindex="0">
+                        </div>
                     </div>
-                    <div class="panel-footer">
-                        <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
-                        <small>Weeks are only displayed if findings are available.</small>
+                    <div id="severity-weekly-description" class="sr-only">
+                        <p>
+                            This chart represents the number of findings per week categorized by severity.
+                            The x-axis represents the weeks, while the y-axis represents the number of findings.
+                            Critical findings are shown in red, high findings are shown in orange, medium findings
+                            are shown in yellow, Low findings are shown in blue, informational findings
+                            are shown in gray. The table below provides the same data in text format.
+                        </p>
                     </div>
+                    <table class="sr-only" id="severity-weekly-table" aria-labelledby="severity-weekly-table-caption" tabindex="0">
+                        <caption id="severity-weekly-table-caption">Weekly findings by severity breakdown</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">Week</th>
+                                <th scope="col">Critical</th>
+                                <th scope="col">High</th>
+                                <th scope="col">Medium</th>
+                                <th scope="col">Low</th>
+                                <th scope="col">Informational</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for week, values in severity_weekly.items %}
+                            <tr>
+                                <td>{{ values.week|safe }}</td>
+                                <td>{{ values.critical }}</td>
+                                <td>{{ values.high }}</td>
+                                <td>{{ values.medium }}</td>
+                                <td>{{ values.low }}</td>
+                                <td>{{ values.info }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            
+                <div class="panel-footer">
+                    <i title="Weeks are only displayed if findings are available." class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
+                    <small>Weeks are only displayed if findings are available.</small>
                 </div>
             </div>
+
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         Critical Week to Week
                         <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                     </div>
                     <div class="panel-body">
-                        <div id="severity_critical" class="graph"></div>
+                        <h3 id="critical-weekly-title" class="sr-only">
+                            Weekly critical findings overview
+                        </h3>
+                        <div
+                        aria-describedby="critical-weekly-description"
+                        aria-labelledby="critical-weekly-title" 
+                        class="graph"
+                        id="severity_critical" 
+                        role="img"
+                        tabindex="0"></div>
                     </div>
+                    <div id="critical-weekly-description" class="sr-only">
+                        <p>
+                            This chart represents the number of critical findings per week.
+                            The x-axis represents the weeks, while the y-axis represents the number of findings.
+                            Critical findings are displayed in red. The table below provides the same data in text format.
+                        </p>
+                    </div>
+                    <p id="critical-weekly-table-intro" class="sr-only">
+                        The following table contains a breakdown of critical findings per week.
+                    </p>
+                    <table class="sr-only" id="critical-weekly-table" aria-labelledby="critical-weekly-table-caption" tabindex="0">
+                        <caption id="critical-weekly-table-caption">Weekly critical findings breakdown</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">Week</th>
+                                <th scope="col">Critical Findings</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for week, values in critical_weekly.items %}
+                            <tr>
+                                <td>{{ values.week|safe }}</td>
+                                <td>{{ values.count }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
                     <div class="panel-footer">
                         <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Weeks are only displayed if findings are available.</small>
                     </div>
-                </div>
             </div>
+
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         High Week to Week
-                        <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                        <i title="Weeks are only displayed if findings are available." class="text-info fa-solid fa-circle-info"
+                            aria-hidden="true"></i>
                     </div>
                     <div class="panel-body">
-                        <div id="severity_high" class="graph"></div>
+                        <h3 id="high-weekly-title" class="sr-only">Weekly High Severity Findings Overview</h3>
+                        <div aria-describedby="high-weekly-description" aria-labelledby="high-weekly-title" class="graph"
+                            id="severity_high" role="img" tabindex="0">
+                        </div>
                     </div>
                     <div class="panel-footer">
                         <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                            class="text-info fa-solid fa-circle-info"></i>
                         <small>Weeks are only displayed if findings are available.</small>
                     </div>
                 </div>
+                <div id="high-weekly-description" class="sr-only">
+                    <p>
+                        This chart represents the number of high-severity findings per week.
+                        The x-axis represents the weeks, while the y-axis represents the number of findings.
+                        High-severity findings are displayed in orange.
+                        The table below provides the same data in text format.
+                    </p>
+                </div>
+                <table class="sr-only" id="high-weekly-table" aria-labelledby="high-weekly-table-caption" tabindex="0">
+                    <caption id="high-weekly-table-caption">Weekly High Severity Findings Breakdown</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">Week</th>
+                            <th scope="col">High severity findings</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for week, values in high_weekly.items %}
+                        <tr>
+                            <td>{{ values.week|safe }}</td>
+                            <td>{{ values.count }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
+
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         Medium Week to Week
                         <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                           class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                     </div>
                     <div class="panel-body">
-                        <div id="severity_medium" class="graph"></div>
+                        <h3 id="medium-weekly-title" class="sr-only">
+                            Weekly medium severity findings Overview
+                        </h3>
+                        <div 
+                             aria-describedby="medium-weekly-description"
+                             aria-labelledby="medium-weekly-title"
+                             class="graph"
+                             id="severity_medium"
+                             role="img"
+                             tabindex="0">
+                        </div>
+                        <div id="medium-weekly-description" class="sr-only">
+                            <p>
+                                This chart represents the number of medium severity findings per week.
+                                The x-axis represents the weeks, while the y-axis represents the number of findings.
+                                Medium severity findings are displayed in yellow.
+                                The table below provides the same data in text format.
+                            </p>
+                        </div>
+                        <table class="sr-only" id="medium-weekly-table"
+                               aria-labelledby="medium-weekly-table-caption"
+                               tabindex="0">
+                            <caption id="medium-weekly-table-caption">Weekly medium severity findings breakdown</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">Week</th>
+                                    <th scope="col">Medium Severity Findings</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for week, values in medium_weekly.items %}
+                                <tr>
+                                    <td>{{ values.week|safe }}</td>
+                                    <td>{{ values.count }}</td>  
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
                     </div>
                     <div class="panel-footer">
                         <i title="Weeks are only displayed if findings are available."
@@ -395,52 +730,163 @@
                     </div>
                 </div>
             </div>
+
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         Finding Age
                     </div>
                     <div class="panel-body">
-                        <div id="finding_age" class="graph"></div>
+                        <h3 id="finding-age-title" class="sr-only">
+                            Finding Age Overview
+                        </h3>
+                        <div aria-describedby="finding-age-description" aria-labelledby="finding-age-title" class="graph"
+                            id="finding_age" role="img" tabindex="0">
+                        </div>
+                        <div id="finding-age-description" class="sr-only">
+                            <p>
+                                This chart represents the distribution of open findings by their age.
+                                The x-axis represents the age of findings.
+                                The y-axis represents the number of open findings.
+                                The table below provides the data in text format.
+                            </p>
+                        </div>
+                        <table class="sr-only" id="finding-age-table" aria-labelledby="finding-age-table-caption" tabindex="0">
+                            <caption id="finding-age-table-caption">Finding Age Breakdown</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">Age in days</th>
+                                    <th scope="col">Open findings</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for age, count in open_objs_by_age.items %}
+                                <tr>
+                                    <td>{{ age }}</td>
+                                    <td>{{ count }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
                     </div>
+            
                     <div class="panel-footer">
                         <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                            class="text-info fa-solid fa-circle-info"></i>
                         <small>Finding age of {{ open_objs|apnumber }} open
                             finding{{ open_objs|pluralize }}</small>
                     </div>
                 </div>
             </div>
+
             <div class="col-md-7">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         Weekly activity of findings reported
-                            <i title="Weeks are only displayed if findings are available."
-                            class="text-info fa-solid fa-circle-info"></i>
+                        <i title="Weeks are only displayed if findings are available." class="text-info fa-solid fa-circle-info"
+                            aria-hidden="true"></i>
                     </div>
                     <div class="panel-body">
-                        <div class="graph" id="punchcard"></div>
+                        <h3 id="punchcard-title" class="sr-only">
+                            Weekly activity of reported findings overview
+                        </h3>
+                        <div aria-describedby="punchcard-description" aria-labelledby="punchcard-title" class="graph" id="punchcard"
+                            role="img" tabindex="0">
+                        </div>
+                        <div id="punchcard-description" class="sr-only">
+                            <p>
+                                This chart represents the weekly activity of findings reported.
+                                The x-axis represents the days of the week, while the y-axis represents the week number.
+                                The size of each dot indicates the number of findings reported on that day.
+                                The table below provides the same data in text format.
+                            </p>
+                        </div>
+                        <table
+                        class="sr-only" 
+                        id="punchcard-table" 
+                        aria-labelledby="punchcard-table-caption"
+                        tabindex="0">
+                     <caption id="punchcard-table-caption">Weekly Findings Activity Breakdown</caption>
+                     <thead>
+                         <tr>
+                             <th scope="col">Week</th>
+                             <th scope="col">Monday</th>
+                             <th scope="col">Tuesday</th>
+                             <th scope="col">Wednesday</th>
+                             <th scope="col">Thursday</th>
+                             <th scope="col">Friday</th>
+                             <th scope="col">Saturday</th>
+                             <th scope="col">Sunday</th>
+                         </tr>
+                     </thead>
+                     <tbody>
+                         {% for week, values in punchcard.items %}
+                         <tr>
+                             <td>{{ week }}</td>
+                             <td>{{ values.Sunday|default:"0" }}</td>
+                             <td>{{ values.Monday|default:"0" }}</td>
+                             <td>{{ values.Tuesday|default:"0" }}</td>
+                             <td>{{ values.Wednesday|default:"0" }}</td>
+                             <td>{{ values.Thursday|default:"0" }}</td>
+                             <td>{{ values.Friday|default:"0" }}</td>
+                             <td>{{ values.Saturday|default:"0" }}</td>
+                         </tr>
+                         {% endfor %}
+                     </tbody>
+                 </table>
+                 
                     </div>
                     <div class="panel-footer">
                         <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                            class="text-info fa-solid fa-circle-info"></i>
                         <small>Weeks are only displayed if findings are available.</small>
                     </div>
                 </div>
             </div>
+
             <div class="col-md-5">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         Findings by Test Type
-                        <i title="Test Types shown only if available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                        <i title="Test Types shown only if available." class="text-info fa-solid fa-circle-info"
+                            aria-hidden="true"></i>
                     </div>
                     <div class="panel-body">
-                        <div class="graph" id="test_type"></div>
+                        <h3 id="test-type-title" class="sr-only">
+                            Findings by test type overview
+                        </h3>
+                        <div aria-describedby="test-type-description" aria-labelledby="test-type-title" class="graph" id="test_type"
+                            role="img" tabindex="0">
+                        </div>
+                        <div id="test-type-description" class="sr-only">
+                            <p>
+                                This chart represents the number of findings categorized by test type.
+                                The x-axis represents different test types.
+                                The y-axis represents the number of findings for each test type.
+                                The table below provides the data in text format.
+                            </p>
+                        </div>
+                        <table class="sr-only" id="test-type-table" aria-labelledby="test-type-table-caption" tabindex="0">
+                            <caption id="test-type-table-caption">Findings by Test Type Breakdown</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">Test Type</th>
+                                    <th scope="col">Findings Count</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for test_type, count in test_data.items %}
+                                <tr>
+                                    <td>{{ test_type }}</td>
+                                    <td>{{ count }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
                     </div>
                     <div class="panel-footer">
                         <i title="Weeks are only displayed if findings are available."
-                           class="text-info fa-solid fa-circle-info"></i>
+                            class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Test Types shown only if available.</small>
                     </div>
                 </div>
@@ -452,25 +898,88 @@
                         Open CWE Vulnerabilities
                     </div>
                     <div class="panel-body">
-                        <div id="open_vulnerabilities" class="graph"></div>
+                        <h3 id="open-vulnerabilities-title" class="sr-only">
+                            Open CWE vulnerabilities overview
+                        </h3>
+                        <div
+                        aria-describedby="open-vulnerabilities-description"
+                        aria-labelledby="open-vulnerabilities-title"
+                        class="graph"
+                        id="open_vulnerabilities"
+                        role="img" 
+                        tabindex="0">
                     </div>
+                    <div id="open-vulnerabilities-description" class="sr-only">
+                        <p>
+                            This chart represents open CWE vulnerabilities identified in findings.
+                            The x-axis represents different CWE categories.
+                            The y-axis represents the number of findings associated with each CWE.
+                            The table below provides the data in text format.
+                        </p>
+                    </div>
+                    <table class="sr-only" id="open-vulnerabilities-table"
+                           aria-labelledby="open-vulnerabilities-table-caption"
+                           tabindex="0">
+                        <caption id="open-vulnerabilities-table">Open CWE Vulnerabilities Breakdown</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">CWE category</th>
+                                <th scope="col">Number of findings</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for cwe, count in open_vulnerabilities.items %}
+                            <tr>
+                                <td>{{ cwe }}</td>
+                                <td>{{ count }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
                     <div class="panel-footer">
-                        <i class="text-info fa-solid fa-circle-info"></i>
+                        <i class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Showing {{ open_vulnerabilities_count|apnumber }}
                             vulnerabilit{{ open_vulnerabilities_count|pluralize:"y,ies"}} from Open findings</small>
                     </div>
                 </div>
             </div>
+
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         Total CWE Vulnerabilities
                     </div>
                     <div class="panel-body">
-                        <div id="all_vulnerabilities" class="graph"></div>
+                        <h3 id="total-vulnerabilities-title" class="sr-only">
+                            Total CWE vulnerabilities overview
+                        </h3>
+                        <div aria-describedby="total-vulnerabilities-description" aria-labelledby="total-vulnerabilities-title"
+                            class="graph" id="all_vulnerabilities" role="img" tabindex="0">
+                        </div>
+                        <div id="total-vulnerabilities-description" class="sr-only">
+                            <p>
+                                This chart represents the total CWE vulnerabilities identified across all findings.
+                                The x-axis represents different CWE categories.
+                                The y-axis represents the number of findings associated with each CWE.
+                                The table below provides the same data in text format.
+                            </p>
+                        </div>
+                        <table class="sr-only" id="total-vulnerabilities-table" aria-labelledby="total-vulnerabilities-table-caption"
+                            tabindex="0">
+                            <caption id="total-vulnerabilities-table-caption">Total CWE Vulnerabilities Breakdown</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">CWE category</th>
+                                    <th scope="col">Number of findings</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            </tbody>
+                        </table>
                     </div>
                     <div class="panel-footer">
-                        <i class="text-info fa-solid fa-circle-info"></i>
+                        <i class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Showing {{ all_vulnerabilities_count|apnumber }}
                             vulnerabilit{{ all_vulnerabilities_count|pluralize:"y,ies"}} from all findings</small>
                     </div>
@@ -535,8 +1044,18 @@
 
             $(document).ready(function() {
                 fetch_burndown_metrics({{ prod.id }});
-            })
 
+                let allVulnerabilities = "{{ all_vulnerabilities|safe }}"; 
+                let openVulnerabilities = "{{ open_vulnerabilities|safe }}"; 
+                updateVulnerabilitiesTable(allVulnerabilities, "total-vulnerabilities-table");
+                updateVulnerabilitiesTable(openVulnerabilities, "open-vulnerabilities-table");
+
+                {%  if punchcard %}
+                let punchcardData = {{ punchcard|safe }};
+                let ticksData = {{ ticks|safe }};
+                updatePunchcardTable(punchcardData, ticksData);
+                {% endif%}
+            })
             function fetch_burndown_metrics(pid) {
                 $.ajax({
                     type: 'GET',
@@ -548,6 +1067,9 @@
                     success: function(response) {
                         $('#open_findings_burndown').show();
                         $('#id_open_findings_burndown_loader').hide();
+                        
+                        updateBurndownTable(response);
+                        
                         open_findings_burndown(
                             response.critical,
                             response.high,
@@ -558,6 +1080,41 @@
                             response.min,
                         );
                     }
+                });
+            }
+
+            function updateBurndownTable(data) {
+                let tableBody = $("#open-findings-table tbody");
+                tableBody.empty();
+
+                // Gathering all timestamps
+                // Taken from 'critical' but severity type does not really matter 
+                // as all of them come with the same bunch of timestamps
+                let timestamps = data.critical.map(entry => entry[0]); 
+
+                timestamps.forEach((timestamp, index) => {
+                    // Converting timestamp to YYYY-MM-DD format
+                    let date = new Date(timestamp).toISOString().split('T')[0]; 
+
+                    // Fetching values for each severity level or default to 0 if missing
+                    let critical = data.critical[index] ? data.critical[index][1] : 0;
+                    let high = data.high[index] ? data.high[index][1] : 0;
+                    let medium = data.medium[index] ? data.medium[index][1] : 0;
+                    let low = data.low[index] ? data.low[index][1] : 0;
+                    let info = data.info[index] ? data.info[index][1] : 0;
+
+                    // Appending the row to the table for each timestamp we got
+                    let newRow = `
+                        <tr>
+                            <td>${date}</td>
+                            <td aria-label="Critical severity findings on ${date}: ${critical}">${critical}</td>
+                            <td aria-label="High severity findings on ${date}: ${high}">${high}</td>
+                            <td aria-label="Medium severity findings on ${date}: ${medium}">${medium}</td>
+                            <td aria-label="Low severity findings on ${date}: ${low}">${low}</td>
+                            <td aria-label="Informational severity findings on ${date}: ${info}">${info}</td>
+                        </tr>
+                    `;
+                    tableBody.append(newRow);
                 });
             }
 
@@ -703,6 +1260,29 @@
             
             draw_vulnerabilities_graph("#open_vulnerabilities", {{ open_vulnerabilities|safe }});
             draw_vulnerabilities_graph("#all_vulnerabilities", {{ all_vulnerabilities|safe }});
+
+            function updateVulnerabilitiesTable(dataInfo, tableId) {
+                let tableBody = $(`#${tableId} tbody`);
+                // Converting raw data to a key-value object
+                let cweDataArray = dataInfo.split(","); 
+                let cweData = {};
+                for (let i = 0; i < cweDataArray.length; i += 2) {
+                    // Trimming and removing unnecessary characters
+                    let cwe = cweDataArray[i].replace(/[\[\]']+/g, "").trim(); 
+                    let count = parseInt(cweDataArray[i + 1], 10) || 0; 
+                    cweData[cwe] = count;
+                }
+                // If we have no valid data, write the info for users
+                if (Object.keys(cweData).length === 0) {
+                    tableBody.append(`<tr><td colspan="2">No vulnerabilities found</td></tr>`);
+                } else {
+                    // Add cwe info to the table
+                    $.each(cweData, function (cwe, count) {
+                        let newRow = `<tr><td>${cwe}</td><td>${count}</td></tr>`;
+                        tableBody.append(newRow);
+                    });
+                }
+            }
 
             //$(".product-graphs").hide();
             $("#meta_accordion").accordion();

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -122,29 +122,29 @@
 <div class="col-md-12">
   <div class="panel panel-default">
     <div class="panel-heading">
-      <h3 class="panel-title"><span class="fa-solid fa-chart-pie" aria-hidden="true"></span>{% trans "Metrics" %}</h3>
+      <h3 class="panel-title"><span class="fa-solid fa-chart-pie mr-2" aria-hidden="true"></span>{% trans "Metrics" %}</h3>
     </div>
     <table class="table table-condensed">
       <tbody>
         <tr>
           <td class="col-sm-2 bg-vuln-critical vuln-count text-center">
-              <a href="{% url 'product_open_findings' prod.id %}?severity=Critical" style="color:#FFFFFF;text-decoration:none">{{ critical }}<span class="hidden-xs"><br>
+              <a aria-label="{{ critical }} critical findings" href="{% url 'product_open_findings' prod.id %}?severity=Critical" style="color:#FFFFFF;text-decoration:none">{{ critical }}<span class="hidden-xs"><br>
               <small>{% trans "CRITICAL" %}</small></span></a>
           </td>
           <td class="col-sm-2 bg-vuln-high vuln-count text-center">
-              <a href="{% url 'product_open_findings' prod.id %}?severity=High" style="color:#FFFFFF;text-decoration:none">{{ high }}<span class="hidden-xs"><br>
+              <a aria-label="{{ high }} high severity findings" href="{% url 'product_open_findings' prod.id %}?severity=High" style="color:#FFFFFF;text-decoration:none">{{ high }}<span class="hidden-xs"><br>
               <small>{% trans "HIGH" %}</small></span></a>
           </td>
           <td class="col-sm-2 bg-vuln-medium vuln-count text-center">
-              <a href="{% url 'product_open_findings' prod.id %}?severity=Medium" style="color:#FFFFFF;text-decoration:none">{{ medium }}<span class="hidden-xs"><br>
+              <a aria-label="{{ medium }} medium severity findings" href="{% url 'product_open_findings' prod.id %}?severity=Medium" style="color:#FFFFFF;text-decoration:none">{{ medium }}<span class="hidden-xs"><br>
               <small>{% trans "MEDIUM" %}</small></span></a>
           </td>
           <td class="col-sm-2 bg-vuln-low vuln-count text-center">
-              <a href="{% url 'product_open_findings' prod.id %}?severity=Low" style="color:#FFFFFF;text-decoration:none">{{ low }}<span class="hidden-xs"><br>
+              <a aria-label="{{ low }} low severity findings" href="{% url 'product_open_findings' prod.id %}?severity=Low" style="color:#FFFFFF;text-decoration:none">{{ low }}<span class="hidden-xs"><br>
               <small>{% trans "LOW" %}</small></span></a>
           </td>
           <td class="col-sm-2 bg-vuln-info vuln-count text-center">
-              <a href="{% url 'product_open_findings' prod.id %}?severity=Info" style="color:#FFFFFF;text-decoration:none">{{ info }}<span class="hidden-xs"><br>
+              <a aria-label="{{ informational }} informational severity findings" href="{% url 'product_open_findings' prod.id %}?severity=Info" style="color:#FFFFFF;text-decoration:none">{{ info }}<span class="hidden-xs"><br>
               <small>{% trans "INFORMATIONAL" %}</small></span></a>
           </td>
           <td class="col-sm-2 bg-muted vuln-count text-center">


### PR DESCRIPTION
Fixes #11798

**Description**

Adding accessibility features for graphs and charts. Basically no visual difference in appearance just added some aria attributes, and tables, with description within the sr-only class

Before
<img width="1328" alt="Screenshot 2025-02-12 at 08 50 56" src="https://github.com/user-attachments/assets/e4ee10df-582d-4fe9-9a90-6acab36dbc9b" />


After

<img width="676" alt="Screenshot 2025-02-12 at 09 20 45" src="https://github.com/user-attachments/assets/64036131-43b2-4f8d-88e1-d1433936ece4" />
<img width="1189" alt="Screenshot 2025-02-12 at 09 21 23" src="https://github.com/user-attachments/assets/4a359251-4848-4aba-a6f7-b9bb348991de" />

tables for complex graphics example
<img width="673" alt="Screenshot 2025-02-12 at 09 22 27" src="https://github.com/user-attachments/assets/aa100808-de3b-4e84-8d08-12ca1b27a0c2" />

