### PR TITLE
tenable: check mandatory columns before importing

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -487,7 +487,7 @@ class BaseImporter(ImporterOptions):
             message += "."
         else:
             # Set the message to convey that all findings processed are identical to the last time an import/reimport occurred
-            message = "No findings were added/updated/closed/reactivated as the findings in Defect Dojo are identical to those in the uploaded report."
+            message = "No findings were added/updated/closed/reactivated as the report is empty or the findings in Defect Dojo are identical to those in the uploaded report."
 
         return message
 

--- a/dojo/tools/tenable/csv_format.py
+++ b/dojo/tools/tenable/csv_format.py
@@ -80,6 +80,9 @@ class TenableCSVParser:
             content = content.decode("utf-8")
         csv.field_size_limit(int(sys.maxsize / 10))  # the request/resp are big
         reader = csv.DictReader(io.StringIO(content), delimiter=delimiter)
+        if "Name" not in reader.fieldnames and "Plugin Name" not in reader.fieldnames and "asset.name" not in reader.fieldnames:
+            msg = "Invalid CSV file: missing 'Name', 'Plugin Name' or 'asset.name' field"
+            raise ValueError(msg)
         dupes = {}
         # Iterate over each line and create findings
         for row in reader:


### PR DESCRIPTION
Throw a clear error message when `Plugin Name` or `asset.name` are missing from the CSV report.

![image](https://github.com/user-attachments/assets/b645ca16-5356-425c-bf9d-066bc9b34070)
