### PR TITLE
most recent note: show date/author

### DIFF
--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -579,7 +579,7 @@
                                             {% if finding.notes.all %}
                                                 <i class="glyphicon glyphicon-comment has-popover dojo-sup"
                                                 data-trigger="hover"
-                                                data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0..date }}: {{ finding.notes.all.0 }}"
+                                                data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0.date }}: {{ finding.notes.all.0 }}"
                                                 data-placement="left"
                                                 data-container="body"
                                                 data-original-title="Most Recent Note ({{ finding.notes.count }} total)"

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -579,7 +579,7 @@
                                             {% if finding.notes.all %}
                                                 <i class="glyphicon glyphicon-comment has-popover dojo-sup"
                                                 data-trigger="hover"
-                                                data-content="{{ finding.notes.all.0 }}"
+                                                data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0..date }}: {{ finding.notes.all.0 }}"
                                                 data-placement="left"
                                                 data-container="body"
                                                 data-original-title="Most Recent Note ({{ finding.notes.count }} total)"

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1178,7 +1178,7 @@
                                         {% if finding.notes.all %}
                                             <i class="glyphicon glyphicon-comment has-popover dojo-sup"
                                             data-trigger="hover"
-                                            data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0..date }}: {{ finding.notes.all.0 }}"
+                                            data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0.date }}: {{ finding.notes.all.0 }}"
                                             data-placement="left"
                                             data-container="body"
                                             data-original-title="Most Recent Note ({{ finding.notes.count }} total)"

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1178,7 +1178,7 @@
                                         {% if finding.notes.all %}
                                             <i class="glyphicon glyphicon-comment has-popover dojo-sup"
                                             data-trigger="hover"
-                                            data-content="{{ finding.notes.all.0 }}"
+                                            data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0..date }}: {{ finding.notes.all.0 }}"
                                             data-placement="left"
                                             data-container="body"
                                             data-original-title="Most Recent Note ({{ finding.notes.count }} total)"

--- a/tests/import_scanner_test.py
+++ b/tests/import_scanner_test.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F821
 import logging
 import os
 import re


### PR DESCRIPTION
Adds the author and date to the most recent note display in lists of findings.

The js/css lib used doesn't support styling the content, this is what it looks like:

![image](https://github.com/user-attachments/assets/014f12c9-b5f2-4e3d-8de5-562828e5502b)

The unrelated commit is a Ruff fix that was automatically applied. When I remove it, it complains that it is a Ruff violation :-) So I left it.