### PR TITLE
fix(ui): Increase readability in "Members" list

### DIFF
--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -344,7 +344,7 @@
                             <td>{{ member.user.get_full_name }}</td>
                             <td>
                                 <a class="" href="{% url 'view_product_type' member.product_type.id %}">
-                                    {{ member.product_type }}
+                                    Product type: {{ member.product_type }}
                                 </a>
                             </td>
                             <td>{{ member.role }}</td>


### PR DESCRIPTION
Until the table was showing only the name of the ProdType but there was a chance for misunderstanding that is the name of ProdType and permissions are inherited. Now it is explicitly mentioned next to name of ProdType