### PR TITLE
Color changes for better accessibility

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -276,11 +276,11 @@ body #header form#api_selector .input input#input_apiKey {
 }
 
 .badge.badge-count {
-    background-color: #d9534f;
+    background-color: #D03540;
 }
 
 .badge.badge-count.badge-count0 {
-    background-color: #5cb85c;
+    background-color: #3a7a3a;
 }
 
 .dropdown-toggle-h {
@@ -331,21 +331,6 @@ form.metric_form p label {
 
 .filters .panel-heading:first-child {
     border-top: 0px solid #ddd;
-}
-
-.panel-blue .panel-heading,
-.panel-blue {
-    color: #f5f5f5;
-    background-color: #546474!important;
-    border-color: #546474!important;
-}
-
-.panel-blue a {
-    color: #546474;
-}
-
-.panel-blue a:hover {
-    color: #38434d;
 }
 
 .nowrap {
@@ -578,27 +563,27 @@ form ul#id_accepted_findings input {
 }
 
 .severity-Low {
-    background-color: #546474;
+    background-color: #147AC1;
 }
 
 .severity-Medium {
-    background-color: #FBE413;
+    background-color: #A46A00;
 }
 
 .severity-High {
-    background-color: #f09835;
+    background-color: #F04421;
 }
 
 .severity-Critical {
-    background-color: #d9534f;
+    background-color: #D03540;
 }
 
 .age-red {
-    background-color: #d9534f;
+    background-color: #D03540;
 }
 
 .age-green {
-    background-color: green;
+    background-color: #3a7a3a;
 }
 
 .age-blue {
@@ -904,7 +889,7 @@ table.centered td {
 }
 
 .text-critical {
-    color: #d9534f
+    color: #D03540
 }
 
 .text-high {
@@ -1355,7 +1340,7 @@ div.custom-search-form {
 .panel-default > .panel-heading {
     color: white;
     font-size: 16px;
-    background-color: rgba(32, 166, 216, 0.75);
+    background-color: #147AC1;
     border-color: #A1C0D7;
 }
 
@@ -1706,7 +1691,7 @@ div.tags .label {
 }
 
 .warning-color {
-    background: red;
+    background: #D03540;
 }
 
 .amber-color {
@@ -1774,19 +1759,19 @@ mark{
 }
 
 .bg-vuln-critical {
-  background-color:#D43F3A
+  background-color:#D03540
 }
 .bg-vuln-high {
-  background-color:#D57A1D
+  background-color: #D64421
 }
 .bg-vuln-medium {
-  background-color:#E4AB18
+  background-color:#A46A00
 }
 .bg-vuln-low {
-  background-color:#4CAE4C
+  background-color:#3a7a3a
 }
 .bg-vuln-info {
-  background-color:#357ABD
+  background-color:#147AC1
 }
 .bg-muted {
   background-color:#777
@@ -1869,4 +1854,92 @@ input[type=number]::-webkit-outer-spin-button {
 }
 .table th:last-child, .table td:last-child {
     border-right: none; 
+}
+
+
+/* Keep the color of the legend in forced color mode */
+.legend td {
+forced-color-adjust: none;
+}
+
+.legend .legendColorBox > div {
+border: 2px solid white;    
+border-radius: 50%;          
+}
+
+.legend .legendColorBox > div > div {
+width: 16px;        
+height: 16px;        
+border-radius: 50%; 
+}
+
+.legend .legendLabel {
+padding-left: 4px;   
+vertical-align: middle;
+forced-color-adjust: auto;
+}
+
+.panel-footer {
+background-color: #fff;
+}
+
+.panel-blue .panel-heading,
+.panel-blue {
+color: #f5f5f5;
+background-color: #147AC1;
+border-color: #147AC1;
+}
+
+.panel-blue a,
+.panel-blue a:hover {
+    color: #147AC1;
+}
+
+.panel-red .panel-heading {
+    border-color: #D03540;
+    background-color: #D03540;
+}
+
+.panel-red a {
+    color: #D03540;
+}
+
+.panel-green .panel-heading {
+    border-color: #3a7a3a;
+    background-color: #3a7a3a;
+}
+
+.panel-green a,
+.panel-green a:hover {
+    color: #3a7a3a;
+}
+
+.panel-yellow,
+.panel-yellow .panel-heading {
+    background-color: #B26400;
+    border-color: #B26400;
+}
+
+.panel-yellow a,
+.panel-yellow a:hover {
+    color: #B26400;
+}
+
+.fa-caret-down,
+.caret {
+    forced-color-adjust: none;
+}
+
+nav .badge.badge-count {
+    border-radius: 15px !important;
+}
+
+
+/* Keep arrows icons in forced color mode  */
+@media (forced-colors: active) {
+
+    .fa-caret-down,
+    .caret {
+        color: ButtonText;
+    }
 }

--- a/dojo/static/dojo/js/metrics.js
+++ b/dojo/static/dojo/js/metrics.js
@@ -5,7 +5,7 @@
 function homepage_pie_chart(critical, high, medium, low, info) {
     var data = [{
         label: "Critical",
-        color: "#d9534f",
+        color: "#D03540",
         data: critical
     }, {
         label: "High",
@@ -17,7 +17,7 @@ function homepage_pie_chart(critical, high, medium, low, info) {
         data: medium
     }, {
         label: "Low",
-        color: "#337ab7",
+        color: "#147AC1",
         data: low
     }, {
         label: "Informational",
@@ -83,7 +83,7 @@ function homepage_severity_plot(critical, high, medium, low) {
     var plotObj = $.plot($("#homepage_severity_plot"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -95,7 +95,7 @@ function homepage_severity_plot(critical, high, medium, low) {
             }, {
                 data: low,
                 label: " Low",
-                color: '#337ab7',
+                color: '#147AC1',
             }],
             options);
 }
@@ -138,7 +138,7 @@ function opened_per_month(critical, high, medium, low) {
     $.plot($("#opened_per_month"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -150,7 +150,7 @@ function opened_per_month(critical, high, medium, low) {
             }, {
                 data: low,
                 label: " Low",
-                color: '#337ab7',
+                color: '#147AC1',
             }],
             options);
 };
@@ -185,7 +185,7 @@ function accepted_per_month(critical, high, medium, low) {
     $.plot($("#accepted_per_month"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -197,7 +197,7 @@ function accepted_per_month(critical, high, medium, low) {
             }, {
                 data: low,
                 label: " Low",
-                color: '#337ab7',
+                color: '#147AC1',
             }],
             options);
 };
@@ -232,7 +232,7 @@ function opened_per_week(critical, high, medium, low) {
     var plotObj = $.plot($("#opened_per_week"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -244,7 +244,7 @@ function opened_per_week(critical, high, medium, low) {
             }, {
                 data: low,
                 label: " Low",
-                color: '#337ab7',
+                color: '#147AC1',
             }],
             options);
 }
@@ -279,7 +279,7 @@ function accepted_per_week(critical, high, medium, low) {
     var plotObj = $.plot($("#accepted_per_week"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -291,7 +291,7 @@ function accepted_per_week(critical, high, medium, low) {
             }, {
                 data: low,
                 label: " Low",
-                color: '#337ab7',
+                color: '#147AC1',
             }],
             options);
 }
@@ -300,7 +300,7 @@ function top_ten_products(critical, high, medium, low, ticks) {
     data1 = [
         {
             data: critical,
-            color: "#d9534f",
+            color: "#D03540",
             bars: {fill: 1},
             label: 'Critical',
         },
@@ -319,7 +319,7 @@ function top_ten_products(critical, high, medium, low, ticks) {
         },
         {
             data: low,
-            color: "#337ab7",
+            color: "#147AC1",
             bars: {fill: 1},
             label: 'Low',
         },
@@ -354,7 +354,7 @@ function top_ten_products(critical, high, medium, low, ticks) {
 function severity_pie(critical, high, medium, low) {
     var data = [{
         label: "Critical",
-        color: "#d9534f",
+        color: "#D03540",
         data: critical
     }, {
         label: "High",
@@ -366,7 +366,7 @@ function severity_pie(critical, high, medium, low) {
         data: medium
     }, {
         label: "Low",
-        color: "#337ab7",
+        color: "#147AC1",
         data: low
     }];
 
@@ -395,7 +395,7 @@ function severity_pie(critical, high, medium, low) {
 function total_accepted_pie(critical, high, medium, low) {
     var data = [{
         label: "Critical",
-        color: "#d9534f",
+        color: "#D03540",
         data: critical
     }, {
         label: "High",
@@ -407,7 +407,7 @@ function total_accepted_pie(critical, high, medium, low) {
         data: medium
     }, {
         label: "Low",
-        color: "#337ab7",
+        color: "#147AC1",
         data: low
     }];
 
@@ -436,7 +436,7 @@ function total_accepted_pie(critical, high, medium, low) {
 function total_closed_pie(critical, high, medium, low) {
     var data = [{
         label: "Critical",
-        color: "#d9534f",
+        color: "#D03540",
         data: critical
     }, {
         label: "High",
@@ -448,7 +448,7 @@ function total_closed_pie(critical, high, medium, low) {
         data: medium
     }, {
         label: "Low",
-        color: "#337ab7",
+        color: "#147AC1",
         data: low
     }];
 
@@ -511,7 +511,7 @@ function opened_per_month_2(critical, high, medium, low) {
     var plotObj = $.plot($("#opened_per_month_2"), [{
             data: critical,
             label: " Critical",
-            color: "#d9534f",
+            color: "#D03540",
 
         }, {
             data: high,
@@ -526,7 +526,7 @@ function opened_per_month_2(critical, high, medium, low) {
         }, {
             data: low,
             label: " Low",
-            color: '#337ab7',
+            color: '#147AC1',
 
         }],
         options);
@@ -565,7 +565,7 @@ function active_per_month(critical, high, medium, low) {
     var plotObj = $.plot($("#active_per_month"), [{
             data: critical,
             label: " Critical",
-            color: "#d9534f",
+            color: "#D03540",
 
         }, {
             data: high,
@@ -580,7 +580,7 @@ function active_per_month(critical, high, medium, low) {
         }, {
             data: low,
             label: " Low",
-            color: '#337ab7',
+            color: '#147AC1',
 
         }],
         options);
@@ -619,7 +619,7 @@ function accepted_per_month_2(critical, high, medium, low) {
     var plotObj = $.plot($("#accepted_per_month_2"), [{
             data: critical,
             label: " Critical",
-            color: "#d9534f"
+            color: "#D03540"
         }, {
             data: high,
             label: " High",
@@ -631,7 +631,7 @@ function accepted_per_month_2(critical, high, medium, low) {
         }, {
             data: low,
             label: " Low",
-            color: '#337ab7'
+            color: '#147AC1'
         }],
         options);
 }
@@ -670,7 +670,7 @@ function opened_per_week_2(critical, high, medium, low) {
     var plotObj = $.plot($("#opened_per_week_2"), [{
             data: critical,
             label: " Critical",
-            color: "#d9534f"
+            color: "#D03540"
         }, {
             data: high,
             label: " High",
@@ -682,7 +682,7 @@ function opened_per_week_2(critical, high, medium, low) {
         }, {
             data: low,
             label: " Low",
-            color: '#337ab7'
+            color: '##147AC1'
         }],
         options);
 }
@@ -721,7 +721,7 @@ function accepted_per_week_2(critical, high, medium, low) {
     var plotObj = $.plot($("#accepted_per_week_2"), [{
             data: critical,
             label: " Critical",
-            color: "#d9534f"
+            color: "#D03540"
         }, {
             data: high,
             label: " High",
@@ -733,7 +733,7 @@ function accepted_per_week_2(critical, high, medium, low) {
         }, {
             data: low,
             label: " Low",
-            color: '#337ab7'
+            color: '#147AC1'
         }],
         options);
 }
@@ -845,7 +845,7 @@ function open_findings_burndown(critical, high, medium, low, info, y_max, y_min)
     var plotObj = $.plot($("#open_findings_burndown"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -861,7 +861,7 @@ function open_findings_burndown(critical, high, medium, low, info, y_max, y_min)
             }, {
                 data: info,
                 label: " Info",
-                color: '#337ab7',
+                color: '#147AC1',
             }],
             options);
 }
@@ -876,9 +876,9 @@ function accepted_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -912,9 +912,9 @@ function accepted_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -968,9 +968,9 @@ function inactive_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -1004,9 +1004,9 @@ function inactive_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -1060,9 +1060,9 @@ function open_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -1096,9 +1096,9 @@ function open_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -1152,9 +1152,9 @@ function false_positive_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -1188,9 +1188,9 @@ function false_positive_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -1244,9 +1244,9 @@ function verified_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -1280,9 +1280,9 @@ function verified_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -1335,9 +1335,9 @@ function out_of_scope_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -1371,9 +1371,9 @@ function out_of_scope_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -1426,9 +1426,9 @@ function all_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -1462,9 +1462,9 @@ function all_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -1518,9 +1518,9 @@ function closed_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -1554,9 +1554,9 @@ function closed_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -1610,9 +1610,9 @@ function new_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -1646,9 +1646,9 @@ function new_objs(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -1720,7 +1720,7 @@ function open_close_weekly(opened, closed, accepted, ticks) {
     var plotObj = $.plot($("#open_close_weekly"), [{
                 data: opened,
                 label: " Opened",
-                color: "#d9534f"
+                color: "#D03540"
             }, {
                 data: closed,
                 label: " Closed",
@@ -1761,7 +1761,7 @@ function severity_weekly(critical, high, medium, low, info, ticks) {
     var plotObj = $.plot($("#severity_weekly"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f"
+                color: "#D03540"
             }, {
                 data: high,
                 label: " High",
@@ -1811,7 +1811,7 @@ function severity_counts_weekly(critical, high, medium, ticks) {
     var plotObj = $.plot($("#severity_critical"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f"
+                color: "#D03540"
             }],
             options);
     var plotObj = $.plot($("#severity_high"), [{
@@ -1823,7 +1823,7 @@ function severity_counts_weekly(critical, high, medium, ticks) {
     var plotObj = $.plot($("#severity_medium"), [{
                 data: medium,
                 label: " Medium",
-                color: "#f0de28"
+                color: "#f0ad4e"
             }],
             options);
 }
@@ -1925,7 +1925,7 @@ function open_bug_count_by_month(critical, high, medium, low, ticks) {
     var plotObj = $.plot($("#chart_div"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -1974,7 +1974,7 @@ function accepted_bug_count_by_month(critical, high, medium, low, ticks) {
     var plotObj = $.plot($("#chart_div2"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -1986,7 +1986,7 @@ function accepted_bug_count_by_month(critical, high, medium, low, ticks) {
             }, {
                 data: low,
                 label: " Low",
-                color: '#337ab7',
+                color: '#147AC1',
             }],
             options);
 }
@@ -2025,7 +2025,7 @@ function open_bug_count_by_week(critical, high, medium, low, ticks) {
     var plotObj = $.plot($("#chart_div3"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -2037,7 +2037,7 @@ function open_bug_count_by_week(critical, high, medium, low, ticks) {
             }, {
                 data: low,
                 label: " Low",
-                color: '#337ab7',
+                color: '#147AC1',
             }],
             options);
 }
@@ -2076,7 +2076,7 @@ function accepted_bug_count_by_week(critical, high, medium, low, ticks) {
     var plotObj = $.plot($("#chart_div4"), [{
                 data: critical,
                 label: " Critical",
-                color: "#d9534f",
+                color: "#D03540",
             }, {
                 data: high,
                 label: " High",
@@ -2088,7 +2088,7 @@ function accepted_bug_count_by_week(critical, high, medium, low, ticks) {
             }, {
                 data: low,
                 label: " Low",
-                color: '#337ab7',
+                color: '#147AC1',
             }],
             options);
 }
@@ -2142,9 +2142,9 @@ function accepted_findings(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -2178,9 +2178,9 @@ function accepted_findings(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -2234,7 +2234,7 @@ function accepted_findings(d1, d2, d3, d4, d5, ticks) {
 
 function finding_age(data_1, ticks) {
     var dataset = [
-        {data: data_1, color: "#337ab7", fillColor: "#337ab7"}
+        {data: data_1, color: "#147AC1", fillColor: "#147AC1"}
     ];
 
     var options = {
@@ -2242,7 +2242,7 @@ function finding_age(data_1, ticks) {
             bars: {
                 show: true,
                 fill: true,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             }
         },
         bars: {
@@ -2286,9 +2286,9 @@ function open_findings(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -2322,9 +2322,9 @@ function open_findings(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",
@@ -2378,9 +2378,9 @@ function closed_findings(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 1,
-                fillColor: "#d9534f"
+                fillColor: "#D03540"
             },
-            color: "#d9534f"
+            color: "#D03540"
         },
         {
             label: "High",
@@ -2414,9 +2414,9 @@ function closed_findings(d1, d2, d3, d4, d5, ticks) {
                 fill: true,
                 lineWidth: 1,
                 order: 4,
-                fillColor: "#337ab7"
+                fillColor: "#147AC1"
             },
-            color: "#337ab7"
+            color: "#147AC1"
         },
         {
             label: "info",


### PR DESCRIPTION
Fixes #12341 (at the main pain points)

**Description**

- Shapes of dropdown icons in forced-contrast mode are now recognizable
- Colour of legend in graphs stays the same also in forced-contrast mode
- Some colours have been slightly redefined in order to get closer to the sufficient contrast for users with individual needs. I tried to find something contrastish enough without spoiling the "mood" that was originally setup
- The legend now starts with ball instead of square and has a bit margin before the legend text, it was not really a bug and part of respective issue but looks a bit cuter 😃 also the notification badge has slightly rounded corners. See the screenshots attached


![Screenshot 2025-04-29 at 17 20 52](https://github.com/user-attachments/assets/b6d0ed1c-3d9e-49f6-9afe-d54b6e4f2643)
![Screenshot 2025-04-29 at 17 20 25](https://github.com/user-attachments/assets/5a76fee2-b66d-43e1-b691-de0dfe6b5c10)
![Screenshot 2025-04-29 at 17 20 19](https://github.com/user-attachments/assets/19c22f91-4819-4490-92c9-1edcc64aee89)
![Screenshot 2025-04-29 at 17 19 55](https://github.com/user-attachments/assets/587beefc-62bd-4dcf-919e-f01c22452fde)
![Screenshot 2025-04-29 at 17 19 37](https://github.com/user-attachments/assets/a1fc672b-59bc-408c-a187-9a29577b13d9)
![Screenshot 2025-04-29 at 17 19 09](https://github.com/user-attachments/assets/b53b7813-0e68-4cef-83f8-faf5d9270365)
![Screenshot 2025-04-29 at 17 18 52](https://github.com/user-attachments/assets/65793ad7-eb89-4bd6-96cb-e4750d44a354)
