### PR TITLE
notifications: add findings_reactivated to notify_scan_added

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -132,6 +132,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             updated_count,
             new_findings=new_findings,
             findings_mitigated=closed_findings,
+            findings_reactivated=reactivated_findings
         )
         # Update the test progress to reflect that the import has completed
         logger.debug("REIMPORT_SCAN: Updating Test progress")


### PR DESCRIPTION
First sorry if the process is wrong, this is just a very small patch.
Happy to close it / update if this is not how things are done to contribute to v2.

**Description**

When using the reimport API on a test, with notificiations configured, the `findings_reactivated` list is always empty: https://github.com/DefectDojo/django-DefectDojo/blob/7d3106e10cd9f3296e24b95b3797df94cf362079/dojo/importers/base_importer.py#L766

This is because the parameter is not given by the `notify_scan_added()` caller.

**Test results**

I didn't find how to test the notification directly via the `process_scan()` or `ImportScanTest`. As the change is very small, I tested by:
- setting up a slack notifications (customized to display `findings_mitigated` in `scan_added.tpl`), where I noticed the problem
- upload a scan with some removed vulns
- reupload the scan with vulns put back to trigger the reactivated findings

**Documentation**

No doc updated