### PR TITLE
Generic JSON: Explicitly process tags like other tools

### DIFF
--- a/dojo/tools/generic/json_parser.py
+++ b/dojo/tools/generic/json_parser.py
@@ -17,22 +17,26 @@ class GenericJSONParser:
         )
         test_internal.findings = []
         for item in data.get("findings", []):
-            # remove endpoints of the dictionnary
+            # remove endpoints from the dictionary
             unsaved_endpoints = None
             if "endpoints" in item:
                 unsaved_endpoints = item["endpoints"]
                 del item["endpoints"]
-            # remove files of the dictionnary
+            # remove files from the dictionary
             unsaved_files = None
             if "files" in item:
                 unsaved_files = item["files"]
                 del item["files"]
-            # remove vulnerability_ids of the dictionnary
+            # remove tags from the dictionary
+            unsaved_tags = None
+            if "tags" in item:
+                unsaved_tags = item["tags"]
+                del item["tags"]
+            # remove vulnerability_ids from the dictionary
             unsaved_vulnerability_ids = None
             if "vulnerability_ids" in item:
                 unsaved_vulnerability_ids = item["vulnerability_ids"]
                 del item["vulnerability_ids"]
-
             # check for required keys
             required = {"title", "severity", "description"}
             missing = sorted(required.difference(item))
@@ -115,6 +119,8 @@ class GenericJSONParser:
                     FileUpload(title=title, file=ContentFile(data)).clean()
 
                 finding.unsaved_files = unsaved_files
+            if unsaved_tags:
+                finding.unsaved_tags = unsaved_tags
             if finding.cve:
                 finding.unsaved_vulnerability_ids = [finding.cve]
             if unsaved_vulnerability_ids:


### PR DESCRIPTION
I noticed that the generic json parser did not make use of the `unsaved_tags` field like other parsers to. We should be consistent here

[sc-10594]