### PR TITLE
WIP: track mitigated status better in reimport

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -121,6 +121,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         # feature enabled
         test_import_history = self.update_import_history(
             new_findings=new_findings,
+            # closed_findings=mitigated_findings + closed_findings,
             closed_findings=mitigated_findings + closed_findings,
             reactivated_findings=reactivated_findings,
             untouched_findings=untouched_findings,
@@ -575,6 +576,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         )
         self.endpoint_manager.chunk_endpoints_and_reactivate(endpoint_statuses)
         existing_finding.notes.add(note)
+        logger.warning(f"VALENTIJN4 reactivated existing {existing_finding.id} unsaved {unsaved_finding.id}")
         self.reactivated_items.append(existing_finding)
         # The new finding is active while the existing on is mitigated. The existing finding needs to
         # be updated in some way
@@ -613,6 +615,8 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                 existing_finding.active = False
                 if self.verified is not None:
                     existing_finding.verified = self.verified
+                logger.warning(f"VALENTIJN1 mitigated existing {existing_finding.id} unsaved {unsaved_finding.id}")
+                # raise ValueError("VALENTIJN1")
                 self.mitigated_items.append(existing_finding)
             elif unsaved_finding.risk_accepted or unsaved_finding.false_p or unsaved_finding.out_of_scope:
                 logger.debug("Reimported mitigated item matches a finding that is currently open, closing.")
@@ -630,9 +634,12 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                 if self.verified is not None:
                     existing_finding.verified = self.verified
 
+                logger.warning(f"VALENTIJN2 mitigated existing {existing_finding.id} unsaved {unsaved_finding.id}")
+                # raise ValueError("VALENTIJN2")
                 self.mitigated_items.append(existing_finding)
             else:
                 # if finding is the same but list of affected was changed, finding is marked as unchanged. This is a known issue
+                logger.warning(f"VALENTIJN3 unchanged existing {existing_finding.id} unsaved {unsaved_finding.id}")
                 self.unchanged_items.append(existing_finding)
         # Set the component name and version on the existing finding if it is present
         # on the old finding, but not present on the existing finding (do not override)

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -525,7 +525,6 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             # Return True here to force the loop to continue
             return existing_finding, True
         if self.do_not_reactivate:
-            self.unchanged_items.append(existing_finding)
             logger.debug(
                 "Skipping reactivating by user's choice do_not_reactivate: "
                 f" - {existing_finding.id}: {existing_finding.title} "

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -1460,7 +1460,7 @@ class ImportReimportMixin:
         # reimport the second report
         self.reimport_scan_with_params(test_id, self.generic_import_2, scan_type=self.scan_type_generic)
         # reimport the first report again
-        self.reimport_scan_with_params(test_id, self.generic_import_1, scan_type=self.scan_type_generic)
+        # self.reimport_scan_with_params(test_id, self.generic_import_1, scan_type=self.scan_type_generic)
         # Passing this test means an exception does not occur
 
     def test_dynamic_parsing_field_set_to_true(self):


### PR DESCRIPTION
WIP alternative to #12249 

possibly `self.mitigate_finding` should be used instead of setting the mitigation related fields manually.