### PR TITLE
remove exclude_search from Features page

### DIFF
--- a/docs/content/en/open_source/archived_docs/usage/features.md
+++ b/docs/content/en/open_source/archived_docs/usage/features.md
@@ -3,7 +3,7 @@ title: "Features"
 description: "Various features help manage vulnerabilities."
 draft: false
 weight: 2
-exclude_search: true
+exclude_search: false
 ---
 
 ## Tags


### PR DESCRIPTION
Second try of https://github.com/DefectDojo/django-DefectDojo/pull/12119:

This feature summary page is useful in search until we get more "Tags" documentation written, so it should not be excluded from search.