### PR TITLE
Revert "Release: Merge back 2.45.2 into dev from: master-into-dev/2.45.2-2.46.0-dev"

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.46.0-dev"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.184-dev
+version: 1.6.183-dev
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap


### PR DESCRIPTION
Reverts DefectDojo/django-DefectDojo#12271