### PR TITLE
generic parser: handle is_mitigated and mitigated

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/file/generic.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/generic.md
@@ -18,8 +18,12 @@ Attributes supported for CSV:
 - Verified: Indicator if the finding has been verified. Must be empty, TRUE, or FALSE
 - FalsePositive: Indicator if the finding is a false positive. Must be TRUE, or FALSE.
 - Duplicate:Indicator if the finding is a duplicate. Must be TRUE, or FALSE
+- IsMitigated: Indicator if the finding is mitigated.  Must be TRUE, or FALSE
+- MitigatedDate: Date the finding was mitigated in mm/dd/yyyy format or ISO format
 
 The CSV expects a header row with the names of the attributes.
+
+Date fields are parsed using [dateutil.parse](https://dateutil.readthedocs.io/en/stable/parser.html) supporting a variety of formats such a YYYY-MM-DD or ISO-8601.
 
 Example of JSON format:
 
@@ -70,6 +74,34 @@ Example of JSON format:
             "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
             "file_path": "src/threeeeeeeeee.cpp",
             "line": 1353
+        },
+        {
+            "title": "test title mitigated",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
+            "severity": "Critical",
+            "mitigation": "Some mitigation",
+            "date": "2021-01-06",
+            "cve": "CVE-2020-36236",
+            "cwe": 287,
+            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+            "file_path": "src/threeeeeeeeee.cpp",
+            "line": 1353,
+            "is_mitigated": true,
+            "mitigated": "2021-01-16"
+        },
+        {
+            "title": "test title mitigated ISO",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
+            "severity": "Critical",
+            "mitigation": "Some mitigation",
+            "date": "2024-01-04T11:02:11Z",
+            "cve": "CVE-2020-36236",
+            "cwe": 287,
+            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+            "file_path": "src/threeeeeeeeee.cpp",
+            "line": 1353,
+            "is_mitigated": true,
+            "mitigated": "2024-01-24T11:02:11Z"
         }
     ]
 }

--- a/dojo/tools/generic/csv_parser.py
+++ b/dojo/tools/generic/csv_parser.py
@@ -34,6 +34,10 @@ class GenericCSVParser:
             # manage active
             if "Active" in row:
                 finding.active = self._convert_bool(row.get("Active"))
+            if "IsMitigated" in row:
+                finding.is_mitigated = self._convert_bool(row.get("IsMitigated"))
+            if "MitigatedDate" in row:
+                finding.mitigated = parse(row["MitigatedDate"])
             # manage mitigation
             if "Mitigation" in row:
                 finding.mitigation = row["Mitigation"]

--- a/dojo/tools/generic/json_parser.py
+++ b/dojo/tools/generic/json_parser.py
@@ -1,5 +1,6 @@
 import base64
 
+import dateutil
 from django.core.files.base import ContentFile
 
 from dojo.models import Endpoint, FileUpload, Finding
@@ -39,6 +40,13 @@ class GenericJSONParser:
                 del item["vulnerability_ids"]
             # check for required keys
             required = {"title", "severity", "description"}
+
+            if "date" in item:
+                item["date"] = dateutil.parser.parse(item["date"]).date()
+
+            if "mitigated" in item:
+                item["mitigated"] = dateutil.parser.parse(item["mitigated"])
+
             missing = sorted(required.difference(item))
             if missing:
                 msg = f"Required fields are missing: {missing}"

--- a/unittests/scans/generic/generic_report3.csv
+++ b/unittests/scans/generic/generic_report3.csv
@@ -1,0 +1,3 @@
+Date,Title,CweId,Url,Severity,Description,Mitigation,Impact,References,Active,Verified,FalsePositive,Duplicate,IsMitigated,MitigatedDate
+2024-01-24T11:02:11Z,Mitigated_ISO_Finding,4,https://vulnerable.endpoint.com/resource4/asdf,Low,Some description,Some mitigation advice,Some Impact,,TRUE,TRUE,FALSE,FALSE,TRUE,2024-02-24T11:02:11Z
+28/02/2021,Mitigated_Finding,5,https://vulnerable.endpoint.com/resource5/asdf,Low,Some description,Some mitigation advice,Some Impact,,TRUE,TRUE,FALSE,FALSE,TRUE,28/03/2021

--- a/unittests/scans/generic/generic_report3.json
+++ b/unittests/scans/generic/generic_report3.json
@@ -34,7 +34,7 @@
             ]
         },
         {
-            "title": "test title",
+            "title": "test title mitigated",
             "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
             "severity": "Critical",
             "mitigation": "Some mitigation",
@@ -43,7 +43,23 @@
             "cwe": 287,
             "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
             "file_path": "src/threeeeeeeeee.cpp",
-            "line": 1353
+            "line": 1353,
+            "is_mitigated": true,
+            "mitigated": "2021-01-16"
+        },
+        {
+            "title": "test title mitigated ISO",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
+            "severity": "Critical",
+            "mitigation": "Some mitigation",
+            "date": "2024-01-04T11:02:11Z",
+            "cve": "CVE-2020-36236",
+            "cwe": 287,
+            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+            "file_path": "src/threeeeeeeeee.cpp",
+            "line": 1353,
+            "is_mitigated": true,
+            "mitigated": "2024-01-24T11:02:11Z"
         }
     ]
 }

--- a/unittests/tools/test_generic_parser.py
+++ b/unittests/tools/test_generic_parser.py
@@ -491,7 +491,7 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
         with open(get_unit_tests_scans_path("generic") / "generic_report3.json", encoding="utf-8") as file:
             parser = GenericParser()
             findings = parser.get_findings(file, Test())
-            self.assertEqual(3, len(findings))
+            self.assertEqual(4, len(findings))
             with self.subTest(i=0):
                 finding = findings[0]
                 finding.clean()
@@ -524,6 +524,21 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
                 self.assertEqual("urlfiltering.paloaltonetworks.com", endpoint.host)
                 self.assertEqual(2345, endpoint.port)
                 self.assertEqual("test-pest", endpoint.path)
+            with self.subTest(i=2):
+                finding = findings[2]
+                self.assertEqual("test title mitigated", finding.title)
+                self.assertEqual(True, finding.active)
+                self.assertEqual(False, finding.duplicate)
+                self.assertEqual(True, finding.is_mitigated)
+                self.assertEqual(datetime.date(2021, 1, 16), finding.mitigated.date())
+            with self.subTest(i=3):
+                finding = findings[3]
+                self.assertEqual("test title mitigated ISO", finding.title)
+                self.assertEqual(True, finding.active)
+                self.assertEqual(False, finding.duplicate)
+                self.assertEqual(True, finding.is_mitigated)
+                self.assertEqual(datetime.date(2024, 1, 4), finding.date)
+                self.assertEqual(datetime.date(2024, 1, 24), finding.mitigated.date())
 
     def test_parse_endpoints_and_vulnerability_ids_json(self):
         with open(get_unit_tests_scans_path("generic") / "generic_report4.json", encoding="utf-8") as file:
@@ -555,6 +570,26 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
             self.assertEqual(2, len(finding.unsaved_vulnerability_ids))
             self.assertEqual("GHSA-5mrr-rgp6-x4gr", finding.unsaved_vulnerability_ids[0])
             self.assertEqual("CVE-2015-9235", finding.unsaved_vulnerability_ids[1])
+
+    def test_mitigated_csv_findings(self):
+        with open(get_unit_tests_scans_path("generic") / "generic_report3.csv", encoding="utf-8") as file:
+            parser = GenericParser()
+            findings = parser.get_findings(file, Test())
+            self.assertEqual(2, len(findings))
+
+            finding = findings[0]
+            finding.clean()
+            self.assertEqual("Mitigated_ISO_Finding", finding.title)
+            self.assertEqual(datetime.date(2024, 1, 24), finding.date)
+            self.assertEqual(True, finding.is_mitigated)
+            self.assertEqual(datetime.date(2024, 2, 24), finding.mitigated.date())
+
+            finding = findings[1]
+            finding.clean()
+            self.assertEqual("Mitigated_Finding", finding.title)
+            self.assertEqual(datetime.date(2021, 2, 28), finding.date)
+            self.assertEqual(True, finding.is_mitigated)
+            self.assertEqual(datetime.date(2021, 3, 28), finding.mitigated.date())
 
     def test_parse_host_and_vulnerability_id_csv(self):
         with open(get_unit_tests_scans_path("generic") / "generic_report4.csv", encoding="utf-8") as file:


### PR DESCRIPTION
fixes #12151 

Handle `is_mitigated` (bool) and `mitigated` (date) fields in generic csv/json imports.

As requested mutliple date formats are now supported.