### PR TITLE
fix(api): Enable to set `recommendation` and `decision` in `risk_acceptance`

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1525,8 +1525,6 @@ class TestImportSerializer(serializers.ModelSerializer):
 
 
 class RiskAcceptanceSerializer(serializers.ModelSerializer):
-    recommendation = serializers.SerializerMethodField()
-    decision = serializers.SerializerMethodField()
     path = serializers.SerializerMethodField()
 
     def create(self, validated_data):
@@ -1553,14 +1551,6 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
         for finding in findings_to_remove:
             ra_helper.remove_finding_from_risk_acceptance(user, instance, finding)
         return instance
-
-    @extend_schema_field(serializers.CharField())
-    def get_recommendation(self, obj):
-        return Risk_Acceptance.TREATMENT_TRANSLATIONS.get(obj.recommendation)
-
-    @extend_schema_field(serializers.CharField())
-    def get_decision(self, obj):
-        return Risk_Acceptance.TREATMENT_TRANSLATIONS.get(obj.decision)
 
     @extend_schema_field(serializers.CharField())
     def get_path(self, obj):

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1009,8 +1009,8 @@ class RiskAcceptanceTest(BaseClass.BaseClassTest):
         self.viewset = RiskAcceptanceViewSet
         self.payload = {
             "id": 2,
-            "recommendation": "Fix (The risk is eradicated)",
-            "decision": "Accept (The risk is acknowledged, yet remains)",
+            "recommendation": "F",
+            "decision": "A",
             "path": "No proof has been supplied",
             "name": "string",
             "recommendation_details": "string",
@@ -1046,8 +1046,8 @@ class RiskAcceptanceTest(BaseClass.BaseClassTest):
     def test_update_forbidden_engagement(self):
         self.payload = {
             "id": 1,
-            "recommendation": "Fix (The risk is eradicated)",
-            "decision": "Accept (The risk is acknowledged, yet remains)",
+            "recommendation": "F",
+            "decision": "A",
             "path": "No proof has been supplied",
             "name": "string",
             "recommendation_details": "string",


### PR DESCRIPTION
# Issue

Until now, the API endpoint `POST /api/v2/risk_acceptance/` (which also applies to `PUT` and `PATCH`) has not accepted `recommendation` and `decision`. As a result, DD used the default value (fix for recommendation and accept for decision). There was no error message.
For `GET` requests, DD translated the chosen value (one of `A`, `V`, `M`, `F`, `T`) to human-readable form.
It sounds nice, but not if it means that fields are not writable.
<img width="703" alt="Screenshot 2025-04-23 at 16 43 24" src="https://github.com/user-attachments/assets/b0d5d24a-8454-498b-81cd-28198cdbd075" />
<img width="498" alt="Screenshot 2025-04-23 at 16 45 00" src="https://github.com/user-attachments/assets/fb4aabae-7b07-4ac4-a0cb-79afb6dcfb31" />

# Solution
This PR dropped `SerializerMethodField`s with `get_...` methods, which locked these fields to read-only mode. Now, during the creation of RiskAcc, the user is able to define `recommendation` and `decision`.
<img width="473" alt="Screenshot 2025-04-23 at 16 59 22" src="https://github.com/user-attachments/assets/5c3cf3e6-7e6f-4a16-9dfc-2d904c72741e" />

# But
The only "disadvantage" is that it is now unable to see a human-readable form anymore.
<img width="555" alt="Screenshot 2025-04-23 at 16 58 59" src="https://github.com/user-attachments/assets/03d9f5c7-4a5b-4bb5-bb69-624f7edfa039" />

# No buts
APIs are not for humans but for machines, so simple values should not be the issue.
Translation is still possible based on the description in the OpenAPI spec:
```bash
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' 2>/dev/null | jq '.paths."/api/v2/risk_acceptance/".get.parameters[] | select(.name=="recommendation").description' -r
Recommendation from the security team.

* `A` - Accept (The risk is acknowledged, yet remains)
* `V` - Avoid (Do not engage with whatever creates the risk)
* `M` - Mitigate (The risk still exists, yet compensating controls make it less of a threat)
* `F` - Fix (The risk is eradicated)
* `T` - Transfer (The risk is transferred to a 3rd party)
```
or
```bash
$ curl -X 'OPTIONS' 'http://localhost:8080/api/v2/risk_acceptance/' -H 'accept: application/json' -H 'Authorization: Token xxx' 2>/dev/null | jq .actions.POST.recommendation.choices
[
  {
    "value": "A",
    "display_name": "Accept (The risk is acknowledged, yet remains)"
  },
  {
    "value": "V",
    "display_name": "Avoid (Do not engage with whatever creates the risk)"
  },
  {
    "value": "M",
    "display_name": "Mitigate (The risk still exists, yet compensating controls make it less of a threat)"
  },
  {
    "value": "F",
    "display_name": "Fix (The risk is eradicated)"
  },
  {
    "value": "T",
    "display_name": "Transfer (The risk is transferred to a 3rd party)"
  }
]
```