### PR TITLE
Async Finding Import: Mark the feature as deprecated

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+from warnings import warn
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -242,7 +243,6 @@ class BaseImporter(ImporterOptions):
         ASYNC_FINDING_IMPORT_CHUNK_SIZE setting will determine how many
         findings will be processed in a given worker/process/thread
         """
-        from warnings import warn
         warn("This experimental feature has been deprecated as of DefectDojo 2.44.0 (March release). Please exercise caution if using this feature with an older version of DefectDojo, as results may be inconsistent.")
         return self.process_findings(parsed_findings, sync=False, **kwargs)
 

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -242,6 +242,8 @@ class BaseImporter(ImporterOptions):
         ASYNC_FINDING_IMPORT_CHUNK_SIZE setting will determine how many
         findings will be processed in a given worker/process/thread
         """
+        from warnings import warn
+        warn("This experimental feature has been deprecated as of DefectDojo 2.44.0 (March release). Please exercise caution if using this feature with an older version of DefectDojo, as results may be inconsistent.")
         return self.process_findings(parsed_findings, sync=False, **kwargs)
 
     def determine_process_method(

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -1,7 +1,6 @@
 import logging
 from warnings import warn
 
-
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.core.serializers import deserialize, serialize
 from django.db.models.query_utils import Q

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -408,6 +408,8 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         ASYNC_FINDING_IMPORT_CHUNK_SIZE setting will determine how many
         findings will be processed in a given worker/process/thread
         """
+        from warnings import warn
+        warn("This experimental feature has been deprecated as of DefectDojo 2.44.0 (March release). Please exercise caution if using this feature with an older version of DefectDojo, as results may be inconsistent.")
         chunk_list = self.chunk_findings(parsed_findings)
         results_list = []
         new_findings = []

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -1,4 +1,6 @@
 import logging
+from warnings import warn
+
 
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.core.serializers import deserialize, serialize
@@ -408,7 +410,6 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         ASYNC_FINDING_IMPORT_CHUNK_SIZE setting will determine how many
         findings will be processed in a given worker/process/thread
         """
-        from warnings import warn
         warn("This experimental feature has been deprecated as of DefectDojo 2.44.0 (March release). Please exercise caution if using this feature with an older version of DefectDojo, as results may be inconsistent.")
         chunk_list = self.chunk_findings(parsed_findings)
         results_list = []

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -330,6 +330,8 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         ASYNC_FINDING_IMPORT_CHUNK_SIZE setting will determine how many
         findings will be processed in a given worker/process/thread
         """
+        from warnings import warn
+        warn("This experimental feature has been deprecated as of DefectDojo 2.44.0 (March release). Please exercise caution if using this feature with an older version of DefectDojo, as results may be inconsistent.")
         # Indicate that the test is not complete yet as endpoints will still be rolling in.
         self.update_test_progress(percentage_value=50)
         chunk_list = self.chunk_findings(parsed_findings)

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -1,4 +1,5 @@
 import logging
+from warnings import warn
 
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.core.serializers import deserialize, serialize
@@ -330,7 +331,6 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         ASYNC_FINDING_IMPORT_CHUNK_SIZE setting will determine how many
         findings will be processed in a given worker/process/thread
         """
-        from warnings import warn
         warn("This experimental feature has been deprecated as of DefectDojo 2.44.0 (March release). Please exercise caution if using this feature with an older version of DefectDojo, as results may be inconsistent.")
         # Indicate that the test is not complete yet as endpoints will still be rolling in.
         self.update_test_progress(percentage_value=50)

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -258,8 +258,10 @@ env = environ.FileAwareEnv(
     # when enabled SonarQube API parser will download the security hotspots
     DD_SONARQUBE_API_PARSER_HOTSPOTS=(bool, True),
     # when enabled, finding importing will occur asynchronously, default False
+    # This experimental feature has been deprecated as of DefectDojo 2.44.0 (March release). Please exercise caution if using this feature with an older version of DefectDojo, as results may be inconsistent.
     DD_ASYNC_FINDING_IMPORT=(bool, False),
     # The number of findings to be processed per celeryworker
+    # This experimental feature has been deprecated as of DefectDojo 2.44.0 (March release). Please exercise caution if using this feature with an older version of DefectDojo, as results may be inconsistent.
     DD_ASYNC_FINDING_IMPORT_CHUNK_SIZE=(int, 100),
     # When enabled, deleting objects will be occur from the bottom up. In the example of deleting an engagement
     # The objects will be deleted as follows Endpoints -> Findings -> Tests -> Engagement


### PR DESCRIPTION
- Added warnings to async_process_findings

- Added comments in settings.dist.py

Note:
I took the text for the warnings  and comments from the [documentation](https://docs.defectdojo.com/en/open_source/installation/running-in-production/#asynchronous-import) . Let me know if I should change this text to something potentially more helpful.

[sc-6355]
