### PR TITLE
Jira Webhook: Prevent finding group findings from being reopened

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1677,7 +1677,7 @@ def escape_for_jira(text):
     return text.replace("|", "%7D")
 
 
-def process_resolution_from_jira(finding, resolution_id, resolution_name, assignee_name, jira_now, jira_issue, finding_is_grouped: bool = False) -> bool:
+def process_resolution_from_jira(finding, resolution_id, resolution_name, assignee_name, jira_now, jira_issue, finding_group: Finding_Group = None) -> bool:
     """Processes the resolution field in the JIRA issue and updated the finding in Defect Dojo accordingly"""
     import dojo.risk_acceptance.helper as ra_helper
     status_changed = False
@@ -1720,7 +1720,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
             finding.false_p = False
             ra_helper.risk_unaccept(User.objects.get_or_create(username="JIRA")[0], finding)
             status_changed = True
-    elif not finding.active and (not finding_is_grouped or settings.JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN):
+    elif not finding.active and (finding_group is None or settings.JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN):
         # Reopen / Open Jira issue
         logger.debug(f"Re-opening related finding of {jira_issue.jira_key}")
         finding.active = True

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1677,7 +1677,7 @@ def escape_for_jira(text):
     return text.replace("|", "%7D")
 
 
-def process_resolution_from_jira(finding, resolution_id, resolution_name, assignee_name, jira_now, jira_issue) -> bool:
+def process_resolution_from_jira(finding, resolution_id, resolution_name, assignee_name, jira_now, jira_issue, finding_is_grouped: bool = False) -> bool:
     """Processes the resolution field in the JIRA issue and updated the finding in Defect Dojo accordingly"""
     import dojo.risk_acceptance.helper as ra_helper
     status_changed = False
@@ -1720,7 +1720,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
             finding.false_p = False
             ra_helper.risk_unaccept(User.objects.get_or_create(username="JIRA")[0], finding)
             status_changed = True
-    elif not finding.active:
+    elif not finding.active and (not finding_is_grouped or settings.JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN):
         # Reopen / Open Jira issue
         logger.debug(f"Re-opening related finding of {jira_issue.jira_key}")
         finding.active = True

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -98,7 +98,6 @@ def webhook(request, secret=None):
             except JIRA_Instance.DoesNotExist:
                 return webhook_responser_handler("info", f"JIRA issue {jid} is not linked to a DefectDojo Finding")
             findings = None
-            finding_is_grouped = False
             # Determine what type of object we will be working with
             if jissue.finding:
                 logger.debug(f"Received issue update for {jissue.jira_key} for finding {jissue.finding.id}")
@@ -106,7 +105,6 @@ def webhook(request, secret=None):
             elif jissue.finding_group:
                 logger.debug(f"Received issue update for {jissue.jira_key} for finding group {jissue.finding_group}")
                 findings = jissue.finding_group.findings.all()
-                finding_is_grouped = True
             elif jissue.engagement:
                 return webhook_responser_handler("debug", "Update for engagement ignored")
             else:
@@ -139,7 +137,7 @@ def webhook(request, secret=None):
 
             if findings:
                 for finding in findings:
-                    jira_helper.process_resolution_from_jira(finding, resolution_id, resolution_name, assignee_name, jira_now, jissue, finding_is_grouped=finding_is_grouped)
+                    jira_helper.process_resolution_from_jira(finding, resolution_id, resolution_name, assignee_name, jira_now, jissue, finding_group=jissue.finding_group)
             # Check for any comment that could have come along with the resolution
             if (error_response := check_for_and_create_comment(parsed)) is not None:
                 return error_response

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -98,6 +98,7 @@ def webhook(request, secret=None):
             except JIRA_Instance.DoesNotExist:
                 return webhook_responser_handler("info", f"JIRA issue {jid} is not linked to a DefectDojo Finding")
             findings = None
+            finding_is_grouped = False
             # Determine what type of object we will be working with
             if jissue.finding:
                 logger.debug(f"Received issue update for {jissue.jira_key} for finding {jissue.finding.id}")
@@ -105,6 +106,7 @@ def webhook(request, secret=None):
             elif jissue.finding_group:
                 logger.debug(f"Received issue update for {jissue.jira_key} for finding group {jissue.finding_group}")
                 findings = jissue.finding_group.findings.all()
+                finding_is_grouped = True
             elif jissue.engagement:
                 return webhook_responser_handler("debug", "Update for engagement ignored")
             else:
@@ -137,7 +139,7 @@ def webhook(request, secret=None):
 
             if findings:
                 for finding in findings:
-                    jira_helper.process_resolution_from_jira(finding, resolution_id, resolution_name, assignee_name, jira_now, jissue)
+                    jira_helper.process_resolution_from_jira(finding, resolution_id, resolution_name, assignee_name, jira_now, jissue, finding_is_grouped=finding_is_grouped)
             # Check for any comment that could have come along with the resolution
             if (error_response := check_for_and_create_comment(parsed)) is not None:
                 return error_response

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -225,6 +225,9 @@ env = environ.FileAwareEnv(
     DD_MAX_REQRESP_FROM_API=(int, -1),
     DD_MAX_AUTOCOMPLETE_WORDS=(int, 20000),
     DD_JIRA_SSL_VERIFY=(bool, True),
+    # When interacting with jira tickets that attached finding groups, we should no be opening any findings
+    # on the DefectDojo side because jira has no way of knowing if a finding really should be reopened or not
+    DD_JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN=(bool, False),
     # You can set extra Jira issue types via a simple env var that supports a csv format, like "Work Item,Vulnerability"
     DD_JIRA_EXTRA_ISSUE_TYPES=(str, ""),
     # if you want to keep logging to the console but in json format, change this here to 'json_console'
@@ -1632,6 +1635,7 @@ if env("DD_JIRA_EXTRA_ISSUE_TYPES") != "":
         JIRA_ISSUE_TYPE_CHOICES_CONFIG += ((extra_type, extra_type),)
 
 JIRA_SSL_VERIFY = env("DD_JIRA_SSL_VERIFY")
+JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN = env("DD_JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN")
 
 # ------------------------------------------------------------------------------
 # LOGGING


### PR DESCRIPTION
When interacting with jira tickets that attached finding groups, we should no be opening any findings on the DefectDojo side because jira has no way of knowing if a finding really should be reopened or not

[sc-10319]