### PR TITLE
Add input validation (branch to release num) for the release gha

### DIFF
--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate proper bugfix branch release_number format is being used
-        if: ${{ github.event.inputs.from_branch == 'bugfix' }}
+        if: ${{ inputs.from_branch == 'bugfix' }}
         run: |
           # Expect the last octet in release_number to not be 0
           echo "${{ github.event.inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.[1-9]$"

--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -11,6 +11,11 @@ on:
       from_branch:
         description: "Select branch to release from ('release/x.y.z'. If `dev` is entered, a new release branch will be created from `dev`)"
         required: true
+        type: choice
+        default: 'bugfix'
+        options:
+          - bugfix
+          - dev
       release_number:
         description: "Release version (x.y.z format)"
         required: true
@@ -19,6 +24,18 @@ jobs:
   create_pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate proper bugfix branch release_number format is being used
+        if: ${{ github.event.inputs.from_branch == 'bugfix' }}
+        run: |
+          # Expect the last octet in release_number to not be 0
+          echo "${{ github.event.inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.[1-9]$"
+
+      - name: Validate proper dev branch release_number format is being used
+        if: ${{ github.event.inputs.from_branch == 'dev' }}
+        run: |
+          # Expect the last octet in release_number to not be 1-9
+          echo "${{ github.event.inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.0$"
+
       - id: Set-GitHub-org
         run: echo "GITHUB_ORG=${GITHUB_REPOSITORY%%/*}" >> $GITHUB_ENV
 

--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -34,7 +34,7 @@ jobs:
         if: ${{ inputs.from_branch == 'dev' }}
         run: |
           # Expect the last octet in release_number to not be 1-9
-          echo "${{ github.event.inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.0$"
+          echo "${{ inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.0$"
 
       - id: Set-GitHub-org
         run: echo "GITHUB_ORG=${GITHUB_REPOSITORY%%/*}" >> $GITHUB_ENV

--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -9,7 +9,7 @@ on:
       # the actual branch that can be chosen on the UI is made irrelevant by further steps
       # because someone will forget one day to change it.
       from_branch:
-        description: "Select branch to release from ('release/x.y.z'. If `dev` or `bugfix` is entered, a new release branch will be created from that branch)"
+        description: "Select branch to release from. Dev branch releases happen the first monday of the month. Otherwise, use bugfix."
         required: true
         type: choice
         default: 'bugfix'
@@ -45,14 +45,8 @@ jobs:
           ref: ${{ github.event.inputs.from_branch }}
 
       - name: Create release branch
-        if: ${{ !startsWith(github.event.inputs.from_branch, 'release/') }}
         run: |
           echo "NEW_BRANCH=release/${{ github.event.inputs.release_number }}" >> $GITHUB_ENV
-
-      - name: Use existing release branch
-        if: startsWith(github.event.inputs.from_branch, 'release/')
-        run: |
-          echo "NEW_BRANCH=${{ github.event.inputs.from_branch }}" >> $GITHUB_ENV
 
       - name: Configure git
         run: |

--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ inputs.from_branch == 'bugfix' }}
         run: |
           # Expect the last octet in release_number to not be 0
-          echo "${{ github.event.inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.[1-9]$"
+          echo "${{ inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.[1-9]$"
 
       - name: Validate proper dev branch release_number format is being used
         if: ${{ github.event.inputs.from_branch == 'dev' }}

--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -9,7 +9,7 @@ on:
       # the actual branch that can be chosen on the UI is made irrelevant by further steps
       # because someone will forget one day to change it.
       from_branch:
-        description: "Select branch to release from ('release/x.y.z'. If `dev` is entered, a new release branch will be created from `dev`)"
+        description: "Select branch to release from ('release/x.y.z'. If `dev` or `bugfix` is entered, a new release branch will be created from that branch)"
         required: true
         type: choice
         default: 'bugfix'

--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -31,7 +31,7 @@ jobs:
           echo "${{ inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.[1-9]$"
 
       - name: Validate proper dev branch release_number format is being used
-        if: ${{ github.event.inputs.from_branch == 'dev' }}
+        if: ${{ inputs.from_branch == 'dev' }}
         run: |
           # Expect the last octet in release_number to not be 1-9
           echo "${{ github.event.inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.0$"


### PR DESCRIPTION
**Description**

- Adds a dropdown choice to the GHA that kicks off the OS release. Currently this is a free form text field which could lead to shenanigans. 
- Adds input validation based on branch and release number. We expect dev releases last octet to end in "0" and bugfix releases to be 1 or greater. 

**Test results**

Validated working and non-working combinations of branch to release number. 
- dev with 2.33.1 (failed validation, as expected)
- dev with 2.33.0 (pass)
- bugfix with 2.33.0 (fail)
- bugfix with 2.33.1 (pass)
- either branch with letters, non-alphanum chars, etc. (fail).
