### PR TITLE
Update wording about async import removal in 2.46.md

### DIFF
--- a/docs/content/en/open_source/upgrading/2.46.md
+++ b/docs/content/en/open_source/upgrading/2.46.md
@@ -40,7 +40,7 @@ Following the deployment of these new behaviors, requests sent to the API or thr
 
 ---
 
-### Asynchronous Import deprecation in 2.47.0
+### Asynchronous Import Feature Removal in 2.47.0
 
 Please note that asynchronous import is already deprecated and will be removed in version 2.47.0. If you haven't migrated from this feature yet, we recommend doing so.
 


### PR DESCRIPTION
I think the wording "deprecation" can confuse people as async import is already deprecated and will be _removed_ in 2.47.0