### PR TITLE
Store fingerprint from bearer in unique_id_from_tool

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1584,6 +1584,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     "MobSF Scorecard Scan": DEDUPE_ALGO_HASH_CODE,
     "OSV Scan": DEDUPE_ALGO_HASH_CODE,
     "Nosey Parker Scan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
+    # The bearer fingerprint is not unique across multiple scans, so it shouldn't be used for deduplication (https://github.com/DefectDojo/django-DefectDojo/pull/12346#issuecomment-2841561634)
     "Bearer CLI": DEDUPE_ALGO_HASH_CODE,
     "Wiz Scan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
     "Deepfence Threatmapper Report": DEDUPE_ALGO_HASH_CODE,

--- a/dojo/tools/bearer_cli/parser.py
+++ b/dojo/tools/bearer_cli/parser.py
@@ -46,6 +46,7 @@ class BearerCLIParser:
                     sast_source_line=bearerfinding["source"]["start"],
                     sast_source_file_path=bearerfinding["filename"],
                     vuln_id_from_tool=bearerfinding["id"],
+                    # the fingerprint is not constant over time, but because it's not used for dedupe it's safe and useful to set it
                     unique_id_from_tool=bearerfinding["fingerprint"],
                 )
 

--- a/dojo/tools/bearer_cli/parser.py
+++ b/dojo/tools/bearer_cli/parser.py
@@ -46,6 +46,7 @@ class BearerCLIParser:
                     sast_source_line=bearerfinding["source"]["start"],
                     sast_source_file_path=bearerfinding["filename"],
                     vuln_id_from_tool=bearerfinding["id"],
+                    unique_id_from_tool=bearerfinding["fingerprint"],
                 )
 
                 items.append(finding)

--- a/unittests/tools/test_bearer_cli_parser.py
+++ b/unittests/tools/test_bearer_cli_parser.py
@@ -20,6 +20,7 @@ class TestBearerParser(TestCase):
         self.assertEqual("https://docs.bearer.com/reference/rules/javascript_lang_dangerous_insert_html", findings[0].references)
         self.assertEqual("js/adminer/editing.js", findings[0].file_path)
         self.assertEqual(581, findings[0].line)
+        self.assertEqual("804174abc284c6bc747d886b3e9ba757_0", findings[0].unique_id_from_tool)
 
     def test_bearer_parser_with_many_vuln_has_many_findings(self):
         testfile = (get_unit_tests_scans_path("bearer_cli") / "bearer_cli_many_vul.json").open(encoding="utf-8")


### PR DESCRIPTION
**Description**

I'm storing the unique fingerprint from bearer which is always present in the scan file in the field unique_id_from_tool. I also changed the deduplication algorithm setting in dojo/settings/settings.dist.py from DEDUPE_ALGO_HASH_CODE to DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE

**Test results**

There is no existing unit test to extend.

**Documentation**

Updating the documentation should not be necessary for this tiny change

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [ ] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

**Extra information**

This is my first PR for defect dojo, please let me know if I made a mistake. I'll fix it right away.