### PR TITLE
h1: vulnerability disclosure parser improvements

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/file/h1.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/h1.md
@@ -2,7 +2,7 @@
 title: "HackerOne Cases"
 toc_hide: true
 ---
-Import HackerOne cases findings in JSON format
+Import HackerOne cases findings in JSON format (vulnerability disclosure parser) or Bug Bounties in JSON or CSV format (bug bounty parser)
 
 ### Sample Scan Data
 Sample HackerOne Cases scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/h1).

--- a/dojo/tools/h1/parser.py
+++ b/dojo/tools/h1/parser.py
@@ -59,7 +59,7 @@ class HackerOneVulnerabilityDisclosureProgram:
             # Set active state of the Dojo finding
             active = True
             if "main_state" in content["attributes"]:
-                active = content["attributes"]["main_state"] == "open"
+                active = content["attributes"]["main_state"] != "closed"
             else:
                 # If there is no main_state, we assume keep the old logic
                 active = content["attributes"]["state"] in {"triaged", "new"}

--- a/dojo/tools/h1/parser.py
+++ b/dojo/tools/h1/parser.py
@@ -4,11 +4,11 @@ import io
 import json
 from contextlib import suppress
 from datetime import datetime
-from django.utils import timezone
 from typing import ClassVar
 
 from dateutil import parser as date_parser
 from django.core.files.uploadedfile import TemporaryUploadedFile
+from django.utils import timezone
 
 from dojo.models import Finding, Test
 

--- a/dojo/tools/h1/parser.py
+++ b/dojo/tools/h1/parser.py
@@ -6,9 +6,8 @@ from contextlib import suppress
 from datetime import datetime
 from typing import ClassVar
 
-
-from cvss.cvss3 import CVSS3
 import cvss.parser
+from cvss.cvss3 import CVSS3
 from dateutil import parser as date_parser
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.utils import timezone
@@ -60,10 +59,8 @@ class HackerOneVulnerabilityDisclosureProgram:
 
             cvssv3_vector = None
             if cvss_vector_string := content.get("relationships", {}).get("severity", {}).get("data", {}).get("attributes", {}).get("cvss_vector_string"):
-                print("CVSSv3 vector string: " + cvss_vector_string)
                 vectors = cvss.parser.parse_cvss_from_text(cvss_vector_string)
                 if len(vectors) > 0 and type(vectors[0]) is CVSS3:
-                    print("CVSSv3 vector found")
                     cvssv3_vector = vectors[0].clean_vector()
                     if cvssv3_score is None:
                         cvssv3_score = vectors[0].scores()[0]

--- a/unittests/scans/h1/vuln_disclosure_main_state.json
+++ b/unittests/scans/h1/vuln_disclosure_main_state.json
@@ -483,7 +483,9 @@
                 "integrity": "medium",
                 "privileges_required": "low",
                 "user_interaction": "required",
-                "scope": "changed"
+                "scope": "changed",
+                "calculation_method": "cvss_3_0_hackerone",
+                "cvss_vector_string": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
               }
             }
           },

--- a/unittests/scans/h1/vuln_disclosure_main_state.json
+++ b/unittests/scans/h1/vuln_disclosure_main_state.json
@@ -1,0 +1,541 @@
+{
+    "data": [
+      {
+        "id": "1337",
+        "type": "report",
+        "attributes": {
+          "title": "XSS in login form",
+          "state": "new",
+          "main_state": "open",
+          "created_at": "2016-02-02T04:05:06.000Z",
+          "vulnerability_information": "...",
+          "triaged_at": null,
+          "closed_at": null,
+          "last_reporter_activity_at": null,
+          "first_program_activity_at": null,
+          "last_program_activity_at": null,
+          "bounty_awarded_at": null,
+          "last_activity_at": null,
+          "last_public_activity_at": null,
+          "swag_awarded_at": null,
+          "disclosed_at": null,
+          "source": null,
+          "reporter_agreed_on_going_public_at": null
+        },
+        "relationships": {
+          "reporter": {
+            "data": {
+              "id": "1337",
+              "type": "user",
+              "attributes": {
+                "username": "api-example",
+                "name": "API Example",
+                "disabled": false,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "profile_picture": {
+                  "62x62": "/assets/avatars/default.png",
+                  "82x82": "/assets/avatars/default.png",
+                  "110x110": "/assets/avatars/default.png",
+                  "260x260": "/assets/avatars/default.png"
+                }
+              }
+            }
+          },
+          "assignee": {
+            "data": {
+              "id": "1337",
+              "type": "user",
+              "attributes": {
+                "username": "member",
+                "name": "Member",
+                "disabled": false,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "profile_picture": {
+                  "62x62": "/assets/avatars/default.png",
+                  "82x82": "/assets/avatars/default.png",
+                  "110x110": "/assets/avatars/default.png",
+                  "260x260": "/assets/avatars/default.png"
+                }
+              }
+            }
+          },
+          "program": {
+            "data": {
+              "id": "1337",
+              "type": "program",
+              "attributes": {
+                "handle": "security",
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "updated_at": "2016-02-02T04:05:06.000Z"
+              }
+            }
+          },
+          "severity": {
+            "data": {
+              "id": "57",
+              "type": "severity",
+              "attributes": {
+                "rating": "high",
+                "author_type": "User",
+                "user_id": 1337,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "score": 8.7,
+                "attack_complexity": "low",
+                "attack_vector": "adjacent",
+                "availability": "high",
+                "confidentiality": "low",
+                "integrity": "high",
+                "privileges_required": "low",
+                "user_interaction": "required",
+                "scope": "changed"
+              }
+            }
+          },
+          "weakness": {
+            "data": {
+              "id": "1337",
+              "type": "weakness",
+              "attributes": {
+                "name": "Cross-Site Request Forgery (CSRF)",
+                "description": "The web application does not, or can not, sufficiently verify whether a well-formed, valid, consistent request was intentionally provided by the user who submitted the request.",
+                "external_id": "cwe-352",
+                "created_at": "2016-02-02T04:05:06.000Z"
+              }
+            }
+          },
+          "structured_scope": {
+            "data": {
+              "id": "57",
+              "type": "structured-scope",
+              "attributes": {
+                "asset_identifier": "api.example.com",
+                "asset_type": "url",
+                "confidentiality_requirement": "high",
+                "integrity_requirement": "high",
+                "availability_requirement": "high",
+                "max_severity": "critical",
+                "created_at": "2015-02-02T04:05:06.000Z",
+                "updated_at": "2016-05-02T04:05:06.000Z",
+                "instruction": null,
+                "eligible_for_bounty": true,
+                "eligible_for_submission": true,
+                "reference": "H001001"
+              }
+            }
+          },
+          "bounties": {
+            "data": [
+
+            ]
+          },
+          "custom_field_values": {
+            "data": [
+
+            ]
+          }
+        }
+      },
+      {
+        "id": "1338",
+        "type": "report",
+        "attributes": {
+          "title": "CSRF in admin panel",
+          "state": "triaged",
+          "main_state": "open",
+          "created_at": "2016-02-02T04:05:06.000Z",
+          "vulnerability_information": "...",
+          "triaged_at": "2016-02-03T03:01:36.000Z",
+          "closed_at": null,
+          "last_reporter_activity_at": null,
+          "first_program_activity_at": null,
+          "last_program_activity_at": null,
+          "bounty_awarded_at": null,
+          "swag_awarded_at": null,
+          "disclosed_at": null,
+          "issue_tracker_reference_id": "T554",
+          "issue_tracker_reference_url": "https://phabricator.tld/T554",
+          "cve_ids": [],
+          "source": null,
+          "reporter_agreed_on_going_public_at": null
+        },
+        "relationships": {
+          "reporter": {
+            "data": {
+              "id": "1337",
+              "type": "user",
+              "attributes": {
+                "username": "api-example",
+                "name": "API Example",
+                "disabled": false,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "profile_picture": {
+                  "62x62": "/assets/avatars/default.png",
+                  "82x82": "/assets/avatars/default.png",
+                  "110x110": "/assets/avatars/default.png",
+                  "260x260": "/assets/avatars/default.png"
+                }
+              }
+            }
+          },
+          "assignee": {
+            "data": {
+              "id": "1337",
+              "type": "group",
+              "attributes": {
+                "name": "Admin",
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "permissions": [
+                  "user_management",
+                  "report_management"
+                ]
+              }
+            }
+          },
+          "program": {
+            "data": {
+              "id": "1337",
+              "type": "program",
+              "attributes": {
+                "handle": "security",
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "updated_at": "2016-02-02T04:05:06.000Z"
+              }
+            }
+          },
+          "severity": {
+            "data": {
+              "id": "64",
+              "type": "severity",
+              "attributes": {
+                "rating": "medium",
+                "author_type": "User",
+                "user_id": 1337,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "score": 6.3,
+                "attack_complexity": "low",
+                "attack_vector": "adjacent",
+                "availability": "medium",
+                "confidentiality": "low",
+                "integrity": "medium",
+                "privileges_required": "low",
+                "user_interaction": "required",
+                "scope": "changed"
+              }
+            }
+          },
+          "weakness": {
+            "data": {
+              "id": "1337",
+              "type": "weakness",
+              "attributes": {
+                "name": "Cross-Site Request Forgery (CSRF)",
+                "description": "The web application does not, or can not, sufficiently verify whether a well-formed, valid, consistent request was intentionally provided by the user who submitted the request.",
+                "external_id": "cwe-352",
+                "created_at": "2016-02-02T04:05:06.000Z"
+              }
+            }
+          },
+          "structured_scope": {
+            "data": {
+              "id": "64",
+              "type": "structured-scope",
+              "attributes": {
+                "asset_identifier": "example.com",
+                "asset_type": "url",
+                "confidentiality_requirement": "medium",
+                "integrity_requirement": "low",
+                "availability_requirement": "high",
+                "max_severity": "critical",
+                "created_at": "2015-03-04T04:05:06.000Z",
+                "updated_at": "2017-06-04T04:05:06.000Z",
+                "instruction": null,
+                "eligible_for_bounty": true,
+                "eligible_for_submission": true,
+                "reference": "T12345"
+              }
+            }
+          },
+          "bounties": {
+            "data": [
+
+            ]
+          },
+          "custom_field_values": {
+            "data": [
+
+            ]
+          }
+        }
+      },
+      {
+        "id": "1339",
+        "type": "report",
+        "attributes": {
+          "title": "CSRF in admin panel2",
+          "state": "duplicate",
+          "main_state": "closed",
+          "created_at": "2016-02-02T04:05:06.000Z",
+          "vulnerability_information": "...",
+          "triaged_at": "2016-02-03T03:01:36.000Z",
+          "closed_at": "2016-10-03T03:01:36.000Z",
+          "last_reporter_activity_at": null,
+          "first_program_activity_at": null,
+          "last_program_activity_at": null,
+          "bounty_awarded_at": null,
+          "swag_awarded_at": null,
+          "disclosed_at": null,
+          "issue_tracker_reference_id": "T554",
+          "issue_tracker_reference_url": "https://phabricator.tld/T554",
+          "cve_ids": [],
+          "source": null,
+          "reporter_agreed_on_going_public_at": null
+        },
+        "relationships": {
+          "reporter": {
+            "data": {
+              "id": "1337",
+              "type": "user",
+              "attributes": {
+                "username": "api-example",
+                "name": "API Example",
+                "disabled": false,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "profile_picture": {
+                  "62x62": "/assets/avatars/default.png",
+                  "82x82": "/assets/avatars/default.png",
+                  "110x110": "/assets/avatars/default.png",
+                  "260x260": "/assets/avatars/default.png"
+                }
+              }
+            }
+          },
+          "assignee": {
+            "data": {
+              "id": "1337",
+              "type": "group",
+              "attributes": {
+                "name": "Admin",
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "permissions": [
+                  "user_management",
+                  "report_management"
+                ]
+              }
+            }
+          },
+          "program": {
+            "data": {
+              "id": "1337",
+              "type": "program",
+              "attributes": {
+                "handle": "security",
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "updated_at": "2016-02-02T04:05:06.000Z"
+              }
+            }
+          },
+          "severity": {
+            "data": {
+              "id": "64",
+              "type": "severity",
+              "attributes": {
+                "rating": "medium",
+                "author_type": "User",
+                "user_id": 1337,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "score": 6.3,
+                "attack_complexity": "low",
+                "attack_vector": "adjacent",
+                "availability": "medium",
+                "confidentiality": "low",
+                "integrity": "medium",
+                "privileges_required": "low",
+                "user_interaction": "required",
+                "scope": "changed"
+              }
+            }
+          },
+          "weakness": {
+            "data": {
+              "id": "1337",
+              "type": "weakness",
+              "attributes": {
+                "name": "Cross-Site Request Forgery (CSRF)",
+                "description": "The web application does not, or can not, sufficiently verify whether a well-formed, valid, consistent request was intentionally provided by the user who submitted the request.",
+                "external_id": "cwe-352",
+                "created_at": "2016-02-02T04:05:06.000Z"
+              }
+            }
+          },
+          "structured_scope": {
+            "data": {
+              "id": "64",
+              "type": "structured-scope",
+              "attributes": {
+                "asset_identifier": "example.com",
+                "asset_type": "url",
+                "confidentiality_requirement": "medium",
+                "integrity_requirement": "low",
+                "availability_requirement": "high",
+                "max_severity": "critical",
+                "created_at": "2015-03-04T04:05:06.000Z",
+                "updated_at": "2017-06-04T04:05:06.000Z",
+                "instruction": null,
+                "eligible_for_bounty": true,
+                "eligible_for_submission": true,
+                "reference": "T12345"
+              }
+            }
+          },
+          "bounties": {
+            "data": [
+
+            ]
+          },
+          "custom_field_values": {
+            "data": [
+
+            ]
+          }
+        }
+      },
+      {
+        "id": "1340",
+        "type": "report",
+        "attributes": {
+          "title": "CSRF in admin panel3",
+          "state": "not-applicable",
+          "main_state": "closed",
+          "created_at": "2016-02-02T04:05:06.000Z",
+          "vulnerability_information": "...",
+          "triaged_at": "2016-02-03T03:01:36.000Z",
+          "closed_at": null,
+          "last_reporter_activity_at": null,
+          "first_program_activity_at": null,
+          "last_program_activity_at": null,
+          "bounty_awarded_at": null,
+          "swag_awarded_at": null,
+          "disclosed_at": null,
+          "issue_tracker_reference_id": "T554",
+          "issue_tracker_reference_url": "https://phabricator.tld/T554",
+          "cve_ids": [],
+          "source": null,
+          "reporter_agreed_on_going_public_at": null
+        },
+        "relationships": {
+          "reporter": {
+            "data": {
+              "id": "1337",
+              "type": "user",
+              "attributes": {
+                "username": "api-example",
+                "name": "API Example",
+                "disabled": false,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "profile_picture": {
+                  "62x62": "/assets/avatars/default.png",
+                  "82x82": "/assets/avatars/default.png",
+                  "110x110": "/assets/avatars/default.png",
+                  "260x260": "/assets/avatars/default.png"
+                }
+              }
+            }
+          },
+          "assignee": {
+            "data": {
+              "id": "1337",
+              "type": "group",
+              "attributes": {
+                "name": "Admin",
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "permissions": [
+                  "user_management",
+                  "report_management"
+                ]
+              }
+            }
+          },
+          "program": {
+            "data": {
+              "id": "1337",
+              "type": "program",
+              "attributes": {
+                "handle": "security",
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "updated_at": "2016-02-02T04:05:06.000Z"
+              }
+            }
+          },
+          "severity": {
+            "data": {
+              "id": "64",
+              "type": "severity",
+              "attributes": {
+                "rating": "medium",
+                "author_type": "User",
+                "user_id": 1337,
+                "created_at": "2016-02-02T04:05:06.000Z",
+                "score": 6.3,
+                "attack_complexity": "low",
+                "attack_vector": "adjacent",
+                "availability": "medium",
+                "confidentiality": "low",
+                "integrity": "medium",
+                "privileges_required": "low",
+                "user_interaction": "required",
+                "scope": "changed"
+              }
+            }
+          },
+          "weakness": {
+            "data": {
+              "id": "1337",
+              "type": "weakness",
+              "attributes": {
+                "name": "Cross-Site Request Forgery (CSRF)",
+                "description": "The web application does not, or can not, sufficiently verify whether a well-formed, valid, consistent request was intentionally provided by the user who submitted the request.",
+                "external_id": "cwe-352",
+                "created_at": "2016-02-02T04:05:06.000Z"
+              }
+            }
+          },
+          "structured_scope": {
+            "data": {
+              "id": "64",
+              "type": "structured-scope",
+              "attributes": {
+                "asset_identifier": "example.com",
+                "asset_type": "url",
+                "confidentiality_requirement": "medium",
+                "integrity_requirement": "low",
+                "availability_requirement": "high",
+                "max_severity": "critical",
+                "created_at": "2015-03-04T04:05:06.000Z",
+                "updated_at": "2017-06-04T04:05:06.000Z",
+                "instruction": null,
+                "eligible_for_bounty": true,
+                "eligible_for_submission": true,
+                "reference": "T12345"
+              }
+            }
+          },
+          "bounties": {
+            "data": [
+
+            ]
+          },
+          "custom_field_values": {
+            "data": [
+
+            ]
+          }
+        }
+      }
+
+    ],
+    "links": {
+      "self": "https://api.hackerone.com/v1/reports?filter%5Bprogram%5D%5B%5D=security&page%5Bnumber%5D=1",
+      "next": "https://api.hackerone.com/v1/reports?filter%5Bprogram%5D%5B%5D=security&page%5Bnumber%5D=2",
+      "last": "https://api.hackerone.com/v1/reports?filter%5Bprogram%5D%5B%5D=security&page%5Bnumber%5D=5"
+    }
+  }

--- a/unittests/tools/test_h1_parser.py
+++ b/unittests/tools/test_h1_parser.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 from unittest.mock import patch
 
 from dateutil import parser as date_parser
-from django.utils import timezone
+
 from dojo.models import Test
 from dojo.tools.h1.parser import H1Parser
 from unittests.dojo_test_case import DojoTestCase, get_unit_tests_scans_path
@@ -14,12 +14,18 @@ class HackerOneVulnerabilityDisclosureProgramTests(DojoTestCase):
             parser = H1Parser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(2, len(findings))
+            self.assertEqual(True, findings[0].active)
+            self.assertEqual(False, findings[0].is_mitigated)
+            self.assertEqual(True, findings[1].active)
+            self.assertEqual(False, findings[1].is_mitigated)
 
     def test_parse_file_with_one_vuln_has_one_finding(self):
         with open(get_unit_tests_scans_path("h1") / "vuln_disclosure_one.json", encoding="utf-8") as testfile:
             parser = H1Parser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
+            self.assertEqual(True, findings[0].active)
+            self.assertEqual(False, findings[0].is_mitigated)
 
     def test_parse_file_with_no_vuln_has_no_finding(self):
         with open(get_unit_tests_scans_path("h1") / "vuln_disclosure_zero.json", encoding="utf-8") as testfile:

--- a/unittests/tools/test_h1_parser.py
+++ b/unittests/tools/test_h1_parser.py
@@ -61,6 +61,9 @@ class HackerOneVulnerabilityDisclosureProgramTests(DojoTestCase):
                 self.assertEqual(False, findings[3].active)
                 self.assertEqual(True, findings[3].is_mitigated)
                 self.assertEqual(mock_now.return_value.date(), findings[3].mitigated.date())
+                self.assertEqual(6.3, findings[3].cvssv3_score)
+                self.assertEqual("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N", findings[3].cvssv3)
+                self.assertIn("**Asset Identifier**: example.com", findings[3].description)
 
 
 class HackerOneBugBountyProgramTests(DojoTestCase):


### PR DESCRIPTION
Hacker One Vulnerability Disclosure parser improvements

For H1 Vulnerability Disclosure reports the field `main_state` should be used. This field can be `open` or `closed`. To be safe we consider everything `Active` unless the `main_state` is `closed`.

Additional changes:

- Update docs on supported formats
- Parse `closed_at` field as mitigation date
- Parse CVSS3 data
- Parse asset metadata
- Parse cve_ids

