### PR TITLE
docker entrypoints: use bash everywhere

### DIFF
--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Run available unittests with a setup for local dev:
 # - Make migrations and apply any needed changes
 # - Leave container up after running tests to allow debugging, rerunning tests, etc.

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Run available unittests with a setup for CI/CD:
 # - Fail if migrations are not created
 # - Exit container after running tests to allow exit code to propagate as test result

--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e  # needed to handle "exit" correctly
 

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-
+#!/bin/bash
 set -e  # needed to handle "exit" correctly
 
 . /secret-file-loader.sh


### PR DESCRIPTION
Some entrypoint scripts where using `sh` which doesn't recognize `if [[...` used in places like `wait_for_database_to_be_reachable`

Fixes these errors on startup:
```
/entrypoint-uwsgi.sh: 21: [[: not found
```

Credits to @9alexx3 on Slack for suggesting this fix.