### PR TITLE
upgrade notes: correct dedupe command lines

### DIFF
--- a/docs/content/en/open_source/upgrading/2.42.md
+++ b/docs/content/en/open_source/upgrading/2.42.md
@@ -9,9 +9,9 @@ exclude_search: true
 **Hash Code changes**
 A few parsers have been updated to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code please execute the following command:
 
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Horusec Scan" --hash_code_only`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Qualys Hacker Guardian Scan --hash_code_only"`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Red Hat Satellite --hash_code_only"`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Horusec Scan' --hash_code_only"`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Qualys Hacker Guardian Scan' --hash_code_only"`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Red Hat Satellite' --hash_code_only"`
 
 This command has various command line arguments to tweak its behaviour, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.

--- a/docs/content/en/open_source/upgrading/2.42.md
+++ b/docs/content/en/open_source/upgrading/2.42.md
@@ -9,9 +9,9 @@ exclude_search: true
 **Hash Code changes**
 A few parsers have been updated to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code please execute the following command:
 
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Horusec Scan' --hash_code_only"`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Qualys Hacker Guardian Scan' --hash_code_only"`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Red Hat Satellite' --hash_code_only"`
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Horusec Scan' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Qualys Hacker Guardian Scan' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Red Hat Satellite' --hash_code_only"
 
 This command has various command line arguments to tweak its behaviour, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.

--- a/docs/content/en/open_source/upgrading/2.43.md
+++ b/docs/content/en/open_source/upgrading/2.43.md
@@ -33,11 +33,11 @@ In the past, when DefectDojo supported different database and message brokers, `
 
 The Rusty Hog parser has been [updated](https://github.com/DefectDojo/django-DefectDojo/pull/11433) to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code and deduplicate existing Rusty Hog findings, please execute the following command:
 
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Rusty Hog Scan)" --hash_code_only`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Choctaw Hog)" --hash_code_only`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Duroc Hog)" --hash_code_only`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Gottingen Hog)" --hash_code_only`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Essex Hog)" --hash_code_only`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Rusty Hog Scan)' --hash_code_only"`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Choctaw Hog)' --hash_code_only"`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Duroc Hog)' --hash_code_only"`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Gottingen Hog)' --hash_code_only"`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Essex Hog)' --hash_code_only"`
 
 This command has various command line arguments to tweak its behaviour, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.

--- a/docs/content/en/open_source/upgrading/2.43.md
+++ b/docs/content/en/open_source/upgrading/2.43.md
@@ -33,11 +33,11 @@ In the past, when DefectDojo supported different database and message brokers, `
 
 The Rusty Hog parser has been [updated](https://github.com/DefectDojo/django-DefectDojo/pull/11433) to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code and deduplicate existing Rusty Hog findings, please execute the following command:
 
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Rusty Hog Scan)' --hash_code_only"`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Choctaw Hog)' --hash_code_only"`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Duroc Hog)' --hash_code_only"`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Gottingen Hog)' --hash_code_only"`
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Essex Hog)' --hash_code_only"`
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Rusty Hog Scan)' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Choctaw Hog)' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Duroc Hog)' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Gottingen Hog)' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Essex Hog)' --hash_code_only"
 
 This command has various command line arguments to tweak its behaviour, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.

--- a/docs/content/en/open_source/upgrading/2.44.md
+++ b/docs/content/en/open_source/upgrading/2.44.md
@@ -1,5 +1,5 @@
 ---
-title: 'Upgrading to DefectDojo Version 2.44.x'
+title: 'Upgrading to DefectDojo Version 2.44.0'
 toc_hide: true
 weight: -20250203
 description: No special instructions.
@@ -9,7 +9,7 @@ description: No special instructions.
 
 The Burp parser now has a custom deduplication configuration to make deduplication more accurate. To recalculate the hash code and deduplicate existing Burp findings, please execute the following command:
 
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Burp Scan' --hash_code_only"`
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Burp Scan' --hash_code_only"
 
 This command has various command line arguments to tweak its behavior, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.

--- a/docs/content/en/open_source/upgrading/2.44.md
+++ b/docs/content/en/open_source/upgrading/2.44.md
@@ -9,7 +9,7 @@ description: No special instructions.
 
 The Burp parser now has a custom deduplication configuration to make deduplication more accurate. To recalculate the hash code and deduplicate existing Burp findings, please execute the following command:
 
-    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Burp Scan" --hash_code_only`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Burp Scan' --hash_code_only"`
 
 This command has various command line arguments to tweak its behavior, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.


### PR DESCRIPTION
Some small fixes here mainly around quoting.