### PR TITLE
close old findings: don't overwrite mitigated timestamp

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -752,7 +752,8 @@ class BaseImporter(ImporterOptions):
         """
         finding.active = False
         finding.is_mitigated = True
-        finding.mitigated = self.scan_date
+        if not finding.mitigated:
+            finding.mitigated = self.scan_date
         finding.mitigated_by = self.user
         finding.notes.create(
             author=self.user,


### PR DESCRIPTION
Sometimes (as in #12168) findings get mitigated during import because the finding is mitigated in the scan report. That scan report can also contain a `mitigated` timestamp. Currently DefectDojo always overwrites this timestamp during reimport. This PR changes that to no overwrite it. 

This is just a quickfix as the root cause is that the findings are already closed and don't need to be seen as old findings are they are still in the report. We'll work on that in a later PR.