### PR TITLE
fix(helm): add spec.strategy in deployment django

### DIFF
--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -20,6 +20,10 @@ metadata:
 {{- end }}
 spec:
   replicas: {{ .Values.django.replicas }}
+  {{- with .Values.django.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- end }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -237,6 +237,7 @@ django:
         memory: 256Mi
   nodeSelector: {}
   replicas: 1
+  strategy: {}
   tolerations: []
   uwsgi:
     livenessProbe:


### PR DESCRIPTION
**Description**

Use case - when I deploy a chart with pvc (ReadWriteOnce), I can't update my Deployment:
```
Multi-Attach error for volume "<volume-name>" Volume is already exclusively attached to one node and can't be attached to another
```

**Test results**

```yaml
...
spec:
...
  strategy:
    type: Recreate
```

**Documentation**

Empty.

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.