### PR TITLE
Generic Parser: Support Test Type Meta

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/generic_findings_import.md
+++ b/docs/content/en/connecting_your_tools/parsers/generic_findings_import.md
@@ -9,6 +9,7 @@ You can use Generic Findings Import as a method to ingest JSON or CSV files into
 Files uploaded using Generic Findings Import must conform to the accepted format with respect to CSV column headers / JSON attributes.
 
 These attributes are supported for CSV:
+
 - Date: Date of the finding in mm/dd/yyyy format.
 - Title: Title of the finding
 - CweId: Cwe identifier, must be an integer value.
@@ -104,7 +105,15 @@ Example:
 }
 ```
 
-This parser supports an attribute `name` and `type` to be able to define `TestType`. Based on this, you can define custom `HASHCODE_FIELDS` or `DEDUPLICATION_ALGORITHM` in the settings.
+This parser supports some additional attributes to be able to define custom `TestTypes` as well as influencing some meta fields on the `Test`:
+
+- `name`: The internal name of the tool you are using. This is primarily informational, and used for reading the report manually.
+- `type`: The name of the test type to create in DefectDojo with the suffix of `(Generic Findings Import)`. The suffix is an important identifier for future users attempting to identify the test type to supply when importing new reports. This value is very important when fetching the correct test type to import findings into, so be sure to keep the `type` consistent from import to import! As an example, a report submitted with a `type` of `Internal Company Tool` will produce a test type in DefectDojo with the title `Internal Company Tool (Generic Findings Import)`. With this newly created test type, you can define custom `HASHCODE_FIELDS` or `DEDUPLICATION_ALGORITHM` in the settings.
+- `version`: The version of the tool you are using. This is primarily informational, and is used for reading the report manually and tracking format changes from version to version.
+- `description`: A brief description of the test. This could be an explanation of what the tool is reporting, where the tools is maintained, who the point of contact is for the tool when issues arise, or anything in between.
+- `static_tool`: Dictates that tool used is running static analysis methods to discover vulnerabilities.
+- `dynamic_tool`: Dictates that tool used is running dynamic analysis methods to discover vulnerabilities.
+- `soc`: Dictates that tool is used for reporting alerts from a soc (Pro Edition Only).
 
 Example:
 
@@ -112,10 +121,16 @@ Example:
 {
     "name": "My wonderful report",
     "type": "My custom Test type",
+    "version": "1.0.5",
+    "description": "A unicorn tool that is capable of static analysis, dynamic analysis, and even capturing soc alerts!",
+    "static_tool": true,
+    "dynamic_tool": true,
+    "soc": true,
     "findings": [
     ]
 }
 ```
 
 ### Sample Scan Data
+
 Sample Generic Findings Import scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/generic).

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -33,6 +33,7 @@ from dojo.models import (
 )
 from dojo.notifications.helper import create_notification
 from dojo.tools.factory import get_parser
+from dojo.tools.parser_test import ParserTest
 from dojo.utils import max_safe
 
 logger = logging.getLogger(__name__)
@@ -179,15 +180,36 @@ class BaseImporter(ImporterOptions):
             logger.warning(e)
             raise ValidationError(e)
 
-    def parse_dynamic_test_type_findings_from_tests(
-        self,
-        tests: list[Test],
-    ) -> list[Finding]:
-        """
-        Currently we only support import one Test
-        so for parser that support multiple tests (like SARIF)
-        we aggregate all the findings into one uniq test
-        """
+    def consolidate_dynamic_tests(self, tests: list[Test]) -> list[Finding]:
+        parsed_findings = []
+        # Make sure we have at least one test returned
+        if len(tests) == 0:
+            logger.info(f"No tests found in import for {self.scan_type}")
+            self.test = None
+            return parsed_findings
+        # for now we only consider the first test in the list and artificially aggregate all findings of all tests
+        # this is the same as the old behavior as current import/reimporter implementation doesn't handle the case
+        # when there is more than 1 test
+        #
+        # we also aggregate the label of the Test_type to show the user the original self.scan_type
+        # only if they are different. This is to support meta format like SARIF
+        # so a report that have the label 'CodeScanner' will be changed to 'CodeScanner Scan (SARIF)'
+        test_raw = tests[0]
+        test_type_name = self.scan_type
+        # Create a new test if it has not already been created
+        if not self.test:
+            # Determine if we should use a custom test type name
+            if test_raw.type:
+                test_type_name = f"{tests[0].type} Scan"
+                if test_type_name != self.scan_type:
+                    test_type_name = f"{test_type_name} ({self.scan_type})"
+            self.test = self.create_test(test_type_name)
+        # This part change the name of the Test
+        # we get it from the data of the parser
+        # Update the test and test type with meta from the raw test
+        self.update_test_from_internal_test(test_raw)
+        self.update_test_type_from_internal_test(test_raw)
+        # Aggregate all of the findings into a single place
         parsed_findings = []
         for test_raw in tests:
             parsed_findings.extend(test_raw.findings)
@@ -205,7 +227,7 @@ class BaseImporter(ImporterOptions):
         This version of this function is intended to be extended by children classes
         """
         tests = self.parse_dynamic_test_type_tests(scan, parser)
-        return self.parse_dynamic_test_type_findings_from_tests(tests)
+        return self.consolidate_dynamic_tests(tests)
 
     def parse_findings(
         self,
@@ -215,12 +237,12 @@ class BaseImporter(ImporterOptions):
         """
         Determine how to parse the findings based on the presence of the
         `get_tests` function on the parser object
-
-        This function will vary by importer, so it is marked as
-        abstract with a prohibitive exception raised if the
-        method is attempted to to be used by the BaseImporter class
         """
-        self.check_child_implementation_exception()
+        # Attempt any preprocessing before generating findings
+        scan = self.process_scan_file(scan)
+        if hasattr(parser, "get_tests"):
+            return self.parse_findings_dynamic_test_type(scan, parser)
+        return self.parse_findings_static_test_type(scan, parser)
 
     def sync_process_findings(
         self,
@@ -538,6 +560,22 @@ class BaseImporter(ImporterOptions):
             test_type.dynamically_generated = True
             test_type.save()
         return test_type
+
+    def update_test_from_internal_test(self, internal_test: ParserTest) -> None:
+        if (name := getattr(internal_test, "name", None)) is not None:
+            self.test.name = name
+        if (description := getattr(internal_test, "description", None)) is not None:
+            self.test.description = description
+        if (version := getattr(internal_test, "version", None)) is not None:
+            self.test.version = version
+        self.test.save()
+
+    def update_test_type_from_internal_test(self, internal_test: ParserTest) -> None:
+        if (static_tool := getattr(internal_test, "static_tool", None)) is not None:
+            self.test.test_type.static_tool = static_tool
+        if (dynamic_tool := getattr(internal_test, "dynamic_tool", None)) is not None:
+            self.test.test_type.dynamic_tool = dynamic_tool
+        self.test.test_type.save()
 
     def verify_tool_configuration_from_test(self):
         """

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -562,8 +562,6 @@ class BaseImporter(ImporterOptions):
         return test_type
 
     def update_test_from_internal_test(self, internal_test: ParserTest) -> None:
-        if (name := getattr(internal_test, "name", None)) is not None:
-            self.test.name = name
         if (description := getattr(internal_test, "description", None)) is not None:
             self.test.description = description
         if (version := getattr(internal_test, "version", None)) is not None:

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -320,21 +320,6 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
 
         return old_findings
 
-    def parse_findings(
-        self,
-        scan: TemporaryUploadedFile,
-        parser: Parser,
-    ) -> list[Finding]:
-        """
-        Determine how to parse the findings based on the presence of the
-        `get_tests` function on the parser object
-        """
-        # Attempt any preprocessing before generating findings
-        scan = self.process_scan_file(scan)
-        if hasattr(parser, "get_tests"):
-            return self.parse_findings_dynamic_test_type(scan, parser)
-        return self.parse_findings_static_test_type(scan, parser)
-
     def parse_findings_static_test_type(
         self,
         scan: TemporaryUploadedFile,
@@ -364,40 +349,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         into a single test, and then renames the test is applicable
         """
         logger.debug("IMPORT_SCAN parser v2: Create Test and parse findings")
-        tests = self.parse_dynamic_test_type_tests(scan, parser)
-        parsed_findings = []
-        # Make sure we have at least one test returned
-        if len(tests) == 0:
-            logger.info(f"No tests found in import for {self.scan_type}")
-            self.test = None
-            return parsed_findings
-        # for now we only consider the first test in the list and artificially aggregate all findings of all tests
-        # this is the same as the old behavior as current import/reimporter implementation doesn't handle the case
-        # when there is more than 1 test
-        #
-        # we also aggregate the label of the Test_type to show the user the original self.scan_type
-        # only if they are different. This is to support meta format like SARIF
-        # so a report that have the label 'CodeScanner' will be changed to 'CodeScanner Scan (SARIF)'
-        test_type_name = self.scan_type
-        # Determine if we should use a custom test type name
-        if tests[0].type:
-            test_type_name = f"{tests[0].type} Scan"
-            if test_type_name != self.scan_type:
-                test_type_name = f"{test_type_name} ({self.scan_type})"
-        # Create a new test if it has not already been created
-        if not self.test:
-            self.test = self.create_test(test_type_name)
-        # This part change the name of the Test
-        # we get it from the data of the parser
-        test_raw = tests[0]
-        if test_raw.name:
-            self.test.name = test_raw.name
-        if test_raw.description:
-            self.test.description = test_raw.description
-        self.test.save()
-        logger.debug("IMPORT_SCAN parser v2: Parse findings (aggregate)")
-        # Aggregate all the findings and return them with the newly created test
-        return self.parse_dynamic_test_type_findings_from_tests(tests)
+        return super().parse_findings_dynamic_test_type(scan, parser)
 
     def async_process_findings(
         self,

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -288,21 +288,6 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
 
         return mitigated_findings
 
-    def parse_findings(
-        self,
-        scan: TemporaryUploadedFile,
-        parser: Parser,
-    ) -> list[Finding]:
-        """
-        Determine how to parse the findings based on the presence of the
-        `get_tests` function on the parser object
-        """
-        # Attempt any preprocessing before generating findings
-        scan = self.process_scan_file(scan)
-        if hasattr(parser, "get_tests"):
-            return self.parse_findings_dynamic_test_type(scan, parser)
-        return self.parse_findings_static_test_type(scan, parser)
-
     def parse_findings_static_test_type(
         self,
         scan: TemporaryUploadedFile,

--- a/dojo/tools/generic/json_parser.py
+++ b/dojo/tools/generic/json_parser.py
@@ -15,6 +15,10 @@ class GenericJSONParser:
             name=data.get("name", self.ID),
             parser_type=data.get("type", self.ID),
             version=data.get("version"),
+            description=data.get("description"),
+            dynamic_tool=data.get("dynamic_tool"),
+            static_tool=data.get("static_tool"),
+            soc=data.get("soc"),
         )
         test_internal.findings = []
         for item in data.get("findings", []):

--- a/dojo/tools/parser_test.py
+++ b/dojo/tools/parser_test.py
@@ -25,9 +25,9 @@ class OpenSourceParserTest:
         parser_type: str,
         version: str,
         *args: list,
-        description: str | None,
-        dynamic_tool: bool | None,
-        static_tool: bool | None,
+        description: str | None = None,
+        dynamic_tool: bool | None = None,
+        static_tool: bool | None = None,
         **kwargs: dict,
     ):
         instance.name = name

--- a/dojo/tools/parser_test.py
+++ b/dojo/tools/parser_test.py
@@ -1,6 +1,41 @@
+import importlib
+from contextlib import suppress
+
+from django.conf import settings
+
+
 class ParserTest:
-    def __init__(self, name: str, parser_type: str, version: str):
-        self.name = name
-        self.type = parser_type
-        self.version = version
-        self.description = None
+    def __init__(self, *args: list, **kwargs: dict):
+        parser_test_class = OpenSourceParserTest
+        with suppress(ModuleNotFoundError):
+            if (
+                class_path := getattr(settings, "PARSER_TEST_CLASS_PATH", None)
+            ) is not None:
+                module_name, _separator, class_name = class_path.rpartition(".")
+                module = importlib.import_module(module_name)
+                parser_test_class = getattr(module, class_name)
+        parser_test_class().apply(self, *args, **kwargs)
+
+
+class OpenSourceParserTest:
+    def apply(
+        self,
+        instance: ParserTest,
+        name: str,
+        parser_type: str,
+        version: str,
+        *args: list,
+        description: str | None,
+        dynamic_tool: bool | None,
+        static_tool: bool | None,
+        **kwargs: dict,
+    ):
+        instance.name = name
+        instance.type = parser_type
+        instance.version = version
+        if description is not None:
+            instance.description = description
+        if dynamic_tool is not None:
+            instance.dynamic_tool = dynamic_tool
+        if static_tool is not None:
+            instance.static_tool = static_tool

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,3 +75,4 @@ vulners==2.3.6
 fontawesomefree==6.6.0
 PyYAML==6.0.2
 pyopenssl==25.0.0
+parameterized==0.9.0

--- a/unittests/scans/generic/generic_custom_test_with_meta.json
+++ b/unittests/scans/generic/generic_custom_test_with_meta.json
@@ -1,0 +1,15 @@
+{
+    "name": "Test 1",
+    "type": "Tool 1",
+    "version": "1.0.0",
+    "description": "The contents of this report is from a tool that gathers vulnerabilities both statically and dynamically",
+    "dynamic_tool": true,
+    "static_tool": true,
+    "findings": [
+        {
+            "title": "test title",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau",
+            "severity": "Medium"
+        }
+    ]
+}

--- a/unittests/test_generic_meta_import.py
+++ b/unittests/test_generic_meta_import.py
@@ -1,0 +1,190 @@
+import io
+import json
+
+from django.conf import settings
+from parameterized import parameterized
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from dojo.models import Test, User
+from unittests.dojo_test_case import DojoAPITestCase
+
+
+class TestGenericMetaImports(DojoAPITestCase):
+    fixtures = ["dojo_testdata.json"]
+
+    def setUp(self):
+        testuser = User.objects.get(username="admin")
+        token = Token.objects.get(user=testuser)
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+        # We must set this to get around forced TLS redirects
+        settings.SECURE_SSL_REDIRECT = False
+
+    def _get_base_payload(self, test_label: str):
+        return {
+            "product_type_name": f"{test_label} Product Type",
+            "product_name": f"{test_label} Product",
+            "engagement_name": f"{test_label} Engagement",
+            "scan_type": "Generic Findings Import",
+            "auto_create_context": "true",
+            "close_old_findings": "true",
+        }
+
+    def _upload_json_as_file(self, data: dict):
+        file = io.BytesIO(json.dumps(data).encode("utf-8"))
+        file.name = "test.json"
+        return file
+
+    def _get_test_object_from_id(self, test_id: int) -> Test:
+        return Test.objects.get(id=test_id)
+
+    def _make_assertions(self, test: Test, data: dict) -> None:
+        if (description := data.get("description")) is not None:
+            self.assertEqual(test.description, description)
+        if (static_tool := data.get("static_tool")) is not None:
+            self.assertEqual(test.test_type.static_tool, static_tool)
+        if (dynamic_tool := data.get("dynamic_tool")) is not None:
+            self.assertEqual(test.test_type.dynamic_tool, dynamic_tool)
+
+    @parameterized.expand(
+        [
+            (
+                "Set Description",
+                {
+                    "description": "some description",
+                },
+            ),
+            (
+                "Set Static Tool",
+                {
+                    "static_tool": True,
+                },
+            ),
+            (
+                "Set Dynamic Tool",
+                {
+                    "dynamic_tool": True,
+                },
+            ),
+            (
+                "Set Static Tool + Dynamic Tool",
+                {
+                    "static_tool": True,
+                    "dynamic_tool": True,
+                },
+            ),
+            (
+                "Set all the things",
+                {
+                    "description": "some description",
+                    "static_tool": True,
+                    "dynamic_tool": True,
+                },
+            ),
+        ],
+    )
+    def test_value_set_at_import_time(
+        self,
+        label: str,
+        data: dict,
+    ):
+        payload = self._get_base_payload(label)
+        # Construct the extra parts of the request
+        file_contents = {
+            "name": label,
+            "type": f"{label} type",
+        }
+        # Iterate over the data and set the values in the file
+        file_contents.update(
+            {key: value for key, value in data.items() if value is not None},
+        )
+        # Create a pseudo file
+        payload["file"] = self._upload_json_as_file(file_contents)
+        # import the scan and get the resulting test ID from the response
+        test_id = self.import_scan(payload, 201).get("test")
+        # Fetch the test from the database
+        test = self._get_test_object_from_id(test_id)
+        # Make all the appropriate assertions
+        self._make_assertions(test, data)
+
+    @parameterized.expand(
+        [
+            (
+                "Update Description",
+                {
+                    "description_before": "some description",
+                    "description_after": "much more detailed description",
+                },
+            ),
+            (
+                "Update Static Tool",
+                {
+                    "static_tool_before": False,
+                    "static_tool_after": True,
+                },
+            ),
+            (
+                "Update Dynamic Tool",
+                {
+                    "dynamic_tool_before": True,
+                    "dynamic_tool_after": False,
+                },
+            ),
+            (
+                "Update Static Tool + Dynamic Tool",
+                {
+                    "static_tool_before": False,
+                    "static_tool_after": True,
+                    "dynamic_tool_before": True,
+                    "dynamic_tool_after": False,
+                },
+            ),
+            (
+                "Update all the things",
+                {
+                    "description_before": "some description",
+                    "description_after": "much more detailed description",
+                    "static_tool_before": False,
+                    "static_tool_after": True,
+                    "dynamic_tool_before": True,
+                    "dynamic_tool_after": False,
+                },
+            ),
+        ],
+    )
+    def test_value_set_at_import_time_then_override_at_reimport(
+        self,
+        label: str,
+        data: dict,
+    ):
+        payload = self._get_base_payload(label)
+        # Construct the extra parts of the request
+        file_contents = {
+            "name": label,
+            "type": f"{label} type",
+        }
+        # Iterate over the data and set the values in the file
+        file_contents.update(
+            {key.replace("_before", ""): value for key, value in data.items() if value is not None and "_before" in key},
+        )
+        # Create a pseudo file
+        payload["file"] = self._upload_json_as_file(file_contents)
+        # import the scan and get the resulting test ID from the response
+        test_id = self.import_scan(payload, 201).get("test")
+        # Fetch the test from the database
+        test = self._get_test_object_from_id(test_id)
+        # Make all the appropriate assertions
+        self._make_assertions(test, {key.replace("_before", ""): value for key, value in data.items() if "_before" in key})
+        # Update the file with the contents of the changes
+        file_contents.update(
+            {key.replace("_after", ""): value for key, value in data.items() if value is not None and "_after" in key},
+        )
+        # Create a pseudo file
+        payload["file"] = self._upload_json_as_file(file_contents)
+        # reimport the scan and get the resulting test ID from the response
+        test_id = self.reimport_scan(payload, 201).get("test")
+        # Fetch the test from the database
+        test = self._get_test_object_from_id(test_id)
+        # Make all the appropriate assertions
+        self._make_assertions(test, {key.replace("_after", ""): value for key, value in data.items() if "_after" in key})

--- a/unittests/tools/test_generic_parser.py
+++ b/unittests/tools/test_generic_parser.py
@@ -651,7 +651,12 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
             parser = GenericParser()
             tests = parser.get_tests(parser.get_scan_types()[0], file)
             self.assertEqual(1, len(tests))
-            findings = tests[0].findings
+            # Verify that the name of the tests are accurate
+            test = tests[0]
+            self.assertEqual(test.name, "Test 1")
+            self.assertEqual(test.type, "Tool 1")
+            self.assertEqual(test.version, None)
+            findings = test.findings
             for finding in findings:
                 for endpoint in finding.unsaved_endpoints:
                     endpoint.clean()
@@ -693,3 +698,17 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
             finding = findings[0]
             self.assertEqual(.00042, finding.epss_score)
             self.assertEqual(.23474, finding.epss_percentile)
+
+    def test_parse_json_custom_test_with_meta(self):
+        with open(get_unit_tests_scans_path("generic") / "generic_custom_test_with_meta.json", encoding="utf-8") as file:
+            parser = GenericParser()
+            tests = parser.get_tests(parser.get_scan_types()[0], file)
+            self.assertEqual(1, len(tests))
+            # Verify that the name of the tests are accurate
+            test = tests[0]
+            self.assertEqual(test.name, "Test 1")
+            self.assertEqual(test.type, "Tool 1")
+            self.assertEqual(test.version, "1.0.0")
+            self.assertEqual(test.description, "The contents of this report is from a tool that gathers vulnerabilities both statically and dynamically")
+            self.assertEqual(test.dynamic_tool, True)
+            self.assertEqual(test.static_tool, True)


### PR DESCRIPTION
Generic Finding Import is capable of importing data from the report that influences the name of the test type and some other fields on the test. This behavior could be expanded to also influence the `static_tool` and `dynamic_tool` fields as well.

The following things were added to accomplish this:
- Expand the `ParserTest` class  to accommodate the new fields
- Rework the dynamic test parser in the importers to allow for fields to be set during import, and overwritten during reimport if fields are supplied
- Unit tests at the parser and import/reimport level to cover to above
- Docs to explain how these fields are used

[sc-11026]