### PR TITLE
sla: parse finding.date implicitly

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -10,6 +10,7 @@ from decimal import Decimal
 from pathlib import Path
 from uuid import uuid4
 
+import dateutil
 import hyperlink
 import tagulous.admin
 from auditlog.registry import auditlog
@@ -3058,9 +3059,8 @@ class Finding(models.Model):
 
         # some parsers provide date as a `str` instead of a `date` in which case we need to parse it #12299 on GitHub
         sla_start_date = self.get_sla_start_date()
-        from dateutil.parser import parse
         if sla_start_date and isinstance(sla_start_date, str):
-            sla_start_date = parse(sla_start_date).date()
+            sla_start_date = dateutil.parser.parse(sla_start_date).date()
 
         sla_period, enforce_period = self.get_sla_period()
         if sla_period is not None and enforce_period:

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3056,6 +3056,7 @@ class Finding(models.Model):
         if not system_settings.enable_finding_sla:
             return
 
+        # some parsers provide date as a `str` instead of a `date` in which case we need to parse it #12299 on GitHub
         sla_start_date = self.get_sla_start_date()
         from dateutil.parser import parse
         if sla_start_date and isinstance(sla_start_date, str):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2682,6 +2682,9 @@ class Finding(models.Model):
 
         from dojo.finding import helper as finding_helper
 
+        # if not isinstance(self.date, (datetime, date)):
+        #     raise ValidationError(_("The 'date' field must be a valid date or datetime object."))
+
         if not user:
             from dojo.utils import get_current_user
             user = get_current_user()
@@ -3053,9 +3056,14 @@ class Finding(models.Model):
         if not system_settings.enable_finding_sla:
             return
 
+        sla_start_date = self.get_sla_start_date()
+        from dateutil.parser import parse
+        if sla_start_date and isinstance(sla_start_date, str):
+            sla_start_date = parse(sla_start_date).date()
+
         sla_period, enforce_period = self.get_sla_period()
         if sla_period is not None and enforce_period:
-            self.sla_expiration_date = self.get_sla_start_date() + relativedelta(days=sla_period)
+            self.sla_expiration_date = sla_start_date + relativedelta(days=sla_period)
         else:
             self.sla_expiration_date = None
 


### PR DESCRIPTION
Fixes #12299 introduced in #11924

The old code had parsing in place for parsers that didn't set the `finding.date` correctly. These parsers provided a `str` instead of `date`. This PR ensures this implicit parsing is performed with the simplified SLA logic.

This implicit parsing was tucked away in the `_age()` method: https://github.com/DefectDojo/django-DefectDojo/blob/8e7cc01142c5f8d7b31b85e686cbd28d341ad2ca/dojo/models.py#L3004-L3007

 The unit tests of parsers don't trigger this SLA logic, we'll look to add more checks to the parser unit tests in a future PR.

All affected parsers are now working again:

<img width="864" alt="image" src="https://github.com/user-attachments/assets/1b2949f4-7f4c-499c-95f4-a6c6bdc7b25a" />

