### PR TITLE
fix(renovate): Add separateMinorPatch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   "dependencyDashboardApproval": false,
   "baseBranches": ["dev"],
   "rebaseWhen": "conflicted",
+  "separateMinorPatch": true,
   "ignorePaths": ["requirements.txt", "requirements-lint.txt", "components/package.json", "components/package-lock.json", "dojo/components/yarn.lock", "dojo/components/package.json", "Dockerfile**"],
   "ignoreDeps": [],
   "packageRules": [{


### PR DESCRIPTION
Until now, every time when new version of the package was released, Renovate offered the latest version (so far so good). This might not be the best situation if it is not possible to update to the latest one (change of license or some other radical change), but upgrading to a higher patch (same major and minor) is safe.
Thanks to this PR, renovate will open a separate PR if there is a newer patch for the same minor.

This will help with:
- Upgrade of Redis `7.2.5` to `7.2.7` (without jumping to `7.4` - https://github.com/DefectDojo/django-DefectDojo/pull/10651, https://hub.docker.com/_/redis/tags?name=7.2.7)


Note: we will need the same for dependabot, because of:
- `urllib3`: `1.26.18` -> [1.26.20](https://pypi.org/project/urllib3/1.26.20/) vs https://github.com/DefectDojo/django-DefectDojo/pull/11455
- `pygithub`: `1.58.2` -> [1.59.1](https://pypi.org/project/PyGithub/1.59.1/) vs https://github.com/DefectDojo/django-DefectDojo/pull/11886
- `datatables.net-colreorder`: `1.6.2` ->  [1.7.2](https://www.npmjs.com/package/datatables.net-colreorder/v/1.7.2) vs https://github.com/DefectDojo/django-DefectDojo/pull/10765
- `datatables.net-dt`: `1.13.4` -> [1.13.11](https://www.npmjs.com/package/datatables.net-dt/v/1.13.11) vs https://github.com/DefectDojo/django-DefectDojo/pull/11734
- `datatables.net`: `1.13.4` -> [1.13.11](https://www.npmjs.com/package/datatables.net/v/1.13.11) vs https://github.com/DefectDojo/django-DefectDojo/pull/11735
- `datatables.net-buttons-dt`: `2.3.6` -> [2.4.3](https://www.npmjs.com/package/datatables.net-buttons-dt/v/2.4.3) vs https://github.com/DefectDojo/django-DefectDojo/pull/11755
- `datatables.net-buttons-bs`: `2.3.6` -> [2.4.3](https://www.npmjs.com/package/datatables.net-buttons-bs/v/2.4.3) vs  https://github.com/DefectDojo/django-DefectDojo/pull/11756