### PR TITLE
Jira webhook comment duplicate patch

### DIFF
--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -255,10 +255,6 @@ def check_for_and_create_comment(parsed_json):
     # Set the fields for the notes
     author, _ = User.objects.get_or_create(username="JIRA")
     entry = f"({commenter_display_name} ({commenter})): {comment_text}"
-    print("\n\n")
-    print(f"\t entry: {entry}")
-    print(f"\t comment_text_without_defectdojo_user: {comment_text_without_defectdojo_user}")
-    print("\n\n")
     # Iterate (potentially) over each of the findings the note should be added to
     for finding in findings:
         # Determine if the same note body was created by either DefectDojo or Jira

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -215,7 +215,7 @@ def check_for_and_create_comment(parsed_json):
     if comment is None:
         return None
     comment_text = comment.get("body")
-    comment_text_without_defectdojo_user = re.sub(r'^\(.*?\):\s*', '', comment_text)
+    comment_text_without_defectdojo_user = re.sub(r"^\(.*?\):\s*", "", comment_text)
     commenter = ""
     if "name" in comment.get("updateAuthor"):
         commenter = comment.get("updateAuthor", {}).get("name")

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -2,12 +2,14 @@
 import datetime
 import json
 import logging
+import re
 
 # Third party imports
 from django.contrib import messages
 from django.contrib.admin.utils import NestedObjects
 from django.core.exceptions import PermissionDenied
 from django.db import DEFAULT_DB_ALIAS
+from django.db.models import Q
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -212,8 +214,8 @@ def check_for_and_create_comment(parsed_json):
     comment = parsed_json.get("comment", None)
     if comment is None:
         return None
-
     comment_text = comment.get("body")
+    comment_text_without_defectdojo_user = re.sub(r'^\(.*?\):\s*', '', comment_text)
     commenter = ""
     if "name" in comment.get("updateAuthor"):
         commenter = comment.get("updateAuthor", {}).get("name")
@@ -253,12 +255,15 @@ def check_for_and_create_comment(parsed_json):
     # Set the fields for the notes
     author, _ = User.objects.get_or_create(username="JIRA")
     entry = f"({commenter_display_name} ({commenter})): {comment_text}"
+    print("\n\n")
+    print(f"\t entry: {entry}")
+    print(f"\t comment_text_without_defectdojo_user: {comment_text_without_defectdojo_user}")
+    print("\n\n")
     # Iterate (potentially) over each of the findings the note should be added to
     for finding in findings:
-        # Determine if this exact note was created within the last 30 seconds to avoid duplicate notes
+        # Determine if the same note body was created by either DefectDojo or Jira
         existing_notes = finding.notes.filter(
-            entry=entry,
-            author=author,
+            Q(entry__icontains=comment_text_without_defectdojo_user) | Q(entry__icontains=entry),
             date__gte=(timezone.now() - datetime.timedelta(seconds=30)),
         )
         # Check the query for any hits


### PR DESCRIPTION
This PR updates a few things to catch some corner cases:
- Remove the check for the same author when looking for existing comments
  - There is [a check further up in the webhook comment processor to skip comments from jira made by the same user that created the jira instance in dojo](https://github.com/DefectDojo/django-DefectDojo/blob/477583eb674a6a93516a2b794cd9889cb6d7ab81/dojo/jira_link/views.py#L234-L238). This is great for all smaller teams, but not larger ones
  - In cases where this is not true, like when a service account is connecting to jira, only the case is considered when the webhook could fire twice (see description in #9513), the content of the message must be checked as well. This will not cause a regression as the content is still a safe check.
- Check for note contents that reflect a comment made in DefectDojo, as well as a comment that would be coming from Jira
  - This additional check will prevent a loop of: 
       1. comment left in dojo and pushed to jira with user prefix
       2. jira comment created and send webhook response
       3. dojo processes webhook responses, and creates comment on finding
       
[sc-10999]