### PR TITLE
docs: source-code-repositories: clarify default scm type

### DIFF
--- a/docs/content/en/open_source/archived_docs/integrations/source-code-repositories.md
+++ b/docs/content/en/open_source/archived_docs/integrations/source-code-repositories.md
@@ -29,7 +29,7 @@ For CI/CD Engagement, where user could set commit hash, branch/tag and code line
 
 If user does not set commit hash or branch/tag in appropriate fields of CI/CD Engagement edit form, the URL should look like in Interactive Engagement edit form.
 
-SCM navigation URL is composed from Repo URL using SCM Type. Github/Gitlab SCM type is default, but user could set certain SCM type in Product custom field "scm-type".
+SCM navigation URL is composed from Repo URL using SCM Type. A specific SCM type can be set in Product custom field "scm-type". If no "scm-type" is set and the URL contains "https://github.com", a "github" SCM type is assumed.
 
 Product custom fields:
 


### PR DESCRIPTION
Small docs update responding to #11945