### PR TITLE
dedupe managament command: ensure ordering

### DIFF
--- a/dojo/management/commands/dedupe.py
+++ b/dojo/management/commands/dedupe.py
@@ -61,6 +61,9 @@ class Command(BaseCommand):
             findings = Finding.objects.all().filter(id__gt=0)
             logger.info("######## Will process the full database with %d findings ########", findings.count())
 
+        # process in reverse order to ensure the newer findings are marked as duplicate of older findings
+        findings.order_by("-id")
+
         # Phase 1: update hash_codes without deduplicating
         if not dedupe_only:
             logger.info("######## Start Updating Hashcodes (foreground) ########")


### PR DESCRIPTION
**Description**
Fixes #11948 
For deduplication it's important to start with the newest findings first to make sure the old(est) existing finding is selected as the original. This is already working correctly inside Defect Dojo, but not in the `dedupe` management command. This PR fixes that.