### PR TITLE
Surveys: Correct Question 404

### DIFF
--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -539,17 +539,17 @@ def edit_question(request, qid):
                 extra_tags="alert-info")
     type = str(ContentType.objects.get_for_model(question))
 
-    if type == "dojo | text question":
+    if type in ["dojo | text question", "Defect Dojo | text question"]:
         form = EditTextQuestionForm(instance=question)
-    elif type == "dojo | choice question":
+    elif type in ["dojo | choice question", "Defect Dojo | choice question"]:
         form = EditChoiceQuestionForm(instance=question)
     else:
         raise Http404
 
     if request.method == "POST":
-        if type == "dojo | text question":
+        if type in ["dojo | text question", "Defect Dojo | text question"]:
             form = EditTextQuestionForm(request.POST, instance=question)
-        elif type == "dojo | choice question":
+        elif type in ["dojo | choice question", "Defect Dojo | choice question"]:
             form = EditChoiceQuestionForm(request.POST, instance=question)
         else:
             raise Http404

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -539,17 +539,17 @@ def edit_question(request, qid):
                 extra_tags="alert-info")
     type = str(ContentType.objects.get_for_model(question))
 
-    if type in ["dojo | text question", "Defect Dojo | text question"]:
+    if type in {"dojo | text question", "Defect Dojo | text question"}:
         form = EditTextQuestionForm(instance=question)
-    elif type in ["dojo | choice question", "Defect Dojo | choice question"]:
+    elif type in {"dojo | choice question", "Defect Dojo | choice question"}:
         form = EditChoiceQuestionForm(instance=question)
     else:
         raise Http404
 
     if request.method == "POST":
-        if type in ["dojo | text question", "Defect Dojo | text question"]:
+        if type in {"dojo | text question", "Defect Dojo | text question"}:
             form = EditTextQuestionForm(request.POST, instance=question)
-        elif type in ["dojo | choice question", "Defect Dojo | choice question"]:
+        elif type in {"dojo | choice question", "Defect Dojo | choice question"}:
             form = EditChoiceQuestionForm(request.POST, instance=question)
         else:
             raise Http404


### PR DESCRIPTION
When editing a survey question, a 404 is presented for a valid object. At some point, the content type for Questions changed to `Defect Dojo` (the verbose name of the app) rather than `dojo` (the common name)

There is only one place where the name of the content type is accessed, so adding some backward compatible checks corrected the issue

[sc-10195]
