### PR TITLE
:arrow_up: Bump urllib3 to 1.26.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ pytz==2025.1
 redis==5.2.1
 requests==2.32.3
 sqlalchemy==2.0.38  # Required by Celery broker transport
-urllib3==1.26.18
+urllib3==1.26.20
 uWSGI==2.0.28
 vobject==0.9.9
 whitenoise==5.2.0


### PR DESCRIPTION
https://www.cvedetails.com/cve/CVE-2024-37891/ 
" Users are advised to update to either version 1.26.19 or version 2.2.2"

https://github.com/DefectDojo/django-DefectDojo/pull/11455