### PR TITLE
SLA Calculations: Add unit tests to capture current behaviour

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3063,6 +3063,7 @@ class Finding(models.Model):
                 self.sla_expiration_date = get_current_date() + relativedelta(days=days_remaining)
 
     def sla_days_remaining(self):
+        logger.error(f"sla_days_remaining: {get_current_date()} {self.mitigated} {self.sla_expiration_date}")
         if self.sla_expiration_date:
             if self.mitigated:
                 mitigated_date = self.mitigated

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -261,32 +261,32 @@ def finding_sla(finding):
     if not get_system_setting("enable_finding_sla"):
         return ""
 
-    sla_age, enforce_sla = finding.get_sla_period()
+    sla_period, enforce_sla = finding.get_sla_period()
     if not enforce_sla:
         return ""
 
     title = ""
     severity = finding.severity
-    find_sla = finding.sla_days_remaining()
+    days_remaining = finding.sla_days_remaining()
     if finding.mitigated:
         status = "blue"
-        status_text = "Remediated within SLA for " + severity.lower() + " findings (" + str(sla_age) + " days since " + finding.get_sla_start_date().strftime("%b %d, %Y") + ")"
-        if find_sla and find_sla < 0:
+        status_text = "Remediated within SLA for " + severity.lower() + " findings (" + str(sla_period) + " days since " + finding.get_sla_start_date().strftime("%b %d, %Y") + ")"
+        if days_remaining and days_remaining < 0:
             status = "orange"
-            find_sla = abs(find_sla)
+            days_remaining = abs(days_remaining)
             status_text = "Out of SLA: Remediated " + str(
-                find_sla) + " days past SLA for " + severity.lower() + " findings (" + str(sla_age) + " days since " + finding.get_sla_start_date().strftime("%b %d, %Y") + ")"
+                days_remaining) + " days past SLA for " + severity.lower() + " findings (" + str(sla_period) + " days since " + finding.get_sla_start_date().strftime("%b %d, %Y") + ")"
     else:
         status = "green"
-        status_text = "Remediation for " + severity.lower() + " findings in " + str(sla_age) + " days or less since " + finding.get_sla_start_date().strftime("%b %d, %Y")
-        if find_sla and find_sla < 0:
+        status_text = "Remediation for " + severity.lower() + " findings in " + str(sla_period) + " days or less since " + finding.get_sla_start_date().strftime("%b %d, %Y")
+        if days_remaining and days_remaining < 0:
             status = "red"
             status_text = "Overdue: Remediation for " + severity.lower() + " findings in " + str(
-                sla_age) + " days or less since " + finding.get_sla_start_date().strftime("%b %d, %Y")
+                sla_period) + " days or less since " + finding.get_sla_start_date().strftime("%b %d, %Y")
 
-    if find_sla is not None:
+    if days_remaining is not None:
         title = '<a class="has-popover" data-toggle="tooltip" data-placement="bottom" title="" href="#" data-content="' + status_text + '">' \
-                                                                                                                           '<span class="label severity age-' + status + '">' + str(find_sla) + "</span></a>"
+                                                                                                                           '<span class="label severity age-' + status + '">' + str(days_remaining) + "</span></a>"
 
     return mark_safe(title)
 

--- a/unittests/test_sla_calculations.py
+++ b/unittests/test_sla_calculations.py
@@ -90,8 +90,9 @@ class TestSLACalculations(DojoTestCase):
             # sla_expiration_date should not change just because a finding is mitigated
             self.assertEqual(initial_sla_expiration_date, finding.sla_expiration_date)
             self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
-            self.assertEqual(self.sla_config.high - 10, finding.sla_days_remaining())
+            self.assertEqual(20, finding.sla_days_remaining())
             self.assertTrue("within SLA" in finding_sla(finding))
+            self.assertTrue(">20<" in finding_sla(finding))
 
         with patch("django.db.models.fields.timezone.now") as mock_now:
             mock_now.return_value = self.now + relativedelta(days=20)
@@ -102,8 +103,9 @@ class TestSLACalculations(DojoTestCase):
             # sla_expiration_date should not change just because a finding is saved
             self.assertEqual(initial_sla_expiration_date, finding.sla_expiration_date)
             self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
-            self.assertEqual(self.sla_config.high - 10, finding.sla_days_remaining())
+            self.assertEqual(20, finding.sla_days_remaining())
             self.assertTrue("within SLA" in finding_sla(finding))
+            self.assertTrue(">20<" in finding_sla(finding))
 
     # Finding mitigated outside SLA should have correct sla_exration_date and days_remaining
     def test_mitigated_outside_sla(self):
@@ -115,7 +117,7 @@ class TestSLACalculations(DojoTestCase):
         initial_sla_expiration_date = finding.sla_expiration_date
 
         with patch("django.db.models.fields.timezone.now") as mock_now:
-            mock_now.return_value = self.now + relativedelta(days=40)
+            mock_now.return_value = self.now + relativedelta(days=45)
             finding.mitigated = mock_now.return_value
             finding.is_mitigated = True
             finding.active = False
@@ -126,11 +128,13 @@ class TestSLACalculations(DojoTestCase):
             # sla_expiration_date should not change just because a finding is mitigated
             self.assertEqual(initial_sla_expiration_date, finding.sla_expiration_date)
             self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
-            self.assertEqual(self.sla_config.high - 40, finding.sla_days_remaining())
+            self.assertEqual(-15, finding.sla_days_remaining())
             self.assertTrue("Out of SLA" in finding_sla(finding))
+            self.assertTrue("15 days past" in finding_sla(finding))
+            self.assertTrue(">15<" in finding_sla(finding))
 
         with patch("django.db.models.fields.timezone.now") as mock_now:
-            mock_now.return_value = self.now + relativedelta(days=50)
+            mock_now.return_value = self.now + relativedelta(days=55)
             finding.save()
             logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.mitigated} {finding.sla_expiration_date}")
             logger.error(finding_sla(finding))
@@ -138,5 +142,7 @@ class TestSLACalculations(DojoTestCase):
             # sla_expiration_date should not change just because a finding is mitigated
             self.assertEqual(initial_sla_expiration_date, finding.sla_expiration_date)
             self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
-            self.assertEqual(self.sla_config.high - 40, finding.sla_days_remaining())
+            self.assertEqual(-15, finding.sla_days_remaining())
             self.assertTrue("Out of SLA" in finding_sla(finding))
+            self.assertTrue("15 days past" in finding_sla(finding))
+            self.assertTrue(">15<" in finding_sla(finding))

--- a/unittests/test_sla_calculations.py
+++ b/unittests/test_sla_calculations.py
@@ -1,0 +1,142 @@
+import datetime
+import logging
+from unittest.mock import patch
+
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
+
+from dojo.models import (
+    Finding,
+    SLA_Configuration,
+    Test,
+)
+from dojo.templatetags.display_tags import finding_sla
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+class TestSLACalculations(DojoTestCase):
+    fixtures = ["dojo_testdata.json"]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.now = timezone.now()
+
+        cls.sla_config = SLA_Configuration.objects.all().first()
+        cls.sla_config.enforce_critical = True
+        cls.sla_config.enforce_high = True
+        cls.sla_config.enforce_medium = True
+        cls.sla_config.enforce_low = True
+        cls.sla_config.save()
+        # for finding in Finding.objects.all().order_by("test"):
+        #     logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.sla_expiration_date}")
+        logger.error(f"SLA Config: {cls.sla_config.critical} {cls.sla_config.high} {cls.sla_config.medium} {cls.sla_config.low}")
+
+    # New finding should have sla_expiration_date set
+    def test_new_finding(self):
+        finding = Finding(test=Test.objects.get(id=89), title="Test Finding", severity="High")
+        finding.save()
+
+        logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.mitigated}  {finding.sla_expiration_date}")
+
+        self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
+        self.assertEqual(self.sla_config.high, finding.sla_days_remaining())
+
+    # Finding within SLA should have correct sla_exration_date and days_remaining
+    def test_active_within_sla(self):
+        finding = Finding(test=Test.objects.get(id=89), title="Test Finding", severity="High")
+        finding.save()
+
+        logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.mitigated}  {finding.sla_expiration_date}")
+
+        with patch("django.db.models.fields.timezone.now") as mock_now:
+            mock_now.return_value = self.now + relativedelta(days=10)
+            self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
+            self.assertEqual(self.sla_config.high - 10, finding.sla_days_remaining())
+
+    # Finding outside SLA should have correct sla_exration_date and days_remaining
+    def test_active_outside_sla(self):
+        finding = Finding(test=Test.objects.get(id=89), title="Test Finding", severity="High")
+        finding.save()
+
+        logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.mitigated} {finding.sla_expiration_date}")
+
+        with patch("django.db.models.fields.timezone.now") as mock_now:
+            mock_now.return_value = self.now + relativedelta(days=50)
+            self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
+            self.assertEqual(self.sla_config.high - 50, finding.sla_days_remaining())
+
+    # Finding mitigated inside SLA should have correct sla_exration_date and days_remaining
+    def test_mitigated_inside_sla(self):
+        finding = Finding(test=Test.objects.get(id=89), title="Test Finding", severity="High")
+        finding.save()
+
+        logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.mitigated}  {finding.sla_expiration_date}")
+
+        initial_sla_expiration_date = finding.sla_expiration_date
+
+        with patch("django.db.models.fields.timezone.now") as mock_now:
+            mock_now.return_value = self.now + relativedelta(days=10)
+            finding.mitigated = mock_now.return_value
+            finding.is_mitigated = True
+            finding.active = False
+            finding.save()
+            logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.mitigated}  {finding.sla_expiration_date}")
+            logger.error(finding_sla(finding))
+
+            # sla_expiration_date should not change just because a finding is mitigated
+            self.assertEqual(initial_sla_expiration_date, finding.sla_expiration_date)
+            self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
+            self.assertEqual(self.sla_config.high - 10, finding.sla_days_remaining())
+            self.assertTrue("within SLA" in finding_sla(finding))
+
+        with patch("django.db.models.fields.timezone.now") as mock_now:
+            mock_now.return_value = self.now + relativedelta(days=20)
+            finding.save()
+            logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.mitigated}  {finding.sla_expiration_date}")
+            logger.error(finding_sla(finding))
+
+            # sla_expiration_date should not change just because a finding is saved
+            self.assertEqual(initial_sla_expiration_date, finding.sla_expiration_date)
+            self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
+            self.assertEqual(self.sla_config.high - 10, finding.sla_days_remaining())
+            self.assertTrue("within SLA" in finding_sla(finding))
+
+    # Finding mitigated outside SLA should have correct sla_exration_date and days_remaining
+    def test_mitigated_outside_sla(self):
+        finding = Finding(test=Test.objects.get(id=89), title="Test Finding", severity="High")
+        finding.save()
+
+        logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.sla_expiration_date}")
+
+        initial_sla_expiration_date = finding.sla_expiration_date
+
+        with patch("django.db.models.fields.timezone.now") as mock_now:
+            mock_now.return_value = self.now + relativedelta(days=40)
+            finding.mitigated = mock_now.return_value
+            finding.is_mitigated = True
+            finding.active = False
+            finding.save()
+            logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.mitigated} {finding.sla_expiration_date}")
+            logger.error(finding_sla(finding))
+
+            # sla_expiration_date should not change just because a finding is mitigated
+            self.assertEqual(initial_sla_expiration_date, finding.sla_expiration_date)
+            self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
+            self.assertEqual(self.sla_config.high - 40, finding.sla_days_remaining())
+            self.assertTrue("Out of SLA" in finding_sla(finding))
+
+        with patch("django.db.models.fields.timezone.now") as mock_now:
+            mock_now.return_value = self.now + relativedelta(days=50)
+            finding.save()
+            logger.error(f"Finding: {finding.test.id} {finding.id} {finding.date} {finding.mitigated} {finding.sla_expiration_date}")
+            logger.error(finding_sla(finding))
+
+            # sla_expiration_date should not change just because a finding is mitigated
+            self.assertEqual(initial_sla_expiration_date, finding.sla_expiration_date)
+            self.assertEqual((self.now + relativedelta(days=self.sla_config.high)).date(), finding.sla_expiration_date)
+            self.assertEqual(self.sla_config.high - 40, finding.sla_days_remaining())
+            self.assertTrue("Out of SLA" in finding_sla(finding))


### PR DESCRIPTION
Adds some unit tests to capture current behaviour:
- to understand the calculation that does some magic with days remaining
- to make sure we don't regress in the future if we simplify the calculation, or add business days support.