### PR TITLE
Allow tab to "Show Password" within Login Page

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1832,6 +1832,14 @@ small {
     min-width:200px;
 }
 
+#toggleBox {
+    background-color: transparent!important;
+    border: none!important;
+    font-weight: bold!important;
+    position: absolute!important;
+    left: 0!important;
+}
+
 .EasyMDEContainer .table {
     width: unset!important;
 }

--- a/dojo/static/dojo/js/index.js
+++ b/dojo/static/dojo/js/index.js
@@ -247,11 +247,11 @@ function togglePassVisibility() {
     if (passwdInput.type === "password") {
         passwdInput.type = "text";
         toggleBox.innerHTML = "<i class='fa-solid fa-eye-slash'></i>\
-        <span><b>Hide Password</b></span>";
+        <span>Hide Password</span>";
     } else {
         passwdInput.type = "password";
         toggleBox.innerHTML = "<i class='fa-solid fa-eye'></i>\
-        <span><b>Show Password</b></span>";
+        <span>Show Password</span>";
     }
 }
 

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -20,9 +20,11 @@
             <div class="form-group">
 
                 {% if SHOW_LOGIN_FORM or 'force_login_form' in request.GET %}
-                    <div class="col-sm-offset-1 col-sm-2" id="toggleBox" onclick="togglePassVisibility()">
-                        <i class="fa-solid fa-eye"></i>
-                        <span><b>{% trans "Show Password" %}</b></span>
+                    <div class="col-sm-offset-1 col-sm-2">
+                        <button class="btn" id="toggleBox" onclick="togglePassVisibility()" type="button">
+                            <i class="fa-solid fa-eye"></i>
+                            {% trans "Show Password" %}
+                        </button>
                     </div>
                 {% endif %}
 


### PR DESCRIPTION
**Description**

If a user is using only the keyboard, they are not able to tab on "Show Password" within the login page.

**Impact on users**

People who are blind (who cannot use devices such as mice that require eye-hand coordination).
People with low vision (who may have trouble finding or tracking a pointer indicator on screen).
Some people with hand tremors find using a mouse very difficult and therefore usually use a keyboard.

**Steps to reproduce**

When you start tabbing within the login page, from the top (URL), Focus goes to Username and then password, and then Login, bypassing show Password.

**Remediation**

Have the "Show Password" keyboard operable by allowing tabbing on the element to be gained.

Image below shows "Show Password" being tabbed over:
![image](https://github.com/user-attachments/assets/97b6e4e3-aee1-49ca-8f88-4d3082a33382)


Instead of just using the div tag and text, I've added a button since it supports tabbing with a keyboard. I added a CSS id selector and rules to match the previous look of the page. The bold tags for "Show Password" were also moved to the CSS rule block.

