### PR TITLE
add resources to wait-for-db

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -103,6 +103,8 @@ spec:
         {{- with .Values.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        resources:
+          {{- toYaml .Values.initializer.resources | nindent 10 }}
       containers:
       - name: initializer
         image: "{{ template "initializer.repository" . }}:{{ .Values.tag }}"


### PR DESCRIPTION
## :warning: Note on feature completeness :warning:

We are narrowing the scope of acceptable enhancements to DefectDojo in preparation for v3. Learn more here:
https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/CONTRIBUTING.md

**Description**

Describe the feature / bug fix implemented by this PR.
If the Kubernetes Namespace has ResourceQuotas set. the "wait-for-db" pod is unable to start, as resources are forced to be set.
For simplicity, I would use the same resources as for the main container from the Job

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [ x ] Bugfixes should be submitted against the `bugfix` branch.
- [ x ] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [] Add the proper label to categorize your PR.
