### PR TITLE
Reimport: Special statuses should be respected from reports

### DIFF
--- a/dojo/tools/checkmarx_one/parser.py
+++ b/dojo/tools/checkmarx_one/parser.py
@@ -71,7 +71,6 @@ class CheckmarxOneParser:
                     "description": (
                         f"{query.get('description')}\n\n"
                         f"**Category**: {query.get('category')}\n"),
-                    "verified": query.get("state") != "TO_VERIFY",
                     "test": test,
                 }
                 # Iterate over the individual issues
@@ -81,6 +80,8 @@ class CheckmarxOneParser:
                         date = self._parse_date(instance.get("firstDetectionDate"))
                     else:
                         date = self._parse_date(instance.get("lastDetectionDate"))
+                    instance_details = self.determine_state(instance)
+                    instance_details.update(base_finding_details)
                     # Create the finding object
                     finding = Finding(
                         severity=instance.get("severity").title(),
@@ -174,14 +175,15 @@ class CheckmarxOneParser:
                     date = self._parse_date(instance.get("firstFoundDate"))
                 else:
                     date = self._parse_date(instance.get("foundDate"))
+                instance_details = self.determine_state(instance)
+                instance_details.update(base_finding_details)
                 # Create the finding object
                 finding = Finding(
                     severity=instance.get("severity").title(),
                     date=date,
                     file_path=instance.get("destinationFileName"),
                     line=instance.get("destinationLine"),
-                    verified=instance.get("state") != "TO_VERIFY",
-                    **base_finding_details,
+                    **instance_details,
                 )
                 # Add some details to the description
                 if node_snippet := get_node_snippet(instance.get("nodes", [])):
@@ -219,11 +221,9 @@ class CheckmarxOneParser:
                 + "**uri**: " + locations_uri + "\n"
                 + "**startLine**: " + str(locations_startLine) + "\n"
                 + "**endLine**: " + str(locations_endLine) + "\n",
-                false_p=False,
-                duplicate=False,
-                out_of_scope=False,
                 static_finding=True,
                 dynamic_finding=False,
+                **self.determine_state(result),
             )
             findings.append(finding)
         return findings
@@ -273,6 +273,7 @@ class CheckmarxOneParser:
             test=test,
             static_finding=True,
             unique_id_from_tool=unique_id_from_tool,
+            **self.determine_state(vulnerability),
         )
 
     def get_results_kics(
@@ -290,11 +291,11 @@ class CheckmarxOneParser:
             title=description,
             description=description,
             severity=vulnerability.get("severity").title(),
-            verified=vulnerability.get("state") != "TO_VERIFY",
             file_path=file_path,
             test=test,
             static_finding=True,
             unique_id_from_tool=unique_id_from_tool,
+            **self.determine_state(vulnerability),
         )
 
     def get_results_sca(
@@ -311,10 +312,10 @@ class CheckmarxOneParser:
             title=description,
             description=description,
             severity=vulnerability.get("severity").title(),
-            verified=vulnerability.get("state") != "TO_VERIFY",
             test=test,
             static_finding=True,
             unique_id_from_tool=unique_id_from_tool,
+            **self.determine_state(vulnerability),
         )
         if (cveId := vulnerability.get("cveId")) is not None:
             finding.unsaved_vulnerability_ids = [cveId]
@@ -332,3 +333,18 @@ class CheckmarxOneParser:
             findings = self.parse_results(test, results)
 
         return findings
+
+    def determine_state(self, data: dict) -> dict:
+        """
+        Determine the state of the findings as set by Checkmarx One docs
+        https://docs.checkmarx.com/en/34965-68516-managing--triaging--vulnerabilities0.html#UUID-bc2397a3-1614-48bc-ff2f-1bc342071c5a_UUID-ad4991d6-161f-f76e-7d04-970f158eff9b
+        """
+        state = data.get("state") 
+        return {
+            "active": state in ["TO_VERIFY", "PROPOSED_NOT_EXPLOITABLE", "CONFIRMED", "URGENT"],
+            "verified": state in ["NOT_EXPLOITABLE", "CONFIRMED", "URGENT"],
+            "false_p": state in ["NOT_EXPLOITABLE"],
+            # These are not managed by checkmarx one, but is nice to explicitly set them
+            "duplicate": False,
+            "out_of_scope": False,
+        }

--- a/dojo/tools/checkmarx_one/parser.py
+++ b/dojo/tools/checkmarx_one/parser.py
@@ -339,11 +339,11 @@ class CheckmarxOneParser:
         Determine the state of the findings as set by Checkmarx One docs
         https://docs.checkmarx.com/en/34965-68516-managing--triaging--vulnerabilities0.html#UUID-bc2397a3-1614-48bc-ff2f-1bc342071c5a_UUID-ad4991d6-161f-f76e-7d04-970f158eff9b
         """
-        state = data.get("state") 
+        state = data.get("state")
         return {
-            "active": state in ["TO_VERIFY", "PROPOSED_NOT_EXPLOITABLE", "CONFIRMED", "URGENT"],
-            "verified": state in ["NOT_EXPLOITABLE", "CONFIRMED", "URGENT"],
-            "false_p": state in ["NOT_EXPLOITABLE"],
+            "active": state in {"TO_VERIFY", "PROPOSED_NOT_EXPLOITABLE", "CONFIRMED", "URGENT"},
+            "verified": state in {"NOT_EXPLOITABLE", "CONFIRMED", "URGENT"},
+            "false_p": state == "NOT_EXPLOITABLE",
             # These are not managed by checkmarx one, but is nice to explicitly set them
             "duplicate": False,
             "out_of_scope": False,

--- a/dojo/tools/checkmarx_one/parser.py
+++ b/dojo/tools/checkmarx_one/parser.py
@@ -91,7 +91,7 @@ class CheckmarxOneParser:
                             f"**Actual Value**: {instance.get('actualValue')}\n"
                             f"**Expected Value**: {instance.get('expectedValue')}\n"
                         ),
-                        **base_finding_details,
+                        **instance_details,
                     )
                     # Add some details to the description
                     finding.description += (

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -513,13 +513,17 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         with (get_unit_tests_path() / filename).open(encoding="utf-8") as testfile:
             payload = {
                     "minimum_severity": minimum_severity,
-                    "active": active,
-                    "verified": verified,
                     "scan_type": scan_type,
                     "file": testfile,
                     "version": "1.0.1",
                     "close_old_findings": close_old_findings,
             }
+
+            if active is not None:
+                payload["active"] = active
+            
+            if verified is not None:
+                payload["verified"] = verified
 
             if engagement:
                 payload["engagement"] = engagement
@@ -669,7 +673,7 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
     def assert_finding_count_json(self, count, findings_content_json):
         self.assertEqual(findings_content_json["count"], count)
 
-    def get_test_findings_api(self, test_id, active=None, verified=None, is_mitigated=None, component_name=None, component_version=None, severity=None):
+    def get_test_findings_api(self, test_id, active=None, verified=None, is_mitigated=None, false_p=None, component_name=None, component_version=None, severity=None):
         payload = {"test": test_id}
         if active is not None:
             payload["active"] = active
@@ -677,6 +681,8 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
             payload["verified"] = verified
         if is_mitigated is not None:
             payload["is_mitigated"] = is_mitigated
+        if false_p is not None:
+            payload["false_p"] = false_p
         if component_name is not None:
             payload["component_name"] = component_name
         if severity is not None:

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -521,7 +521,7 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
             if active is not None:
                 payload["active"] = active
-            
+
             if verified is not None:
                 payload["verified"] = verified
 

--- a/unittests/scans/checkmarx_one/one-open-one-false-positive.json
+++ b/unittests/scans/checkmarx_one/one-open-one-false-positive.json
@@ -1,0 +1,238 @@
+{
+  "results": [
+    {
+      "type": "sast",
+      "label": "sast",
+      "id": "0qB0NWis13+GAUmerweOUDyZzmk=",
+      "similarityId": "-1781066682",
+      "status": "RECURRENT",
+      "state": "NOT_EXPLOITABLE",
+      "severity": "CRITICAL",
+      "created": "2025-04-11T10:20:15Z",
+      "firstFoundAt": "2024-07-22T14:05:10Z",
+      "foundAt": "2025-04-11T10:20:15Z",
+      "firstScanId": "7083ee4e-2eff-4e2f-9d98-1aae8023169f",
+      "description": "The application's  method executes an SQL query with executeUpdate, at line 63 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java. The application constructs this SQL query by embedding an untrusted string into the query without proper sanitization. The concatenated string is submitted to the database, where it is parsed and executed accordingly.\n\nAn attacker would be able to inject arbitrary syntax and data into the SQL query, by crafting a malicious payload and providing it via the input query; this input is then read by the  method at line 53 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java. This input then flows through the code, into a query and to the database server - without sanitization.\r\n\r\nThis may enable an SQL Injection attack.\n\n",
+      "descriptionHTML": "\u003cp\u003eThe application‘s  method executes an SQL query with executeUpdate, at line 63 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java. The application constructs this SQL query by embedding an untrusted string into the query without proper sanitization. The concatenated string is submitted to the database, where it is parsed and executed accordingly.\u003c/p\u003e\n\n\u003cp\u003eAn attacker would be able to inject arbitrary syntax and data into the SQL query, by crafting a malicious payload and providing it via the input query; this input is then read by the  method at line 53 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java. This input then flows through the code, into a query and to the database server - without sanitization.\u003c/p\u003e\n\n\u003cp\u003eThis may enable an SQL Injection attack.\u003c/p\u003e\n",
+      "data": {
+        "queryId": 14517067005933136034,
+        "queryName": "SQL_Injection",
+        "group": "Java_Critical_Risk",
+        "resultHash": "0qB0NWis13+GAUmerweOUDyZzmk=",
+        "languageName": "Java",
+        "nodes": [
+          {
+            "id": "0BQetI+3nx066RIjhL4RXixfgGs=",
+            "line": 53,
+            "name": "query",
+            "column": 54,
+            "length": 5,
+            "nodeID": 79013,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.completed.query",
+            "methodLine": 53
+          },
+          {
+            "id": "ZZtfb86lLjmfYOKSTKP04NigAnI=",
+            "line": 54,
+            "name": "query",
+            "column": 28,
+            "length": 5,
+            "nodeID": 79011,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.completed.query",
+            "methodLine": 53
+          },
+          {
+            "id": "34zDkUrPrO+2mIQJIxZOImmdHOE=",
+            "line": 57,
+            "name": "query",
+            "column": 49,
+            "length": 5,
+            "nodeID": 79379,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.injectableQuery.query",
+            "methodLine": 57
+          },
+          {
+            "id": "Wv2DomzUnGITGzTxS9xYSIr4pL4=",
+            "line": 63,
+            "name": "query",
+            "column": 33,
+            "length": 5,
+            "nodeID": 79113,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.injectableQuery.query",
+            "methodLine": 57
+          },
+          {
+            "id": "Wk8aYr9/jNUfhXn42U+ia7A0YVU=",
+            "line": 63,
+            "name": "executeUpdate",
+            "column": 32,
+            "length": 1,
+            "nodeID": 79109,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.injectableQuery.statement.executeUpdate",
+            "methodLine": 57
+          }
+        ]
+      },
+      "comments": {},
+      "vulnerabilityDetails": {
+        "cweId": 89,
+        "cvss": {},
+        "compliances": [
+          "ASD STIG 6.1",
+          "Base Preset",
+          "OWASP Mobile Top 10 2016",
+          "SANS top 25",
+          "PCI DSS v4.0",
+          "OWASP Mobile Top 10 2024",
+          "OWASP Top 10 2013",
+          "ASA Mobile Premium",
+          "ASA Premium",
+          "OWASP Top 10 API",
+          "PCI DSS v3.2.1",
+          "FISMA 2014",
+          "OWASP Top 10 2017",
+          "MOIS(KISA) Secure Coding 2021",
+          "OWASP ASVS",
+          "OWASP Top 10 2021",
+          "Top Tier",
+          "CWE top 25",
+          "NIST SP 800-53"
+        ]
+      }
+    },
+    {
+      "type": "sast",
+      "label": "sast",
+      "id": "4/tlPdgnp5kS5PNqjnoXQagLbQE=",
+      "similarityId": "2067045827",
+      "status": "RECURRENT",
+      "state": "TO_VERIFY",
+      "severity": "CRITICAL",
+      "created": "2025-04-11T10:20:15Z",
+      "firstFoundAt": "2024-07-22T14:05:10Z",
+      "foundAt": "2025-04-11T10:20:15Z",
+      "firstScanId": "7083ee4e-2eff-4e2f-9d98-1aae8023169f",
+      "description": "The application's  method executes an SQL query with executeQuery, at line 74 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java. The application constructs this SQL query by embedding an untrusted string into the query without proper sanitization. The concatenated string is submitted to the database, where it is parsed and executed accordingly.\n\nAn attacker would be able to inject arbitrary syntax and data into the SQL query, by crafting a malicious payload and providing it via the input userId; this input is then read by the  method at line 56 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java. This input then flows through the code, into a query and to the database server - without sanitization.\r\n\r\nThis may enable an SQL Injection attack.\n\n",
+      "descriptionHTML": "\u003cp\u003eThe application‘s  method executes an SQL query with executeQuery, at line 74 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java. The application constructs this SQL query by embedding an untrusted string into the query without proper sanitization. The concatenated string is submitted to the database, where it is parsed and executed accordingly.\u003c/p\u003e\n\n\u003cp\u003eAn attacker would be able to inject arbitrary syntax and data into the SQL query, by crafting a malicious payload and providing it via the input userId; this input is then read by the  method at line 56 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java. This input then flows through the code, into a query and to the database server - without sanitization.\u003c/p\u003e\n\n\u003cp\u003eThis may enable an SQL Injection attack.\u003c/p\u003e\n",
+      "data": {
+        "queryId": 14517067005933136034,
+        "queryName": "SQL_Injection",
+        "group": "Java_Critical_Risk",
+        "resultHash": "4/tlPdgnp5kS5PNqjnoXQagLbQE=",
+        "languageName": "Java",
+        "nodes": [
+          {
+            "id": "h9+K/VCYy1hzaOuJGXAg7Q/2EGE=",
+            "line": 56,
+            "name": "userId",
+            "column": 75,
+            "length": 6,
+            "nodeID": 76692,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.completed.userId",
+            "methodLine": 56
+          },
+          {
+            "id": "QV2emb87v+UWl0+V/EIowjpHYuY=",
+            "line": 57,
+            "name": "userId",
+            "column": 28,
+            "length": 6,
+            "nodeID": 76690,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.completed.userId",
+            "methodLine": 56
+          },
+          {
+            "id": "8E8sNxUhnzn4/CcQ2zMi0zOfr/4=",
+            "line": 62,
+            "name": "accountName",
+            "column": 46,
+            "length": 11,
+            "nodeID": 77202,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.accountName",
+            "methodLine": 62
+          },
+          {
+            "id": "3a/7HgY2k0OJlt2CDKR+aVmb0vM=",
+            "line": 66,
+            "name": "accountName",
+            "column": 63,
+            "length": 11,
+            "nodeID": 76766,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.accountName",
+            "methodLine": 62
+          },
+          {
+            "id": "z5XE8sZNwVqn0L+7hHnlfBT5gZg=",
+            "line": 66,
+            "name": "query",
+            "column": 7,
+            "length": 5,
+            "nodeID": 76768,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.query",
+            "methodLine": 62
+          },
+          {
+            "id": "wFKklmrWDUKyZ973GslHu6IJ3l8=",
+            "line": 74,
+            "name": "query",
+            "column": 52,
+            "length": 5,
+            "nodeID": 76826,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.query",
+            "methodLine": 62
+          },
+          {
+            "id": "qRZ9lc8euTZVkXlHbHwO6kpHsoA=",
+            "line": 74,
+            "name": "executeQuery",
+            "column": 51,
+            "length": 1,
+            "nodeID": 76822,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.statement.executeQuery",
+            "methodLine": 62
+          }
+        ]
+      },
+      "comments": {},
+      "vulnerabilityDetails": {
+        "cweId": 89,
+        "cvss": {},
+        "compliances": [
+          "ASD STIG 6.1",
+          "Base Preset",
+          "OWASP Mobile Top 10 2016",
+          "SANS top 25",
+          "PCI DSS v4.0",
+          "OWASP Mobile Top 10 2024",
+          "OWASP Top 10 2013",
+          "ASA Mobile Premium",
+          "ASA Premium",
+          "OWASP Top 10 API",
+          "PCI DSS v3.2.1",
+          "FISMA 2014",
+          "OWASP Top 10 2017",
+          "MOIS(KISA) Secure Coding 2021",
+          "OWASP ASVS",
+          "OWASP Top 10 2021",
+          "Top Tier",
+          "CWE top 25",
+          "NIST SP 800-53"
+        ]
+      }
+    }
+  ],
+  "totalCount": 75,
+  "scanID": "d121274d-3cb6-4bae-b02a-3eede9eac3d9"
+}

--- a/unittests/scans/checkmarx_one/two-false-positive.json
+++ b/unittests/scans/checkmarx_one/two-false-positive.json
@@ -1,0 +1,238 @@
+{
+  "results": [
+    {
+      "type": "sast",
+      "label": "sast",
+      "id": "0qB0NWis13+GAUmerweOUDyZzmk=",
+      "similarityId": "-1781066682",
+      "status": "RECURRENT",
+      "state": "NOT_EXPLOITABLE",
+      "severity": "CRITICAL",
+      "created": "2025-04-11T10:20:15Z",
+      "firstFoundAt": "2024-07-22T14:05:10Z",
+      "foundAt": "2025-04-11T10:20:15Z",
+      "firstScanId": "7083ee4e-2eff-4e2f-9d98-1aae8023169f",
+      "description": "The application's  method executes an SQL query with executeUpdate, at line 63 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java. The application constructs this SQL query by embedding an untrusted string into the query without proper sanitization. The concatenated string is submitted to the database, where it is parsed and executed accordingly.\n\nAn attacker would be able to inject arbitrary syntax and data into the SQL query, by crafting a malicious payload and providing it via the input query; this input is then read by the  method at line 53 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java. This input then flows through the code, into a query and to the database server - without sanitization.\r\n\r\nThis may enable an SQL Injection attack.\n\n",
+      "descriptionHTML": "\u003cp\u003eThe application‘s  method executes an SQL query with executeUpdate, at line 63 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java. The application constructs this SQL query by embedding an untrusted string into the query without proper sanitization. The concatenated string is submitted to the database, where it is parsed and executed accordingly.\u003c/p\u003e\n\n\u003cp\u003eAn attacker would be able to inject arbitrary syntax and data into the SQL query, by crafting a malicious payload and providing it via the input query; this input is then read by the  method at line 53 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java. This input then flows through the code, into a query and to the database server - without sanitization.\u003c/p\u003e\n\n\u003cp\u003eThis may enable an SQL Injection attack.\u003c/p\u003e\n",
+      "data": {
+        "queryId": 14517067005933136034,
+        "queryName": "SQL_Injection",
+        "group": "Java_Critical_Risk",
+        "resultHash": "0qB0NWis13+GAUmerweOUDyZzmk=",
+        "languageName": "Java",
+        "nodes": [
+          {
+            "id": "0BQetI+3nx066RIjhL4RXixfgGs=",
+            "line": 53,
+            "name": "query",
+            "column": 54,
+            "length": 5,
+            "nodeID": 79013,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.completed.query",
+            "methodLine": 53
+          },
+          {
+            "id": "ZZtfb86lLjmfYOKSTKP04NigAnI=",
+            "line": 54,
+            "name": "query",
+            "column": 28,
+            "length": 5,
+            "nodeID": 79011,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.completed.query",
+            "methodLine": 53
+          },
+          {
+            "id": "34zDkUrPrO+2mIQJIxZOImmdHOE=",
+            "line": 57,
+            "name": "query",
+            "column": 49,
+            "length": 5,
+            "nodeID": 79379,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.injectableQuery.query",
+            "methodLine": 57
+          },
+          {
+            "id": "Wv2DomzUnGITGzTxS9xYSIr4pL4=",
+            "line": 63,
+            "name": "query",
+            "column": 33,
+            "length": 5,
+            "nodeID": 79113,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.injectableQuery.query",
+            "methodLine": 57
+          },
+          {
+            "id": "Wk8aYr9/jNUfhXn42U+ia7A0YVU=",
+            "line": 63,
+            "name": "executeUpdate",
+            "column": 32,
+            "length": 1,
+            "nodeID": 79109,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/introduction/SqlInjectionLesson3.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.introduction.SqlInjectionLesson3.injectableQuery.statement.executeUpdate",
+            "methodLine": 57
+          }
+        ]
+      },
+      "comments": {},
+      "vulnerabilityDetails": {
+        "cweId": 89,
+        "cvss": {},
+        "compliances": [
+          "ASD STIG 6.1",
+          "Base Preset",
+          "OWASP Mobile Top 10 2016",
+          "SANS top 25",
+          "PCI DSS v4.0",
+          "OWASP Mobile Top 10 2024",
+          "OWASP Top 10 2013",
+          "ASA Mobile Premium",
+          "ASA Premium",
+          "OWASP Top 10 API",
+          "PCI DSS v3.2.1",
+          "FISMA 2014",
+          "OWASP Top 10 2017",
+          "MOIS(KISA) Secure Coding 2021",
+          "OWASP ASVS",
+          "OWASP Top 10 2021",
+          "Top Tier",
+          "CWE top 25",
+          "NIST SP 800-53"
+        ]
+      }
+    },
+    {
+      "type": "sast",
+      "label": "sast",
+      "id": "4/tlPdgnp5kS5PNqjnoXQagLbQE=",
+      "similarityId": "2067045827",
+      "status": "RECURRENT",
+      "state": "NOT_EXPLOITABLE",
+      "severity": "CRITICAL",
+      "created": "2025-04-11T10:20:15Z",
+      "firstFoundAt": "2024-07-22T14:05:10Z",
+      "foundAt": "2025-04-11T10:20:15Z",
+      "firstScanId": "7083ee4e-2eff-4e2f-9d98-1aae8023169f",
+      "description": "The application's  method executes an SQL query with executeQuery, at line 74 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java. The application constructs this SQL query by embedding an untrusted string into the query without proper sanitization. The concatenated string is submitted to the database, where it is parsed and executed accordingly.\n\nAn attacker would be able to inject arbitrary syntax and data into the SQL query, by crafting a malicious payload and providing it via the input userId; this input is then read by the  method at line 56 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java. This input then flows through the code, into a query and to the database server - without sanitization.\r\n\r\nThis may enable an SQL Injection attack.\n\n",
+      "descriptionHTML": "\u003cp\u003eThe application‘s  method executes an SQL query with executeQuery, at line 74 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java. The application constructs this SQL query by embedding an untrusted string into the query without proper sanitization. The concatenated string is submitted to the database, where it is parsed and executed accordingly.\u003c/p\u003e\n\n\u003cp\u003eAn attacker would be able to inject arbitrary syntax and data into the SQL query, by crafting a malicious payload and providing it via the input userId; this input is then read by the  method at line 56 of /src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java. This input then flows through the code, into a query and to the database server - without sanitization.\u003c/p\u003e\n\n\u003cp\u003eThis may enable an SQL Injection attack.\u003c/p\u003e\n",
+      "data": {
+        "queryId": 14517067005933136034,
+        "queryName": "SQL_Injection",
+        "group": "Java_Critical_Risk",
+        "resultHash": "4/tlPdgnp5kS5PNqjnoXQagLbQE=",
+        "languageName": "Java",
+        "nodes": [
+          {
+            "id": "h9+K/VCYy1hzaOuJGXAg7Q/2EGE=",
+            "line": 56,
+            "name": "userId",
+            "column": 75,
+            "length": 6,
+            "nodeID": 76692,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.completed.userId",
+            "methodLine": 56
+          },
+          {
+            "id": "QV2emb87v+UWl0+V/EIowjpHYuY=",
+            "line": 57,
+            "name": "userId",
+            "column": 28,
+            "length": 6,
+            "nodeID": 76690,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.completed.userId",
+            "methodLine": 56
+          },
+          {
+            "id": "8E8sNxUhnzn4/CcQ2zMi0zOfr/4=",
+            "line": 62,
+            "name": "accountName",
+            "column": 46,
+            "length": 11,
+            "nodeID": 77202,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.accountName",
+            "methodLine": 62
+          },
+          {
+            "id": "3a/7HgY2k0OJlt2CDKR+aVmb0vM=",
+            "line": 66,
+            "name": "accountName",
+            "column": 63,
+            "length": 11,
+            "nodeID": 76766,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.accountName",
+            "methodLine": 62
+          },
+          {
+            "id": "z5XE8sZNwVqn0L+7hHnlfBT5gZg=",
+            "line": 66,
+            "name": "query",
+            "column": 7,
+            "length": 5,
+            "nodeID": 76768,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.query",
+            "methodLine": 62
+          },
+          {
+            "id": "wFKklmrWDUKyZ973GslHu6IJ3l8=",
+            "line": 74,
+            "name": "query",
+            "column": 52,
+            "length": 5,
+            "nodeID": 76826,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.query",
+            "methodLine": 62
+          },
+          {
+            "id": "qRZ9lc8euTZVkXlHbHwO6kpHsoA=",
+            "line": 74,
+            "name": "executeQuery",
+            "column": 51,
+            "length": 1,
+            "nodeID": 76822,
+            "fileName": "/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java",
+            "fullName": "org.owasp.webgoat.lessons.sqlinjection.advanced.SqlInjectionLesson6a.injectableQuery.statement.executeQuery",
+            "methodLine": 62
+          }
+        ]
+      },
+      "comments": {},
+      "vulnerabilityDetails": {
+        "cweId": 89,
+        "cvss": {},
+        "compliances": [
+          "ASD STIG 6.1",
+          "Base Preset",
+          "OWASP Mobile Top 10 2016",
+          "SANS top 25",
+          "PCI DSS v4.0",
+          "OWASP Mobile Top 10 2024",
+          "OWASP Top 10 2013",
+          "ASA Mobile Premium",
+          "ASA Premium",
+          "OWASP Top 10 API",
+          "PCI DSS v3.2.1",
+          "FISMA 2014",
+          "OWASP Top 10 2017",
+          "MOIS(KISA) Secure Coding 2021",
+          "OWASP ASVS",
+          "OWASP Top 10 2021",
+          "Top Tier",
+          "CWE top 25",
+          "NIST SP 800-53"
+        ]
+      }
+    }
+  ],
+  "totalCount": 75,
+  "scanID": "d121274d-3cb6-4bae-b02a-3eede9eac3d9"
+}

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -102,6 +102,10 @@ class ImportReimportMixin:
         self.anchore_grype_file_name = get_unit_tests_scans_path("anchore_grype") / "check_all_fields.json"
         self.anchore_grype_scan_type = "Anchore Grype"
 
+        self.checkmarx_one_open_and_false_positive = get_unit_tests_scans_path("checkmarx_one") / "one-open-one-false-positive.json"
+        self.checkmarx_one_two_false_positive = get_unit_tests_scans_path("checkmarx_one") / "two-false-positive.json"
+        self.scan_type_checkmarx_one = "Checkmarx One Scan"
+
     # import zap scan, testing:
     # - import
     # - active/verifed = True
@@ -1481,6 +1485,22 @@ class ImportReimportMixin:
         test = Test.objects.get(id=test_id)
         self.assertFalse(test.test_type.dynamically_generated)
 
+    def test_false_positive_status_applied_after_reimport(self):
+        # Test that checkmarx one with a file that has one open finding, and one false positive finding
+        import0 = self.import_scan_with_params(self.checkmarx_one_open_and_false_positive, scan_type=self.scan_type_checkmarx_one, active=None, verified=None)
+        test_id = import0["test"]
+        active_finding_before = self.get_test_findings_api(test_id, active=True)
+        false_p_finding_before = self.get_test_findings_api(test_id, false_p=True)
+        # Make sure we get the expeceted results
+        self.assertEqual(1, active_finding_before.get("count", 0))
+        self.assertEqual(1, false_p_finding_before.get("count", 0))
+        # reimport the next report that sets the active finding to false positive
+        self.reimport_scan_with_params(test_id, self.checkmarx_one_two_false_positive, scan_type=self.scan_type_checkmarx_one)
+        active_finding_after = self.get_test_findings_api(test_id, active=True)
+        false_p_finding_after = self.get_test_findings_api(test_id, false_p=True)
+        # Make sure we get the expeceted results
+        self.assertEqual(0, active_finding_after.get("count", 0))
+        self.assertEqual(2, false_p_finding_after.get("count", 0))
 
 class ImportReimportTestAPI(DojoAPITestCase, ImportReimportMixin):
     fixtures = ["dojo_testdata.json"]
@@ -1814,13 +1834,13 @@ class ImportReimportTestUI(DojoAPITestCase, ImportReimportMixin):
         activePayload = "not_specified"
         if force_active:
             activePayload = "force_to_true"
-        elif not active:
+        elif active is False:
             activePayload = "force_to_false"
 
         verifiedPayload = "not_specified"
         if force_verified:
             verifiedPayload = "force_to_true"
-        elif not verified:
+        elif verified is False:
             verifiedPayload = "force_to_false"
 
         with Path(filename).open(encoding="utf-8") as testfile:

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -1502,6 +1502,7 @@ class ImportReimportMixin:
         self.assertEqual(0, active_finding_after.get("count", 0))
         self.assertEqual(2, false_p_finding_after.get("count", 0))
 
+
 class ImportReimportTestAPI(DojoAPITestCase, ImportReimportMixin):
     fixtures = ["dojo_testdata.json"]
 

--- a/unittests/tools/test_checkmarx_one_parser.py
+++ b/unittests/tools/test_checkmarx_one_parser.py
@@ -153,3 +153,15 @@ class TestCheckmarxOneParser(DojoTestCase):
             sast_finding = findings[124]
             self.maxDiff = None
             test_sast_finding(sast_finding)
+
+    def test_checkmarx_one_false_positive_status(self):
+        with (get_unit_tests_scans_path("checkmarx_one") / "one-open-one-false-positive.json").open(encoding="utf-8") as testfile:
+            parser = CheckmarxOneParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(2, len(findings))
+            # check the first first finding is false positive
+            self.assertEqual(True, findings[0].false_p)
+            self.assertEqual(False, findings[0].active)
+            # check the first second finding is not false positive
+            self.assertEqual(False, findings[1].false_p)
+            self.assertEqual(True, findings[1].active)


### PR DESCRIPTION
Replacement of #12249 

When performing a reimport, the status of a finding from the report that is either false positive, out of scope, or risk accepted is being discarded. This is due to a flaw in the  way findings are calculated for the `close_old_findings` function.

Let's say we have a finding in the database that is active. In the next reimport, the same finding is being reported form the tool as false positive. Reimport will do the following:
1.  Store the list of original findings
2. Parse the findings
3. Find a match between this new false positive finding, and the existing active finding
4. Set the active finding to false positive, and save the finding to the database
5. Determine the findings to be closed by subtracting the findings from the report from the original list of findings from step 1.
    - This is just the original active finding (though the record is stale since it was updated in step 4.)
6. Close the active finding by setting the mitigated status
7. Find out that the false positive status was discarded

This situation is caused from attempting to close a stale record, that may or may not already be closed, and therefore overwrite any other statuses. The solution here is simple: fetch the latest status on the finding before deciding if it needs to be closed. 

[sc-10908]