### PR TITLE
fix(helm-metrics): Flag format for promExporter changed

### DIFF
--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -136,7 +136,7 @@ spec:
       - name: metrics
         image: {{ .Values.monitoring.prometheus.image }}
         imagePullPolicy: {{ .Values.monitoring.prometheus.imagePullPolicy }}
-        command: [ '/usr/bin/nginx-prometheus-exporter', '-nginx.scrape-uri', 'http://127.0.0.1:8080/nginx_status']
+        command: [ '/usr/bin/nginx-prometheus-exporter', '--nginx.scrape-uri', 'http://127.0.0.1:8080/nginx_status']
         ports:
         - name: http-metrics
           protocol: TCP


### PR DESCRIPTION
For `nginx-prometheus-exporter` from `v1.0.0`, the flag format was changed. Old is still not deprecated, but there is already a warning:
```
the flag format is deprecated and will be removed in a future release, please use the new format: --nginx.scrape-uri
```

