### PR TITLE
Session timeout notification

### DIFF
--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -59,7 +59,7 @@ def bind_announcement(request):
     return {}
 
 
-def session_expiry(request):
+def session_expiry_notification(request):
     import time
 
     try:
@@ -69,12 +69,10 @@ def session_expiry(request):
             warning_time = settings.SESSION_EXPIRE_WARNING  # Show warning X seconds before expiry
             notify_time = expiry_time - warning_time
         else:
-            expiry_time = None
             notify_time = None
     except Exception:
         return {}
     else:
         return {
-            "session_expiry_time": expiry_time,
             "session_notify_time": notify_time,
         }

--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -71,9 +71,10 @@ def session_expiry(request):
         else:
             expiry_time = None
             notify_time = None
+    except Exception:
+        return {}
+    else:
         return {
             "session_expiry_time": expiry_time,
             "session_notify_time": notify_time,
         }
-    except Exception:
-        return {}

--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -57,3 +57,23 @@ def bind_announcement(request):
             ).get(user=request.user)
             return {"announcement": user_announcement.announcement}
     return {}
+
+
+def session_expiry(request):
+    import time
+
+    try:
+        if request.user.is_authenticated:
+            last_activity = request.session.get("_last_activity", time.time())
+            expiry_time = last_activity + settings.SESSION_COOKIE_AGE  # When the session will expire
+            warning_time = settings.SESSION_EXPIRE_WARNING  # Show warning X seconds before expiry
+            notify_time = expiry_time - warning_time
+        else:
+            expiry_time = None
+            notify_time = None
+        return {
+            "session_expiry_time": expiry_time,
+            "session_notify_time": notify_time,
+        }
+    except Exception:
+        return {}

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -42,6 +42,7 @@ env = environ.FileAwareEnv(
     DD_SECURE_HSTS_SECONDS=(int, 31536000),  # One year expiration
     DD_SESSION_COOKIE_SECURE=(bool, False),
     DD_SESSION_EXPIRE_AT_BROWSER_CLOSE=(bool, False),
+    DD_SESSION_EXPIRE_WARNING=(int, 300),  # warning 5 mins before expiration
     DD_SESSION_COOKIE_AGE=(int, 1209600),  # 14 days
     DD_CSRF_COOKIE_SECURE=(bool, False),
     DD_CSRF_TRUSTED_ORIGINS=(list, []),
@@ -758,6 +759,7 @@ if env("DD_SECURE_HSTS_INCLUDE_SUBDOMAINS"):
     SECURE_HSTS_INCLUDE_SUBDOMAINS = env("DD_SECURE_HSTS_INCLUDE_SUBDOMAINS")
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = env("DD_SESSION_EXPIRE_AT_BROWSER_CLOSE")
+SESSION_EXPIRE_WARNING = env("DD_SESSION_EXPIRE_WARNING")
 SESSION_COOKIE_AGE = env("DD_SESSION_COOKIE_AGE")
 
 # ------------------------------------------------------------------------------
@@ -860,6 +862,7 @@ TEMPLATES = [
                 "dojo.context_processors.bind_system_settings",
                 "dojo.context_processors.bind_alert_count",
                 "dojo.context_processors.bind_announcement",
+                "dojo.context_processors.session_expiry",
             ],
         },
     },

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -862,7 +862,7 @@ TEMPLATES = [
                 "dojo.context_processors.bind_system_settings",
                 "dojo.context_processors.bind_alert_count",
                 "dojo.context_processors.bind_announcement",
-                "dojo.context_processors.session_expiry",
+                "dojo.context_processors.session_expiry_notification",
             ],
         },
     },

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -1032,6 +1032,26 @@
             </div>
             <!-- /.dojo-modals-wrapper -->
 
+            <!-- Session Timeout Modal -->
+            <div class="modal fade" id="sessionTimeoutModal" tabindex="-1" role="dialog" aria-labelledby="sessionModalLabel" aria-hidden="true">
+                <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header"> 
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    <h4 class="modal-title" id="sessionModalLabel">Session Expiring Soon</h4>
+                    </div>
+                    <div class="modal-body">
+                        Your session is about to expire due to inactivity.
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+                    </div>
+                </div>
+                </div>
+            </div>
+
             <!-- #footer-wrapper -->
             <div id="footer-wrapper">
             {% block footer %}
@@ -1083,6 +1103,19 @@
                     function() { $(this).popover('show'); }, // hover
                     function() { $(this).popover('hide'); } // unhover
                 );
+
+                function session_notifcation() {
+                    var warningTime = "{{ session_notify_time|default:0|escapejs }}"; // When the warning will show
+                    var expiryTime = "{{ session_expiry_time|default:0|escapejs }}";  // When the session will expire
+                    var currentTime = Math.floor(Date.now() / 1000);  // Get current timestamp in seconds
+                    var timeout = warningTime - currentTime; // how many seconds until warning needs to show
+
+                    setTimeout(() => {
+                        $("#sessionTimeoutModal").modal("show");
+                    }, timeout * 1000);
+                }  
+                session_notifcation();
+
                 {% if request.user.is_authenticated and not 'DISABLE_ALERT_COUNTER'|setting_enabled %}
                     function get_alerts() {
                         $('.dropdown-alerts').html('<div class="text-center"><i class="fa-solid fa-spinner fa-spin"></i></div>');

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -1106,7 +1106,6 @@
 
                 function session_notifcation() {
                     var warningTime = "{{ session_notify_time|default:0|escapejs }}"; // When the warning will show
-                    var expiryTime = "{{ session_expiry_time|default:0|escapejs }}";  // When the session will expire
                     var currentTime = Math.floor(Date.now() / 1000);  // Get current timestamp in seconds
                     var timeout = warningTime - currentTime; // how many seconds until warning needs to show
 


### PR DESCRIPTION
Re-creation of https://github.com/DefectDojo/django-DefectDojo/pull/12054

**Description**

Issue: Session timeout without letting the user either extend the time or have any type of indication that the session is about to expire.
A warning will appear shortly before the session expires using Bootstrap's modal components warning the user their session will expire soon.

**Impact on Users**

People with physical disabilities often need more time to react, to type and to complete activities. People with low vision need more time to locate things on screen and to read. People who are blind and using screen readers may need more time to understand screen layouts, to find information and to operate controls. People who have cognitive or language limitations need more time to read and to understand. People who are deaf and communicate in sign language may need more time to read information printed in text (which may be a second language for some).

In circumstances where a sign-language interpreter may be relating audio content to a user who is deaf, control over time limits is also important.

People with reading disabilities, cognitive limitations, and learning disabilities who may need more time to read or comprehend information can have additional time to read the information by pausing the content.

**Remediation**

![image](https://github.com/user-attachments/assets/b97cb04f-4deb-4954-a541-bedcc81577fd)

The user is warned before time expires.
I used a context processor to pass the session cookie age value to base.html. Since no view directly renders base.html, I didn't think I could use a view-based approach. If there is a better idea, I can modify the PR.
