### PR TITLE
sla_config: use mass update for recalculation

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1210,6 +1210,7 @@ class Product(models.Model):
                     sla_config.async_updating = True
                     super(SLA_Configuration, sla_config).save()
                 # launch the async task to update all finding sla expiration dates
+                from dojo.sla_config.helpers import update_sla_expiration_dates_product_async
                 update_sla_expiration_dates_product_async(self, sla_config)
 
     def get_absolute_url(self):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2674,6 +2674,7 @@ class Finding(models.Model):
 
     def save(self, dedupe_option=True, rules_option=True, product_grading_option=True,  # noqa: FBT002
              issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):  # noqa: FBT002 - this is bit hard to fix nice have this universally fixed
+        logger.debug("Start saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is %s)", "None" if self.pk is None else "not None")
 
         from dojo.finding import helper as finding_helper
 
@@ -3135,6 +3136,7 @@ class Finding(models.Model):
         return self.finding_group is not None
 
     def save_no_options(self, *args, **kwargs):
+        logger.debug("save_no_options")
         return self.save(dedupe_option=False, rules_option=False, product_grading_option=False,
              issue_updater_option=False, push_to_jira=False, user=None, *args, **kwargs)
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -42,7 +42,6 @@ from pytz import all_timezones
 from tagulous.models import TagField
 from tagulous.models.managers import FakeTagRelatedManager
 
-
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from uuid import uuid4
 
 import hyperlink
+from dojo.sla_config.helpers import update_sla_expiration_dates_product_async
 import tagulous.admin
 from auditlog.registry import auditlog
 from cvss import CVSS3
@@ -1209,7 +1210,6 @@ class Product(models.Model):
                     sla_config.async_updating = True
                     super(SLA_Configuration, sla_config).save()
                 # launch the async task to update all finding sla expiration dates
-                from dojo.product.helpers import update_sla_expiration_dates_product_async
                 update_sla_expiration_dates_product_async(self, sla_config)
 
     def get_absolute_url(self):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1048,7 +1048,7 @@ class SLA_Configuration(models.Model):
                     super(Product, product).save()
                 # launch the async task to update all finding sla expiration dates
                 from dojo.sla_config.helpers import update_sla_expiration_dates_sla_config_async
-                update_sla_expiration_dates_sla_config_async(self, tuple(severities), products)
+                update_sla_expiration_dates_sla_config_async(self, products, tuple(severities))
 
     def clean(self):
         sla_days = [self.critical, self.high, self.medium, self.low]
@@ -3039,7 +3039,7 @@ class Finding(models.Model):
         return self.date
 
     def get_sla_period(self):
-        sla_configuration = SLA_Configuration.objects.filter(id=self.test.engagement.product.sla_configuration_id).first()
+        sla_configuration = self.test.engagement.product.sla_configuration
         sla_period = getattr(sla_configuration, self.severity.lower(), None)
         enforce_period = getattr(sla_configuration, str("enforce_" + self.severity.lower()), None)
         return sla_period, enforce_period

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from uuid import uuid4
 
 import hyperlink
-from dojo.sla_config.helpers import update_sla_expiration_dates_product_async
 import tagulous.admin
 from auditlog.registry import auditlog
 from cvss import CVSS3
@@ -42,6 +41,7 @@ from polymorphic.models import PolymorphicModel
 from pytz import all_timezones
 from tagulous.models import TagField
 from tagulous.models.managers import FakeTagRelatedManager
+
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")

--- a/dojo/product/helpers.py
+++ b/dojo/product/helpers.py
@@ -10,27 +10,6 @@ logger = logging.getLogger(__name__)
 
 @dojo_async_task
 @app.task
-def update_sla_expiration_dates_product_async(product, sla_config, *args, **kwargs):
-    update_sla_expiration_dates_product_sync(product, sla_config)
-
-
-def update_sla_expiration_dates_product_sync(product, sla_config):
-    logger.info(f"Updating finding SLA expiration dates within product {product}")
-    # update each finding that is within the SLA configuration that was saved
-    for f in Finding.objects.filter(test__engagement__product=product):
-        f.save_no_options()
-    # reset the async updating flag to false for the sla config assigned to this product
-    if sla_config:
-        sla_config.async_updating = False
-        super(SLA_Configuration, sla_config).save()
-    # set the async updating flag to false for the sla config assigned to this product
-    product.async_updating = False
-    super(Product, product).save()
-    logger.info(f"DONE Updating finding SLA expiration dates within product {product}")
-
-
-@dojo_async_task
-@app.task
 def propagate_tags_on_product(product_id, *args, **kwargs):
     with contextlib.suppress(Product.DoesNotExist):
         product = Product.objects.get(id=product_id)

--- a/dojo/product/helpers.py
+++ b/dojo/product/helpers.py
@@ -3,7 +3,7 @@ import logging
 
 from dojo.celery import app
 from dojo.decorators import dojo_async_task
-from dojo.models import Endpoint, Engagement, Finding, Product, SLA_Configuration, Test
+from dojo.models import Endpoint, Engagement, Finding, Product, Test
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/product/helpers.py
+++ b/dojo/product/helpers.py
@@ -18,7 +18,7 @@ def update_sla_expiration_dates_product_sync(product, sla_config):
     logger.info(f"Updating finding SLA expiration dates within product {product}")
     # update each finding that is within the SLA configuration that was saved
     for f in Finding.objects.filter(test__engagement__product=product):
-        f.save()
+        f.save_no_options()
     # reset the async updating flag to false for the sla config assigned to this product
     if sla_config:
         sla_config.async_updating = False
@@ -26,6 +26,7 @@ def update_sla_expiration_dates_product_sync(product, sla_config):
     # set the async updating flag to false for the sla config assigned to this product
     product.async_updating = False
     super(Product, product).save()
+    logger.info(f"DONE Updating finding SLA expiration dates within product {product}")
 
 
 @dojo_async_task

--- a/dojo/sla_config/helpers.py
+++ b/dojo/sla_config/helpers.py
@@ -40,9 +40,6 @@ def update_sla_expiration_dates_sla_config_sync(sla_config, products, severities
 
     mass_model_updater(Finding, findings, lambda f: f.set_sla_expiration_date(), fields=["sla_expiration_date"])
 
-    # for f in findings:
-    #     f.save_no_options()
-
     # reset the async updating flag to false for all products using this sla config
     for product in products:
         product.async_updating = False

--- a/dojo/sla_config/helpers.py
+++ b/dojo/sla_config/helpers.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 def update_sla_expiration_dates_sla_config_async(sla_config, products, severities, *args, **kwargs):
     update_sla_expiration_dates_sla_config_sync(sla_config, products, severities)
 
+
 @dojo_async_task
 @app.task
 def update_sla_expiration_dates_product_async(product, sla_config, *args, **kwargs):
@@ -35,7 +36,7 @@ def update_sla_expiration_dates_sla_config_sync(sla_config, products, severities
             "test__engagement__product__sla_configuration",
     )
 
-    findings = findings.order_by('id').only('id', 'sla_start_date', 'date', 'severity', 'test')
+    findings = findings.order_by("id").only("id", "sla_start_date", "date", "severity", "test")
 
     mass_model_updater(Finding, findings, lambda f: f.set_sla_expiration_date(), fields=["sla_expiration_date"])
 
@@ -52,4 +53,3 @@ def update_sla_expiration_dates_sla_config_sync(sla_config, products, severities
     sla_config.async_updating = False
     super(SLA_Configuration, sla_config).save()
     logger.info(f"DONE Updating finding SLA expiration dates within the {sla_config} SLA configuration")
-

--- a/dojo/sla_config/helpers.py
+++ b/dojo/sla_config/helpers.py
@@ -3,26 +3,53 @@ import logging
 from dojo.celery import app
 from dojo.decorators import dojo_async_task
 from dojo.models import Finding, Product, SLA_Configuration
+from dojo.utils import calculate_grade, mass_model_updater
 
 logger = logging.getLogger(__name__)
 
 
 @dojo_async_task
 @app.task
-def update_sla_expiration_dates_sla_config_async(sla_config, severities, products, *args, **kwargs):
-    update_sla_expiration_dates_sla_config_sync(sla_config, severities, products)
+def update_sla_expiration_dates_sla_config_async(sla_config, products, severities, *args, **kwargs):
+    update_sla_expiration_dates_sla_config_sync(sla_config, products, severities)
+
+@dojo_async_task
+@app.task
+def update_sla_expiration_dates_product_async(product, sla_config, *args, **kwargs):
+    update_sla_expiration_dates_sla_config_sync(sla_config, [product])
 
 
-def update_sla_expiration_dates_sla_config_sync(sla_config, severities, products):
+def update_sla_expiration_dates_sla_config_sync(sla_config, products, severities=None):
     logger.info(f"Updating finding SLA expiration dates within the {sla_config} SLA configuration")
     # update each finding that is within the SLA configuration that was saved
-    for f in Finding.objects.filter(test__engagement__product__sla_configuration_id=sla_config.id, severity__in=severities):
-        f.save_no_options()
+    findings = Finding.objects.filter(test__engagement__product__sla_configuration_id=sla_config.id)
+    if products:
+        findings = findings.filter(test__engagement__product__in=products)
+    if severities:
+        findings = findings.filter(severity__in=severities)
+
+    findings = findings.prefetch_related(
+            "test",
+            "test__engagement",
+            "test__engagement__product",
+            "test__engagement__product__sla_configuration",
+    )
+
+    findings = findings.order_by('id').only('id', 'sla_start_date', 'date', 'severity', 'test')
+
+    mass_model_updater(Finding, findings, lambda f: f.set_sla_expiration_date(), fields=["sla_expiration_date"])
+
+    # for f in findings:
+    #     f.save_no_options()
+
     # reset the async updating flag to false for all products using this sla config
     for product in products:
         product.async_updating = False
         super(Product, product).save()
+        calculate_grade(product)
+
     # reset the async updating flag to false for this sla config
     sla_config.async_updating = False
     super(SLA_Configuration, sla_config).save()
     logger.info(f"DONE Updating finding SLA expiration dates within the {sla_config} SLA configuration")
+

--- a/dojo/sla_config/helpers.py
+++ b/dojo/sla_config/helpers.py
@@ -17,7 +17,7 @@ def update_sla_expiration_dates_sla_config_sync(sla_config, severities, products
     logger.info(f"Updating finding SLA expiration dates within the {sla_config} SLA configuration")
     # update each finding that is within the SLA configuration that was saved
     for f in Finding.objects.filter(test__engagement__product__sla_configuration_id=sla_config.id, severity__in=severities):
-        f.save()
+        f.save_no_options()
     # reset the async updating flag to false for all products using this sla config
     for product in products:
         product.async_updating = False
@@ -25,3 +25,4 @@ def update_sla_expiration_dates_sla_config_sync(sla_config, severities, products
     # reset the async updating flag to false for this sla config
     sla_config.async_updating = False
     super(SLA_Configuration, sla_config).save()
+    logger.info(f"DONE Updating finding SLA expiration dates within the {sla_config} SLA configuration")

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2241,22 +2241,19 @@ def mass_model_updater(model_type, models, function, fields, page_size=1000, ord
     i = 0
     batch = []
     total_pages = (total_count // page_size) + 2
-    # logger.info('pages to process: %d', total_pages)
+    # logger.debug("pages to process: %d", total_pages)
     logger.debug("%s%s out of %s models processed ...", log_prefix, i, total_count)
     for _p in range(1, total_pages):
-        # logger.info('page: %d', p)
         if order == "asc":
             page = models.filter(id__gt=last_id)[:page_size]
         else:
             page = models.filter(id__lt=last_id)[:page_size]
 
-        # logger.info('page query: %s', page.query)
-        # if p == 23:
-        #     raise ValueError('bla')
+        logger.debug("page query: %s", page.query)
         for model in page:
             i += 1
             last_id = model.id
-            # logger.info('last_id: %s', last_id)
+            logger.debug("last_id: %s", last_id)
 
             function(model)
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2253,7 +2253,6 @@ def mass_model_updater(model_type, models, function, fields, page_size=1000, ord
         for model in page:
             i += 1
             last_id = model.id
-            logger.debug("last_id: %s", last_id)
 
             function(model)
 


### PR DESCRIPTION
This PR optimizes the updating of the `sla_expiration_date` field. A change to an SLA Configuration or Product can trigger a recalculation of this field for all affected findings. 

Before this PR this took ~8.5 minutes for 20k findings. This is on a i9 16 core with an NVM SSD. 
This PR used the `mass_model_updater` function that has proven to work more efficiently. Now the job completes in ~30s time.

Before this PR, every finding would be post processed in the background celery work. This isn't needed as a change to the SLA expiration doesn't affect dedupe or pushing to JIRA. Also the product grade would be calculated for each affected finding (so multiple times per product). This is not needed. This background work took over 30 minutes for 20k (I killed the instance after 30 minutes).

The PR also removes some code duplication.

I can imagine this change is also beneficial for Pro users where larger instances are more common, as well as more intensive usage of the instances.