### PR TITLE
Notes history/edit/delete bugfix

### DIFF
--- a/dojo/notes/urls.py
+++ b/dojo/notes/urls.py
@@ -3,7 +3,7 @@ from django.urls import re_path
 from . import views
 
 urlpatterns = [
-    re_path(r"^notes/(?P<id>\d+)/delete/(?P<page>[\w-]+)/(?P<objid>\d+)$", views.delete_note, name="delete_note"),
-    re_path(r"^notes/(?P<id>\d+)/edit/(?P<page>[\w-]+)/(?P<objid>\d+)$", views.edit_note, name="edit_note"),
-    re_path(r"^notes/(?P<id>\d+)/history/(?P<page>[\w-]+)/(?P<objid>\d+)$", views.note_history, name="note_history"),
+    re_path(r"^notes/(?P<note_id>\d+)/delete/(?P<page>[\w-]+)/(?P<objid>\d+)$", views.delete_note, name="delete_note"),
+    re_path(r"^notes/(?P<note_id>\d+)/edit/(?P<page>[\w-]+)/(?P<objid>\d+)$", views.edit_note, name="edit_note"),
+    re_path(r"^notes/(?P<note_id>\d+)/history/(?P<page>[\w-]+)/(?P<objid>\d+)$", views.note_history, name="note_history"),
                 ]

--- a/dojo/notes/views.py
+++ b/dojo/notes/views.py
@@ -141,8 +141,8 @@ def edit_note(request, note_id, page, objid):
         })
 
 
-def note_history(request, elem_id, page, objid):
-    note = get_object_or_404(Notes, id=elem_id)
+def note_history(request, note_id, page, objid):
+    note = get_object_or_404(Notes, id=note_id)
     reverse_url = None
     object_id = None
 


### PR DESCRIPTION
Recent linter updates changed some view method parameter names to avoid shadowing builtin names; this patch simply updates the corresponding url routes to use these new names.

[sc-10365]