### PR TITLE
fix / cleanup paths in integration tests

### DIFF
--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -251,7 +251,7 @@ else
     else
         fail "$test"
     fi
-    
+
     test="False Positive History tests"
     echo "Running: $test"
     if python3 tests/false_positive_history_test.py ; then

--- a/docs/content/en/open_source/upgrading/2.44.md
+++ b/docs/content/en/open_source/upgrading/2.44.md
@@ -14,6 +14,6 @@ The Burp parser now has a custom deduplication configuration to make deduplicati
 This command has various command line arguments to tweak its behavior, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.
 
---- 
+---
 
 Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.44.0) for the contents of the release.

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -1585,6 +1585,7 @@ def get_foreign_keys():
 
 
 def csv_export(request):
+    logger.debug("starting csv export")
     engagements, test_counts = get_engagements(request)
 
     response = HttpResponse(content_type="text/csv")
@@ -1617,11 +1618,12 @@ def csv_export(request):
             fields.append(test_counts.get(engagement.id, 0))
 
             writer.writerow(fields)
-
+    logger.debug("done with csv export")
     return response
 
 
 def excel_export(request):
+    logger.debug("starting excel export")
     engagements, test_counts = get_engagements(request)
 
     workbook = Workbook()
@@ -1667,4 +1669,5 @@ def excel_export(request):
         content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     )
     response["Content-Disposition"] = "attachment; filename=engagements.xlsx"
+    logger.debug("done with excel export")
     return response

--- a/tests/Import_scanner_test.py
+++ b/tests/Import_scanner_test.py
@@ -13,7 +13,7 @@ from product_test import ProductTest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
 
-dir_path = str(Path(os.path.realpath(__file__)).parent)
+dir_path = Path(os.path.realpath(__file__)).parent
 
 logger = logging.getLogger(__name__)
 
@@ -21,16 +21,16 @@ logger = logging.getLogger(__name__)
 class ScannerTest(BaseTestCase):
     def setUp(self):
         super().setUp(self)
-        self.repo_path = dir_path + "/scans"
-        if Path(self.repo_path).is_dir():
-            shutil.rmtree(self.repo_path)
-        Path(self.repo_path).mkdir()
-        git.Repo.clone_from("https://github.com/DefectDojo/sample-scan-files", self.repo_path)
+        self.repo_path = dir_path / "scans"
+        if self.repo_pathpyt.is_dir():
+            shutil.rmtree(str(self.repo_path))
+        self.repo_path.mkdir()
+        git.Repo.clone_from("https://github.com/DefectDojo/sample-scan-files", str(self.repo_path))
         self.remove_items = ["__init__.py", "__init__.pyc", "factory.py", "factory.pyc",
                         "factory.py", "LICENSE", "README.md", ".gitignore", ".git", "__pycache__"]
-        tool_path = Path(dir_path[:-5] + "dojo/tools")
-        tools = sorted(any(tool_path.iterdir()))
-        p = Path(self.repo_path)
+        tool_path = dir_path.parent / "dojo" / "tools"
+        tools = sorted(any(tool_path.iterdir())
+        p = self.repo_path
         tests = sorted(any(p.iterdir()))
         self.tools = [i for i in tools if i not in self.remove_items]
         self.tests = [i for i in tests if i not in self.remove_items]
@@ -44,7 +44,7 @@ class ScannerTest(BaseTestCase):
         missing_tests += ["\nNO TEST FILES"]
 
         for test in self.tests:
-            p = Path(self.repo_path + "/" + test)
+            p = self.repo_path / test
             cases = sorted(any(p.iterdir()))
             cases = [i for i in cases if i not in self.remove_items]
             if len(cases) == 0 and tool not in missing_tests:
@@ -60,7 +60,7 @@ class ScannerTest(BaseTestCase):
         self.assertEqual(len(missing_tests), 0)
 
     def test_check_for_forms(self):
-        forms_path = dir_path[:-5] + "dojo/forms.py"
+        forms_path = dir_path.parent / "dojo" / "forms.py"
         file = open(forms_path, "r+", encoding="utf-8")
         forms = file.readlines()
         file.close()
@@ -98,7 +98,7 @@ class ScannerTest(BaseTestCase):
 
     @unittest.skip("Deprecated since Dynamic Parser infrastructure")
     def test_check_for_options(self):
-        template_path = dir_path[:-5] + "dojo/templates/dojo/import_scan_results.html"
+        template_path = dir_path.parent / "dojo" / "templates" / "dojo" / "import_scan_results.html"
         file = open(template_path, "r+", encoding="utf-8")
         templates = file.readlines()
         file.close()
@@ -179,7 +179,7 @@ class ScannerTest(BaseTestCase):
 
         failed_tests = []
         for test in self.tests:
-            p = Path(self.repo_path + "/" + test)
+            p = self.repo_path / test
             cases = sorted(any(p.iterdir()))
             cases = [i for i in cases if i not in self.remove_items]
             if len(cases) == 0:
@@ -195,8 +195,8 @@ class ScannerTest(BaseTestCase):
                     driver.find_element(By.ID, "id_verified").get_attribute("checked")
                     scan_type = scan_map[test]
                     Select(driver.find_element(By.ID, "id_scan_type")).select_by_visible_text(scan_type)
-                    test_location = self.repo_path + "/" + test + "/" + case
-                    driver.find_element(By.ID, "id_file").send_keys(test_location)
+                    test_location = self.repo_path / test / case
+                    driver.find_element(By.ID, "id_file").send_keys(str(test_location))
                     driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
                     EngagementTXT = "".join(driver.find_element(By.TAG_NAME, "BODY").text).split("\n")
                     reg = re.compile(r"processed, a total of")
@@ -221,7 +221,7 @@ class ScannerTest(BaseTestCase):
 
     def tearDown(self):
         super().tearDown(self)
-        shutil.rmtree(self.repo_path)
+        shutil.rmtree(str(self.repo_path))
 
 
 def suite():

--- a/tests/Import_scanner_test.py
+++ b/tests/Import_scanner_test.py
@@ -13,7 +13,7 @@ from product_test import ProductTest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
 
-dir_path = Path(os.path.realpath(__file__)).parent
+dir_path = str(Path(os.path.realpath(__file__)).parent)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/Import_scanner_test.py
+++ b/tests/Import_scanner_test.py
@@ -29,7 +29,7 @@ class ScannerTest(BaseTestCase):
         self.remove_items = ["__init__.py", "__init__.pyc", "factory.py", "factory.pyc",
                         "factory.py", "LICENSE", "README.md", ".gitignore", ".git", "__pycache__"]
         tool_path = dir_path.parent / "dojo" / "tools"
-        tools = sorted(any(tool_path.iterdir())
+        tools = sorted(any(tool_path.iterdir()))
         p = self.repo_path
         tests = sorted(any(p.iterdir()))
         self.tools = [i for i in tools if i not in self.remove_items]

--- a/tests/Import_scanner_test.py
+++ b/tests/Import_scanner_test.py
@@ -22,10 +22,10 @@ class ScannerTest(BaseTestCase):
     def setUp(self):
         super().setUp(self)
         self.repo_path = dir_path / "scans"
-        if self.repo_pathpyt.is_dir():
-            shutil.rmtree(str(self.repo_path))
+        if self.repo_path.is_dir():
+            shutil.rmtree(self.repo_path)
         self.repo_path.mkdir()
-        git.Repo.clone_from("https://github.com/DefectDojo/sample-scan-files", str(self.repo_path))
+        git.Repo.clone_from("https://github.com/DefectDojo/sample-scan-files", self.repo_path)
         self.remove_items = ["__init__.py", "__init__.pyc", "factory.py", "factory.pyc",
                         "factory.py", "LICENSE", "README.md", ".gitignore", ".git", "__pycache__"]
         tool_path = dir_path.parent / "dojo" / "tools"
@@ -221,7 +221,7 @@ class ScannerTest(BaseTestCase):
 
     def tearDown(self):
         super().tearDown(self)
-        shutil.rmtree(str(self.repo_path))
+        shutil.rmtree(self.repo_path)
 
 
 def suite():

--- a/tests/close_old_findings_dedupe_test.py
+++ b/tests/close_old_findings_dedupe_test.py
@@ -135,7 +135,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_endpoint_1.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -152,7 +152,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_endpoint_1.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -174,7 +174,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_and_close_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_and_close_1.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="1 findings and closed 2 findings"))
@@ -242,7 +242,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_endpoint_1.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -259,7 +259,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_endpoint_1.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -281,7 +281,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_and_close_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_and_close_1.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="1 findings and closed 2 findings"))

--- a/tests/close_old_findings_dedupe_test.py
+++ b/tests/close_old_findings_dedupe_test.py
@@ -14,8 +14,6 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 
 logger = logging.getLogger(__name__)
 
-dir_path = Path(os.path.realpath(__file__)).parent
-
 
 class CloseOldDedupeTest(BaseTestCase):
     # --------------------------------------------------------------------------------------------------------
@@ -137,7 +135,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -154,7 +152,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -176,7 +174,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/dedupe_scans/dedupe_and_close_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_and_close_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="1 findings and closed 2 findings"))
@@ -244,7 +242,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -261,7 +259,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -283,7 +281,7 @@ class CloseOldDedupeTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/dedupe_scans/dedupe_and_close_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_and_close_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="1 findings and closed 2 findings"))

--- a/tests/close_old_findings_test.py
+++ b/tests/close_old_findings_test.py
@@ -13,8 +13,6 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 
 logger = logging.getLogger(__name__)
 
-dir_path = Path(os.path.realpath(__file__)).parent
-
 
 class CloseOldTest(BaseTestCase):
     # --------------------------------------------------------------------------------------------------------
@@ -95,7 +93,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/close_old_scans/closeold_nodedupe_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "close_old_scans/closeold_nodedupe_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -112,7 +110,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/close_old_scans/closeold_nodedupe_2.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "close_old_scans/closeold_nodedupe_2.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 3 findings"))
@@ -134,7 +132,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/dedupe_scans/dedupe_and_close_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_and_close_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="1 findings and closed 3 findings"))
@@ -198,7 +196,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/close_old_scans/closeold_nodedupe_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "close_old_scans/closeold_nodedupe_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -215,7 +213,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/close_old_scans/closeold_nodedupe_2.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "close_old_scans/closeold_nodedupe_2.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 3 findings"))
@@ -237,7 +235,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/dedupe_scans/dedupe_and_close_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_and_close_1.xml")
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="1 findings and closed 3 findings"))

--- a/tests/close_old_findings_test.py
+++ b/tests/close_old_findings_test.py
@@ -93,7 +93,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "close_old_scans/closeold_nodedupe_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "close_old_scans" / "closeold_nodedupe_1.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -110,7 +110,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "close_old_scans/closeold_nodedupe_2.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "close_old_scans" / "closeold_nodedupe_2.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 3 findings"))
@@ -196,7 +196,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "close_old_scans/closeold_nodedupe_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "close_old_scans" / "closeold_nodedupe_1.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 0 findings"))
@@ -213,7 +213,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "close_old_scans/closeold_nodedupe_2.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "close_old_scans" / "closeold_nodedupe_2.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="3 findings and closed 3 findings"))
@@ -235,7 +235,7 @@ class CloseOldTest(BaseTestCase):
         scan_environment = Select(driver.find_element(By.ID, "id_environment"))
         scan_environment.select_by_visible_text("Development")
         driver.find_element(By.ID, "id_close_old_findings_product_scope").click()
-        driver.find_element(By.ID, "id_file").send_keys(self.relative_path / "dedupe_scans/dedupe_and_close_1.xml")
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_and_close_1.xml"))
         driver.find_elements(By.CLASS_NAME, "btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="1 findings and closed 3 findings"))

--- a/tests/dedupe_test.py
+++ b/tests/dedupe_test.py
@@ -14,8 +14,6 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 
 logger = logging.getLogger(__name__)
 
-dir_path = Path(os.path.realpath(__file__)).parent
-
 
 class DedupeTest(BaseTestCase):
     # --------------------------------------------------------------------------------------------------------
@@ -23,7 +21,7 @@ class DedupeTest(BaseTestCase):
     # --------------------------------------------------------------------------------------------------------
     def setUp(self):
         super().setUp()
-        self.relative_path = str(Path(os.path.realpath(__file__)).parent)
+        self.relative_path = Path(os.path.realpath(__file__)).parent
 
     def check_nb_duplicates(self, expected_number_of_duplicates):
         logger.debug("checking duplicates...")
@@ -140,7 +138,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 1").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/dedupe_path_1.json"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_path_1.json"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         # 'Bandit Scan processed a total of 1 findings created 1 findings did not touch 1 findings.'
@@ -154,7 +152,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/dedupe_path_2.json"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_path_2.json"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         # 'Bandit Scan processed a total of 2 findings created 2 findings did not touch 1 findings.'
@@ -212,7 +210,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Endpoint Test 1").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -223,7 +221,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Endpoint Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/dedupe_endpoint_2.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_endpoint_2.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -276,7 +274,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Same Eng Test 1").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -287,7 +285,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Same Eng Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/dedupe_cross_1.csv"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_cross_1.csv"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -345,7 +343,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
         # os.path.realpath makes the path canonical
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 2 findings"))
@@ -356,7 +354,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/multiple_findings_line_changed.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings_line_changed.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 2 findings"))
@@ -419,7 +417,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Immuniweb Test").click()
         driver.find_element(By.CSS_SELECTOR, "i.fa-solid.fa-ellipsis-vertical").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan Results").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -430,7 +428,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Generic Test").click()
         driver.find_element(By.CSS_SELECTOR, "i.fa-solid.fa-ellipsis-vertical").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan Results").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/dedupe_cross_1.csv"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_cross_1.csv"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -452,7 +450,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 1").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="Checkmarx Scan processed a total of 2 findings created 2 findings."))
@@ -463,7 +461,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="Checkmarx Scan processed a total of 2 findings created 2 findings."))
@@ -484,7 +482,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
         driver.find_element(By.ID, "id_service").send_keys("service_1")
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="Checkmarx Scan processed a total of 2 findings created 2 findings."))
@@ -496,7 +494,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
         driver.find_element(By.ID, "id_service").send_keys("service_2")
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path + "/dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="Checkmarx Scan processed a total of 2 findings created 2 findings."))

--- a/tests/dedupe_test.py
+++ b/tests/dedupe_test.py
@@ -138,7 +138,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 1").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_path_1.json"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_path_1.json"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         # 'Bandit Scan processed a total of 1 findings created 1 findings did not touch 1 findings.'
@@ -152,7 +152,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_path_2.json"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_path_2.json"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         # 'Bandit Scan processed a total of 2 findings created 2 findings did not touch 1 findings.'
@@ -210,7 +210,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Endpoint Test 1").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_endpoint_1.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -221,7 +221,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Endpoint Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_endpoint_2.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_endpoint_2.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -274,7 +274,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Same Eng Test 1").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_endpoint_1.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -285,7 +285,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Same Eng Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_cross_1.csv"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_cross_1.csv"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -343,7 +343,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
         # os.path.realpath makes the path canonical
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 2 findings"))
@@ -354,7 +354,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings_line_changed.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "multiple_findings_line_changed.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 2 findings"))
@@ -417,7 +417,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Immuniweb Test").click()
         driver.find_element(By.CSS_SELECTOR, "i.fa-solid.fa-ellipsis-vertical").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan Results").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_endpoint_1.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_endpoint_1.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -428,7 +428,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Generic Test").click()
         driver.find_element(By.CSS_SELECTOR, "i.fa-solid.fa-ellipsis-vertical").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan Results").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/dedupe_cross_1.csv"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "dedupe_cross_1.csv"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="a total of 3 findings"))
@@ -450,7 +450,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 1").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="Checkmarx Scan processed a total of 2 findings created 2 findings."))
@@ -461,7 +461,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Path Test 2").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="Checkmarx Scan processed a total of 2 findings created 2 findings."))
@@ -482,7 +482,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
         driver.find_element(By.ID, "id_service").send_keys("service_1")
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="Checkmarx Scan processed a total of 2 findings created 2 findings."))
@@ -494,7 +494,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Re-Upload Scan").click()
         driver.find_element(By.ID, "id_service").send_keys("service_2")
-        driver.find_element(By.ID, "id_file").send_keys(os.path.realpath(self.relative_path / "dedupe_scans/multiple_findings.xml"))
+        driver.find_element(By.ID, "id_file").send_keys(str(self.relative_path / "dedupe_scans" / "multiple_findings.xml"))
         driver.find_elements(By.CSS_SELECTOR, "button.btn.btn-primary")[1].click()
 
         self.assertTrue(self.is_success_message_present(text="Checkmarx Scan processed a total of 2 findings created 2 findings."))

--- a/tests/report_builder_test.py
+++ b/tests/report_builder_test.py
@@ -1,7 +1,5 @@
-import os
 import sys
 import unittest
-from pathlib import Path
 
 from base_test_class import BaseTestCase
 from product_test import ProductTest
@@ -9,8 +7,6 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
-
-dir_path = Path(os.path.realpath(__file__)).parent
 
 
 class ReportBuilderTest(BaseTestCase):


### PR DESCRIPTION
Remove unused variables and fix the error(s) in integration tests caused by Ruff linting PRs.

```
integration-tests-1  | ======================================================================
integration-tests-1  | ERROR: test_import_same_engagement_tests (__main__.CloseOldDedupeTest.test_import_same_engagement_tests)
integration-tests-1  | ----------------------------------------------------------------------
integration-tests-1  | Traceback (most recent call last):
integration-tests-1  |   File "/app/tests/base_test_class.py", line 24, in wrapper
integration-tests-1  |     return func(self, *args, **kwargs)
integration-tests-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
integration-tests-1  |   File "/app/tests/close_old_findings_dedupe_test.py", line 141, in test_import_same_engagement_tests
integration-tests-1  |     driver.find_element(By.ID, "id_file").send_keys(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml")
integration-tests-1  |                                                     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
integration-tests-1  | TypeError: unsupported operand type(s) for +: 'PosixPath' and 'str'
```