### PR TITLE
Remove non-working DD_SLA_BUSINESS_DAYS feature to avoid confusion

### DIFF
--- a/docs/content/en/open_source/upgrading/2.46.md
+++ b/docs/content/en/open_source/upgrading/2.46.md
@@ -5,7 +5,8 @@ weight: -20250407
 description: Tag Formatting Changes + Import Payload Changes
 ---
 
-### Tag Formatting Update
+
+## Tag Formatting Update
 
 Tags can no longer contain the following characters:
 
@@ -37,6 +38,13 @@ This update improves consistency, enhances search capabilities, and aligns with 
 We recommend reviewing your current tags, specifically CI/CD processes before upgrading to ensure they align with the new format. Performing a database backup is also suggested as this migration cannot be reverted.
 
 Following the deployment of these new behaviors, requests sent to the API or through the UI with any of the violations listed above will result in an error, with the details of the error raised in the response.
+
+
+## Feature Removal
+The `DD_SLA_BUSINESS_DAYS` flag was no longer working and has been removed to avoid confusion.
+If it returns, it will probably be part of the SLA Configuration settings in the UI.
+There are currently no plans to reimplemnt this feature.
+Please follow [11833](https://github.com/DefectDojo/django-DefectDojo/issues/11833) for updates.
 
 ---
 
@@ -79,3 +87,4 @@ After:
 ---
 
 Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.46.0) for the contents of the release.
+

--- a/dojo/db_migrations/0201_populate_finding_sla_expiration_date.py
+++ b/dojo/db_migrations/0201_populate_finding_sla_expiration_date.py
@@ -5,8 +5,6 @@ from django.conf import settings
 from dateutil.relativedelta import relativedelta
 import logging
 
-from dojo.utils import get_work_days
-
 logger = logging.getLogger(__name__)
 
 
@@ -44,19 +42,13 @@ def calculate_sla_expiration_dates(apps, schema_editor):
             sla_period = getattr(sla_config, find.severity.lower(), None)
 
             days = None
-            if settings.SLA_BUSINESS_DAYS:
-                if find.mitigated:
-                    days = get_work_days(find.date, find.mitigated.date())
-                else:
-                    days = get_work_days(find.date, timezone.now().date())
-            else:
-                if isinstance(start_date, datetime):
-                    start_date = start_date.date()
+            if isinstance(start_date, datetime):
+                start_date = start_date.date()
 
-                if find.mitigated:
-                    days = (find.mitigated.date() - start_date).days
-                else:
-                    days = (timezone.now().date() - start_date).days
+            if find.mitigated:
+                days = (find.mitigated.date() - start_date).days
+            else:
+                days = (timezone.now().date() - start_date).days
 
             days = days if days > 0 else 0
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3007,27 +3007,17 @@ class Finding(models.Model):
         if start_date and isinstance(start_date, str):
             start_date = parse(start_date).date()
 
-        from dojo.utils import get_work_days
-        if settings.SLA_BUSINESS_DAYS:
-            if self.mitigated:
-                mitigated_date = self.mitigated
-                if isinstance(mitigated_date, datetime):
-                    mitigated_date = self.mitigated.date()
-                days = get_work_days(self.date, mitigated_date)
-            else:
-                days = get_work_days(self.date, get_current_date())
-        else:
-            if isinstance(start_date, datetime):
-                start_date = start_date.date()
+        if isinstance(start_date, datetime):
+            start_date = start_date.date()
 
-            if self.mitigated:
-                mitigated_date = self.mitigated
-                if isinstance(mitigated_date, datetime):
-                    mitigated_date = self.mitigated.date()
-                diff = mitigated_date - start_date
-            else:
-                diff = get_current_date() - start_date
-            days = diff.days
+        if self.mitigated:
+            mitigated_date = self.mitigated
+            if isinstance(mitigated_date, datetime):
+                mitigated_date = self.mitigated.date()
+            diff = mitigated_date - start_date
+        else:
+            diff = get_current_date() - start_date
+        days = diff.days
         return max(0, days)
 
     @property

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -217,8 +217,6 @@ env = environ.FileAwareEnv(
     # finetuning settings for when enabled
     DD_SLA_NOTIFY_PRE_BREACH=(int, 3),
     DD_SLA_NOTIFY_POST_BREACH=(int, 7),
-    # Use business day's to calculate SLA's and age instead of calendar days
-    DD_SLA_BUSINESS_DAYS=(bool, False),
     # maximum number of result in search as search can be an expensive operation
     DD_SEARCH_MAX_RESULTS=(int, 100),
     DD_SIMILAR_FINDINGS_MAX_RESULTS=(int, 25),
@@ -654,7 +652,6 @@ SLA_NOTIFY_ACTIVE_VERIFIED_ONLY = env("DD_SLA_NOTIFY_ACTIVE_VERIFIED_ONLY")
 SLA_NOTIFY_WITH_JIRA_ONLY = env("DD_SLA_NOTIFY_WITH_JIRA_ONLY")  # Based on the 2 above, but only with a JIRA link
 SLA_NOTIFY_PRE_BREACH = env("DD_SLA_NOTIFY_PRE_BREACH")  # in days, notify between dayofbreach minus this number until dayofbreach
 SLA_NOTIFY_POST_BREACH = env("DD_SLA_NOTIFY_POST_BREACH")  # in days, skip notifications for findings that go past dayofbreach plus this number
-SLA_BUSINESS_DAYS = env("DD_SLA_BUSINESS_DAYS")  # Use business days to calculate SLA's and age of a finding instead of calendar days
 
 
 SEARCH_MAX_RESULTS = env("DD_SEARCH_MAX_RESULTS")

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1624,35 +1624,6 @@ def get_celery_worker_status():
         return False
 
 
-def get_work_days(start: date, end: date):
-    """
-    Math function to get workdays between 2 dates.
-    Can be used only as fallback as it doesn't know
-    about specific country holidays or extra working days.
-    https://stackoverflow.com/questions/3615375/number-of-days-between-2-dates-excluding-weekends/71977946#71977946
-    """
-    # if the start date is on a weekend, forward the date to next Monday
-    if start.weekday() > WEEKDAY_FRIDAY:
-        start += timedelta(days=7 - start.weekday())
-
-    # if the end date is on a weekend, rewind the date to the previous Friday
-    if end.weekday() > WEEKDAY_FRIDAY:
-        end -= timedelta(days=end.weekday() - WEEKDAY_FRIDAY)
-
-    if start > end:
-        return 0
-    # that makes the difference easy, no remainders etc
-    diff_days = (end - start).days + 1
-    weeks = int(diff_days / 7)
-
-    remainder = end.weekday() - start.weekday() + 1
-
-    if remainder != 0 and end.weekday() < start.weekday():
-        remainder += 5
-
-    return weeks * 5 + remainder
-
-
 # Used to display the counts and enabled tabs in the product view
 class Product_Tab:
     def __init__(self, product, title=None, tab=None):
@@ -2479,26 +2450,17 @@ def calculate_finding_age(f):
     if start_date and isinstance(start_date, str):
         start_date = parse(start_date).date()
 
-    if settings.SLA_BUSINESS_DAYS:
-        if f.get("mitigated"):
-            mitigated_date = f.get("mitigated")
-            if isinstance(mitigated_date, datetime):
-                mitigated_date = f.get("mitigated").date()
-            days = get_work_days(f.get("date"), mitigated_date)
-        else:
-            days = get_work_days(f.get("date"), timezone.now().date())
-    else:
-        if isinstance(start_date, datetime):
-            start_date = start_date.date()
+    if isinstance(start_date, datetime):
+        start_date = start_date.date()
 
-        if f.get("mitigated"):
-            mitigated_date = f.get("mitigated")
-            if isinstance(mitigated_date, datetime):
-                mitigated_date = f.get("mitigated").date()
-            diff = mitigated_date - start_date
-        else:
-            diff = timezone.now().date() - start_date
-        days = diff.days
+    if f.get("mitigated"):
+        mitigated_date = f.get("mitigated")
+        if isinstance(mitigated_date, datetime):
+            mitigated_date = f.get("mitigated").date()
+        diff = mitigated_date - start_date
+    else:
+        diff = timezone.now().date() - start_date
+    days = diff.days
     return max(0, days)
 
 


### PR DESCRIPTION
As reported in #11833 the SLA Business days feature is nog longer working. There are currently no plans to reintroduce it. This PR removes left over code and configuration settings to avoid confusion.
If the feature returns, it will probably be part of the SLA Configuration settings so it can re-use the existing recalculation logic on configuration changes.
Please follow #11833 for future developments.