### PR TITLE
update permissions documentation links to reflect correct paths

### DIFF
--- a/dojo/templates/dojo/profile.html
+++ b/dojo/templates/dojo/profile.html
@@ -46,7 +46,7 @@
                     <div class="clearfix">
                         <h4 class="pull-left">{% trans "Groups" %}</h4>
                         &nbsp;
-                        <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
+                        <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/about_perms_and_roles/#group-memberships" target="_blank">
                             <i class="fa-solid fa-circle-question"></i></a>
                         {% if request.user.is_superuser %}
                         <div class="dropdown pull-right">

--- a/dojo/templates/dojo/view_group.html
+++ b/dojo/templates/dojo/view_group.html
@@ -45,7 +45,7 @@
                 <div class="clearfix">
                     <h4 class="pull-left">Members of this Group</h4>
                     &nbsp;
-                    <a href="https://documentation.defectdojo.com/usage/permissions/#groups" target="_blank">
+                    <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/create_user_group/#manage-a-groups-users" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
                     {% if group|has_object_permission:"Group_Manage_Members" %}
                     <div class="dropdown pull-right">
@@ -118,7 +118,7 @@
                 <div class="clearfix">
                     <h4 class="pull-left">Product Types this Group can access</h4>
                     &nbsp;
-                    <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
+                    <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/create_user_group/#add-product-roles-or-product-type-roles-for-a-group" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">
@@ -192,7 +192,7 @@
                 <div class="clearfix">
                     <h4 class="pull-left">Products this Group can access</h4>
                     &nbsp;
-                    <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
+                    <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/create_user_group/#add-product-roles-or-product-type-roles-for-a-group" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -277,7 +277,7 @@
             <div class="clearfix">
                 <h4 class="pull-left">{% trans "Members" %}</h4>
                 &nbsp;
-                <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
+                <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/about_perms_and_roles/#productproduct-type-membership--roles" target="_blank">
                     <i class="fa-solid fa-circle-question"></i></a>
                 {% if prod|has_object_permission:"Product_Manage_Members" %}
                 <div class="dropdown pull-right">
@@ -374,7 +374,7 @@
               <div class="clearfix">
                   <h4 class="pull-left">{% trans "Groups" %}</h4>
                   &nbsp;
-                  <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
+                  <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/about_perms_and_roles/#group-memberships" target="_blank">
                       <i class="fa-solid fa-circle-question"></i></a>
                   {% if prod|has_object_permission:"Product_Group_Add" %}
                   <div class="dropdown pull-right">

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -135,7 +135,7 @@
                         <div class="clearfix">
                             <h4 class="pull-left">{% trans "Members" %}</h4>
                             &nbsp;
-                            <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
+                            <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/about_perms_and_roles/#productproduct-type-membership--roles" target="_blank">
                                 <i class="fa-solid fa-circle-question"></i></a>
                             {% if pt|has_object_permission:"Product_Type_Manage_Members" %}
                             <div class="dropdown pull-right">
@@ -216,7 +216,7 @@
                     <div class="clearfix">
                         <h4 class="pull-left">{% trans "Groups" %}</h4>
                         &nbsp;
-                        <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
+                        <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/about_perms_and_roles/#group-memberships" target="_blank">
                             <i class="fa-solid fa-circle-question"></i></a>
                         {% if pt|has_object_permission:"Product_Type_Group_Add" %}
                         <div class="dropdown pull-right">

--- a/dojo/templates/dojo/view_user.html
+++ b/dojo/templates/dojo/view_user.html
@@ -106,7 +106,7 @@
                 <div class="clearfix">
                     <h4 class="pull-left">{% trans "Product Types this User can access" %}</h4>
                     &nbsp;
-                    <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
+                    <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/about_perms_and_roles/#productproduct-type-membership--roles" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">
@@ -179,7 +179,7 @@
                 <div class="clearfix">
                     <h4 class="pull-left">{% trans "Products this User can access" %}</h4>
                     &nbsp;
-                    <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
+                    <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/about_perms_and_roles/#productproduct-type-membership--roles" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">
@@ -253,7 +253,7 @@
                 <div class="clearfix">
                     <h4 class="pull-left">{% trans "Groups this User is a member of" %}</h4>
                     &nbsp;
-                    <a href="https://documentation.defectdojo.com/usage/permissions/#groups" target="_blank">
+                    <a href="https://docs.defectdojo.com/en/customize_dojo/user_management/about_perms_and_roles/#group-memberships" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">


### PR DESCRIPTION
The links to existing permissions/groups documentation (e.g. [https://documentation.defectdojo.com/usage/permissions/](https://documentation.defectdojo.com/usage/permissions/)) no longer exist.

This pull request updates documentation links for Product Type and Product membership, as well as Group Membership in the User, Group, Product Type, and Product views.

[sc-10454]