### PR TITLE
jira auth: add docs

### DIFF
--- a/docs/content/en/share_your_findings/jira_integration/connect_to_jira.md
+++ b/docs/content/en/share_your_findings/jira_integration/connect_to_jira.md
@@ -5,15 +5,22 @@ weight: 1
 ---
 
 Connecting a Jira Instance is the first step to take when setting up DefectDojo’s Jira integration.
+Please note Jira Service Management is currently not supported.
 
 #### Required information from Jira
 
-You will need:
-* a Jira URL
+Atlassian uses different ways of authentication between Jira Cloud and Jira Data Center. You will need:
+
+Jira Cloud:
+* a Jira URL, i.e. https://yourcompany.atlassian.net/
 * an account with permissions to create and update issues in your Jira instance.  This can be:
-    * A standard **username / password** combination
-    * A **username / API Key** combination **(Jira Cloud)**
+    * A **username / Personal Access Token** combination **(JIRA Data Center / Server)
     * A **Personal Access Token (aka PAT, used in Jira Data Center and Jira Server only)**
+
+Jira Data Center (or Server):
+* a Jira URL, i.e. https://jira.yourcompany.com
+* an account with permissions to create and update issues in your Jira instance.  This can be:
+    * A **emailaddress / Personal Access Token** combination
 
 Optionally, you can map:
 * Jira Transitions to trigger Re-Opening and Closing Findings

--- a/docs/content/en/share_your_findings/jira_integration/troubleshooting_jira.md
+++ b/docs/content/en/share_your_findings/jira_integration/troubleshooting_jira.md
@@ -5,6 +5,53 @@ description: "Fixing issues with a Jira integration"
 
 Here are some common issues with the Jira integration, and ways to address them.
 
+## Unable to setup Jira configuration in DefectDojo due to 404, 401 or 403 errors
+Jira Cloud:
+- Consult the Jira Cloud REST API documentation on authentication: https://developer.atlassian.com/cloud/jira/software/basic-auth-for-rest-apis/
+- Verify on the command line that the provided credentials can access the necessary issues in Jira:
+
+```
+curl -D- \
+   -u <emailaddress>:<personal_access_token> \
+   -X GET \
+   -H "Content-Type: application/json" \
+   https://<COMPANY>.atlassian.net/rest/api/latest/issue/<JIRA_ISSUE_KEY>/transitions?expand=transitions.fields
+```
+
+For example:
+```
+curl -D- \
+   -u defectdojo@example.com:ATATT1234567890abcdefghijklmnopqrstuvwxyz \
+   -X GET \
+   -H "Content-Type: application/json" \
+   https://defectdojo.atlassian.net/rest/api/latest/issue/VULNERABILITY-1/transitions?expand=transitions.fields
+```
+
+Jira Data Center or Server:
+- Consult the Jira Data Center REST API documentation on authentication:
+    - https://developer.atlassian.com/server/jira/platform/basic-authentication/ (username + password)
+    - https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html (personal access token)
+- Verify on the command line that the provided credentials can access the necessary issues in Jira:
+
+```
+curl -u username:password -X GET -H "Content-Type: application/json" https://<COMPANY>.atlassian.net/rest/api/latest/issue/<JIRA_ISSUE_KEY>/transitions?expand=transitions.fields
+```
+
+For example:
+```
+curl -u defectdojo@example.com:123456 -X GET -H "Content-Type: application/json" https://defectdojo.atlassian.net/rest/api/latest/issue/VULNERABILITY-1/transitions?expand=transitions.fields
+```
+
+When using personal access tokens:
+```
+curl -H "Authorization: Bearer <personal_access_token>" https://<COMPANY>.atlassian.net/rest/api/latest/issue/<JIRA_ISSUE_KEY>/transitions?expand=transitions.fields
+```
+
+For example:
+```
+curl -H "Authorization: Bearer ATATT1234567890abcdefghijklmnopqrstuvwxyz" https://<COMPANY>.atlassian.net/rest/api/latest/issue/<JIRA_ISSUE_KEY>/transitions?expand=transitions.fields
+```
+
 ## Findings that I 'Push To Jira' do not appear in Jira
 Using the 'Push To Jira' workflow triggers an asynchronous process, however an Issue should be created in Jira fairly quickly after 'Push To Jira' is triggered.
 


### PR DESCRIPTION
- Make authentication differences between Jira Cloud and Jira Data Center more clear/correct
- Add authentication troubleshooting steps to verify credentials on CLI