### PR TITLE
fix(notif): Add findings_reactivated and findings_untouched again

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -131,7 +131,9 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             self.test,
             updated_count,
             new_findings=new_findings,
+            findings_reactivated=reactivated_findings,
             findings_mitigated=closed_findings,
+            findings_untouched=untouched_findings,
         )
         # Update the test progress to reflect that the import has completed
         logger.debug("REIMPORT_SCAN: Updating Test progress")


### PR DESCRIPTION
`findings_reactivated` and `findings_untouched` had been dropped during some migration, and copy-pasting from `DefaultImporter` did not work.

Notifications are triggered correctly but list (e.g. in email) is empty.