### PR TITLE
Urllib3 upgrade + Rerecord JIra responses

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ pytz==2025.1
 redis==5.2.1
 requests==2.32.3
 sqlalchemy==2.0.40  # Required by Celery broker transport
-urllib3==1.26.20
+urllib3==2.4.0
 uWSGI==2.0.28
 vobject==0.9.9
 whitenoise==5.2.0

--- a/unittests/vcr/jira/JIRAConfigEngagementEpicTest.test_add_engagement_with_jira_project_and_epic_mapping.yaml
+++ b/unittests/vcr/jira/JIRAConfigEngagementEpicTest.test_add_engagement_with_jira_project_and_epic_mapping.yaml
@@ -1,13 +1,13 @@
 interactions:
 - request:
     body: '{"description": "Event engagement_added has occurred.", "title": "Engagement
-      created for &quot;Python How-to&quot;: new engagement", "user": null, "url_ui":
-      "http://localhost:8080/engagement/7", "url_api": "http://localhost:8080/api/v2/engagements/7/",
-      "product_type": {"name": "books", "id": 1, "url_ui": "http://localhost:8080/product/type/1",
-      "url_api": "http://localhost:8080/api/v2/product_types/1/"}, "product": {"name":
-      "Python How-to", "id": 1, "url_ui": "http://localhost:8080/product/1", "url_api":
-      "http://localhost:8080/api/v2/products/1/"}, "engagement": {"name": "new engagement",
-      "id": 7, "url_ui": "http://localhost:8080/engagement/7", "url_api": "http://localhost:8080/api/v2/engagements/7/"}}'
+      created for \"Python How-to\": new engagement", "user": null, "url_ui": "http://localhost:8080/engagement/7",
+      "url_api": "http://localhost:8080/api/v2/engagements/7/", "product_type": {"name":
+      "books", "id": 1, "url_ui": "http://localhost:8080/product/type/1", "url_api":
+      "http://localhost:8080/api/v2/product_types/1/"}, "product": {"name": "Python
+      How-to", "id": 1, "url_ui": "http://localhost:8080/product/1", "url_api": "http://localhost:8080/api/v2/products/1/"},
+      "engagement": {"name": "new engagement", "id": 7, "url_ui": "http://localhost:8080/engagement/7",
+      "url_api": "http://localhost:8080/api/v2/engagements/7/"}}'
     headers:
       Accept:
       - application/json
@@ -18,11 +18,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '710'
+      - '702'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.3
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - engagement_added
       X-DefectDojo-Instance:
@@ -34,15 +34,15 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"710\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"702\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"engagement_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
         \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
-        \"172.18.0.2:48456\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \"172.18.0.9:34022\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
         \ \"data\": \"{\\\"description\\\": \\\"Event engagement_added has occurred.\\\",
-        \\\"title\\\": \\\"Engagement created for &quot;Python How-to&quot;: new engagement\\\",
-        \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/7\\\",
+        \\\"title\\\": \\\"Engagement created for \\\\\\\"Python How-to\\\\\\\": new
+        engagement\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/7\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/7/\\\", \\\"product_type\\\":
         {\\\"name\\\": \\\"books\\\", \\\"id\\\": 1, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/1\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/1/\\\"}, \\\"product\\\":
@@ -59,9 +59,9 @@ interactions:
         \   },\n    \"product_type\": {\n      \"id\": 1,\n      \"name\": \"books\",\n
         \     \"url_api\": \"http://localhost:8080/api/v2/product_types/1/\",\n      \"url_ui\":
         \"http://localhost:8080/product/type/1\"\n    },\n    \"title\": \"Engagement
-        created for &quot;Python How-to&quot;: new engagement\",\n    \"url_api\":
-        \"http://localhost:8080/api/v2/engagements/7/\",\n    \"url_ui\": \"http://localhost:8080/engagement/7\",\n
-        \   \"user\": null\n  }\n}\n"
+        created for \\\"Python How-to\\\": new engagement\",\n    \"url_api\": \"http://localhost:8080/api/v2/engagements/7/\",\n
+        \   \"url_ui\": \"http://localhost:8080/engagement/7\",\n    \"user\": null\n
+        \ }\n}\n"
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -70,7 +70,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 29 Jan 2025 20:45:18 GMT
+      - Wed, 30 Apr 2025 16:23:42 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -95,26 +95,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bqkS2mXN5ngFJ1Cu5eJSJpcMJompUkHY+y7m+DQ+aa+HXe/
-        //2OO6CWe9gMBjH0GkLv2WwmQYEI0r25jAfDvdfcZhYCmiCpfW/4/h98DcNOC5Dg31dg+iXYAMNf
-        lyydVWYEK+B3yR0MXjsbYYIxyXCGp/X68rFePTTf0/XYtbFC7ClBEzzBz9EJvXH7Ll7Z7PtkWxo3
-        yhhqR23kZwSxGMjL8tS84iGBOc6LKSbTvGoIZZSweZVhjC9whGPexz/A0OjuB7tocsJowUiVUUK/
-        WNHdWOUiqIqCAJRz0koQVAgOwElbSUUWJVeERoFqC8jPBMEkw60eeHohKD6acOcET+0DMqcKgX3Z
-        1Oh4ftjW2TS5vm/Q8QMAAP//AwDv8BdOIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:23:42.478+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 0142053b-a7dc-4dfd-b59f-77a77e6ddd88
+      - 6af19709-e928-4ec7-9500-a6bcf64a94d4
       Atl-Traceid:
-      - 0142053ba7dc4dfdb59f77a77e6ddd88
+      - 6af19709e9284ec79500a6bcf64a94d4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:18 GMT
+      - Wed, 30 Apr 2025 16:23:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -124,7 +120,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=170,atl-edge-internal;dur=16,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=20,cdn-upstream-fbl;dur=399,atl-edge;dur=316,atl-edge-internal;dur=14,atl-edge-upstream;dur=302,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="Kd0c8DMTzurmrrMBZ5YAL7WlVVSbQZZxOEdT5hMhO2Bk2XdYK3ItRA==",cdn-downstream-fbl;dur=403
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -133,10 +129,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5b8f26c7595104a396342213c43d8b98.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Kd0c8DMTzurmrrMBZ5YAL7WlVVSbQZZxOEdT5hMhO2Bk2XdYK3ItRA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - fdc0e3fa7a97f7656746ccc3405af67e
+      - 8ec8683265d84b3dc1da60445ee79828
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -163,41 +167,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 1f2a65fd-a609-4604-a5b0-57706c020c82
+      - 0f03dd41-a463-46e5-bb94-ab4949b45e85
       Atl-Traceid:
-      - 1f2a65fda6094604a5b057706c020c82
+      - 0f03dd41a46346e5bb94ab4949b45e85
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:18 GMT
+      - Wed, 30 Apr 2025 16:23:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -207,7 +198,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=288,atl-edge-internal;dur=15,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="M_3oZdIgh3rGOfLfMy6TpK5Y-oP1XKWWQUOQwHOiOxdI0X8mxQJuPw==",cdn-downstream-fbl;dur=447,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=444,atl-edge;dur=355,atl-edge-internal;dur=17,atl-edge-upstream;dur=338,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -216,13 +207,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 36e36df999d8d13e1e708941d33a5866.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - M_3oZdIgh3rGOfLfMy6TpK5Y-oP1XKWWQUOQwHOiOxdI0X8mxQJuPw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - a2c7004340d79a5385a3da9a87056ab4
+      - c98a8df1e27f386dd155e374408dd339
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -249,26 +248,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpc19ItbzLBKTqFdi+KSJpcMJompUkHY+y7m6Cw+aa+HXe/
-        //2OO5CWe9wOhjDyFkLv2WwmUaEI0r27jAfDvdfcZhYDmRCpfW/4/h98jcNOC5ToP9Zo+hXagMNf
-        l6ycVWZEK/B3yR0OXjsbYaAUMprRab25fKzXD81puhm7NlaEPSdoQif0JTqxN27fxSubfZ9sK+NG
-        GUPtqI38ihAWA3lVfTeveEhgTvNySmGaLxooWAFsvsgopRc0wjHv4x9waHT3g102ObCiZLDMoDqx
-        oruxykVQlSUgVnNoJYpCCI7IoV1IBcuKKyiiQLUl5meCYJLhVg88vRAVH024c4Kn9oGY74qgfd3W
-        5Hh+2JOzaXJ935DjJwAAAP//AwCGwdS4IAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:23:43.402+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - a128a453-82a5-46fe-a051-0d622a2f0da1
+      - c7b97827-1755-4de6-aa7a-507289d22131
       Atl-Traceid:
-      - a128a45382a546fea0510d622a2f0da1
+      - c7b9782717554de6aa7a507289d22131
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:19 GMT
+      - Wed, 30 Apr 2025 16:23:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -278,7 +273,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=14,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="dKisb8BoI_Mt_XbGepch_aZp21wttgb_-AWR47klCYCAKG-78tc2Tw==",cdn-downstream-fbl;dur=233,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=230,atl-edge;dur=152,atl-edge-internal;dur=15,atl-edge-upstream;dur=138,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -287,10 +282,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e61f6cd3dfbf1a805c935627b416490e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - dKisb8BoI_Mt_XbGepch_aZp21wttgb_-AWR47klCYCAKG-78tc2Tw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 4c5701eb45fee93086d2d076d9db96b1
+      - 6608d2f06d9a1abf8d69bd0184ab0d2b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -317,42 +320,31 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Epic&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xWW0/bMBT+K1aeS0JLxVClaZqASWwTmsTlZULIbU5bg2NnttMmQ/3vO6e5OKVs
-        S9nGXshTfHIu37G/88UPAeQpV3EwClKj72DibNDzr6OvD95BWJuBK1IgFwtyira5c6kdRVEMUwyI
-        9Z0OuZPcWsFVqMBFBqyLeCqiQVRljfr7+GAKQUnrxT0UuDq/PL24xJXiCeDySgnnMAEV5AvuuLky
-        ElE9BMOjfHi0Y/1MiQUYy+VtmStaCFhG1FADrfrQ3x/uv8Gag2E+GP7bKu+s+A5vbcKlxIL9w7x/
-        +BIF87riwSA/GLxExQRikSXBqtfmEfHrGUxqMjzNpRjsxIjUCa3Q+p6NxYxlFgyzTpuCuTl3TAHE
-        ljnNxsDGRt+DYrFeqpAdG+AOYjYu2EdhOLvQU7fkBtgeOjClHcNGHNOGxSDBQUjVJ1ohM7t0IRI+
-        AxtRhPV92AhSMQntYubJf4oWXGXKGa6sJFDnG19sNnbc3gejKZcWesFcgOFmMi8+wwIQTL/nZ3cq
-        QMY0RtULjpDNkoSbgl4NfMuEAXR0JsNMdjKHhNMXAofh1hmhCJstrIOELFX0qsF7UVnqWa49EBi3
-        JzDlmXTXXGbQANYpAqZTIiIgD1xw06ZHJ2TeuwXOGz28M7Kxy9KzRNiO7YTxBmVISr2EeO30yt8O
-        /P0tS1d06BOdpFqBon9O+9SroK1j58ZwopbAA8cQH9+mQSup58GxN9Y8aPl1JELA45gqAdUzkOgF
-        BE+QgzrbOMwurW3PWjuFb+SkZa07aXt2baWeu0q6O01d7dsCWZs8wC+NUwnOB+0AbHtTnzVxf3b3
-        qKJJPD6V2lYNFW2ASFIpUFb9kb5eVf5mwf93VSmVKUPVTda/zVskTL+/4xSX8cFaZcK0yIUNZwZA
-        zXWKbA/vUKNHs/ke6eee5GOgTsuYM0y/ruhHijSVrW8BjXZtwdtpvFZ0I8ivcYtKc5fWHmsvbXAp
-        OI0YtHN69B9EzipnL75t112g9yoN/rX6pkZoI9yjW87POmu8N3StsrWFrXGrla0xbDVQKug2/icA
-        P1PZhP4BAAD//7xYwW6DMAz9lx16XLaWHhHabZOYVKm79kAZAlQGGxBVPfTfZ8cJOINJlKAea7Dz
-        Yr/afuDZAis/d5DrIDkYsjzNILo9y1/JiCeoxgnJcAO7Xg7sEKmBuXaGuVkGJjUUG+g7NRkNdeMM
-        1VsGKjDSxhlWZwPScwa5XQzkgKKhshmo24frAXcv/k90g35PKoyMHW9aB4tKbEI3zZy8PHUuZuR4
-        f0ZOSC+Njxxk3qDt/du3sSurOTdz2gzXYx2thxySweDVz6HfyrbC9R9lz8Qydkx4fnwSFEg0MoXS
-        tsGPTOqLP/nyY5IBMEdtG8XZF0qXWflg/iwnzNrn5YW/SrmxvKfdg24QV9+XXq4jiWbWk/kz/MzK
-        6gq/QdkqJd+X1wrgUmKtywUQ/pTUQSzrGvKiVczbp79qsuq8l8cPkLO7CJ/5ONy5uSGLdlVAQTD4
-        pSyK1Sy6dGlGwCmI/mlJxq8FFh2MNyODMXVU6A1uWcTDBUWLjkUimgT1fqD3bV/prFuzQZ0DN/LD
-        9RcAAP//AwBwEqjntBYAAA==
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","untranslatedName":"Epic","subtask":false,"hierarchyLevel":1,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1}]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"customfield_10011":{"required":false,"schema":{"type":"string","custom":"com.pyxis.greenhopper.jira:gh-epic-label","customId":10011},"name":"Epic
+        Name","key":"customfield_10011","hasDefaultValue":false,"operations":["set"]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 73c8b0f9-1d75-4368-acd7-aa0789b267cf
+      - 71778293-41e4-43a2-bba0-62ca40c1905e
       Atl-Traceid:
-      - 73c8b0f91d754368acd7aa0789b267cf
+      - 7177829341e443a2bba062ca40c1905e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:19 GMT
+      - Wed, 30 Apr 2025 16:23:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -362,7 +354,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=297,atl-edge-internal;dur=15,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="kCRrafBXnH6Ao4668Di4X-zfuIIyiISUqNG4uefJlDrU77hgIVTdqg==",cdn-downstream-fbl;dur=333,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=331,atl-edge;dur=256,atl-edge-internal;dur=18,atl-edge-upstream;dur=238,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -371,13 +363,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f82a4020c8fc9b14a403737c65661074.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - kCRrafBXnH6Ao4668Di4X-zfuIIyiISUqNG4uefJlDrU77hgIVTdqg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - ad710f2110169e1ee2d8b1c8c01707f3
+      - 02e0063e85db7de3f693f95ab9029c67
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -407,18 +407,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16611","key":"NTEST-1828","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16611"}'
+      string: '{"id":"18155","key":"NTEST-1830","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18155"}'
     headers:
       Atl-Request-Id:
-      - e5d301a0-db46-476e-a680-b2b0eb8a1db6
+      - 05e1afff-12a9-450e-b9de-fcf7259a4a72
       Atl-Traceid:
-      - e5d301a0db46476ea680b2b0eb8a1db6
+      - 05e1afff12a9450eb9defcf7259a4a72
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:20 GMT
+      - Wed, 30 Apr 2025 16:23:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -428,7 +430,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=750,atl-edge-internal;dur=13,atl-edge-upstream;dur=737,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="b0UAhMmguWyTv95Evp4KyvPQj5Sg93v_CZeDN5OvPpQgZTLydN-68g==",cdn-downstream-fbl;dur=873,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=870,atl-edge;dur=786,atl-edge-internal;dur=15,atl-edge-upstream;dur=771,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -437,10 +439,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c1388c9ad241eb02cd4ddbe69b1a2d34.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - b0UAhMmguWyTv95Evp4KyvPQj5Sg93v_CZeDN5OvPpQgZTLydN-68g==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 4476e86ab623cefcadc29c6eea3b1844
+      - c7c28b6474367809d0f45d2201d8a6eb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -464,52 +474,36 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1828
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1830
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX23LbNhD9FQxfK4kXXaxoptNpHaWT1nE8tpw+dDoeiFxRiECABUBd4vrfuyBI
-        ypbEtlameROxwF7Pnl09erDNqUi8iadAJKAgeceAJ7ojaAa6o+MlZLQjc1DUMCl0BxJmMjC0Ey+p
-        SIHLtLMGpVEGyS3kCjQIU92NC21ktrAKH8IgCIOegj8L0Ga2y+FG0diwGLyOx6z9cDQKQ/zQwBf4
-        uTQm1xPfT2ABsUnkZ9mjhlOtGRU9AcZHS8anOfMjn2ldgF8rWMEO31/PpnezbjiOxnhUuqC9yaOn
-        0bdCx9RAKtXOxZDgF76IgmjYDcJu9GYWhZPBcBIFvf5w9B36HVgnrRGDjpdqznTSvvdRn9NYhl19
-        JKBjxXKbODz9kcxZSgoNimAK1Y6YJTVEACSaGEnmQOZKrkCQRG5Ej1wqwBgSMt+RX5ii5E4uzIYq
-        IF28QIQ0xJaNSEUS4GCgZ63HUtwr/l+iYBlNQfv2hd7HoX3IWdzT6xS1Wbigqime2BoWc0P1ypss
-        KNfQ8ZYM8aPi5e4K1oAmw6eOZxgCLEeweBNRcN7xDtDSD2pBruRndOzMvFevT2f9GVb2QdwLZgwq
-        0F5j2wL21/KurlJro2RZzhk6nDSB0jU1VGFaS7ANxtvB+JXuFoLZfqL8weny1ww2fombOpJKEAaD
-        4ALdiAbbaPD/WvlBsy/wvc4o52gwHG3D0bcwuK0t9qNtP/oWFjPskyLznp6O4Ri24TSqBQu2/eSo
-        EKv/+x/HN/v1TZqmClJs2aMmwAAkLxwLnDY3bBOM2gQXLYKoVTBuE7w59tOxpzvdSLUqB4U36Yb4
-        SQ3OD8e7r29cx+p7HvedOmXbsvx5KQubuNBy82/2gInUmxhVAJYPlZpPWHHbnFUsjiRbmD4IxjXT
-        HwbdENGhoA0SUQOJXDGpmNmdmYL6ud//CsKulDA8cPB+SdkfHOQrYux7x9CPGtxyOgdLbSfAHbXB
-        z1LFaQHCz0uoWj3sgHO5Oc58OLZ5W1Jtx8oVE6t3VvIWcruqiHjX0K5eyk0pa06EFFMceXTO4Rao
-        tu30iKB1v7ybq/uf318/XL2/nF7fTR+mt7cfb9E89qLGxOGF2RLIDbK8MMTaJUwTKfiOIGMwbpXa
-        KVyO2hsFGeavnNW6d4o5QmwaL/iLBYFafJl4bvJhjbFI+855wQhYrpQJyg8vVYtWVYCyPzh6V33b
-        +qe4ItS3i9y2Zhvew/Cixrvbic6EqHvcTNeXa8zrULvH5E80XuFmWYOyVu5sXVbL21c5XG+AflQZ
-        ieplQECJRMmlunbezHkB3VTR3d7BmSRvpSu2zHLcfYU53RbDNvIYNuTxTxV/mU50jYBIEaKZHRnH
-        OptGPYRgmxe4MP+72jA6M9VOT9mYH8sYLEyQDxDJFHPa5HFfZhSeaCAMy0uX225JP11bscMbg+fJ
-        NPjPYlXOgscTytrm56CZbQeCoO1F0DCbhrhwNH/6YtugDdoGbdA4Q42h8bIsjOvy50RxCBddZBm1
-        nXGipnb6SXVmJf8GAAD//+xYPW/CMBD9K10Yk4YkNGFAFKFW6sDSoQObYzttpJBE+aBFKP+9z3Zw
-        IYpRVVWIAYnBxPbdceTevXcC3eaEUtFxX9hswrwwCKNx4HCPTh06nbjxdByLf1Yfgoczx6Aqk3TB
-        GHygcFBFbPd4FAiqStg6y6Zl0rmNwpTHxJ0Do/M5egdhY99/CGgYTLxpRKPAgfuY8DikczaTVkbe
-        YuQ+46PuWRuSdRmzLPWospvK+kQiLNcGbWR20UQpVA8yZRWEVCJRuJ9AMiToPFguV5ZjF5kArz4z
-        v/6I+9T++iPuS4NrjxiIxJKqSMmu6y5LvPp3KxLHDaWJLKAawkXxWIVna/QXHHxqyhziZQ2koR8/
-        lSakKXZ16QoPnf4ebkm+qRn4Jj7raz7b39ANp+RFXtb8hi+Xe5Nu+HKJiG/4MoAvfRjQ9EuzE0T9
-        rmpvL2Zo3dqBw7wmUAPOgBUjzzLikklaOu4w8hl5mIk4C0AY3HD0T+5teKYbnqZ0PNsmZZ4pTqce
-        saabQquvv8pevlEW9odlB/d/gN+jAfr9wS7kMPl65VWTCsNHvqUOK+tFreLY5vX/jXiUMW0UvqD+
-        33IpY6Wyb9WQSYhD4VIHchqtexJud0Gmp23bbwAAAP//AwA6zCNv9BgAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18155","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18155","key":"NTEST-1830","fields":{"statuscategorychangedate":"2025-04-30T18:23:44.992+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1},"timespent":null,"customfield_10030":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10031":null,"customfield_10032":null,"fixVersions":[],"customfield_10033":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"aggregatetimespent":null,"resolution":null,"customfield_10035":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"lastViewed":null,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1830/watchers","watchCount":1,"isWatching":true},"created":"2025-04-30T18:23:44.633+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},"customfield_10023":null,"labels":[],"customfield_10026":null,"customfield_10016":null,"customfield_10017":"teal","customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sx3:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:44.761+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"new
+        engagement","customfield_10010":null,"customfield_10055":null,"customfield_10011":"new
+        engagement","customfield_10056":null,"customfield_10012":{"self":"https://defectdojo.atlassian.net/rest/api/2/customFieldOption/10016","value":"To
+        Do","id":"10016"},"customfield_10013":"ghx-label-11","customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10049":null,"customfield_10005":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"aggregatetimeestimate":null,"attachment":[],"customfield_10009":null,"summary":"new
+        engagement","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10047":null,"customfield_10003":null,"customfield_10048":null,"customfield_10004":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1830/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18155/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - fc062cd3-da38-4d95-8b00-ecc24bb3dcb2
+      - 5f0659c7-5b3c-4bc2-8bf5-053a88006161
       Atl-Traceid:
-      - fc062cd3da384d958b00ecc24bb3dcb2
+      - 5f0659c75b3c4bc28bf5053a88006161
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:20 GMT
+      - Wed, 30 Apr 2025 16:23:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -519,7 +513,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=271,atl-edge-internal;dur=14,atl-edge-upstream;dur=258,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="V7l25GXPxmIUA1lRT2C2YBKpySbfjWDak_CEAv9wxZFUMrH0OSDm-g==",cdn-downstream-fbl;dur=358,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=356,atl-edge;dur=272,atl-edge-internal;dur=19,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -528,10 +522,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 bd02c4a72f88f2bbd693051675941962.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - V7l25GXPxmIUA1lRT2C2YBKpySbfjWDak_CEAv9wxZFUMrH0OSDm-g==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 446c00b1e72bcc391857513273a2fa6a
+      - 8ec2bc5269a95ba5dfa77a91fbd97e91
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_create_edit_update_finding.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_create_edit_update_finding.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"838\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:42676\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:34024\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,111 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:15:06 GMT
+      - Wed, 30 Apr 2025 16:23:46 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/90", "url_api": "http://localhost:8080/api/v2/tests/90/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      90, "url_ui": "http://localhost:8080/test/90", "url_api": "http://localhost:8080/api/v2/tests/90/"},
+      "finding_count": 2, "findings": {"new": [{"id": 232, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/232",
+      "url_api": "http://localhost:8080/api/v2/findings/232/"}, {"id": 233, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/233",
+      "url_api": "http://localhost:8080/api/v2/findings/233/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1310\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:34026\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/90\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/90/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 90, \\\"url_ui\\\": \\\"http://localhost:8080/test/90\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/90/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 232, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/232\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/232/\\\"},
+        {\\\"id\\\": 233, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/233\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/233/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 232,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/232/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/232\"\n        },\n
+        \       {\n          \"id\": 233,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/233/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/233\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        90,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/90/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/90\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/90/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/90\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:23:46 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -101,26 +205,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1nZb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwCbz0/NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4DTnUKRLSr9Z
-        2d0YZQOY0WIhBWCOStLZHEWmVKZAKrac5YtaFRmyQgE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMA84tLBiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:23:46.724+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - bdd5b965-17d0-4429-9661-305450f49640
+      - 96ebd2aa-f3d6-471f-909f-443199eb8e81
       Atl-Traceid:
-      - bdd5b96517d044299661305450f49640
+      - 96ebd2aaf3d6471f909f443199eb8e81
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:06 GMT
+      - Wed, 30 Apr 2025 16:23:46 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +230,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=198,atl-edge-internal;dur=14,atl-edge-upstream;dur=181,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=288,atl-edge;dur=160,atl-edge-internal;dur=16,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Q-qP-AHAgvFOCA_S0eFIZGmKfAYg4AlgT94smSdF9DrRr35SkEgwyw==",cdn-downstream-fbl;dur=291
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,10 +239,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5ea7f8bcbac3004590a821cdd0466e1c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Q-qP-AHAgvFOCA_S0eFIZGmKfAYg4AlgT94smSdF9DrRr35SkEgwyw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4f5cdcd68950633360f5024567ee1e99
+      - 1f41bb813e740faff8aff3cb09113484
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -169,41 +277,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 84218274-9d44-4e0f-bae2-67df44567992
+      - 0a8417c8-7279-40a6-9cee-2896bc3640b2
       Atl-Traceid:
-      - 842182749d444e0fbae267df44567992
+      - 0a8417c8727940a69cee2896bc3640b2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:07 GMT
+      - Wed, 30 Apr 2025 16:23:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -213,7 +308,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=354,atl-edge-internal;dur=15,atl-edge-upstream;dur=338,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="6jgpDU6wZCWK_5DWGVhSgO6GSJPEZVE5vShc5m4MXWDBAYJzbud8-g==",cdn-downstream-fbl;dur=365,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=362,atl-edge;dur=276,atl-edge-internal;dur=15,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -222,13 +317,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 40867fef594010a8d9ec2cb0a5cb2350.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 6jgpDU6wZCWK_5DWGVhSgO6GSJPEZVE5vShc5m4MXWDBAYJzbud8-g==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 20e293d67ac4ff73f4ba120e7ac80afb
+      - 7146018f99c9137897c570af605b6201
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -240,14 +343,14 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Jira Api Test 2", "description": "\n\n\n\n\n\n*Title*: [Jira Api
       Test 2|http://localhost:8080/finding/235]\n\n*Defect Dojo link:* http://localhost:8080/finding/235
-      (235)\n\n*Severity:* Low\n\n\n*Due Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      (235)\n\n*Severity:* Low\n\n\n*Due Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
       cookie has been set without the secure flag, which means that the cookie can\nbe
       accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -259,7 +362,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1170'
+      - '1190'
       Content-Type:
       - application/json
       User-Agent:
@@ -268,18 +371,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16075","key":"NTEST-1591","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16075"}'
+      string: '{"id":"18157","key":"NTEST-1831","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18157"}'
     headers:
       Atl-Request-Id:
-      - 678fbcef-124e-4c6c-bc67-52d078bafe33
+      - 359e64f2-a512-491a-8883-37b5b40efa65
       Atl-Traceid:
-      - 678fbcef124e4c6cbc6752d078bafe33
+      - 359e64f2a512491a888337b5b40efa65
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:08 GMT
+      - Wed, 30 Apr 2025 16:23:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -289,7 +394,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=809,atl-edge-internal;dur=26,atl-edge-upstream;dur=782,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="RDmo3H_adebdHM-lb0Hg2sYMEY4iVAOWKfYzwrn4rfDoEhMYjieRZQ==",cdn-downstream-fbl;dur=844,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=98,cdn-upstream-fbl;dur=841,atl-edge;dur=709,atl-edge-internal;dur=15,atl-edge-upstream;dur=695,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -298,10 +403,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - RDmo3H_adebdHM-lb0Hg2sYMEY4iVAOWKfYzwrn4rfDoEhMYjieRZQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e138368e74a2ff8bdf38a75b32a9e026
+      - 79abb4b717c4395071d791355b987dd2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -325,60 +438,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1591
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1831
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa2/bNhT9K4Q+bZlsPWI7joBhyBJ3S5dlWeKkwNIiYKhrmTVFaiQV22v733ep
-        l5uHWyTDCgOJyMv7Pjy8HzxYFVSmXuJpkCloSF9xEKnxJc3B+IbNIae+KkBTy5U0PqTc5mCpz+ZU
-        ZiBU5t+BNiiD9BwKDQakbc6y0liVz5zBmygMo7Cv4e8SjJ2uCzjTlFnOwPM97vxHo3BviAsDYobL
-        ubWFSYIghRkwm6r3qk+toMZwKvsSbICebEALHsQBN6aEoDWwgDXqn04nF9NeNNyPcKsKwXjJB89g
-        bKVh1EKm9LrOIcUVasRhPOyFUS8Kp3GYRMMkHPfj3eEPGHfognROLAZemXlhkE4/QHth3KXdLFIw
-        TPPCFQ53D4jJqRA+SbmxXDJLCg4MiJqRpdKLvtNmSl5q8cwoSsldu6i4oXfUUh3ccVgGVVibABtR
-        FO5G458M/wd+zLHtZY5eHSzQ5ZSahetVeWvdVzKjwoDv1YrHmFel63tzjsDRbL4+gTvAWMNPvmc5
-        IqtAlHiJLDFH7wFMdsNWUGj1HjN6YcEb7arcVQPbcrvFZyDZZHUpubVowHidb4fU36qzRs3skmqH
-        V8PzQnAMOH2QOfajQtlgvBqMnxnuFzrTZtL1ZRDuYRjxYBUP/l8vdfcrLKLDaLSKRt/C4ar1uBuv
-        duNv4bEB+KdPj+EYbcNp3ApmfHVVcyB2//rd45O77UmaZRoy5JuvXoJhK8DMlChrXnj66GibYG+L
-        IN4qGG8T7D8Op6bNeteRUvVCeEkvarjStURzVkf+4dGeuyhYbTNXpUiPuCkEXTfXCbeX1OLTU1P2
-        869+/SBsnoCgNqfdxa4+D1XpSl+F+sZtcJl5idWl841G7RVixl3vphoaMFnHH48fib3+eBS2j8TD
-        snVU9lCwDVRxB6pCc6W5Xb+wBK16MHjeW8FzmoEJnIZpjXDcEGrZN3fZhixP1LIl1YH3+NrEHeYF
-        vQVHi09cDMcmT5Yh2obQaOzqMadmUnB2wuXilZMcQeGmF8laBFW4WlaybkcqOcHhhd4KOAdqalTq
-        5ss7O7n85fj05uT4cHJ6MbmZnJ//cY754S01WBA8MJ0DOUP+l5Y4v4QboqRYE+QSLpxRYhV5zTUl
-        ZxpyJBNSGkRc/ylOifA6eeFHHoZFvpd49ZuIvcPib+7UPa7ANmRcUvHwUDN7NeWtcC8wumbt+ppJ
-        6E6Xhbu023C8Pxy1OK7HpBdCr1bu3t37k83z0LiB28+ULXDYbCHXGq99HTbz3H8KuB0Kg3Y2i9sx
-        QYKDOlNC6dM6mltRQi/TyFibkUiRI1U3W+UFjsPSPg364TZSGHak8KWO3y/nW7n57Uy5FbCTkOsK
-        hgcFJ1PUJvFHVwyshVCMirkyNhmH4zCYcZki7wU45L6r9I+qWmEa7xVxKEp2yFc1yXf45/tK/QJn
-        PEc5qIbk0MR0VAI5wvBx83e6JlHoE4e9LubDNxMUXeO/3igaVJG6trEl9HNuNfSVzgJELXWd5Dig
-        ObQHeLQ/t7mo4q7tXDk7l3Ih1fLzmpxplZb45E9khvc4x64ErijO5wWw0sVLflXLnlVbqlQ0BuJ3
-        JCDXEdbzz5JqC5psTG5RhY3PqNL+6+CMXDAqt5x3s2ewH3ZJPfXDJnX930neygPClFpwIMiJ5BZA
-        EgOWLLnFd9USi6RlXJpAZoJmPlnOOZuTHKg0KKT1icYCBvZW3gKhjCHrQUruOCUlApnpfwEAAP//
-        7Flta9swEP4rplBIofac2GmSQelC2WAfykYLK5RBUPzSmMay8UvS0uW/7zlJ0VwtKqOMkg+BfnBt
-        6V6ku+eeuzyVgA2s4zyRxdtT1lzhQu5Fu0fG3C4STkHgMC2zQDeYQRnawhprV4mT8bSocrHHKSrC
-        UYavNcEYIPQh4adkFIRnjSPZgcOWa/ZE7jklE5a1NcLPYdzpGIdejidLD9dSk7/aO+n/T04HQNro
-        fGCBsrDemkgC6xaHs9NS5W/nHq6RLKgGOCryXF3oer32ijWrSxG2yJLk0SsXpQg5KJhB3kzpnbEG
-        VGje4tJnvW+305vv7s2Vi8IpkkkoKAuKMwrVHovzjJ84vZNfOcpNU3xEkPzNN4a66JoFx4Y5/bCL
-        OQ168gdBhYiamUs1JTU+hJocGh982w5f131xOYLl7F5o4wG+jan62hicL4sWlH2qGHbrqYmqdZvn
-        jArIkYGddMjE/orqjcWFWMAFUooY59f4fBgH49F43h/5SRBN/GgyHKSTfnoGPXoRNLyyLKEImMYx
-        dKDAoNrET586hqD6kKxX+1GZEh4KmFhGe7Y9UZiAY7G4H4Zno2g8GgaTeTQf+VCfsiQdRxfxuZBy
-        HEyPB1/wJ/e5OeMK61xXvqq9tnbXOAh34BGIemU7X2YRnZRbMlbTQWG/wHQwNDxeIv69klORN3vb
-        /bfYbI7332Kzud53iwFJsewTFQu7ROiDVaRpG0WZSCCCbdnHSUC7Aw/Dws9tVaD9vwPURIs/mUbD
-        HXzVqUsa1EhrN3ULbTAa2vq5UPdzlYLzA4y8W8AcYOQ9LD7AyA4YMWHARsxCzb80PYE79zIpn2kK
-        rZ59WFI0TM3QTSlWomXFJdvkxR/sRj4rEbN6ZmVo2mXjQ2DbEWhOl/BVVhVckjr5Km7VDzjy3385
-        vVXR/L/RohSmhUITOrEfhRizbKeZSAFp8vP2UdWXNxsgfuz6sJV7epSzx+ukbpckuOOsGJBUzbSR
-        jtOYloYo5Lp+/3Lz4MVutUFYu9lsfgMAAP//AwBbhUXlLxwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18157","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18157","key":"NTEST-1831","fields":{"statuscategorychangedate":"2025-04-30T18:23:48.080+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1831/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:47.768+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxb:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:47.872+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 2|http://localhost:8080/finding/235]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/235 (235)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 2","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1831/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18157/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3a59524b-ce73-4ec1-a362-ec191d99997e
+      - 038992ce-9f30-4c8d-82bb-2ad6f4ab6c8d
       Atl-Traceid:
-      - 3a59524bce734ec1a362ec191d99997e
+      - 038992ce9f304c8d82bb2ad6f4ab6c8d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:08 GMT
+      - Wed, 30 Apr 2025 16:23:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -388,7 +484,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=300,atl-edge-internal;dur=14,atl-edge-upstream;dur=287,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=32,cdn-upstream-fbl;dur=517,atl-edge;dur=388,atl-edge-internal;dur=18,atl-edge-upstream;dur=370,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="v4zZUY95r4HFbuYneM_3vPZsYRJjQ_4wAio89ociI3y4SvEv05NS7Q==",cdn-downstream-fbl;dur=522
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -397,10 +493,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - v4zZUY95r4HFbuYneM_3vPZsYRJjQ_4wAio89ociI3y4SvEv05NS7Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 02eecd3d41741f0921acb5b3a1ac3848
+      - 1730874687ad03bbd9fd21854fa93814
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -424,60 +528,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16075
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18157
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8aukk8yAJYaSqopBtt6WUQmClsitkPDcTbzz21PaQpLv8917P
-        K7uEbAVVV5Fg7Ov7Pj6+HzxYFVSmXuJpkCloSF9xEKnxJc3B+IbNIae+KkBTy5U0PqTc5mCpz+ZU
-        ZiBU5t+DNiiD9AIKDQakbc6y0liVz5zB2ygMo7Cv4a8SjJ2uCzjXlFnOwPM97vxHo/BgiAsDYobL
-        ubWFSYIghRkwm6r3qk+toMZwKvsSbICebEALHsQBN6aEoDWwgDXqn00nl9NeNDyMcKsKwXjJB89g
-        bKVh1EKm9LrOIcUVasRhPOyFUS8Kp3GYRMMkHPfj/eF3GHfognROLAZemXlhkE4/QHth3KXdLFIw
-        TPPCFQ53j4jJqRA+SbmxXDJLCg4MiJqRpdKLvtNmSl5p8cwoSsldu6i4pffUUh3cc1gGVVibABtR
-        FO5H4x8M/xu+z7HtZY5eHSzQ5ZSahetVeWfdVzKjwoDv1YqvMa9K1/fmHIGj2Xx9CveAsYYPvmc5
-        IqtAlHiJLDFH7xFM9sNWUGj1HjN6YcEb7arcVQPbcrvFJyDZZHUlubVowHidb4fUX6uzRs3skmqH
-        V8PzQnAMOH2UOfajQtlgvBqMnxnuFzrTZtL1ZRAeYBjxYBUP/l8vdfcrLKLDaLSKRl/D4ar1uB+v
-        9uOv4bEB+MPDNhyjXTiNW8GMr65rDsTu37zbPrnfnqRZpiFDvtm6BJiAEmV9/Z92N9wlGO0SHOwQ
-        xDsF412Cw+04a9qsdx0pVS+El/SihitdSzRndUoftvbcRcFqm7kqRXrCTSHourlOuI29tdfYN3fF
-        GhfU4mNUk/jzyaB+IjaPQlCb0+6qV5/HqnTNqIJ/4za4zLzE6tJFwzRgso4/th+Jg/54FLaPxOOy
-        dVT2WLALVHEHqkJzpbldvzDhVj0YPO+t4DnNwAROw7RGOG4Iteyb+2xDlqdq2ZLqwNu+NnGHeUHv
-        wNHiExfDscmTZYh2ITQau3rMqZkUnJ1yuXjlJCdQuOlFshZBFa6WlazbkUpOcHihdwIugJoalbr5
-        8s5Pr356fXZ7+vp4cnY5uZ1cXPx+gfnhLTVYEDwwnQM5R/6Xlji/hBuipFgT5BIunFFiFfmFa0rO
-        NeRIJqQ0iK/+U5wS4XXywo88DIv8IPHqNxF7h8Xf3KnPuALbkHFJxeNDzezVlLdCucDomrXrayah
-        O10W7tLuwvHhcNTiuB6TXgi9Wrl7dz+fbJ6Hxg3cfqRsgcNmC7nWeO3ruJnn/lPA7VAYtLNZ3I4J
-        EhzUmRJKn9XR3IkSeplGxtqMRIqcqLrZKi9wHJb2adAPO1L4UmMfK3WE8Xk538rNb2/KrYC9hNxU
-        MDwqOJmiWRJ/dMXAWgjFqJgrY5NxOA6DGZcpslyAQ+67Sv+kqhWm8V4Rh6Jkj/yrJvkG/3xbqV/i
-        jOcoB9WQHJqYTkogJ5gXbv5G1yQKfeKw18V8/GaCohv81xtFgypS1za2hH7OrYa+0lmAqKWukxwH
-        NIf2AI/25zYXVdy1nWtn50oupFp+WpNzrdISn/yJzPAe59iVwBXF+bwEVrp4yc9q2bNqR5WKxkD8
-        jgTkJsJ6/lFSbUGTjckdqrDxGVXafx6dk0tG5Y7zbvYMDsMuqad+2KSu/3vJW3lEmFILDgQ5kdwB
-        SGLAkiW3+K5aYpG0jEsTyEzQzCfLOWdzkgOVBoW0PtFYwMDeyjsglDFkPUjJPaekRCAz/Q8AAAD/
-        /+xZbWvbMBD+K6ZQSKH2nMRpkkHpQtlgH8pGCyuUQVD80pjGsrHsuKXLf99zkqK5XlRGGSUfAv3g
-        2tK9SHfPPXd5KgAbWMd5rIq3p625woXcy3aPjLldxpyCwGFGZo5uMIUytIUCa9exk/IkLzO5x8lL
-        wlGGr4JgDBD6EPNTMgrC08pR7MBhq4Y9kXtOwaRltUD4OYw7LePQy/F45eFaBPlrvFP+/+R0AKSN
-        zgcWaAvF1kQSKGoczk5Ltb+te7hGsqAa4KjIc32hTdN4ecNEIcMWWRI/esWykCEHBXPIm2u9c1aB
-        Ci1qXPq89+12dvPdvblyUThlMkkFRU5xRqHaY1GW8hOnd/IrQ7mp8o8Ikr/5xsgU3W7BsRGRftAG
-        owo9+YMkPkTNukttBNS3fQgMa+zuMHVfXo5kObsX2niAb2OqvtGJ82XhkrJPF8N2Pe3CraizjFEB
-        OepgJx0ysb+8fGNxIRZwgZQifvk1Oh9Fw8l4suiP/XgYTv1wOhok035yBj1mETS8siymCJhFEXSg
-        wKDaRE+fWoag+pCsV/tRlRIeCphcRnu2PVEQg2OxqB8EZ+NwMh4Np4twMfahPmFxMgkvonMp5Xg4
-        Ox58wZ/a52aMa6xzXfVKeLVwGxyEO/AIRL2iXqzSkE7KLRgTdFDYLzEdDA2Pl4h/r+BU5Lu97f5b
-        3G2O99/ibnO97xYDkiLVJ2oWdonQB6tIkjoMU5lABNuqa1OAdgcehoWf6zJH+38HqAmXfzKNhjv4
-        alKXNOiR1m7qFthgNLD1c4Hp50oN5wcYebeAOcDIe1h8gJEdMNKFARsxCwz/MvQE7tyrpHymKbR+
-        9mFJXjE9Q+9KsTEw34ZL/mA3wNkGMr7VAStDM551d9io29D6wXC6mK/TMueK1KlXUa1/wFH//svp
-        rfPq/w0SlTAjFJrQif3I5ZhlO81ECiiTn7ePur682QD5Y9eHrdzTo4w9XseiXpHglrNyQFJWs0o5
-        TmNaGqKQ6+b9y82DF7v1BmntZrP5DQAA//8DAFihCXYvHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18157","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18157","key":"NTEST-1831","fields":{"statuscategorychangedate":"2025-04-30T18:23:48.080+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1831/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:47.768+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxb:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:47.872+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 2|http://localhost:8080/finding/235]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/235 (235)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 2","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1831/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18157/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 7e9d5b0a-239b-469e-ab48-f12cef206d70
+      - 2565d373-862e-440b-ae8d-da80cae6214f
       Atl-Traceid:
-      - 7e9d5b0a239b469eab48f12cef206d70
+      - 2565d373862e440bae8dda80cae6214f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:09 GMT
+      - Wed, 30 Apr 2025 16:23:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -487,7 +574,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=271,atl-edge-internal;dur=17,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="URf9JlTZwVXl-_8fxg7OuCAxEWC91kIGXxKyLtY6AKtUX-L4nwJw8g==",cdn-downstream-fbl;dur=400,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=95,cdn-upstream-fbl;dur=397,atl-edge;dur=270,atl-edge-internal;dur=18,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -496,10 +583,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 de5b26aba33b480d2b740b96a34fe916.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - URf9JlTZwVXl-_8fxg7OuCAxEWC91kIGXxKyLtY6AKtUX-L4nwJw8g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 89881329fd196b94ed7a5cb1507c6e65
+      - f641f6dae978f5880b4509854f6d1763
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -526,26 +621,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2T9WPLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPARYUZyaV8JHkAHLpkCnsKwY4+mcp0EMcAEBDnkX/oBD1XbnLIWKAacZh2VSQP7N
-        yu7GKBvAlOYLKQAzVJLOCxSpUqkCqdhyni1qlafIcgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAmyOwxyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:23:49.941+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 25e1dd43-e85e-4d77-a920-e7b83c95876e
+      - 80bb533c-3dfc-4959-b6c8-2fe6491f744c
       Atl-Traceid:
-      - 25e1dd43e85e4d77a920e7b83c95876e
+      - 80bb533c3dfc4959b6c82fe6491f744c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:09 GMT
+      - Wed, 30 Apr 2025 16:23:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -555,7 +646,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=172,atl-edge-internal;dur=14,atl-edge-upstream;dur=158,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="eRDa8jszcNv9GBXtQwv1VbD96U9ha8W4VvZ1pH1wOxexCBIdqPsR-w==",cdn-downstream-fbl;dur=302,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=97,cdn-upstream-fbl;dur=299,atl-edge;dur=165,atl-edge-internal;dur=18,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -564,10 +655,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - eRDa8jszcNv9GBXtQwv1VbD96U9ha8W4VvZ1pH1wOxexCBIdqPsR-w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c1bc7f96d428ffd4e578fdac1cc8658a
+      - ae46b4c87036ed92b65aa373618902d4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -594,41 +693,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - bd7c4015-9eab-4e84-95bf-41a29e2c27b5
+      - 3875504f-163b-48e4-8795-32e35683dfa1
       Atl-Traceid:
-      - bd7c40159eab4e8495bf41a29e2c27b5
+      - 3875504f163b48e4879532e35683dfa1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:10 GMT
+      - Wed, 30 Apr 2025 16:23:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -638,7 +724,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=358,atl-edge-internal;dur=14,atl-edge-upstream;dur=344,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="fie3rXSD9GuNg3_CulBgqCgbrRzV88Pz9Jl0pUJ-5MrO1_iiDHEvAQ==",cdn-downstream-fbl;dur=410,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=408,atl-edge;dur=323,atl-edge-internal;dur=15,atl-edge-upstream;dur=308,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -647,13 +733,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 3cab2977109e9e185607e6a3005951e0.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - fie3rXSD9GuNg3_CulBgqCgbrRzV88Pz9Jl0pUJ-5MrO1_iiDHEvAQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 8f008c16fd4bd9d54bf5d44bcd360659
+      - 8f82990c0f4b8d0717100f8cab9b350c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -665,14 +759,14 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Jira Api Test 3", "description": "\n\n\n\n\n\n*Title*: [Jira Api
       Test 3|http://localhost:8080/finding/236]\n\n*Defect Dojo link:* http://localhost:8080/finding/236
-      (236)\n\n*Severity:* Low\n\n\n*Due Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      (236)\n\n*Severity:* Low\n\n\n*Due Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
       cookie has been set without the secure flag, which means that the cookie can\nbe
       accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -684,7 +778,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1170'
+      - '1190'
       Content-Type:
       - application/json
       User-Agent:
@@ -693,18 +787,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16076","key":"NTEST-1592","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16076"}'
+      string: '{"id":"18159","key":"NTEST-1832","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159"}'
     headers:
       Atl-Request-Id:
-      - d19ebdf4-5044-44e6-9f19-b47e62bad918
+      - 53d80a72-0728-4136-a9be-c61ac9a29101
       Atl-Traceid:
-      - d19ebdf4504444e69f19b47e62bad918
+      - 53d80a7207284136a9bec61ac9a29101
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:10 GMT
+      - Wed, 30 Apr 2025 16:23:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -714,7 +810,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=628,atl-edge-internal;dur=17,atl-edge-upstream;dur=616,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=817,atl-edge;dur=690,atl-edge-internal;dur=16,atl-edge-upstream;dur=673,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="aNy_k1TepuD992apdXK-jkBJR9TtmcH1rGv7YRv7Y1T41eiFG0QHRg==",cdn-downstream-fbl;dur=821
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -723,10 +819,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - aNy_k1TepuD992apdXK-jkBJR9TtmcH1rGv7YRv7Y1T41eiFG0QHRg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ee9fd3c176083908df67298da8a27cfb
+      - 0df92f866bb3b1a6339a5ce88d9ba5df
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -750,60 +854,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1592
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZlsvdhxHQHDkCXuli3LssRJgaVFwFBnmTVFaiQV22vz33fU
-        m9vE7pAMKwK0Fo/3/tzD++DBqqAy9RJPg0xBQ/qag0iNL2kOxjdsDjn1VQGaWq6k8SHlNgdLfTan
-        MgOhMv8etEEZpBdQaDAgbXOXlcaqfOYM3kZhGIV9DX+VYOx0XcC5psxyBp7vcec/GoWvRvhhQMzw
-        c25tYZIgSGEGzKbqvepTK6gxnMq+BBugJxvQggdxwI0pIWgNLGCN+mfTyeW0F+0fxHhUhWC85INn
-        MLbSMGohU3pd55DiF2rEYbzfC6NeFE7jMIn2E4x3HMbfYdyhC9I5sRh4ZeaFQTr9AO2FLqo67eYj
-        BcM0L1zh8PSQmJwK4ZOUG8sls6TgwICoGVkqveg7babklRbPjKKU3LWLilt6Ty3VwT2HZVCFtQmw
-        EUXhIBr/YPjf8H2ObS9z9OpggS6n1Cxcr8o7634lMyoM+F6teIJ5Vbq+N+cIHM3m61O4B4w1fPA9
-        yxFZBaLES2SJOXqPYDIIW0Gh1XvM6IUFb7SrclcNbMvtPj4BySarK8mtRQPG63w7pP5a3TVqZpdU
-        O7wanheCY8Dpo8yxHxXKhuPVcPzMcL/QmTaTri/D8BWGEQ9X8fD/9VJ3v8IiOoxGq2j0NRyuWo+D
-        eDWIv4bHBuAPD0/hGO3CadwKZnx1XXMgdv/m3dObg/YmzTINGfLNkyHABJQo6/Hf7m5/l2C0S/Bq
-        hyDeKRjvEhw8jbOmzfrUkVL1QnhJL2q40rVEc1an9OHJmRsUrLaZq1Kkx9wUgq6bccLjJbX49NSU
-        /fzRrx+EzRMQ1Oa0G+zq55EqXemrUN+4Ay4zL7G6dL7RqL1GzLjxbqqhAZN1/LHtkRiOxu0j8bhs
-        HZU9FuwCVdyBqtBcaW7XLyxBqx4Mn/dW8JxmYAKnYVojHA+EWvbNfbYhy1O1bEl16D0dm7jDvKB3
-        4Ghxy2A4NtlahmgXQqOxq8ecmknB2SmXi9dOcgyF214kaxFU4WpZyboTqeQElxd6J+ACqKlRqZtf
-        3vnp1U8nZ7enJ0eTs8vJ7eTi4vcLzA+n1GBB8MJ0DuQc+V9a4vwSboiSYk2QS7hwRolV5BeuKTnX
-        kCOZkNIg4vrbOCXCcfLCjzwMi3yWePWbiL3D4m9m6jOuwDZkXFLx+FKzezXlrXAvMLrm2/U1k9Dd
-        Lgs3tLtwvD88aHFcr0kvhF6t3L27n282z0PjBm4/UrbAZbOFXGu89nXU7HP/KeB2KQza3Sxu1wQJ
-        DupMCaXP6mjuRAm9TCNjbVYiRY5V3WyVF7gOS7sd9PsdKXypsY+VOsL4vJxv5eZvb8qtgL2E3FQw
-        PCw4maJZMvjoioG1EIpRMVfGJuNwHAYzLlPkvSAejN5V+sdVrTCN94o4FCV75F81yTf4z7eV+iXu
-        eI5yUA3JoYnpuARyjHnh4W90TaLQJw57XcxHbyYousH/eqNoWEXq2saW0M+51dBXOgsQtdR1kuOC
-        5tAe4NX+3Oaiiru2c+3sXMmFVMtPa3KuVVrikz+RGc5xjl0JXFGcz0tgpYuX/KyWPat2VKloDMTv
-        SEBuIqznHyXVFjTZmNyhChufUaX95+E5uWRU7rjvds/gIOyS2vaHTer6v5e8lYeEKbXgQJATyR2A
-        JAYsWXKL76olFknLuDSBzATNfLKcczYnOVBpUEjrG40FDOytvANCGUPWg5Tcc0pKBDLT/wAAAP//
-        7Flta9swEP4rplBIofacxFmSQelC2WAfykYLK5RBUPzSmMaysey4pct/73OSorleVEYZJR8C/eDa
-        0r1Id889d3ksABtYx3msirenrbnEhdzJdo+MuVnGnILAYUZmjm4whTK0hQJr17GT8iQvM7nHyUvC
-        UYavgmAMEHof81MyCsLTylHswGGrhj2Se07BpGW1QPg5jDst49DL8Xjl4VoE+Wu8U/7/4nQApI3O
-        BxZoC8XWRBIoahzOTku1v617uEKyoBrgqMhzfaFN03h5w0QhwxZZEj94xbKQIQcFc8iba71zVoEK
-        LWpc+rz3/WZ2/cO9vnRROGUySQVFTnFGodpjUZbyE6d38jtDuanyTwiSv/nGyBTdbsGxEZF+0Aaj
-        Cj35vaRCRM26S20E1Ld9CAxr7O4wdV9ejmQ5uxfaeIBvY6q+0YnzZeGSsk8Xw3Y97cKtqLOMUQE5
-        6mAnHTKxv7x8Y3EhFnCOlCLG+S06G0XDyXiy6I/9eBhO/XA6GiTTfkKDC7MIGl5ZFlMEzKIIOlBg
-        UG2ix88tQ1B9SNar/ahKCQ8FTC6jPdueKIjBsVjUD4KP43AyHg2ni3Ax9qE+YXEyCc+jMynleDg7
-        HnzFn9rnZoxrrHNd9Up4tXAbHIQ78AhEvaJerNKQTsotGBN0UNgvMR0MDY8XiH+v4FTku73t/lvc
-        bY733+Juc73vFgOSItUnahZ2gdAHq0iSOgxTmUAE26qPU4B2Cx6GhV/qMkf7fwuoCZd/Mo2GO/hq
-        Upc06JHWbuoW2GA0sPVzgennSg3nBxh5t4A5wMh7WHyAkR0w0oUBGzELDP8y9ATu3KmkfKIptH72
-        YUleMT1D70qxMTDfhkv+YDfA2QYyvtUBK0MznnV32Kjb0PrBcLqYr9My54rUqVdRrX/AUf/+y+mt
-        8+r/jRaVMCMUmtCJ/czlmGU7zUQKKJOfto+6vrzZAPlj14et3NOjjD1cxaJekeCWs3JAUlazSjlO
-        Y1oaopDr5v3LzYMXu/UGae1ms3kGAAD//wMA+Zj0WC8cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18159","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159","key":"NTEST-1832","fields":{"statuscategorychangedate":"2025-04-30T18:23:51.540+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:51.255+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:51.338+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 3|http://localhost:8080/finding/236]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/236 (236)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 1240c15c-ba64-41f4-91b0-6f7f006025b1
+      - 39705df9-cd05-49ef-b2e5-78c6f65bb839
       Atl-Traceid:
-      - 1240c15cba6441f491b06f7f006025b1
+      - 39705df9cd0549efb2e578c6f65bb839
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:11 GMT
+      - Wed, 30 Apr 2025 16:23:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -813,7 +900,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=278,atl-edge-internal;dur=17,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=413,atl-edge;dur=286,atl-edge-internal;dur=17,atl-edge-upstream;dur=269,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="l9R2x3dKxnjfuqw1UTfmrBUU5g8ZcS8GfUBrvkVenHl_Jc9-B22mZg==",cdn-downstream-fbl;dur=416
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -822,10 +909,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9fe7d47ea2a815113a41181f1d63f69e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - l9R2x3dKxnjfuqw1UTfmrBUU5g8ZcS8GfUBrvkVenHl_Jc9-B22mZg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4e03322c8aa6526a991704cdfe1c0e77
+      - 155b34752b0ce19b083a1cbab3700d3a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -849,128 +944,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16076
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18159
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZlsvfiljoBhyBJ3y5ZlWeK0wNIiYKizzJoiNZKK7bX97zvq
-        xW4Tq0MyrDCQiDze3XN3D4/33oN1QWXqJZ4GmYKG9CUHkRpf0hyMb9gCcuqrAjS1XEnjQ8ptDpb6
-        bEFlBkJl/j1ogzJIL6HQYEDa5iwrjVX53Bm8jcIwCvsa/irB2NmmgAtNmeUMPN/jzn80Dl+McWFA
-        zHG5sLYwSRCkMAdmU/VO9akV1BhOZV+CDdCTDWjBgzjgxpQQtAaWsEH989n0ataLRocxblUQjJe8
-        9wxiKw2jFjKlN3UMKa5QIw7jUS+MelE4i8MkGiWIdxLG3yHu0IF0TiwCr8w8E6TTD9Be6FDVYTeL
-        FAzTvHCJw90jYnIqhE9SbiyXzJKCAwOi5mSl9LLvtJmS11o8EUUpuSsXFbf0nlqqg3sOq6CCtQPY
-        iKJwEE1+MPxv+D7Hspc5enW0QJczapauVuWddV/JnAoDvlcrnmJcla7vLTgSR7PF5gzuAbGGH33P
-        cmRWgSzxEllijN4DmgzCVlBo9Q4jembCG+0q3VUB23S7xSck2UV1Lbm1aMB4W9+Oqb9WZ42a2xXV
-        jq+G54XgCDh9EDnWo2LZcLIeTp4I9wuVaSPZ1mUYvkAY8XAdD/9fL3X1Ky6iw2i8jsZfw+G69TiI
-        14P4a3hsCP7x42M6Rl08jVvBnK9f1T0Qq3/z9vHJQXuSZpmGDPvNo0uAAShR1td/v7tRl2DcJXjR
-        IYg7BZMuweFjnHXbrHddU6peCC/pRbikFh+OuuE+/eLW7XzXwIPanHbXsvo8VqVLXOSa8mu3wWXm
-        JVaXgOVDo/YVVtxdzhpcZc/Z15zVCX7/aM9hRWWzUKVIT7gpBN00l9tRQgMG6/rHvkdiOJ60j8TD
-        tG1b2UNBF6niLakKzZXmdvPMJLbqwfBpbwXPaQYmcBqmNcJxQ6hV39xnu2Z5plZtUx16j69NvOW8
-        oHfg2uKei+G6yd40RF0MjSYuHwtqpgVnZ1wuXzrJCRRuepGsrVlVyVUl2+5IJac4vNA7AZdATc0D
-        3Xx5F2fXP52e356dHk/Pr6a308vL3y8xPrylBhOCB2YLIBfY/6Ulzi/hhigpNgR7CRfOKLGK/MI1
-        JRcacmwmpDTI2f6+nhLhdfLCDzwMi3yeePWbiLXD5O/u1Ge9AsuQcUnFw0PN7NWkt2K1QHTN2tU1
-        k7A9XRbu0nbxeDQ8bHlcj0nPpF6tvH13P59snsbGHd1+pGyJw2ZLudZ47eu4mef+E+B2KAza2Sxu
-        xwQJjupMCaXPazR3ooReprFH7EYiRU5UXWyVFzgOS7uf9KOupjDaNoUvVfzzdL6Ru9/BjFsBBwm5
-        qWh4VHAyQ20y+OCSgbkQilGxUMYmk3ASBnMuU+ycQTwYv630T6pcYRjvFHEsSg7Iv2qSb/DPt5X6
-        Fc54ruWgGjaHBtNJCeQE4ePmb3RDotAnjntbzMevpyi6wX+9cTSskLqysRX0c2419JXOAmQtdZXk
-        OKA5tgd4tL+wuahw13ZeOTvXcinV6tOcXGiVlvjkT2WG9zjHqgQuKc7nFbDS4SU/q1XPqo4sFY2B
-        +C0JyE2E+fyjpNqCJjuTHaqw8xlV2n8eXZArRmXHeTd7BofhNqh9PyzStv4HyRt5RJhSSw4EeyK5
-        A5DEgCUrbvEls8Ri0zIuTCBzQTOfrBacLUgOVBoU0vpEYwGBvZF3QChj2PUgJfeckhKJzPQ/AAAA
-        ///sWW1r2zAQ/iumUEih9pzEWZJB6ULZYB/KRgsrlEFQ/NKYxpLxS9LQ5b/3OUnREs8qo4ySD4F+
-        SCPp7nS6e+65yzoHbGAf57Eql5625hoP8iDbPTLmbh5zCgKHGZkC3WAKZWgLS+xdxk7KE1Fk8owj
-        CsJRhtWSYAwQ+hjzczIKwtPKUfXYYYsVW9P1nJxJy+oS4ecw7uwYh16OxwsPz1LSfc3t1P1/cXIA
-        aSP/wAJtYbk1kQSWNZzTaqm+78473CBZUA3gKrq5ftDVauWJFStzGbbIkvjJy+e5DDkomELeVOud
-        sgrkY1bj0aed73eT2x/u7bWLwimTSSrIBcUZhWqHRVnKz5zO2e8M5aYSnxAkf/ONgSm6zYJjw5xu
-        YFswdJPAqEKz/ihZFrGkxtbAkMPGgm+jrL6t7vum7stXk/SnfaONqfrGmL362URROJ+Fc0pNhdFl
-        nWWMCshJAzvJycT+RPHG4kIs4BIpRZz1W3QxiPqj4WjWHfpxPxz74XjQS8bdhAYXZhM0vLItpgiY
-        RBF0oMCg2kTrzzuGoPqQrFf7UZUSHgqY3EZntj1REINjsagbBB+H4Wg46I9n4WzoQ33C4mQUXkYX
-        Usppf3La+4o/dc7NGNdY57rqq9KrS3cFR7g9j0DUy+vZIg3JU27OWEmOwnmJ6WBo+HiF+PdyTkW+
-        2dsevsXN5vjwLW4214duMZAnUp2ZZmFXCH2wiiSpwzCVCUSwrTpBhVv34GHY+KUuBNr/eyBKOP+T
-        aTTcwapJXdKgR1rt1C2wwWhg6+cC0881FwxUFxrnj/jybpF0xJf3sPiILy340oQBw78MXYHVDyr3
-        nmkKrT/7UCgqpmfoTSlWomXFJSsD67Ujn20g49soJwFC64Jvo5x924m+4XQxX6aF4Iq3qa+iWv+A
-        o/79J++JTEl43n7UcP8G+N357enDVu75ScaebuKyXpDgHd1yXlFUk0rZsRTV/xuSKmFGKHShI/wp
-        5LhnO8ekMS0NUUilMWTf2t6eufqAdM9ms3kBAAD//wMA2B+XAy8cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18159","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159","key":"NTEST-1832","fields":{"statuscategorychangedate":"2025-04-30T18:23:51.540+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:51.255+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:51.338+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 3|http://localhost:8080/finding/236]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/236 (236)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 10f84f5b-dc90-47de-aedc-31775e8423e7
+      - a637266f-e145-48c0-973c-275e6ecd553a
       Atl-Traceid:
-      - 10f84f5bdc9047deaedc31775e8423e7
+      - a637266fe14548c0973c275e6ecd553a
       Cache-Control:
       - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:15:11 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=307,atl-edge-internal;dur=13,atl-edge-upstream;dur=294,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - 5df82e132a19d3bf3c18ea0672875886
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TtfvIDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC18LjtDeHkLYTO88mkQYUyNO7dZSIY4b0WNrMYyIg02ndG7P/Bl9jvtMQG/ccaTbdCG7D/
-        65KVs8oMaCX+LrnD3mtnI0wBaAYZjMvN5WO5fqh+ppuhrWNF+HOCRjCCl+jEzrh9G6+s9l2yrYwb
-        mhiqB22arwjhMcDm81PzSoQEMmDFGOgYlhVjPJ/yPIoBLiDCMe/jH7CvdHvOUqgYcFpwSrNlXnyz
-        sr2xykUwp7OFFIAFKkmncxS5UrkCqdhyWixqNcuRzRSwM0EwyXCre5FeiEoMJtw5KVL7QMypImhf
-        tyU5nh/25GyaXN9X5PgJAAD//wMAXjYbdyACAAA=
-    headers:
-      Atl-Request-Id:
-      - 99bf6f9f-e6ab-4431-b60e-551f548ac6e4
-      Atl-Traceid:
-      - 99bf6f9fe6ab4431b60e551f548ac6e4
-      Cache-Control:
-      - no-cache, no-store, no-transform
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:11 GMT
+      - Wed, 30 Apr 2025 16:23:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -980,7 +990,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=187,atl-edge-internal;dur=26,atl-edge-upstream;dur=164,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=318,atl-edge;dur=285,atl-edge-internal;dur=15,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="RWY2b5xZRIVEY2ORoueQ7fAXlSLyD2FObJ1F9NIVI0jfbp-MPxY-vA==",cdn-downstream-fbl;dur=322
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -989,109 +999,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - RWY2b5xZRIVEY2ORoueQ7fAXlSLyD2FObJ1F9NIVI0jfbp-MPxY-vA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e8e13b851171218e4de9e9ed650ee738
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16076
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa2/bNhT9K4Q+bZlsPey4joBhyBJ3S5dlWeK0wNIiYKhrmTVFaiQV22vz33ep
-        l9vEbpEMKwwkIi/v+/DwfvBgVVCZeomnQaagIX3JQaTGlzQH4xs2h5z6qgBNLVfS+JBym4OlPptT
-        mYFQmX8H2qAM0gsoNBiQtjnLSmNVPnMGb6IwjMK+hr9LMHa6LuBcU2Y5A8/3uPMfjcIXI1wYEDNc
-        zq0tTBIEKcyA2VS9V31qBTWGU9mXYAP0ZANa8CAOuDElBK2BBaxR/2w6uZz2ov2DGLeqEIyXfPAM
-        xlYaRi1kSq/rHFJcoUYcxvu9MOpF4TQOk2g/wXjHYfwDxh26IJ0Ti4FXZp4ZpNMP0F7ooqrTbhYp
-        GKZ54QqHu4fE5FQIn6TcWC6ZJQUHBkTNyFLpRd9pMyWvtHhiFKXkrl1U3NA7aqkO7jgsgyqsTYCN
-        KAoH0fgnw/+BH3Nse5mjVwcLdDmlZuF6Vd5a95XMqDDge7XiCeZV6frenCNwNJuvT+EOMNbw3vcs
-        R2QViBIvkSXm6D2AySBsBYVW7zGjZxa80a7KXTWwLbdbfAKSTVZXkluLBozX+XZI/a06a9TMLql2
-        eDU8LwTHgNMHmWM/KpQNx6vh+InhfqEzbSZdX4bhCwwjHq7i4f/rpe5+hUV0GI1W0ehbOFy1Hgfx
-        ahB/C48NwO/vH8Mx2oXTuBXM+Op1zYHY/et3j08O2pM0yzRkyDdfvQT7rQAzU6KseWH70dEuwYsd
-        gninYLxLcPA4nJo2611HStUL4SW9CJfU4sNRE+7TL25N5xsCD2pz2l3L6vNIla5wkSPlN26Dy8xL
-        rC7hvuFpZ01zVlftw6M9FxkeNXNVivSYm0LQdXOVcRvDsq8RM+56N9XQgMk6/tj2SAxH4/aReFi2
-        jsoeCnaBKu5AVWiuNLfrZxaxVQ+GT3sreE4zMIHTMK0RjhtCLfvmLtuQ5alatqQ69B5fm7jDvKC3
-        4Ghxy8VwbLK1DNEuhEZjV485NZOCs1MuFy+d5BgKN71I1nax6u2yknU7UskJDi/0VsAFUFMjQzdf
-        3vnp1S8nZzenJ0eTs8vJzeTi4o8LzA9vqcGC4IHpHMg58r+0xPkl3BAlxZogl3DhjBKryCuuKTnX
-        kCOZkNIgZvvbOCXC6+SFH3kYFvks8eo3EXuHxd/cqc+4AtuQcUnFw0PN7NWUt8K5wOiatetrJqE7
-        XRbu0u7C8f7woMVxPSY9E3q1cvfufj7ZPA2NG7j9TNkCh80Wcq3x2tdRM8/9p4DboTBoZ7O4HRMk
-        OKgzJZQ+q6O5FSX0Mo2ssRmJFDlWdbNVXuA4LO120O93pPClxj5U6gjj83K+lZvf3pRbAXsJua5g
-        eFhwMkWzZPDRFQNrIRSjYq6MTcbhOAxmXKbInEE8GL2r9I+rWmEa7xVxKEr2yFc1yXf45/tK/RJn
-        PEc5qIbk0MR0XAI5xrxw83e6JlHoE4e9LuajNxMUXeO/3igaVpG6trEl9HNuNfSVzgJELXWd5Dig
-        ObQHeLQ/t7mo4q7tvHZ2ruRCquWnNTnXKi3xyZ/IDO9xjl0JXFGcz0tgpYuX/KqWPat2VKloDMTv
-        SECuI6znnyXVFjTZmNyhChufUaX91+E5uWRU7jjvZs/gIOyS2vbDJnX930veykPClFpwIMiJ5BZA
-        EgOWLLnFt80Si6RlXJpAZoJmPlnOOZuTHKg0KKT1icYCBvZW3gKhjCHrQUruOCUlApnpfwEAAP//
-        7Flta9swEP4rplBIofacxFmSQelC2WAfykYLK5RBUPzSmMay8Uvc0OW/9zlJ0RItKqOMkg+BfnBt
-        6V6ku+eeu6wKwAbWcR7LAuopa65xIQ+i3SNj7uYxpyBwmJaZoxtMoQxtYYW1y9hJeZKXmdjj5CXh
-        KMPXimAMEPoY83MyCsLT2pEV2mGLlq3IPadgwrKmQvg5jDtbxqGX4/HCw7VU5K/2Tvr/i9MBkDY6
-        H1igLKw2JpLAqsHh7LVU+bt1DzdIFlQDHBV5ri60bVsvb1lViLBFlsRPXjEvRMhBwRTypkrvlNWg
-        I7MGlz7tfL+b3P5wb69dFE6RTEJBkVOcUah2WJSl/MzpnP3OUG7q/BOC5G++MdBF1yw4NiLSDbbB
-        qEZP/ijIFNEjc6mmpMYH3/Yh0KzR3KHrvrgcwXL2L7TxAN/GVH2tc6d+mvCKw2fhnFJTYnTVZBmj
-        AnJiYCcdMrG/vHxjcSEWcImUIs76LboYRP3RcDTrDv24H479cDzoJeNuQoMLvQgaXlkWUwRMogg6
-        UGBQbaLV5y1DUH1I1qv9qEwJDwVMLKM9m54oiMGxWNQNgo/DcDQc9MezcDb0oT5hcTIKL6MLIeW0
-        PzntfcWf3OdmjCusc135qvKaym1xEG7PIxD1ima2SEM6KbdgrKKDwn6B6WBoeLxC/HsFpyJv9raH
-        b7HZHB++xWZzfegWA5Ii2aspFnaF0AerSJImDFORQATbshOUgHYPHoaFX5oyR/t/D6gJ538yjYY7
-        +KpTlzSokdZ+6hbYYDSw9XOB7udKBedHGHm3gDnCyHtYfISRPTBiwoCNmAWaf2m6AnceZFI+0xRa
-        PfuwJK+ZmqGbUmwMzLfhkt/bD3C2gYxvdcDK0LRn5g4bdetbP2hOF/NlWuZc8jb5KmrUDzjy3385
-        vWVe/7/hpBSmhUITOrGfuRizbCaKSAFp8vPmUdWXNxsgfuz6sJF7fpKxp5u4ahYkeMtZMSAp60kt
-        HacxLQ1RyHX9fndzb2e32iCsXa/XLwAAAP//AwCEUmvYLxwAAA==
-    headers:
-      Atl-Request-Id:
-      - 6a802c45-3a6a-4495-87ff-d4f4e0a3e5e2
-      Atl-Traceid:
-      - 6a802c453a6a449587ffd4f4e0a3e5e2
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:15:12 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=303,atl-edge-internal;dur=14,atl-edge-upstream;dur=289,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - fefbc11a255e86437222d5ed58a80b1d
+      - 824fb8a1b6fda208caab991bb226f23c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1118,26 +1037,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmB5AjSBZcUYz2Y8C2KACwhwyLvwBxyqtjtnKVQMOM05ZWnBim9W
-        djdG2QBmdL6QAjBHJemsQJEplSmQii1n+aJW8wzZXAE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMAGM2CUiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:23:53.078+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 03655e4f-e2e2-4925-9797-85abc69d7708
+      - be5baa6a-2a6c-4b44-b224-3ab4966b1815
       Atl-Traceid:
-      - 03655e4fe2e24925979785abc69d7708
+      - be5baa6a2a6c4b44b2243ab4966b1815
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:12 GMT
+      - Wed, 30 Apr 2025 16:23:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1147,7 +1062,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=169,atl-edge-internal;dur=18,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="q2JcJofduVzwhHNgc7ksFnxJGNgKu2n_jlUPBjyw0Fu4Mj3msbSL5g==",cdn-downstream-fbl;dur=254,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=251,atl-edge;dur=167,atl-edge-internal;dur=13,atl-edge-upstream;dur=154,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1156,10 +1071,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c80d7d73c19744418338fdf12216d306.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - q2JcJofduVzwhHNgc7ksFnxJGNgKu2n_jlUPBjyw0Fu4Mj3msbSL5g==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 8073dedf38870432afadb27637692e66
+      - a5aad0b948364700b71f7650bdd80d22
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1183,60 +1106,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16076
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18159
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa2/bNhT9K4Q+bZltPey4joBhyBJ3S5dlWeK0wNIiYKhrmTVFaiQV22vz33ep
-        l1snapEMKwwkIi/v+/DwfvBgnVOZeLGnQSagIXnJQSSmJ2kGpmfYAjLaUzloarmSpgcJtxlY2mML
-        KlMQKu3dgTYog+QCcg0GpK3PssJYlc2dwZswCMJgoOHvAoydbXI415RZzsDredz5D8fBizEuDIg5
-        LhfW5ib2/QTmwGyi3qsBtYIaw6kcSLA+erI+zbkf+dyYAvzGwBI2qH82m17O+uH+QYRbZQjGiz94
-        BmMrDKMWUqU3VQ4JrlAjCqL9fhD2w2AWBXG4H2O8kyD6AeMOXJDOicXASzPPDNLp+2gvcFFVadeL
-        BAzTPHeFw91DYjIqRI8k3FgumSU5BwZEzclK6eXAaTMlr7R4YhSF5K5dVNzQO2qp9u84rPwyrG2A
-        tSgMhuHkJ8P/gR8zbHuRoVcHC3Q5o2bpelXcWvcVz6kw0PMqxRPMq9TteQuOwNFssTmFO8BYg/ue
-        ZzkiK0eUeLEsMEdvBybDoBHkWr3HjJ5Z8Fq7LHfZwKbcbvEJSLZZXUluLRowXuvbIfW38qxRc7ui
-        2uHV8CwXHANOdjLHfpQoG03Wo8kTw/1CZ5pM2r6MghcYRjRaR6P/10vV/RKL6DAcr8Pxt3C4bjwO
-        o/Uw+hYea4Df3z+EY9iF06hLMGwEc75+XZEjwuL6HcIkTTWkyDdfvQT7jQAzU6KoeOHxo+MuwYsO
-        QdQpmHQJDh6GU9FmtetIqXwhvLgf4pJafDgqwn36xa3ofEvgfmVOu2tZfh6pwhUudKT8xm1wmXqx
-        1QXc1zztrGnOqqp9eLDnIsOjZqEKkRxzkwu6qa8ybmNY9jVixl3vuhoaMFnHH489EqPxpHkkdsvW
-        UtmuoAtUUQuqXHOlud08s4iNuj962lvBM5qC8Z2GaYxw3BBqNTB36ZYsT9WqIdWR9/DaRO0lEPQW
-        HC06/O9OBF3QDbsQGk5cPRbUTHPOTrlcvnSSY8jd9CJZ08Wyt6tS1u5IJac4vNBbARdATYUMXX95
-        56dXv5yc3ZyeHE3PLqc304uLPy4wP7ylBguCB2YLIOfI/9IS55dwQ5QUG4JcwoUzSqwir7im5FxD
-        hmRCCoOYHTzGKSFeJy/4yIMgz+axV72J2Dss/vZOfcYV2IaUSyp2D9WzV13eEucCo2voBvuaSmhP
-        F7m7tF043h8dNDiuxqRnQq9Sbt/dzyebp6FxC7efKVvisNlArjFe+Tqq57n/FHAzFPrNbBY1Y4IE
-        B3WmhNJnVTS3ooB+qpE1tiORIseqarbKchyHpX0c9PstKXypsbtKLWF8Xs63cvvbm3ErYC8m1yUM
-        D3NOZmiWDD+6YmAthGJULJSx8SSYBP6cywSZ04+G43el/nFZK0zjvSIORfEe+aom+Q7/fF+qX+KM
-        5ygH1ZAc6piOCyDHmBdu/k43JAx6xGGvjfnozRRF1/ivPw5HZaSubWwFg4xbDQOlUx9RS10nOQ5o
-        Du0+Hh0sbCbKuCs7r52dK7mUavVpTc61Sgp88qcyxXucYVd8VxTn8xJY4eIlv6pV36qOKuW1gegd
-        8cl1iPX8s6DagiZbkx2qsPUZltp/HZ6TS0Zlx3k3e/oHQZvUYz9sUtv/vfitPCRMqSUHgpxIbgEk
-        MWDJilt82yyxSFrGpQlkLmjaI6sFZwuSAZUGhbQ6UVvAwN7KWyCUMWQ9SMgdp6RAIDP9LwAAAP//
-        7Flta9swEP4rplBIofacxFmSQelC2WAfykYLK5RBUPzSmMaS8UvS0OW/9zlJ0RLPKqOMkg+Bfkgj
-        6e50unvuucs6B2xgH+exKqCetuYaD/Ig2z0y5m4ecwoChxmZAt1gCmVoC0vsXcZOyhNRZPKMIwrC
-        UYbVkmAMEPoY83MyCsLTylEV2mGLFVvT9ZycScvqEuHnMO7sGIdejscLD89S0n3N7dT9f3FyAGkj
-        /8ACbWG5NZEEljWc02qpvu/OO9wgWVAN4Cq6uX7Q1WrliRUrcxm2yJL4ycvnuQw5KJhC3lTrnbIK
-        dGRW49Gnne93k9sf7u21i8Ipk0kqyAXFGYVqh0VZys+cztnvDOWmEp8QJH/zjYEpus2CYyMi3cC2
-        YAgooVSFZv1RsiziTY2tgSGHjQXfyGgu2Oq+b+q+fDVJf9o32piqb4zZq59NeIXzWTin1FQYXdZZ
-        xqiAnDSwk5xM7E8UbywuxAIukVLEWb9FF4OoPxqOZt2hH/fDsR+OB71k3E1ocGE2QcMr22KKgEkU
-        QQcKDKpNtP68YwiqD8l6tR9VKeGhgMltdGbbEwUxOBaLukHwcRiOhoP+eBbOhj7UJyxORuFldCGl
-        nPYnp72v+FPn3IxxjXWuq74qvbp0V3CE2/MIRL28ni3SkDzl5oyV5Cicl5gOhoaPV4h/L+dU5Ju9
-        7eFb3GyOD9/iZnN96BYDeSLVq2kWdoXQB6tIkjoMU5lABNuqE1S4dQ8eho1f6kKg/b8HooTzP5lG
-        wx2smtQlDXqk1U7dAhuMBrZ+LrANCQID1YXG+SO+vFskHfHlPSw+4ksLvjRhwPAvQ1dg9YPKvWea
-        QuvPPhSKiukZelOKlWhZccnKwHrtyGcbyPg2ykmA0Lrg2yhn33aibzhdzJdpIbjibeqrqNY/4Kh/
-        /8l7IlMSnrcfNdy/AX53fnv6sJV7fpKxp5u4rBckeEe3nFcU1aRSdixF9f+GpEqYEQpd6Ah/Cjnu
-        2U42aUxLQxRSaQzZt7a3Z64+IN2z2WxeAAAA//8DALOxzUQvHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18159","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159","key":"NTEST-1832","fields":{"statuscategorychangedate":"2025-04-30T18:23:51.540+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:51.255+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:51.338+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 3|http://localhost:8080/finding/236]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/236 (236)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 655283a6-3cf4-4392-900d-0d845b220e38
+      - 6b670f7b-3509-4169-aefd-0eca51fc4c76
       Atl-Traceid:
-      - 655283a63cf44392900d0d845b220e38
+      - 6b670f7b35094169aefd0eca51fc4c76
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:13 GMT
+      - Wed, 30 Apr 2025 16:23:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1246,7 +1152,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=264,atl-edge-internal;dur=14,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=340,atl-edge;dur=252,atl-edge-internal;dur=17,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="vVpQ3QFQQDdtZhUM4hBQ0EkGU7kHp2q4ZSanq1WCZLySskOM9FAG8A==",cdn-downstream-fbl;dur=344
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1255,10 +1161,180 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ed78483d37e5338746e5a4b545e5818e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - vVpQ3QFQQDdtZhUM4hBQ0EkGU7kHp2q4ZSanq1WCZLySskOM9FAG8A==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 25f71426b4057a9bbabb368e97e935ec
+      - 629dee93735f6ec03acb2dd48399b43d
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:23:53.951+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
+    headers:
+      Atl-Request-Id:
+      - 9855d93e-5b0d-4dbe-8a1e-8016178d0966
+      Atl-Traceid:
+      - 9855d93e5b0d4dbe8a1e8016178d0966
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:23:53 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=32,cdn-upstream-fbl;dur=273,atl-edge;dur=143,atl-edge-internal;dur=15,atl-edge-upstream;dur=128,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="16Qf7AgGwEHa6EAaWtdqEsnPQIARc818Ti-YMiv8Z5EMs1NYAlAQuA==",cdn-downstream-fbl;dur=276
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 c31337642f54c5bd34bb485701d02e8a.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 16Qf7AgGwEHa6EAaWtdqEsnPQIARc818Ti-YMiv8Z5EMs1NYAlAQuA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - dcb7d0ae868cbb87086643b459a1ed46
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18159
+  response:
+    body:
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18159","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159","key":"NTEST-1832","fields":{"statuscategorychangedate":"2025-04-30T18:23:51.540+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:51.255+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:51.338+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 3|http://localhost:8080/finding/236]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/236 (236)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
+    headers:
+      Atl-Request-Id:
+      - 8913cb8b-9aa5-4f6b-be45-a391f9ed4e0c
+      Atl-Traceid:
+      - 8913cb8b9aa54f6bbe45a391f9ed4e0c
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:23:54 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=257,atl-edge;dur=224,atl-edge-internal;dur=17,atl-edge-upstream;dur=207,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Ne95likRpMWRaa_AgMpJ7ZDuOSn3g4lfeAc4DL53cfgrP2iyM1yoGQ==",cdn-downstream-fbl;dur=261
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Ne95likRpMWRaa_AgMpJ7ZDuOSn3g4lfeAc4DL53cfgrP2iyM1yoGQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - 61c883a9f07172cddd18711c47f6437e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1285,41 +1361,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 19d3f489-746a-4aca-8a18-7f7e00321359
+      - 6f344ea6-a6e7-472e-b3b1-10f3dd2ba492
       Atl-Traceid:
-      - 19d3f489746a4aca8a187f7e00321359
+      - 6f344ea6a6e7472eb3b110f3dd2ba492
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:13 GMT
+      - Wed, 30 Apr 2025 16:23:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1329,7 +1392,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=337,atl-edge-internal;dur=13,atl-edge-upstream;dur=324,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=309,atl-edge;dur=276,atl-edge-internal;dur=15,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="oyJ9Oas0GwZLph86ZVRkzhRx4EMvS3ASWr1DqxFIhAoRkBQK3esmog==",cdn-downstream-fbl;dur=313
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1338,13 +1401,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - oyJ9Oas0GwZLph86ZVRkzhRx4EMvS3ASWr1DqxFIhAoRkBQK3esmog==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d4df97964543bdc623b282099346f384
+      - e24ffacf1181fc666c8ba9496010bd46
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1356,14 +1427,14 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Jira Api Test 3", "description": "\n\n\n\n\n\n*Title*: [Jira Api
       Test 3|http://localhost:8080/finding/236]\n\n*Defect Dojo link:* http://localhost:8080/finding/236
-      (236)\n\n*Severity:* Low\n\n\n*Due Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      (236)\n\n*Severity:* Low\n\n\n*Due Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
       cookie has been set without the secure flag, which means that the cookie can\nbe
       accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -1375,27 +1446,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1155'
+      - '1175'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16076
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18159
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - b24738cc-8fd4-49e8-a45a-d7df16054796
+      - 899f5682-d564-4e5d-8622-e861072fcbfe
       Atl-Traceid:
-      - b24738cc8fd449e8a45ad7df16054796
+      - 899f5682d5644e5d8622e861072fcbfe
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:13 GMT
+      - Wed, 30 Apr 2025 16:23:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1405,17 +1478,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=289,atl-edge-internal;dur=21,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=419,atl-edge;dur=292,atl-edge-internal;dur=29,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="zpfA-IKkbvRDztZqk8CxSTxa6XEVZgu1BHMzjY2XxXqQOMSCdDjW6A==",cdn-downstream-fbl;dur=423
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9fe7d47ea2a815113a41181f1d63f69e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - zpfA-IKkbvRDztZqk8CxSTxa6XEVZgu1BHMzjY2XxXqQOMSCdDjW6A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 862b3b16138ba961c947b7ff44f69156
+      - a19c456879264d7fe538facffa3699a8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1439,60 +1520,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16076
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18159
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8aukk80jIhpGqikK2paWUQmClsitkPDcTbzz21PaQpLv8917P
-        K7uQbAVVV5Fg7Ov7Pj6+HzxYFVSmXuJpkCloSF9zEKnxJc3B+IbNIae+KkBTy5U0PqTc5mCpz+ZU
-        ZiBU5t+DNiiD9AIKDQakbc6y0liVz5zB2ygMo7Cv4a8SjJ2uCzjXlFnOwPM97vxHo/DVCBcGxAyX
-        c2sLkwRBCjNgNlXvVZ9aQY3hVPYl2AA92YAWPIgDbkwJQWtgAWvUP5tOLqe9aP8gxq0qBOMlHzyD
-        sZWGUQuZ0us6hxRXqBGH8X4vjHpROI3DJNpPMN5xGH+HcYcuSOfEYuCVmRcG6fQDtBe6qOq0m0UK
-        hmleuMLh7iExORXCJyk3lktmScGBAVEzslR60XfaTMkrLZ4ZRSm5axcVt/SeWqqDew7LoAprE2Aj
-        isJBNP7B8L/h+xzbXubo1cECXU6pWbhelXfWfSUzKgz4Xq14gnlVur435wgczebrU7gHjDV88D3L
-        EVkFosRLZIk5eo9gMghbQaHVe8zohQVvtKtyVw1sy+0Wn4Bkk9WV5NaiAeN1vh1Sf63OGjWzS6od
-        Xg3PC8Ex4PRR5tiPCmXD8Wo4fma4X+hMm0nXl2H4CsOIh6t4+P96qbtfYREdRqNVNPoaDletx0G8
-        GsRfw2MD8IeHp3CMduE0bgUzvrquORC7f/Pu6clBe5JmmYYM+ebJJcAElCjr67/d3f4uwWiX4NUO
-        QbxTMN4lOHgaZ02b9a4jpeqF8JJe1HCla4nmrE7pw5M9d1Gw2mauSpEec1MIum6uE25jb+019s1d
-        scYFtfgY1ST+fDKon4jNoxDU5rS76tXnkSpdM6rg37gNLjMvsbp00TANmKzjj22PxHA0bh+Jx2Xr
-        qOyxYBeo4g5UheZKc7t+YcKtejB83lvBc5qBCZyGaY1w3BBq2Tf32YYsT9WyJdWh9/TaxB3mBb0D
-        R4tbLoZjk61liHYhNBq7esypmRScnXK5eO0kx1C46UWyFkEVrpaVrNuRSk5weKF3Ai6AmhqVuvny
-        zk+vfjo5uz09OZqcXU5uJxcXv19gfnhLDRYED0znQM6R/6Ulzi/hhigp1gS5hAtnlFhFfuGaknMN
-        OZIJKQ3iq7+NUyK8Tl74kYdhkc8Sr34TsXdY/M2d+owrsA0Zl1Q8PtTMXk15K5QLjK5Zu75mErrT
-        ZeEu7S4c7w8PWhzXY9ILoVcrd+/u55PN89C4gduPlC1w2Gwh1xqvfR0189x/CrgdCoN2NovbMUGC
-        gzpTQumzOpo7UUIv08hYm5FIkWNVN1vlBY7D0m4H/X5HCl9q7GOljjA+L+dbufntTbkVsJeQmwqG
-        hwUnUzRLBh9dMbAWQjEq5srYZByOw2DGZYosF8SD0btK/7iqFabxXhGHomSP/Ksm+Qb/fFupX+KM
-        5ygH1ZAcmpiOSyDHmBdu/kbXJAp94rDXxXz0ZoKiG/zXG0XDKlLXNraEfs6thr7SWYCopa6THAc0
-        h/YAj/bnNhdV3LWda2fnSi6kWn5ak3Ot0hKf/InM8B7n2JXAFcX5vARWunjJz2rZs2pHlYrGQPyO
-        BOQmwnr+UVJtQZONyR2qsPEZVdp/Hp6TS0bljvNu9gwOwi6pbT9sUtf/veStPCRMqQUHgpxI7gAk
-        MWDJklt8Vy2xSFrGpQlkJmjmk+WcsznJgUqDQlqfaCxgYG/lHRDKGLIepOSeU1IikJn+BwAA///s
-        WW1r2zAQ/iumUEih9pzEWZJB6ULZYB/KRgsrlEFQ/NKYxrKx7Lily3/vc5KipZ5VRhklHwL94NrS
-        vUh3zz13eSwAG1jHeayKt6etucSF3Ml2j4y5WcacgsBhRmaObjCFMrSFAmvXsZPyJC8zucfJS8JR
-        hq+CYAwQeh/zUzIKwtPKUezAYauGPZJ7TsGkZbVA+DmMOzvGoZfj8crDtQjy13in/P/F6QBIG50P
-        LNAWiq2JJFDUOJxOS7W/O/dwhWRBNcBRkef6Qpum8fKGiUKGLbIkfvCKZSFDDgrmkDfXeuesAhVa
-        1Lj0ee/7zez6h3t96aJwymSSCoqc4oxCtceiLOUnTu/kd4ZyU+WfECR/842RKbrtgmMjIv3A9sHQ
-        TUKpCs36vWRExNlaS30bMw0Ma2zvMHVfXo5kOd0LbTzAtzFV3+jE+bJwSdmni+FuPW3DraizjFEB
-        OWphJx0ysb+8fGNxIRZwjpQifvktOhtFw8l4suiP/XgYTv1wOhok035CgwuzCBpeWRZTBMyiCDpQ
-        YFBtosfPO4ag+pCsV/tRlRIeCphcRnu2PVEQg2OxqB8EH8fhZDwaThfhYuxDfcLiZBKeR2dSyvFw
-        djz4ij+1z80Y11jnuuqV8GrhNjgId+ARiHpFvVilIZ2UWzAm6KCwX2I6GBoeLxD/XsGpyLd72/23
-        uN0c77/F7eZ63y0G8kSqT9Qs7AKhD1aRJHUYpjKBCLZV16Zw6xY8DAu/1GWO9v8WUBMu/2QaDXfw
-        1aQuadAjrW7qFthgNLD1c4Hp50oN5wcYebeAOcDIe1h8gJEOGGnDgI2YBYZ/GXoCd+5UUj7RFFo/
-        +7Akr5ieobel2BiYb8Mlf9ANcLaBjG91wMrQbMySIKTzw9D6wXC6mK/TMueK1KlXUa1/wFH//svp
-        rfPq/w0SlTAjFJrQif3M5ZhlO81ECiiTn7aPur682QD5Y9eHrdzTo4w9XMWiXpHgHWflgKSsZpVy
-        nMa0NEQh1837l5sHL3brDdLazWbzDAAA//8DAK/nhxYvHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18159","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159","key":"NTEST-1832","fields":{"statuscategorychangedate":"2025-04-30T18:23:51.540+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:51.255+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:51.338+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 3|http://localhost:8080/finding/236]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/236 (236)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 970c413e-d556-44ab-a372-2cec871b022a
+      - 1aeb0f23-25e6-4261-beef-4ff008e7bba1
       Atl-Traceid:
-      - 970c413ed55644aba3722cec871b022a
+      - 1aeb0f2325e64261beef4ff008e7bba1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:14 GMT
+      - Wed, 30 Apr 2025 16:23:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1502,7 +1566,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=273,atl-edge-internal;dur=13,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="uNegs_rC469E6yAFJIJLp6SyA-SlzLg9VTeuDaAx9f4ifb4xEy5PQQ==",cdn-downstream-fbl;dur=363,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=360,atl-edge;dur=274,atl-edge-internal;dur=22,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1511,10 +1575,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 bbfdc39b99d2b072cca90c3f38450aea.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - uNegs_rC469E6yAFJIJLp6SyA-SlzLg9VTeuDaAx9f4ifb4xEy5PQQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 0ae358c7c10197d1a334111a2bfdb5fc
+      - 530ab790904d35be9b94d94a76f9f774
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1540,21 +1612,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1592/transitions
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/transitions
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 15c97d82-18b8-4112-b0b0-413a4ac235d0
+      - 1efa2b32-7305-4707-9da8-f80209c07a3d
       Atl-Traceid:
-      - 15c97d8218b84112b0b0413a4ac235d0
+      - 1efa2b32730547079da8f80209c07a3d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:15 GMT
+      - Wed, 30 Apr 2025 16:23:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1564,17 +1638,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=841,atl-edge-internal;dur=14,atl-edge-upstream;dur=827,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=639,atl-edge;dur=606,atl-edge-internal;dur=16,atl-edge-upstream;dur=590,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="PYnRDmeuSf3kzL5il-2F8bQM04akewsDr3FGEEONSKdkuk6-BkgJHA==",cdn-downstream-fbl;dur=643
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 60b2b330807c6611e06e3923c8e315cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - PYnRDmeuSf3kzL5il-2F8bQM04akewsDr3FGEEONSKdkuk6-BkgJHA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 432edf01e9c3969aad226ef863005118
+      - d1f2754f07d01d9271f5950ebe0714fc
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1601,26 +1683,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1q5b32SCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1QhD8fd
-        75/fcQfScIfbQZOSvHnfu3I6bVGi8K19tyn3mjunuEkNejIhrXK95vt/8BUOOyWwRfexRt2v0Hgc
-        /vrJyhqpRzQCf5fc4eCUNQGmADSFFJJqc/lYrR/qn+lm7JpQkfI5QhOYwEtwYq/tvgtb1vs+2lba
-        jm0INaPS7VeElCHAiuLUvOI+ggxYngBNYFkzVmazMgtigAsIcMi7cAccatWdsxRqBiXNw0uzRfHN
-        iu7GSBvAjM4XggPmKAWdFcgzKTMJQrLlLF80cp4hm0tgZwKvo+FWDTyeECUftb+zgsf2gehTRdC8
-        bityPF/syZo4ub6vyfETAAD//wMAH3la6CACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:23:56.812+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - fb3f2192-0a59-4fcf-9086-5456251a1b46
+      - b86d5c10-8e64-4d7b-8827-c7f1d218407f
       Atl-Traceid:
-      - fb3f21920a594fcf90865456251a1b46
+      - b86d5c108e644d7b8827c7f1d218407f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:15 GMT
+      - Wed, 30 Apr 2025 16:23:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1630,7 +1708,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=177,atl-edge-internal;dur=22,atl-edge-upstream;dur=156,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=200,atl-edge;dur=168,atl-edge-internal;dur=18,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="N8BidY2nIeijgdJXEeqAMlDSKyC__C2lgAPLK05TaXUE6yWyC-yp1w==",cdn-downstream-fbl;dur=205
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1639,10 +1717,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 771067dca4682f83a6c9963c412d66cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - N8BidY2nIeijgdJXEeqAMlDSKyC__C2lgAPLK05TaXUE6yWyC-yp1w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3a9703db0d33d8dc155f9b9ccc3a1c63
+      - 508cb38f388a769052d44c686dbd626c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1666,61 +1752,42 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16076
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18159
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbVPjNhD+Kxp/atMQv+SF4JlO54bk2rtSSiHAB8pkhL1xdNiSK8kk6cF/765f
-        kiMQrtDpDTPB0mpftPvso/3swDLnMnZCR4OMQUP8XkAam7bkGZi2ieaQ8bbKQXMrlDRtiIXNwPJ2
-        NOcygVQl7TvQBmUQn0KuwYC09dmoMFZlMzI49T3P9zoa/irA2MkqhxPNIysicNqOIP/+wNsf4MJA
-        OsPl3NrchK4bwwwiG6tPqsNtyo0RXHYkWBc9WZfnwg1cYUwBbmPgFlaofzwZn032/P5BgFtlCMYJ
-        PzsGYytMxC0kSq+qO8S4Qo3AC/p7nr/ne5PAC/1+6Pc6/cHwB4zboyDJicXASzNvDJL0XbTnUVTV
-        tetFDCbSIqfE4e47ZjKepm0WC2OFjCzLBUTA1IwtlL7tkHak5LlOXxlFIQWVi6dTfsct1+6dgIVb
-        hrUJsBb5Xtcf/mTE3/BjhmUvMvRKsECXE25uqVbFjaWvcMZTA22nUvyA9yp1285cIHB0NF8dwR1g
-        rN5D27ECkZUjSpxQFnhHZwsmXa8R5Fp9whu9MeG1dpnusoBNumnxBUg2tzqXwlo0YJy1b0Lqr+VZ
-        o2Z2wTXh1YgsTwUGHG/dHOtRoqw3XPaGrwz3hco0N1nXpeftYxhBbxn0/l8vVfVLLKJDf7D0B9/C
-        4bLx2A2W3eBbeKwB/vDwFI7+LpwGuwTdRjATy4uKHBEWV9cIkyTRkCDffLUJ+o0Ab6bSouKFN/XB
-        xsDzrfCYeS6RXticG3YDIFmkEOlgIWZKMjsXhpUsQfxT98wIid95JmuDXRfb3yEIdgqGuwQHT3P0
-        Epf3gobLiUPLB80J93xccovvXPU+vD6/1euzeW/cypwmFik/D1VBdfbpDbmkDSETJ7S6AMwbGrUX
-        CFDikuoypT2yr0XUlH17j2JFZTNXRRqPhMlTvqq5iGqhAdNANX6aB6/T27xp2wldM++2YFcPBOse
-        yLVQWtjVG5PYqLs9gue/f9pExhMwLmmYxojAjVQtOuYu2eD0SC0a4PeewWvQbTpi2gpbU7/87XkH
-        B9PWfYsOeMEXAspdym+A2J7aenvQ2QV+fxfG/SHlDdtunIvoSMjb9yQZQU5DmYya2pYVX5Sy9Y5U
-        cowzGb9J4RS4qfCi6y/n5Oj85w/H06MPh+Pjs/F0fHr6+ykGj+RjMHF4YDIHdoLPmrSM/GJ/Y6un
-        K4YUKVIyyqxiH4Xm7ERDhhzJCoPY7jxHlT42pOPdC8/Ls1noVE891hiLRF1Z3fwRBWK5EiF5un2o
-        Hinr9JboTzG6hkWx/omE9ekip7Z/Hu80w+03eK+mvzdCtFJeT2+PafN1qN2iz61RsHJ0WM+o/yna
-        ZtB1u7WTbjP6xJXjSKVKH1exYF1AboVWVhkfAfyW9nm093exRn/NGi+V+nEe/5Sbv9ZE2BRaIbsq
-        8fcuF2yC2qx7T4nAPKQq4ulcGRsOvaHnzoSMkVrdoDu4LvVHZZ7YCBPFCD5hi31Vk32HP9+X6mc4
-        sxInoRqyRx3TqAA2wvBx8ze+Yr7XZgS6dcyHl2MUXeG/vYHfKyOlkkUL6GTCaugonbgIV05VFDhw
-        EsxdPNqZ2ywt467sXJCdc3kr1eLLnJxoFRc4woxlgg2cYVVcSgr5PIOooHjZL2qxZ9WOLOW1geCa
-        uezKx3z+UXBtQbONySeq/wAAAP//7Flta9swEP4rolBoR+06ibMkhdKFssE+lJUWViiFoMhyYhrL
-        xi91y9b/vuckRU29uIwySj+U5IMTSXcn6e65585mqXzS2dOrr6fn7FJw1TGfuPThJHCb2vbBJbn7
-        /3R0o6bgHNltIp84SCkr1iQVUl0FCiLxG9uULF7xxQFrlolYslRyVWKQmxlWAgy7UXPJuBCAO3CY
-        u4SzGo4sioecOA0CVkmTT31rzRkuZKHLVzLmaikVOQHjTmaG6jaBMpS5JebeSZaoOCtSvYZlBQEo
-        x2hJ+AXsvJXqgIyC8KRiJmEzvmr4A22P5VxbVpdwP8YV2zAOtamSKx/XUtJ+3e7M/m8UHQBpo/OB
-        BdbCcm0iCSxrHM5WS+1+N+7hAsGCNICjop3bC22axs8aXubabREl8t7Pl7l2OSiYQd7M6p3xCuxk
-        XuPSZ3s/rqaX597lmQdE08GkFeQZ+Rm56h6P0kTts7393ynyTJUdwUn+JiRDx6TbmaYLc3ph14Aj
-        1ARGVcHFraZhRKNaU0PHK1sDgZPRHuhK+IFL+PrWND/aPrGL5AbOmGeJs42iOHwulhSaBqPLOk05
-        JY+dFnbSIRM9zIpXJhZK/ycIKSK136PjYTQYj8bz3iiQAzEJxGTYjye9mBoxbhI0vDBNkgdMowg6
-        kGCQbaKHLxuGIPuQrBfraxMS/qIw02jNusYLJcgVj3ph+HkkxqPhYDIX81EA9TGX8VicRMdayu5g
-        utv/hq9Z56VcWazzPPNX6del1+AgvL5PIOrn9XyVCDopL+e8pIPCeo3poGZ4PIX/+7kiFtqu1d+/
-        xe1i//1b3G4WvHeLgTyRKd0sATuF64NVxHEtRKIDiGDblIoGt66Jkx3tfK2LLJeH10AUsXyKNGpW
-        YdSFLmmwLbrt1C3sgtGwq+ALu5oeoYPqwuL8B768mSd94MtbWPyBL1vwpQ0Djn85ugKrFyb2flFX
-        3T4HUJhV3L4TaEvpJFqduNTJwPrbka+rExN0UU4ChK0DQRflHHStGDhOJ9VdUmTK8DbzV1TbF1Lm
-        5z+dXpYaCb/WjxbuXwG/G+/SDtdyD3ZSfn8hy3pFgjd0615FUU0rY8ddVv2/LqoR5oRCFyrCn5nu
-        86wbndTHXWXE4jcMeW5t/5m5doE+nsfHxz8AAAD//wMAby/Ljf8cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18159","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159","key":"NTEST-1832","fields":{"statuscategorychangedate":"2025-04-30T18:23:56.152+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:23:56.128+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:51.255+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_4897_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:56.152+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 3|http://localhost:8080/finding/236]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/236 (236)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1832/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18159/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - efc68561-acf5-4712-b69f-a82293725c6a
+      - 1713c299-e55c-4f03-8cb3-2936d4aa75aa
       Atl-Traceid:
-      - efc68561acf54712b69fa82293725c6a
+      - 1713c299e55c4f038cb32936d4aa75aa
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:16 GMT
+      - Wed, 30 Apr 2025 16:23:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1730,7 +1797,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=441,atl-edge-internal;dur=14,atl-edge-upstream;dur=426,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=642,atl-edge;dur=608,atl-edge-internal;dur=15,atl-edge-upstream;dur=593,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="sOoXbvVcjL9O9VjTJVDRKSXYBbDuCuzbUNXlNEj6G-xPerh6JFnY5A==",cdn-downstream-fbl;dur=645
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1739,10 +1806,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 771067dca4682f83a6c9963c412d66cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - sOoXbvVcjL9O9VjTJVDRKSXYBbDuCuzbUNXlNEj6G-xPerh6JFnY5A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - b9e94f8cc25252f82d54dc21a03d3292
+      - 175363aa17b659914027d2fb5edabc0b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1769,26 +1844,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1nZb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwCbz0/NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4DTntEiLPP9m
-        ZXdjlA1gRouFFIA5KklncxSZUpkCqdhyli9qVWTICgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMARjbH1SACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:23:58.125+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 918752df-33cb-474e-a321-a4ab04e5e27e
+      - 4519ae0c-75ae-459d-a569-94163135ab28
       Atl-Traceid:
-      - 918752df33cb474ea321a4ab04e5e27e
+      - 4519ae0c75ae459da56994163135ab28
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:16 GMT
+      - Wed, 30 Apr 2025 16:23:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1798,7 +1869,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=184,atl-edge-internal;dur=13,atl-edge-upstream;dur=171,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=297,atl-edge;dur=166,atl-edge-internal;dur=17,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="wKh1MqyV-2zXtG6XJ5dE6EM1VcILZHgm3b203B1rQZ-ke1T2Y_Yfdg==",cdn-downstream-fbl;dur=302
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1807,10 +1878,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ad310b4d7c581c35032fa3fce068e53c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - wKh1MqyV-2zXtG6XJ5dE6EM1VcILZHgm3b203B1rQZ-ke1T2Y_Yfdg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e8cd7726be4bb2aa152b29373499a484
+      - d0f2bc94a4e1d6f1b848b61e162d214c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1837,41 +1916,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - a5e92b23-0a21-47a8-a59f-4f04b86f8a12
+      - 1f695ad4-a578-4dc6-a62c-7e9ea3ecfc5f
       Atl-Traceid:
-      - a5e92b230a2147a8a59f4f04b86f8a12
+      - 1f695ad4a5784dc6a62c7e9ea3ecfc5f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:17 GMT
+      - Wed, 30 Apr 2025 16:23:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1881,7 +1947,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=287,atl-edge-internal;dur=13,atl-edge-upstream;dur=274,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="0fmbjwNAnrkpMLtLpBEiLuopUfGyKFi1ISJqdbKkm56Myw_snY9j2A==",cdn-downstream-fbl;dur=426,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=423,atl-edge;dur=340,atl-edge-internal;dur=21,atl-edge-upstream;dur=319,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1890,13 +1956,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 13926aef629bc9518d9ad769185e8c4e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0fmbjwNAnrkpMLtLpBEiLuopUfGyKFi1ISJqdbKkm56Myw_snY9j2A==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 93b1e515cdfe9f3680565dff9d5ff991
+      - a98a943824a748768b23f6d31f335dd4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1908,14 +1982,14 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Jira Api Test 4", "description": "\n\n\n\n\n\n*Title*: [Jira Api
       Test 4|http://localhost:8080/finding/237]\n\n*Defect Dojo link:* http://localhost:8080/finding/237
-      (237)\n\n*Severity:* Low\n\n\n*Due Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      (237)\n\n*Severity:* Low\n\n\n*Due Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
       cookie has been set without the secure flag, which means that the cookie can\nbe
       accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -1927,7 +2001,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1170'
+      - '1190'
       Content-Type:
       - application/json
       User-Agent:
@@ -1936,18 +2010,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16077","key":"NTEST-1593","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16077"}'
+      string: '{"id":"18161","key":"NTEST-1833","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18161"}'
     headers:
       Atl-Request-Id:
-      - 64d82500-6d38-452d-bc8b-e63dd1cb9522
+      - f65cd2da-817e-4475-a210-1b04505c62e2
       Atl-Traceid:
-      - 64d825006d38452dbc8be63dd1cb9522
+      - f65cd2da817e4475a2101b04505c62e2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:17 GMT
+      - Wed, 30 Apr 2025 16:23:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1957,7 +2033,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=668,atl-edge-internal;dur=23,atl-edge-upstream;dur=645,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="FwXbMEo9L_ojLAaPqo57AScigLvWeBFSr2noPSp_l4GOCwW5I9VeVg==",cdn-downstream-fbl;dur=710,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=708,atl-edge;dur=621,atl-edge-internal;dur=18,atl-edge-upstream;dur=603,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1966,10 +2042,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f497fa2422d5b3ba3b34ed87ffef89a6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - FwXbMEo9L_ojLAaPqo57AScigLvWeBFSr2noPSp_l4GOCwW5I9VeVg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 69e18d96b7ef58cbc4bbcce65c06dd00
+      - 1ea9337ee6363ceaf6c7d6ed2fe2ce21
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1993,60 +2077,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1593
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1833
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW/U8bNxj+V6z7aWOX3EcCpCdNE4N0o2OMQWil0QoZ35uLG599s30kWcv/vtf3
-        lRa4VjCtigRnv36/Hz9+P3iwLqhMvcTTIFPQkL7kIFLjS5qD8Q1bQE59VYCmlitpfEi5zcFSny2o
-        zECozL8FbVAG6TkUGgxI25xlpbEqnzuD11EYRuFQw98lGDvbFHCmKbOcged73PmP9sL9fVwYEHNc
-        LqwtTBIEKcyB2VS9V0NqBTWGUzmUYAP0ZANa8CAOuDElBK2BJWxQ/3Q2vZgNot0XI9yqQjBe8sEz
-        GFtpGLWQKb2pc0hxhRpxGO8OwmgQhbM4TKLdJNof7keTHzDu0AXpnFgMvDLzzCCdfoD2wrhLu1mk
-        YJjmhSsc7h4Qk1MhfJJyY7lklhQcGBA1Jyull0OnzZS81OKJUZSSu3ZRcU1vqaU6uOWwCqqwtgE2
-        oigcRZOfDP8Hfsyx7WWOXh0s0OWMmqXrVXlj3Vcyp8KA79WKx5hXpet7C47A0WyxOYFbwFjDO9+z
-        HJFVIEq8RJaYo3cPJqOwFRRavceMnlnwRrsqd9XAttxu8QlItlldSm4tGjBe59sh9bfqrFFzu6La
-        4dXwvBAcA07vZY79qFA2nqzHkyeG+4XOtJl0fRmHDujxeB2P/18vdfcrLKLDaG8d7X0Lh+vW4yhe
-        j+Jv4bEB+N3dQzhGfTiN+wSjVjDn69c1OSIsrt4hTLJMQ4Z889VLsNsKMDMlypoXHj+61yfY7xHE
-        vYJJn+DFw3Bq2qx3HSlVL4SXDCJcUosPR024T7+4NZ1vCTyozWl3LavPQ1W6wkWOlN+4DS4zL7G6
-        hLuGp501zVldtQ8P9lxkeNQsVCnSI24KQTfNVcZtDMu+Rsy4691UQwMm6/jjsUdiHI3bR+J+2Toq
-        uy/oA1XcgarQXGluN88sYqsejJ/2VvCcZmACp2FaIxw3hFoNzW22JcsTtWpJdew9vDZxdwkEvQFH
-        iw7/9yeCPuhGfQiNJq4eC2qmBWcnXC5fOskRFG56kaztYtXbVSXrdqSSUxxe6I2Ac6CmRoZuvryz
-        k8tfjk+vT44Pp6cX0+vp+fkf55gf3lKDBcEDswWQM+R/aYnzS7ghSooNQS7hwhklVpFXXFNypiFH
-        MiGlQcwOH+OUCK+TF37kYVjkMvHqNxF7h8Xf3qnPuALbkHFJxf1DzezVlLfCucDoWrrBvmYSutNl
-        4S5tL44nUYvjekx6JvRq5e7d/XyyeRoat3D7mbIlDpst5Frjta/DZp77TwG3Q2HQzmZxOyZIcFBn
-        Sih9WkdzI0oYZBpZYzsSKXKk6marvMBxWNrHQb/bRwq7HSl8qeOfl/Ot3P52ZtwK2EnIVQXDg4KT
-        GWqT8UdXDKyFUIyKhTI2mYSTMJhzmSJzBvFo/12lf1TVCtN4r4hDUbJDvqpJvsM/31fqFzjjOcpB
-        NSSHJqajEsgRho+bv9MNiUKfOOx1MR++maLoCv8N9qI6Utc2toJhzq2GodJZgKilrpMcBzSH9gCP
-        Dhc2F1XctZ3Xzs6lXEq1+rQmZ1qlJT75U5nhPc6xK4ErivN5Aax08ZJf1WpgVU+VisZA/I4E5CrC
-        ev5ZUm1Bk63JHlXY+owq7b8OzsgFo7LnvJs9gxdhl9RjP2xS1/+d5K08IEypJQeCnEhuACQxYMmK
-        W3zbLLFIWsalCWQuaOaT1YKzBcmBSoNCWp9oLGBgb+UNEMoYsh6k5JZTUiKQmf4XAAD//+xZbWvb
-        MBD+K6ZQSKH2nMRpkkHpQtlgH8pGCyuUQVD80pjGkvFL0tDlv+85SdESzyqjjJIPgX5II+nudLp7
-        7rnLOgdsYB/nsSqgnrbmBg/yKNs9MuZ+HnMKAocZmQLdYAplaAtL7F3GTsoTUWTyjCMKwlGG1ZJg
-        DBD6FPNzMgrC08pRFdphixVb0/WcnEnL6hLh5zDu7BiHXo7HCw/PUtJ9ze3U/X9ycgBpI//AAm1h
-        uTWRBJY1nNNqqb7vzjvcIllQDeAqurl+0NVq5YkVK3MZtsiS+NnL57kMOSiYQt5U652yCnRkVuPR
-        p51v95O77+7djYvCKZNJKsgFxRmFaodFWcrPnM7ZrwzlphIfESR/842BKbrNgmPDnG6wizkVevIn
-        SaaIHjW3GkraWAgMOWws+LYTvq3u+6buy1eT9Kd9o42p+saYvfrZRFE4n4VzSk2F0WWdZYwKyEkD
-        O8nJxP5E8cbiQizgCilFnPVrdDmI+qPhaNYd+nE/HPvheNBLxt3kAnrMJmh4ZVtMETCJIuhAgUG1
-        idafdgxB9SFZr/ajKiU8FDC5jc5se6IgBsdiUTcILobhaDjoj2fhbOhDfcLiZBReRZdSyml/ctr7
-        gj91zs0Y11jnuuqr0qtLdwVHuD2PQNTL69kiDclTbs5YSY7CeYnpYGj4eI3493JORb7Z2x6+xc3m
-        +PAtbjbXh24xIClSvZpmYdcIfbCKJKnDMJUJRLCtOkEFaA/gYdj4uS4E2v8HIEo4/5NpNNzBqkld
-        0qBHWu3ULbDBaGDr5wLbkCAwUF1onD/iy7tF0hFf3sPiI7604EsTBgz/MnQFVj+q3HuhKbT+7EOh
-        qJieoTelWImWFZesDKzXjny2gYxvo5wECK0LvrlyY6FvO9E3nC7my7QQXPE29VVU6x9w1L//5D2R
-        KQkv248a7t8Avzu/PX3Yyj0/ydjzbVzWCxK8o1vOK4pqUik7lqL6f0NSJcwIhS50hD+EHPdsJ5s0
-        pqUhCqk0huxb29szVx+Q7tlsNr8BAAD//wMACsqGCi8cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18161","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18161","key":"NTEST-1833","fields":{"statuscategorychangedate":"2025-04-30T18:23:59.793+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1833/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:59.521+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxr:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:59.596+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 4|http://localhost:8080/finding/237]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/237 (237)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 4","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1833/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18161/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 83ee993f-97a6-4566-96d7-693a2f0e67e3
+      - 04569ff1-4327-4b0e-b3e4-add822b28cd7
       Atl-Traceid:
-      - 83ee993f97a6456696d7693a2f0e67e3
+      - 04569ff143274b0eb3e4add822b28cd7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:18 GMT
+      - Wed, 30 Apr 2025 16:24:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2056,7 +2123,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=287,atl-edge-internal;dur=14,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="jn0PxAFgM7vRHMOhasMR7mfOhTSMCLD18SOtFhh0p3pys1Gm--BtuQ==",cdn-downstream-fbl;dur=358,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=355,atl-edge;dur=269,atl-edge-internal;dur=15,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2065,10 +2132,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 452324c4cfd54555e3a2d8c074edaf78.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - jn0PxAFgM7vRHMOhasMR7mfOhTSMCLD18SOtFhh0p3pys1Gm--BtuQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - a535bc942a26724c6b4044ebf2feb5d9
+      - 994c1a8a3806bb189b5d133aa8dbb3dd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2092,60 +2167,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16077
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18161
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa2/bNhT9K4Q+bZlsPewkroBhyBJv65ZlWeK0wNIiYKhrmTVFaiQV22vz33ep
-        l1snapEMKwwkIi/v+/DwvvdgXVCZeomnQaagIf2Jg0iNL2kOxjdsATn1VQGaWq6k8SHlNgdLfbag
-        MgOhMv8OtEEZpBdQaDAgbXOWlcaqfO4M3kRhGIVDDX+XYOxsU8C5psxyBp7vcec/OggPD3FhQMxx
-        ubC2MEkQpDAHZlP1Tg2pFdQYTuVQgg3Qkw1owYM44MaUELQGlrBB/bPZ9HI2iPZfjHCrCsF4yXvP
-        YGylYdRCpvSmziHFFWrEYbw/CKNBFM7iMIn2k+hweBhNvsO4Qxekc2Ix8MrMM4N0+gHaC+Mu7WaR
-        gmGaF65wuHtETE6F8EnKjeWSWVJwYEDUnKyUXg6dNlPySosnRlFK7tpFxQ29o5bq4I7DKqjC2gbY
-        iKJwFE1+MPwf+D7Htpc5enWwQJczapauV+WtdV/JnAoDvlcrvsS8Kl3fW3AEjmaLzSncAcYa3vue
-        5YisAlHiJbLEHL0dmIzCVlBo9Q4zembBG+2q3FUD23K7xUcg2WZ1Jbm1aMB4nW+H1N+qs0bN7Ypq
-        h1fD80JwDDjdyRz7UaFsPFmPJ08M9zOdaTPp+jIOHdDj8Toe/79e6u5XWESH0cE6OvgaDtetx1G8
-        HsVfw2MD8Pv7h3CM+nAa9wlGrWDO169qckRYXL9FmGSZhgz55ouXYL8VYGZKlDUvPH70oE9w2COI
-        ewWTPsGLh+HUtFnvOlKqXggvGUS4pBYfjppwn35xazrfEnhQm9PuWlafx6p0hYscKb92G1xmXmJ1
-        CfcNTztrmrO6au8f7LnI8KhZqFKkJ9wUgm6aq4zbGJZ9hZhx17uphgZM1vHHY4/EOBq3j8Ru2Toq
-        2xX0gSruQFVorjS3m2cWsVUPxk97K3hOMzCB0zCtEY4bQq2G5i7bkuWpWrWkOvYeXpu4uwSC3oKj
-        RYf/3YmgD7pRH0KjiavHgpppwdkpl8ufnOQECje9SNZ2sertqpJ1O1LJKQ4v9FbABVBTI0M3X975
-        6dXPL89uTl8eT88upzfTi4s/LjA/vKUGC4IHZgsg58j/0hLnl3BDlBQbglzChTNKrCK/ck3JuYYc
-        yYSUBjE7fIxTIrxOXviBh2GRy8Sr30TsHRZ/e6c+4QpsQ8YlFbuHmtmrKW+Fc4HRtXSDfc0kdKfL
-        wl3aXhxPohbH9Zj0TOjVyt27++lk8zQ0buH2I2VLHDZbyLXGa1/HzTz3nwJuh8Kgnc3idkyQ4KDO
-        lFD6rI7mVpQwyDSyxnYkUuRE1c1WeYHjsLSPg36/I4XPNXZXqSOMT8v5Rm5/ezNuBewl5LqC4VHB
-        yQzNkvEHVwyshVCMioUyNpmEkzCYc5kicwbx6PBtpX9S1QrTeKeIQ1GyR76oSb7BP99W6pc44znK
-        QTUkhyamkxLICeaFm7/TDYlCnzjsdTEfv56i6Br/DQ6iOlLXNraCYc6thqHSWYCopa6THAc0h/YA
-        jw4XNhdV3LWdV87OlVxKtfq4JudapSU++VOZ4T3OsSuBK4rzeQmsdPGSX9RqYFVPlYrGQPyWBOQ6
-        wnr+WVJtQZOtyR5V2PqMKu2/js7JJaOy57ybPYMXYZfUYz9sUtf/veSNPCJMqSUHgpxIbgEkMWDJ
-        ilt82yyxSFrGpQlkLmjmk9WCswXJgUqDQlqfaCxgYG/kLRDKGLIepOSOU1IikJn+FwAA///sWW1r
-        2zAQ/iumUEih9pzEaZJB6ULZYB/KRgsrlEFQ/NKYxpLxS9LQ5b/vOUnREs8qo4ySD4F+SCPp7nS6
-        e+65yzoHbGAf57EqoJ625gYP8ijbPTLmfh5zCgKHGZkC3WAKZWgLS+xdxk7KE1Fk8owjCsJRhtWS
-        YAwQ+hTzczIKwtPKURXaYYsVW9P1nJxJy+oS4ecw7uwYh16OxwsPz1LSfc3t1P1/cnIAaSP/wAJt
-        Ybk1kQSWNZzTaqm+78473CJZUA3gKrq5ftDVauWJFStzGbbIkvjZy+e5DDkomELeVOudsgp0ZFbj
-        0aedb/eTu+/u3Y2LwimTSSrIBcUZhWqHRVnKz5zO2a8M5aYSHxEkf/ONgSm6zYJjIyLdwLZgCCih
-        VIVm/UmyLOJNja2BIYeNBd/IaC7Y6r5v6r58NUl/2jfamKpvjNmrn014hfNZOKfUVBhd1lnGqICc
-        NLCTnEzsTxRvLC7EAq6QUsRZv0aXg6g/Go5m3aEf98OxH44HvWTcTS6gx2yChle2xRQBkyiCDhQY
-        VJto/WnHEFQfkvVqP6pSwkMBk9vozLYnCmJwLBZ1g+BiGI6Gg/54Fs6GPtQnLE5G4VV0KaWc9ien
-        vS/4U+fcjHGNda6rviq9unRXcITb8whEvbyeLdKQPOXmjJXkKJyXmA6Gho/XiH8v51Tkm73t4Vvc
-        bI4P3+Jmc33oFgN5ItWraRZ2jdAHq0iSOgxTmUAE26oTVLj1AB6GjZ/rQqD9fwCihPM/mUbDHaya
-        1CUNeqTVTt0CG4wGtn4usA0JAgPVhcb5I768WyQd8eU9LD7iSwu+NGHA8C9DV2D1o8q9F5pC688+
-        FIqK6Rl6U4qVaFlxycrAeu3IZxvI+DbKSYDQuuDbKGffdqJvOF3Ml2khuOJt6quo1j/gqH//yXsi
-        UxJeth813L8Bfnd+e/qwlXt+krHn27isFyR4R7ecVxTVpFJ2LEX1/4akSpgRCl3oCH8IOe7ZTjZp
-        TEtDFFJpDNm3trdnrj4g3bPZbH4DAAD//wMAwXJUiS8cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18161","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18161","key":"NTEST-1833","fields":{"statuscategorychangedate":"2025-04-30T18:23:59.793+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1833/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:59.521+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxr:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:59.596+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 4|http://localhost:8080/finding/237]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/237 (237)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 4","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1833/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18161/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - db8b0269-9794-45c2-a91e-656ee9407048
+      - 895877c0-07ae-46aa-aa18-80915f2a9e58
       Atl-Traceid:
-      - db8b0269979445c2a91e656ee9407048
+      - 895877c007ae46aaaa1880915f2a9e58
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:18 GMT
+      - Wed, 30 Apr 2025 16:24:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2155,7 +2213,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=262,atl-edge-internal;dur=14,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="-wHFTXZLJtehiBOe0hvCciIYFvgAdnkibIUBoAufsZdH-mrSH6NlvA==",cdn-downstream-fbl;dur=350,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=67,cdn-upstream-fbl;dur=348,atl-edge;dur=258,atl-edge-internal;dur=19,atl-edge-upstream;dur=239,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2164,10 +2222,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 40867fef594010a8d9ec2cb0a5cb2350.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -wHFTXZLJtehiBOe0hvCciIYFvgAdnkibIUBoAufsZdH-mrSH6NlvA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 76e18307de26d8832a8ab79823d78335
+      - f236535d820c725346f063f8dc976e82
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2194,26 +2260,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TtfvIDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC18LjtDeHkLYTO88mkQYUyNO7dZSIY4b0WNrMYyIg02ndG7P/Bl9jvtMQG/ccaTbdCG7D/
-        65KVs8oMaCX+LrnD3mtnI0wBaAYZjMvN5WO5fqh+ppuhrWNF+HOCRjCCl+jEzrh9G6+s9l2yrYwb
-        mhiqB22arwjhMcDm81PzSoQEMmDFGOgYlhVjPJ/yPIoBLiDCMe/jH7CvdHvOUqgYcFpwuows+2Zl
-        e2OVi2BOZwspAAtUkk7nKHKlcgVSseW0WNRqliObKWBngmCS4Vb3Ir0QlRhMuHNSpPaBmFNF0L5u
-        S3I8P+zJ2TS5vq/I8RMAAP//AwAH7XmOIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:01.357+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - bbc0abee-f702-4430-86bf-5d083dd264f6
+      - 0fba323d-44cd-4c55-924e-f982158ec593
       Atl-Traceid:
-      - bbc0abeef702443086bf5d083dd264f6
+      - 0fba323d44cd4c55924ef982158ec593
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:19 GMT
+      - Wed, 30 Apr 2025 16:24:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2223,7 +2285,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=181,atl-edge-internal;dur=27,atl-edge-upstream;dur=163,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=271,atl-edge;dur=142,atl-edge-internal;dur=14,atl-edge-upstream;dur=128,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="EPe6Ngr_IcVwkC2JrGg5LYu66Gqaa9sGHrPihN3TYQYYmbHauxiqiw==",cdn-downstream-fbl;dur=275
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2232,10 +2294,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 de5b26aba33b480d2b740b96a34fe916.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - EPe6Ngr_IcVwkC2JrGg5LYu66Gqaa9sGHrPihN3TYQYYmbHauxiqiw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e58122565bf46716ba55c7c69d97615d
+      - 0737a3435c4d762ddf22d94cefd7d8d3
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2259,60 +2329,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16077
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18161
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa2/bNhT9K4Q+bZlsPewkroBhyBJ365ZlWeK0wNIiYKhrmTVFaiQV22vz33ep
-        l9vE6pAMKwwkIi/v+/DwfvBgXVCZeomnQaagIX3JQaTGlzQH4xu2gJz6qgBNLVfS+JBym4OlPltQ
-        mYFQmX8H2qAM0gsoNBiQtjnLSmNVPncGb6IwjMKhhr9KMHa2KeBcU2Y5A8/3uPMfHYSHh7gwIOa4
-        XFhbmCQIUpgDs6l6r4bUCmoMp3IowQboyQa04EEccGNKCFoDS9ig/tlsejkbRPsvRrhVhWC85INn
-        MLbSMGohU3pT55DiCjXiMN4fhNEgCmdxmET7SXQ4PIwm32HcoQvSObEYeGXmmUE6/QDthXGXdrNI
-        wTDNC1c43D0iJqdC+CTlxnLJLCk4MCBqTlZKL4dOmyl5pcUToygld+2i4obeUUt1cMdhFVRhbQNs
-        RFE4iiY/GP43fJ9j28scvTpYoMsZNUvXq/LWuq9kToUB36sVX2Fela7vLTgCR7PF5hTuAGMN733P
-        ckRWgSjxEllijt4DmIzCVlBo9R4zembBG+2q3FUD23K7xScg2WZ1Jbm1aMB4nW+H1F+rs0bN7Ypq
-        h1fD80JwDDh9kDn2o0LZeLIeT54Y7hc602bS9WUcOqDH43U8/n+91N2vsIgOo4N1dPA1HK5bj6N4
-        PYq/hscG4Pf3j+EY9eE0bgVzvn5dcyB2//rd45Oj9iTNMg0Z8s2jS4AJKFHW13+3u/0+wUGf4LBH
-        EPcKJn2CF4/jrGmz3nWkVL0QXjKIcEktPhw14T794tZ0viXwoDan3bWsPo9V6QoXOVJ+4za4zLzE
-        6hLuG5521jRndTk/PNpzkeFRs1ClSE+4KQTdNFcZtzEs+xox4653Uw0NmKzjj12PxDgat4/Ew7J1
-        VPZQ0AequANVobnS3G6eWcRWPRg/7a3gOc3ABE7DtEY4bgi1Gpq7bEuWp2rVkurYe3xt4g7zgt6C
-        o8UdF8Oxyc4yRH0IjSauHgtqpgVnp1wuXzrJCRRuepGs7WLV21Ul63akklMcXuitgAugpkaGbr68
-        89Orn16d3Zy+Op6eXU5vphcXv19gfnhLDRYED8wWQM6R/6Ulzi/hhigpNgS5hAtnlFhFfuGaknMN
-        OZIJKQ1idriLUyK8Tl74kYdhkcvEq99E7B0Wf3unPuMKbEPGJRUPDzWzV1PeCucCo2vWrq+ZhO50
-        WbhL24vjSdTiuB6Tngm9Wrl7dz+fbJ6Gxi3cfqRsicNmC7nWeO3ruJnn/lPA7VAYtLNZ3I4JEhzU
-        mRJKn9XR3IoSBplG1tiORIqcqLrZKi9wHJZ2N+j3+0hhvyOFL3X883K+ldvf3oxbAXsJua5geFRw
-        MkNtMv7oioG1EIpRsVDGJpNwEgZzLlNkziAeHb6r9E+qWmEa7xVxKEr2yL9qkm/wz7eV+iXOeI5y
-        UA3JoYnppARyguHj5m90Q6LQJw57XczHb6YousZ/g4OojtS1ja1gmHOrYah0FiBqqeskxwHNoT3A
-        o8OFzUUVd23ntbNzJZdSrT6tyblWaYlP/lRmeI9z7ErgiuJ8XgIrXbzkZ7UaWNVTpaIxEL8jAbmO
-        sJ5/lFRb0GRrskcVtj6jSvvPo3NyyajsOe9mz+BF2CW164dN6vq/l7yVR4QpteRAkBPJLYAkBixZ
-        cYtvmyUWScu4NIHMBc18slpwtiA5UGlQSOsTjQUM7K28BUIZQ9aDlNxxSkoEMtP/AAAA///sWW1r
-        2zAQ/iumUEih9pzEaZJB6ULZYB/KRgsrlEFQ/NKYxpLxS9LQ5b/vOUnREs8qo4ySD4F+SCPp7nS6
-        e+65yzoHbGAf57EqoJ625gYP8ijbPTLmfh5zCgKHGZkC3WAKZWgLS+xdxk7KE1Fk8owjCsJRhtWS
-        YAwQ+hTzczIKwtPKURXaYYsVW9P1nJxJy+oS4ecw7uwYh16OxwsPz1LSfc3t1P1/cnIAaSP/wAJt
-        Ybk1kQSWNZzTaqm+78473CJZUA3gKrq5ftDVauWJFStzGbbIkvjZy+e5DDkomELeVOudsgp0ZFbj
-        0aedb/eTu+/u3Y2LwimTSSrIBcUZhWqHRVnKz5zO2a8M5aYSHxEkf/ONgSm6zYJjw5xuYFswdJPA
-        qEKz/iRZFvGmxtbAkMPGgm+jrL6t7vum7stXk/SnfaONqfrGmL362URROJ+Fc0pNhdFlnWWMCshJ
-        AzvJycT+RPHG4kIs4AopRZz1a3Q5iPqj4WjWHfpxPxz74XjQS8bd5AJ6zCZoeGVbTBEwiSLoQIFB
-        tYnWn3YMQfUhWa/2oyolPBQwuY3ObHuiIAbHYlE3CC6G4Wg46I9n4WzoQ33C4mQUXkWXUsppf3La
-        +4I/dc7NGNdY57rqq9KrS3cFR7g9j0DUy+vZIg3JU27OWEmOwnmJ6WBo+HiN+PdyTkW+2dsevsXN
-        5vjwLW4214duMZAnUr2aZmHXCH2wiiSpwzCVCUSwrTpBhVsP4GHY+LkuBNr/ByBKOP+TaTTcwapJ
-        XdKgR1rt1C2wwWhg6+cC0881FwxUFxrnj/jybpF0xJf3sPiILy340oQBw78MXYHVjyr3XmgKrT/7
-        UCgqpmfoTSlWomXFJSsD67Ujn20g49soJwFC64Jvo5x924m+4XQxX6aF4Iq3qa+iWv+Ao/79J++J
-        TEl42X7UcP8G+N357enDVu75Scaeb+OyXpDgHd1yXlFUk0rZsRTV/xuSKmFGKHShI/wh5LhnO9mk
-        MS0NUUilMWTf2t6eufqAdM9ms/kNAAD//wMAwK6bBi8cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18161","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18161","key":"NTEST-1833","fields":{"statuscategorychangedate":"2025-04-30T18:23:59.793+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1833/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:59.521+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxr:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:59.596+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 4|http://localhost:8080/finding/237]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/237 (237)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 4","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1833/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18161/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 5cc301be-cea6-4ec3-8c64-ee968c89ba30
+      - 71416e4c-236d-405a-b320-5b0edd609c1b
       Atl-Traceid:
-      - 5cc301becea64ec38c64ee968c89ba30
+      - 71416e4c236d405ab3205b0edd609c1b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:19 GMT
+      - Wed, 30 Apr 2025 16:24:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2322,7 +2375,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=13,atl-edge-upstream;dur=281,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=424,atl-edge;dur=391,atl-edge-internal;dur=14,atl-edge-upstream;dur=377,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="q2dXXmQv2AmxKhdx4iKK81Fk2QZngc29IIvpPRkGlVCkCjwlS-5cGg==",cdn-downstream-fbl;dur=427
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2331,10 +2384,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a65725dd05dc27eea7ae75a2e122228e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - q2dXXmQv2AmxKhdx4iKK81Fk2QZngc29IIvpPRkGlVCkCjwlS-5cGg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7e26d223e96d3bfdd30753868b4aec0a
+      - 7b934bb098eac300f115e9a1c09b954a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2361,41 +2422,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 84382ce2-2589-4494-bcba-dd29dd3a1a92
+      - 7b42c8a7-330c-4161-a0c0-311cb7fd128e
       Atl-Traceid:
-      - 84382ce225894494bcbadd29dd3a1a92
+      - 7b42c8a7330c4161a0c0311cb7fd128e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:19 GMT
+      - Wed, 30 Apr 2025 16:24:02 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2405,7 +2453,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=305,atl-edge-internal;dur=21,atl-edge-upstream;dur=286,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=324,atl-edge;dur=292,atl-edge-internal;dur=15,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="6S78cYP_Oh_i9g3fmuFBg7znp1bgzupRVU-aTeXcFH_QSJLrPIou5w==",cdn-downstream-fbl;dur=328
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2414,13 +2462,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8139bc666c011a53bdc5037ba6d5931e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 6S78cYP_Oh_i9g3fmuFBg7znp1bgzupRVU-aTeXcFH_QSJLrPIou5w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f0deb1616c3f11325db51711cb001aee
+      - 6cdf9f4846b7a9beb2b9d1a3173f4634
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2432,14 +2488,14 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Jira Api Test 4", "description": "\n\n\n\n\n\n*Title*: [Jira Api
       Test 4|http://localhost:8080/finding/237]\n\n*Defect Dojo link:* http://localhost:8080/finding/237
-      (237)\n\n*Severity:* Low\n\n\n*Due Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      (237)\n\n*Severity:* Low\n\n\n*Due Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
       cookie has been set without the secure flag, which means that the cookie can\nbe
       accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -2451,27 +2507,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1155'
+      - '1175'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16077
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18161
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 74548d6c-5cc9-43ad-acad-793114f91aed
+      - 5f9a5a97-27fc-4a2e-b472-1d550c1f8645
       Atl-Traceid:
-      - 74548d6c5cc943adacad793114f91aed
+      - 5f9a5a9727fc4a2eb4721d550c1f8645
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:20 GMT
+      - Wed, 30 Apr 2025 16:24:02 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2481,17 +2539,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=15,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="U8QkVqqALc_h_dGN3EmEqkBP2CZ46hH_0mIv0hZqSGFx5mpWztQ2mQ==",cdn-downstream-fbl;dur=356,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=354,atl-edge;dur=265,atl-edge-internal;dur=15,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 3cab2977109e9e185607e6a3005951e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - U8QkVqqALc_h_dGN3EmEqkBP2CZ46hH_0mIv0hZqSGFx5mpWztQ2mQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 0448c99f76292759f2a464d748965924
+      - cc3d07b225539de69c8dacc542c7a83b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2515,60 +2581,43 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16077
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18161
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbVMbNxD+K5r71NKz78UGnJvpdCg4LSmlFAyZKckwQrc+K9ZJV0mH7ZL8967u
-        zQHsZKDTDDOJT6t9f/bR3nuwLKhMvcTTIFPQkL7mIFLjS5qD8Q2bQU59VYCmlitpfEi5zcFSn82o
-        zECozL8DbVAG6TkUGgxI29xlpbEqnzqDN1EYRmFfw98lGDtZFXCmKbOcged73PmP9sL9ffwwIKb4
-        ObO2MEkQpDAFZlP1QfWpFdQYTmVfgg3Qkw1owYM44MaUELQG5rBC/dPJ+GLSi3ZfDfCoCsF4yb1n
-        MLbSMGohU3pV55DiF2rEYbzbC6NeFE7iMIl2k2i/vx+NfsC4Qxekc2Ix8MrMC4N0+gHaC+Mu7eYj
-        BcM0L1zh8PSAmJwK4ZOUG8sls6TgwICoKVkoPe87babkpRbPjKKU3LWLiht6Ry3VwR2HRVCFtQ6w
-        EUXhIBr9ZPg/8GOObS9z9OpggS4n1Mxdr8pb634lUyoM+F6teIx5Vbq+N+MIHM1mqxO4A4w1/OR7
-        liOyCkSJl8gSc/QewWQQbhNEraDQ6gOm+sJONNpVH6rOtn1wH5+hZ53upeTWogHjdb4dhH+r7ho1
-        tQuqHZANzwvBMeD0UUmwURX8hqPlcPTMcL/QsjaTrmHD0E1APFzGw//XSw2LCqToMNpbRnvfwuGy
-        9TiIl4P4W3hskP/p01M4xi0cp3x5VXMgNvn6/dObg/YmzTINGfLNV4dgtxVgAkqUNS9svrq3TbC/
-        RRBvFYy2CV49DaemzfrUkVL1QnhJL2q40lVec1ZHfv/kzM0DFtXMVCnSI24KQVfN1OAxttBeYXvc
-        JDUuqMXHqCbx5898/USsH4WgNqfdRFc/D1XpmlEF/9YdcJl5idWli4ZpwGQdTWx6JIbRsH0kHpdt
-        G5XFHZU9FnSgKjRXmtvVCxNu1YPh894KntMMTOA0TGuE44FQi765y9aceKIWLXcOvafTEXeYF/QW
-        HPttGAxHGhvLEG1DaDRy9ZhRMy44O+Fy/tpJjqBw24tkLYIqXC0qWXcilRzj8kJvBZwDNTUqdfPL
-        Ozu5/OX49Obk+HB8ejG+GZ+f/3GO+eGUGiwIXpjMgJwhzUtLnF/CDVFSrAhSBhfOKLGKvOGakjMN
-        OXIGKQ3iq7+JOiIcJy/8yMOwyGXi1W8i9g6Lv56pB1yBbci4pOLxpWb3aspboVxgdM2362smobtd
-        Fm5ot+J4FLU4rtekF0KvVu6e14ebzfPQuIbbz5TNcdlsIdcar30dNvvcfwq4XQqDdjeL221AgoM6
-        U0Lp0zqaW1FCL9PIWOuVSJEjVTdb5QWuw9JuBv3uNlLY7UjhSx1/WM53cv23M+FWwE5CrisYHhSc
-        TFCbDD+6YmAthGJUzJSxySgchcGUyxRZLogH++8r/aOqVpjGB0UcipId8lVN8h3+832lfoE7nqMc
-        VENyaGI6KoEcYfh4+DtdkSj0icNeF/Ph2zGKrvG/3l5UR+raxhbQz7nV0Fc6CxC11HWS4x7m0B7g
-        1f7M5qKKu7Zz5excyrlUi89rcqZVWuLLPpYZznGOXQlcUZzPC2Cli5f8qhY9q7ZUqWgMxO9JQK4j
-        rOefJdUWNFmb3KIKa59Rpf3XwRm5YFRuue9WzOBV2CW16Q+b1PV/J3knDwhTas6BICeSWwBJDFiy
-        4BbfVUsskpZxaQKZCpr5ZDHjbEZyoNKgkNY3GgsY2Dt5C4QyhqwHKbnjlJQIZKb/BQAA///sWW1r
-        2zAQ/iumUEih9pzYaZJB6ULZYB/KRgsrlEFQ/NKYxrLxS9LS5b/vOUnRXC0qo4ySD4F+cG3pXqS7
-        5567PJWADazjPJHF21PWXOFC7kW7R8bcLhJOQeAwLbNAN5hBGdrCGmtXiZPxtKhysccpKsJRhq81
-        wRgg9CHhp2QUhGeNI9mBw5Zr9kTuOSUTlrU1ws9h3OkYh16OJ0sP11KTv9o76f9PTgdA2uh8YIGy
-        sN6aSALrFoez01Llb+cerpEsqAY4KvJcXeh6vfaKNatLEbbIkuTRKxelCDkomEHeTOmdsQZUaN7i
-        0me9b7fTm+/uzZWLwimSSSgoC4ozCtUei/OMnzi9k185yk1TfESQ/M03hrromgXHhjn9sIs5DXry
-        B0F8iJqZSzUlNT6EmhwaH3zbDl/XfXE5guXsXmjjAb6NqfraGJwvixaUfaoYduupiap1m+eMCsiR
-        gZ10yMT+iuqNxYVYwAVSivjl1/h8GAfj0XjeH/lJEE38aDIcpJN+egY9ehE0vLIsoQiYxjF0oMCg
-        2sRPnzqGoPqQrFfbTpkSHgqYWEZ7tq1PmIBjsbgfhmejaDwaBpN5NB/5UJ+yJB1HF/G5kHIcTI8H
-        X/An97k54wrrXFe+qr22dtc4CHfgEYh6ZTtfZhGdlFsyVtNBYb/AdDA0PF4i/r2SU5E3W9j9t9js
-        gfffYrOH3neLAUmx7BMVC7tE6INVpGkbRZlIIIJt2bVJQLsDD8PCz21VoMu/A9REiz+ZRjMcfNWp
-        SxrUSGs3dQttMBra+rlQ93OVgvMDjLxbwBxg5D0sPsDIDhgxYcBGzELNvzQ9gTv3Mimfadisnn1Y
-        UjRMzdBNKVaiZcUl2+TFH+xGPisRs3pmZWjaZeNDYNsRaE6X8FVWFVySOvkqbtUPOPLffzm9VdH8
-        v0GiFKaFQhM6sR+FGLNsp5lIAWny8/ZR1Zc3GyB+7PqwlXt6lLPH66RulyS446wYkFTNtJGO05iW
-        hijkun7/cvPgxW61QVi72Wx+AwAA//8DAMS3mCYvHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18161","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18161","key":"NTEST-1833","fields":{"statuscategorychangedate":"2025-04-30T18:23:59.793+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1833/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:23:59.521+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxr:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:23:59.596+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 4|http://localhost:8080/finding/237]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/237 (237)\n\n*Severity:* Low\n\n\n*Due Date:*
+        Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 4","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1833/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18161/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - bc5d6c61-6d87-49ce-b5b2-bfc2cee377b7
+      - d99c201b-c87d-4d0d-a998-cf9f00672dd0
       Atl-Traceid:
-      - bc5d6c616d8749ceb5b2bfc2cee377b7
+      - d99c201bc87d4d0da998cf9f00672dd0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:20 GMT
+      - Wed, 30 Apr 2025 16:24:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2578,7 +2627,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=307,atl-edge-internal;dur=35,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="BoxPam2QuLWQ8lrWN11ISIUIR0wIrRQYPMue9FSVjeraAiZCgcxFGw==",cdn-downstream-fbl;dur=356,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=353,atl-edge;dur=270,atl-edge-internal;dur=16,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2587,10 +2636,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - BoxPam2QuLWQ8lrWN11ISIUIR0wIrRQYPMue9FSVjeraAiZCgcxFGw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 0cd7bbefec0a37b5d4ed1f94e0e49c4a
+      - 72c4ac5284c9e3b1e8082224ae260fa7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_creation.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_creation.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bqka+iWN6ngFJ1Cu5eJSJpcMJompUkHY+y7m+DQ+aa+HXe/
-        //2OO6CWe9gMBjH0GkLv2WwmQYEI0r25jAfDvdfcZhYCmiCpfW/4/h98DcNOC5Dg31dg+gpsgOGv
-        SypnlRnBCvhdcgeD185GmGBMMpzhab2+fKxXD833dD12bawQe0rQBE/wc3RCb9y+i1c2+z7ZKuNG
-        GUPtqI38jCAWA3lZnppXPCQwxzmdYjLNFw0pWEHYfJFhjC9whGPexz/A0OjuB7tscsIKygjNCkq+
-        WNHdWOUiqCglAOWctBJEIQQH4KRdSEWWJVekiALVUsjPBMEkw60eeHohKD6acOcET+0DMqcKgX3Z
-        1Oh4ftjW2TS5vm/Q8QMAAP//AwAhfxRWIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:03.746+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - a416e98b-18d8-450f-852c-5a7cdd05e165
+      - e11e785c-f165-4540-bb51-9b9ddc359f66
       Atl-Traceid:
-      - a416e98b18d8450f852c5a7cdd05e165
+      - e11e785cf1654540bb519b9ddc359f66
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:15 GMT
+      - Wed, 30 Apr 2025 16:24:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=147,atl-edge-internal;dur=18,atl-edge-upstream;dur=130,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="kr1IKPTBG0xRGbwPqF-6847GCYqFbeJ6LVV1ZqMhr-PspJjPP2u3Zg==",cdn-downstream-fbl;dur=239,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=236,atl-edge;dur=163,atl-edge-internal;dur=15,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c4fd63432996b55c90ff4db02c11a616.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - kr1IKPTBG0xRGbwPqF-6847GCYqFbeJ6LVV1ZqMhr-PspJjPP2u3Zg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 308663ded5c76f207008e263d9d9948f
+      - b36248e46c0245f1e0bcb01ea58caba2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,42 +90,31 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Epic&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xWW0/bMBT+K1aeS0JLxVClaZqASWwTmsTlZULIbU5bg2NnttMmQ/3vO6e5OKVs
-        S9nGXshTfHIu37G/88UPAeQpV3EwClKj72DibNDzr6OvD95BWJuBK1IgFwtyira5c6kdRVEMUwyI
-        9Z0OuZPcWsFVqMBFBqyLeCqiQVRljfr7+GAKQUnrxT0UuDq/PL24xJXiCeDySgnnMAEV5AvuuLky
-        ElE9BMOjfHi0Y/1MiQUYy+VtmStaCFhG1FADrfrQ3x/uv8Gag2E+GP7bKu+s+A5vbcKlxIL9w7x/
-        +BIF87riwSA/GLxExQRikSXBqtfmEfHrGUxqMjzNpRjsxIjUCa3Q+p6NxYxlFgyzTpuCuTl3TAHE
-        ljnNxsDGRt+DYrFeqpAdG+AOYjYu2EdhOLvQU7fkBtgeOjClHcNGHNOGxSDBQUjVJ1ohM7t0IRI+
-        AxtRhPV92AhSMQntYubJf4oWXGXKGa6sJFDnG19sNnbc3gejKZcWesFcgOFmMi8+wwIQTL/nZ3cq
-        QMY0RtULjpDNkoSbgl4NfMuEAXR0JsNMdjKHhNMXAofh1hmhCJstrIOELFX0qsF7UVnqWa49EBi3
-        JzDlmXTXXGbQANYpAqZTIiIgD1xw06ZHJ2TeuwXOGz28M7Kxy9KzRNiO7YTxBmVISr2EeO30yt8O
-        /P0tS1d06BOdpFqBon9O+9SroK1j58ZwopbAA8cQH9+mQSup58GxN9Y8aPl1JELA45gqAdUzkOgF
-        BE+QgzrbOMwurW3PWjuFb+SkZa07aXt2baWeu0q6O01d7dsCWZs8wC+NUwnOB+0AbHtTnzVxf3b3
-        qKJJPD6V2lYNFW2ASFIpUFb9kb5eVf5mwf93VSmVKUPVTda/zVskTL+/4xSX8cFaZcK0yIUNZwZA
-        zXWKbA/vUKNHs/ke6eee5GOgTsuYM0y/ruhHijSVrW8BjXZtwdtpvFZ0I8ivcYtKc5fWHmsvbXAp
-        OI0YtHN69B9EzipnL75t112g9yoN/rX6pkZoI9yjW87POmu8N3StsrWFrXGrla0xbDVQKug2/icA
-        P1PZhP4BAAD//7xYwW6DMAz9lx16XLaWHhHabZOYVKm79kAZAlQGGxBVPfTfZ8cJOINJlKAea7Dz
-        Yr/afuDZAis/d5DrIDkYsjzNILo9y1/JiCeoxgnJcAO7Xg7sEKmBuXaGuVkGJjUUG+g7NRkNdeMM
-        1VsGKjDSxhlWZwPScwa5XQzkgKKhshmo24frAXcv/k90g35PKoyMHW9aB4tKbEI3zZy8PHUuZuR4
-        f0ZOSC+Njxxk3qDt/du3sSurOTdz2gzXYx2thxySweDVz6HfyrbC9R9lz8Qydkx4fnwSFEg0MoXS
-        tsGPTOqLP/nyY5IBMEdtG8XZF0qXWflg/iwnzNrn5YW/SrmxvKfdg24QV9+XXq4jiWbWk/kz/MzK
-        6gq/QdkqJd+X1wrgUmKtywUQ/pTUQSzrGvKiVczbp79qsuq8l8cPkLO7CJ/5ONy5uSGLdlVAQTD4
-        pSyK1Sy6dGlGwCmI/mlJxq8FFh2MNyODMXVU6A1uWcTDBUWLjkUimgT1fqD3bV/prFuzQZ0DN/LD
-        9RcAAP//AwBwEqjntBYAAA==
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","untranslatedName":"Epic","subtask":false,"hierarchyLevel":1,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1}]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"customfield_10011":{"required":false,"schema":{"type":"string","custom":"com.pyxis.greenhopper.jira:gh-epic-label","customId":10011},"name":"Epic
+        Name","key":"customfield_10011","hasDefaultValue":false,"operations":["set"]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 369f45ce-734a-4a76-8264-4f6e40681459
+      - 7ab78b1b-7d54-48b0-9563-4bf5b37e406a
       Atl-Traceid:
-      - 369f45ce734a4a7682644f6e40681459
+      - 7ab78b1b7d5448b095634bf5b37e406a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:15 GMT
+      - Wed, 30 Apr 2025 16:24:04 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -131,7 +124,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=279,atl-edge-internal;dur=14,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=18,cdn-upstream-fbl;dur=362,atl-edge;dur=286,atl-edge-internal;dur=14,atl-edge-upstream;dur=272,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="uihz5jw3hmT-71OUjeIQXXn7rdlZ_QUEvOyU3P1LLgBRq2hhKci9kQ==",cdn-downstream-fbl;dur=366
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -140,13 +133,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 6bddabf0adf0131ec8169647c939d30c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - uihz5jw3hmT-71OUjeIQXXn7rdlZ_QUEvOyU3P1LLgBRq2hhKci9kQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 9a47223711d986c096a708b4d5d8fd13
+      - 1a466f5899246695c245da5a8cbcd670
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -177,18 +178,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16610","key":"NTEST-1827","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16610"}'
+      string: '{"id":"18163","key":"NTEST-1834","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18163"}'
     headers:
       Atl-Request-Id:
-      - 05bc7a5a-49d2-4e5d-a335-da7fd0a8cd07
+      - b3f988cb-8b86-4db1-a05e-636bfd43b9d6
       Atl-Traceid:
-      - 05bc7a5a49d24e5da335da7fd0a8cd07
+      - b3f988cb8b864db1a05e636bfd43b9d6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:16 GMT
+      - Wed, 30 Apr 2025 16:24:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -198,7 +201,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=811,atl-edge-internal;dur=15,atl-edge-upstream;dur=797,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=882,atl-edge;dur=849,atl-edge-internal;dur=15,atl-edge-upstream;dur=835,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="OejwQZFXY8I2sdfXVd59ZpeumxUYTvDMpMRD1D3HEpaX_QJ2xnKyuQ==",cdn-downstream-fbl;dur=885
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -207,10 +210,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 535c2b5354e6ba6798fd64420ee97a2c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - OejwQZFXY8I2sdfXVd59ZpeumxUYTvDMpMRD1D3HEpaX_QJ2xnKyuQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a127865b86cdb4616e34c4e57c1539cb
+      - 7294b2e8f6e9b87fef81afbdd6d2a5bc
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -234,52 +245,36 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1827
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1834
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4S+zrZerDiJgWLYUnfolqVB4rQfhiGgpbPMmiI1kortZfnvO4qS
-        3NjS0KRYv1k88l6fe+786MG2oCL1pp4CkYKC9B0DnuqBoDnogU5WkNOBLEBRw6TQA0iZycHQQbKi
-        IgMus8EDKI0ySG+gUKBBmPpuUmoj86VVeB8GQRiMFPxVgjbzXQHXiiaGJeANPGbth5NJGOCHBr7E
-        z5UxhZ76fgpLSEwqP8sRNZxqzagYCTA+WjI+LZgf+UzrEvxGwRp2+P5qPrudD8Oz6BSPKhe0N330
-        NPpW6oQayKTauRhS/MIXURCdDINwGJ3Po3Aan0zDyeg0jH5Av63ayohBxys1r3TSvvdRn9NYhV1/
-        pKATxQqbODz9iSxYRkoNimAK1Y6YFTVEAKSaGEkWQBZKrkGQVG7EiFwowBhSstiRX5mi5FYuzYYq
-        IEO8QIQ0xJaNSEVS4GBgZK0nUtwp/jVRsJxmoH37Qu/j0D4ULBnphwy1Wbigqhme2BqWC0P12psu
-        Kdcw8FYM8aOS1e4SHgBNhk8DzzAEWIFg8aai5HzgHaBlHDSCQsnP6Ngr816/7s76F1jZB3EnmDGo
-        QHutbQvY36q7uk6tjZLlBWfocNoGSh+ooQrTWoEtPtvGZy90txTM9hPl906X/8Bg41e4aSKpBWEQ
-        BxbcUbyN4v/Xyo+a/Q1vdE45R4PhZBtOvofBbWNxHG3H0fewmGOflLn39HQMx7APp1EjWLLtR0eF
-        WP0//jy+OW5u0ixTkGHLHjUBBiB56Vig29xJn2DSJzjtEUS9grM+wfmxn4493elGqnU1KLzpMMRP
-        anB+ON59eeM6Vt/zuO/UKduW1c8LWdrEhZabP9kDJjJvalQJWD5Uaj5ixW1z1rE4kuxh+nEcN0x/
-        GHRLRIeCPkhELSQKxaRiZvfKFDTP/fE3EHathOGBg/dzyv7dQb4mxrF3DP2oxS2nC7DU1gHuqA9+
-        liq6BQg/L6Vqfb/gpeXTQ/mZzdqKajtULplYv7OSt1DYRUUku5Z09UpuKll7IqSY4cCjCw43QLVt
-        pkeErPvlXV/e/fL+6v7y/cXs6nZ2P7u5+XCD5rETNaYNL8xXQK6R44Uh1i5hmkjBdwT5gnGr1M7g
-        atBeK8gxe9Wk1qMu3gixZbzgHxYEaqmmnpt7WGEs0b5vnvEBFitjgvLDS/WaVae/6g6O3tXftvoZ
-        LgjN7bKwjdmH9nhy3qDdbUSvBKh73M7W50vMyzC7R+TPNFnjXtlAslHubF3Uq9s3Odzsf35UG4ma
-        VUDAxiJRcqmunDcWnMNM0d3ewbkkb6UrtswL3HyF6W6Kk5Y6/quwh49aWnmezg3AGkEIIkOU5nZm
-        HD9tO/UQhX0cFoZfpzmMXplwp6dqzw9VJBYsyAmIZ2rbvsnmvtgo7GgjjMzLVtthRUHDuMPD+Mtc
-        G/x3sa7mwWOHsr4ZGvQJ4nbwHb5o2U1DUjqq777YN2yDvmEbtDaf0cMheqgxNFlVVasgqMs8p7Y/
-        ustqh6BULy3mvwAAAP//7FhNb4JAEP0rvXiEroAFDsYa0yY9eOmhB2/LLlQSBMKHrTH8975lYWsJ
-        a5qmMR5MPKzs7sw4Mm/em55TAeYWlDHReF/4fMZtz/WCqUtCm/mE+TMr8qeR+HPVIXg4cwziMk6W
-        nMMHKgjlxA+PJ4GgvISts6S6zXtookLbY+JOT+ycEE2E8qnjPLjMc2e2H7DAJXAf0TDy2ILPWysT
-        ezmxnvGR94wdTbuMGYZ8VJp1aXwgEYZlgj1yM6+DBOIHmTJySkuRKNyPoRxitCAsV2uDmHkqUGxI
-        0K8/4iHDv/6Ihwrh2iMGKPG4zBN66NrMCq/+3ZpGUc1Y3BZQBf0i6ayEtA0aDQ4+1UUGDbMB2LDt
-        d6UJhYpdVbrCQyfDx3uTo2sJjo7WOorWDjdU2ynCPCuq8IYvl3uTbvhyiYhv+DKCL0MYUAxMERZE
-        /S5r7yhGad2awGFWUcgCMmJFx8GIDpeINQ5wOuFJdCzZ0XI09cuGN3TkzdZuKFYXpvu4yFLJ3OQj
-        XnfDaPn1V9nLdtLCsV92cP8H+D2Zo9/3dqGL6edrWNaJMHziuxVkRbWsZBz7rPq/SY80pozC15aW
-        b1mrZ1uJ38hZk1CJwqUK5Ge01o9wuwttepqm+QIAAP//AwA6/KnH+xgAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18163","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18163","key":"NTEST-1834","fields":{"statuscategorychangedate":"2025-04-30T18:24:05.156+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1},"timespent":null,"customfield_10030":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10031":null,"customfield_10032":null,"fixVersions":[],"customfield_10033":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"aggregatetimespent":null,"resolution":null,"customfield_10035":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"lastViewed":null,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1834/watchers","watchCount":1,"isWatching":true},"created":"2025-04-30T18:24:04.775+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},"customfield_10023":null,"labels":[],"customfield_10026":null,"customfield_10016":null,"customfield_10017":"dark_teal","customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sxz:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:04.919+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"weekly
+        engagement","customfield_10010":null,"customfield_10055":null,"customfield_10011":"weekly
+        engagement","customfield_10056":null,"customfield_10012":{"self":"https://defectdojo.atlassian.net/rest/api/2/customFieldOption/10016","value":"To
+        Do","id":"10016"},"customfield_10013":"ghx-label-5","customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10049":null,"customfield_10005":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"aggregatetimeestimate":null,"attachment":[],"customfield_10009":null,"summary":"weekly
+        engagement","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10047":null,"customfield_10003":null,"customfield_10048":null,"customfield_10004":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1834/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18163/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 71ee13bb-d170-48a6-906c-72016de1bb34
+      - bc345e84-9f04-474f-a8bb-ba1a1e2c9ce2
       Atl-Traceid:
-      - 71ee13bbd17048a6906c72016de1bb34
+      - bc345e849f04474fa8bbba1a1e2c9ce2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:17 GMT
+      - Wed, 30 Apr 2025 16:24:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -289,7 +284,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=249,atl-edge-internal;dur=14,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="AKledC5X5DQThSDgMJGUou96C3yEoSvGiKsiqx6z1U7bRo785Is7Hw==",cdn-downstream-fbl;dur=559,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=96,cdn-upstream-fbl;dur=556,atl-edge;dur=427,atl-edge-internal;dur=19,atl-edge-upstream;dur=408,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -298,10 +293,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - AKledC5X5DQThSDgMJGUou96C3yEoSvGiKsiqx6z1U7bRo785Is7Hw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 99e237ceb0c6f5fc7a7b096b25effccd
+      - 3b00967d3d5b23f46015be455c6ff525
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_disabled_create_epic_and_push_findings.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_disabled_create_epic_and_push_findings.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1q5b3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkIKSbm5fCzXD9XPdDO0dawIfx6hCUzgJTqxM27fxiurfTfaVsYN
-        TQzVgzbNV4TwGGBFcWpeiTCCDFieAE1gWTHGsxnPohjgAiIc8z7+AftKt+cshYoBpzlnLM0L9s3K
-        9sYqF8GMzhdSAOaoJJ0VKDKlMgVSseUsX9RqniGbK2BngmBGw63uxfhCVGIw4c5JMbYPxJwqgvZ1
-        W5Lj+WFPzo6T6/uKHD8BAAD//wMAywm9oCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:06.411+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 9201b83c-15d9-4c46-9f61-f0a372d55018
+      - ca09616d-5d09-411b-8bc7-09a852efb6c2
       Atl-Traceid:
-      - 9201b83c15d94c469f61f0a372d55018
+      - ca09616d5d09411b8bc709a852efb6c2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:22 GMT
+      - Wed, 30 Apr 2025 16:24:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=141,atl-edge-internal;dur=17,atl-edge-upstream;dur=127,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=211,atl-edge;dur=177,atl-edge-internal;dur=15,atl-edge-upstream;dur=163,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="KDK8ldWW1mSlc5LONYyZZQHG20PqXU58ax7roKtp3KBTBmaAHHGxew==",cdn-downstream-fbl;dur=216
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - KDK8ldWW1mSlc5LONYyZZQHG20PqXU58ax7roKtp3KBTBmaAHHGxew==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 16909ee7da3ff8018d8978c6291bc3ad
+      - 89e78cfb0c4e3913a5f66ec5ca70fce1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 956675fd-b0da-4f15-9be7-8a588f66f806
+      - 840eebe8-5b89-4e4c-8453-51703703f968
       Atl-Traceid:
-      - 956675fdb0da4f159be78a588f66f806
+      - 840eebe85b894e4c845351703703f968
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:22 GMT
+      - Wed, 30 Apr 2025 16:24:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=311,atl-edge-internal;dur=20,atl-edge-upstream;dur=291,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=330,atl-edge;dur=297,atl-edge-internal;dur=15,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="UKh63rflT8rK_5gCNCnEKJawgZqlWJchBxiSk3clUjRIk6u57aDAFw==",cdn-downstream-fbl;dur=335
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e9bcf307d6ed54e3e501e39bc538dcfc.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - UKh63rflT8rK_5gCNCnEKJawgZqlWJchBxiSk3clUjRIk6u57aDAFw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 9d516ffba8c89e4fa1c50bbbf114163a
+      - 2c6ee454c39e7b1aa06327656ae63add
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/238]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/238 (238)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/91]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1297'
+      - '1317'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16079","key":"NTEST-1595","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16079"}'
+      string: '{"id":"18165","key":"NTEST-1835","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18165"}'
     headers:
       Atl-Request-Id:
-      - b3de40fc-8540-4877-92b3-116e462e4442
+      - 16f6c288-90b8-4e64-b6cd-61c8e900598e
       Atl-Traceid:
-      - b3de40fc8540487792b3116e462e4442
+      - 16f6c28890b84e64b6cd61c8e900598e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:23 GMT
+      - Wed, 30 Apr 2025 16:24:07 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=682,atl-edge-internal;dur=25,atl-edge-upstream;dur=657,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="SjwqmibxJIz-3kA3_x_shCN2ywIBrE3OV6NXI0zNpDW-NxfPqldfTQ==",cdn-downstream-fbl;dur=788,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=786,atl-edge;dur=708,atl-edge-internal;dur=15,atl-edge-upstream;dur=693,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 82e46a17c2e4998f87de230e61a57612.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - SjwqmibxJIz-3kA3_x_shCN2ywIBrE3OV6NXI0zNpDW-NxfPqldfTQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 5fd91b40ec7f4a4cc825715be8375ebf
+      - aba75712d2f9efbfd74c1530043fb353
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1595
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1835
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxtXvpCiTRNjJaNjTEEBaTLEDLJaWrq2Jnt0HZc/vuOkyaF
-        Qu4VTLtCKrGPz/vjx+fRgWVGReyEjgIRg4L4kAGPdUvQFHRLRzNIaUtmoKhhUugWxMykYGgrmlGR
-        AJdJ6wGURhnEZ5Ap0CDM+myUayPTqTV463ue73UU/J2DNpNVBqeKRoZF4LQcZv37A293Dxca+BSX
-        M2MyHbpuDFOITCzvZYcaTrVmVHQEGBc9GZdmzA1cpnUObmVgDivUP5mMzydtv7/Xx60iBO2Ej47G
-        2HIdUQOJVKsyhxhXqBF4Qb/t+W3fmwRe6PfDoNsZDPs/YNyeDdI6MRh4YeaDQVp9F+15QZ32ehGD
-        jhTLbOFwd5/olHLeIjHThonIkIxBBEROyUKqecdqR1JcKP7OKHLBbLsov6UP1FDlPjBYuEVYmwDX
-        It/r+sOfNPsHfkyx7XmKXi0s0OWE6rntVX5n7Fc4pVxDyykVjzCvQrflzBgCR0Wz1TE8AMbqPbUc
-        wxBZGaLECUWOOTpbMOl6lSBT8h4z+mDB19pFuYsGVuW2i2cg2WR1IZgxaEA7tW+L1N+Ls1pOzYIq
-        i1fN0owzDDjeyhz7UaCsN1z2hu8M9wudqTKp+9LzdjGMoLcMev+vl7L7BRbRoT9Y+oNv4XBZeewG
-        y27wLTyuAf709BqOfhNOgyZBtxJM2fKyJEeExfUNwiRJFCTIN1+9BP1KgJlJnpe88PbRQZNgt0EQ
-        NAqGTYK91+GUtFnuWlIqXggnbPu4pAYfjpJw339xSzrfELhbmlP2WhafBzK3hfMtKV/ZDSYSJzQq
-        B2wfGjWX2HF7OcvgCnvWvmJRWcfHV3s2VlTWM5nzeMR0xulqfbktJBRgspY/3nokukO/eiS2y1ZT
-        2bagCVRBDapMMamYWX2wiJW623vfW8FSmoB2rYaujDDc4HLR0Q/JhiyP5aIi1Z7z+toE9SXg9A4s
-        LVr8b08ETdD1mxDqD209ZlSPMxYdMzE/tJIRZHZ6EVHVs6KTi0JW7wgpxji80DsOZ0B1iQO1/nJO
-        jy9+OTq5PT46GJ+cj2/HZ2d/nmF+eEs1FgQPTGZATpH/hSHWL2GaSMFXBLmEcWuUGEl+Y4qSUwUp
-        kgnJNWK28xan+HidHO8z87xMdEOnfBOxd1j8zZ16wRXYhoQJyrcPrWevdXkLVHOMrqIb7GsioD6d
-        Z/bSNuG4N+hVOC7HpA9Cr1Su392Xk8370LiB2880muOwWUGuMl76OljPc/8p4GoodKvZLKjGBAEW
-        6pHkUp2U0dzxHNqJQo7YjESSjGTZbJlmOA4L8zbo+02k0K9J4Usdf1nOv8Tmb2fCDIedkFx/opkf
-        kgMp5wzIFTPIaoacQ5QrIIecJp9tdbA4XEaUz6Q24dAbeu6UiRip1A26w5vC4KgoHuZ1L4mFVbhD
-        vqpJvsOf7wv1cxz6LAehGrLFOshRDmSE+eDmH3RFfK9FLBjrJA6uxii6xn/tgd8rIrV9jBbQSZlR
-        0JEqcRHG1LaW4cRm4e/i0c7MpLyIu7Rzae1ciLmQi+dFOlUyznEGGIsEL3aKbXInWGPrs6gQxkt+
-        lYu2kQ1VytYGghvikusFwBxZAGprDVqbA263UPy0f0rOIyoazts51N3z63yeZXC+0gZSjRnEmWQI
-        s52w2C96Y2uVUiY0M9BBJGKp9OxOUhU3nXhlf7RBmLW8TyL5LwAAAP//7FlRa9swEP4rolBooXad
-        xGmSQelC6WAPZaOFFUohyLbcmMWysey6Zet/33eSoqVe3I0ySh8KeXAi6e50vvvuu4sOJKAui4SQ
-        TImatTaqasCiMpGVIrIOWLvM4iXLBZcKi9zssBJw3RsZCcbjGLgqEnaXcdYgVeLqoQQwYZ+UwhRk
-        f8Oic7zlW91UkkFXSyEpshh3cgv0nLgRLKFrgf+xTKZFleszrKgIrTlWFYElgPq7kAdkGIRnNTNV
-        n/FVyx/oiqzk2rpGIaYZl2zDQHSMUqx8diYV3dnd0PjgRpITSBv5CBZYC9XaRBKoGjhoq6Ubd964
-        /QWyEHUHLqPb23Bp29YvWq5KnQ9IP3Hvl8tSxzKULCBzYXUveA2aEzUIqcXel6v55Vfv8txDidZZ
-        6pSURVWLivJgjyd5JvfZ3v5PBMqqLj4gDP9kN2NX4rvlrQ/hBmHfgqO7BH11BbDXnI44WWdr6Kho
-        ZyFwMroLfSwjcCxDvz1NtrZv7OPFgTPmSbXuYjZeAI+XlPymIqgmzzmVq52/ITV5nchnUb2wthEJ
-        OUG+EWX+nByPk9F0Mo0Gk0CM4lkQz8bDdDZIj6DHbYKGZ7YJCol5kkAH6huKXfLwccMQAArJerYd
-        Nrnio37qbRqmbEsWClA8ngzC8GgSTyfj0SyKo0kA9SkX6TQ+SY61lN3RfHf4CR9zzsu5tPDqeeYn
-        5TfKa+EIb+gTZPtlE62ymDzllZwrchTO6woCgojHUySFX0ryebe1fvsWd3vzt29xt7d/6xYDihLT
-        GFoSeIrQB4dJ0yaOM51AhOemETVAdg0aiI1nTVWU4vAaEBMvf2cazZaw6lKXNNiJ2nbmGPbhatjX
-        ToZ9M4rQYXdlgf8dX14tkt7x5TUsfseXLfjShQFHyBx/gdW3Jvd+0BDcPgdQWNTcjvC7UnqZVy8u
-        9VKy4Xbk65sHBX0clABh60LQx0FHfSdGjuQJeZdVhTREzvyUNPb/I/P1n7xX5EbCj/WjhfsXwO/G
-        X1+Ha7kHOzm/vxCqWZHgDd16XFLV89rYcVfU/29Ga4Q5odCFdvFboadN6zEqTYlphkMqnSFPrR0+
-        Mdce0O55fHz8BQAA//8DACY1SgquHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18165","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18165","key":"NTEST-1835","fields":{"statuscategorychangedate":"2025-04-30T18:24:07.850+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1835/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:07.543+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sy7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:07.631+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/238]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/238 (238)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/91]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1835/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18165/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - cf83cb0c-17a8-4746-804a-975499866154
+      - c0b9019d-bb77-444f-bfb8-674c14c4530c
       Atl-Traceid:
-      - cf83cb0c17a84746804a975499866154
+      - c0b9019dbb77444fbfb8674c14c4530c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:24 GMT
+      - Wed, 30 Apr 2025 16:24:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=292,atl-edge-internal;dur=25,atl-edge-upstream;dur=269,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=323,atl-edge;dur=290,atl-edge-internal;dur=15,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="oSsn3dghiMb68xLL86YZNtXxTwiSQ5zwpoRgHZGvTublZ476snjXYw==",cdn-downstream-fbl;dur=328
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a183b6545fea485604515ba7931cb9b8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - oSsn3dghiMb68xLL86YZNtXxTwiSQ5zwpoRgHZGvTublZ476snjXYw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 0672659fb3952f76e9f92709d77c0738
+      - 316267bc5f6b89f950c28b56dcbb9df6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16079
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18165
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9pHHhZWqipLQXkspggDSUYTM7mRj4rW3tpck5fjfO95X
-        eO2doOrpJC7r8by/+Tz3DqwzKmIndBSIGBTEBwx4rDuCpqA7OlpASjsyA0UNk0J3IGYmBUM70YKK
-        BLhMOnegNMogPoFMgQZhqrtRro1M59bgte95vtdT8HcO2sw2GRwrGhkWgdNxmPXvj7wPu/ihgc/x
-        c2FMpkPXjWEOkYnlrexRw6nWjIqeAOOiJ+PSjLmBy7TOwa0NLGGD+kez6ems6w93h3hUhKCd8N7R
-        GFuuI2ogkWpT5hDjF2oEXjDsen7X92aBF/rDMOj3RuPhDxi3Z4O0TgwGXph5Z5BW30V7XtCkXX3E
-        oCPFMls4PN0jOqWcd0jMtGEiMiRjEAGRc7KSatmz2pEUZ4q/MYpcMNsuyq/pHTVUuXcMVm4R1jbA
-        SuR7fX/8k2b/wI8ptj1P0auFBbqcUb20vcpvjP0VzinX0HFKxY+YV6HbcRYMgaOixeYQ7gBj9R46
-        jmGIrAxR4oQixxydZzDpe20CvxZkSt5iqu/sRKVd9KHobN0H+/EIPdt0zwQzBg1op/FtIfx7cVfL
-        uVlRZYGsWZpxhgHHz0qCjSrgNxivB+M3hvuFltWZNA0beB8wjGCwDgb/r5cSFgVI0aE/Wvujb+Fw
-        XXvsB+t+8C08Vsh/eHgJx6CG45ytz0sOxCZfXr282a9v0iRRkCDffHUIhrUAE5A8L3nh9aujNsGH
-        FkHQKhi3CXZfhlPSZnlqSal4IZyw61dcaSuvWFRGfv/izM4DFlUvZM7jCdMZp5tqavAYW2jOsT12
-        kioX1OBjVJL422e+fCK2j4JbmlN2oouf+zK3zSiCv7AHTCROaFRuo4kUYLKWJl57JPpjv34knpet
-        jcqChsqeCxpQZYpJxczmnQnX6u7gbW8FS2kC2rUaujbC8IDLVU/fJVtOPJSrmjsHzsvpCBrMc3oD
-        lv1eGQxLGq+WwW9DqD+29VhQPc1YdMjE8sBKJpDZ7UVENYIKXK0KWXMipJji8kJvOJwA1SUqVfXL
-        OT48++Xj0fXhx/3p0en0enpy8ucJ5odTqrEgeGG2AHKMNC8MsX4J00QKviFIGYxbo8RI8htTlBwr
-        SJEzSK4RX73XqMPHcXK8z8zzMtEPnfJNxN5h8bcz9YQrsA0JE5Q/v1TtXlV5C5RzjK76tn1NBDS3
-        88wObRuOB6NBjeNyTXon9Erl5nl9utm8DY1buP1MoyUumzXkauOlr/1qn/tPAddLoVvvZkG9DQiw
-        UI8kl+qojOaG59BNFDLWdiWSZCLLZss0w3VYmNdBP2wjhWFDCl/q+NNy/iW2/3ZmzHDYCcnlJ5r5
-        IdmXcsmAXDCDHGvIKUS5AnLAafLZVgeLw2VE+UJqE469sefOmYiR9tygP74qDE6K4mFet5JYWIU7
-        5Kua5Dv8832hfopLn+UgVEO2qIKc5EAmmA8e/kE3xPc6xIKxSWL/YoqiS/yvO/IHRaS2j9EKeikz
-        CnpSJS7CmNrWMlzMLPxdvNpbmJQXcZd2zq2dM7EUcvW4SMdKxjk+9VOR4GCn2CZ3hjW2PosKYbzk
-        V7nqGtlSpawyEFwRl1yuAJbIAtBYa9HaXnD7heKnvWNyGlHRct+um+6u3+TzKIPTjTaQaswgziRD
-        mO2ExXnRG1urlDKhmYEeIhFLpRc3kqq47cYL+5MtwqzlPRLJfwEAAP//7Flta9swEP4rolBooXad
-        xGmSQelC6WAfykYLK5RCkGW5MUtk45e6Zet/33OSorle3I0ySj8U8sGxpNPd5e655y46kIC6LJJS
-        sVJWrLFRVQEWSxNZCSLrgDXLVCzZWnJVYpGbHVYCzL1RkWRcCOCqjNldylmNVBHFQw5gwj6lpKEH
-        fkujc/zKt7qpJIWullJRZDHu5GboOWERNCGzQPNYqpKsWOszLCsIrTlWSwJLAPV3qQ5IMQhPK2Y4
-        COOrhj+QiSznWru6REwzrlhLQXSMSq58dqZKstlZaHxwo8gJdBv5CBpYDcuNiiSwrOGgrZq2bG5Z
-        f4EsRN2By8h6Gy5N0/hZw8tc5wPST977+TLXsYxLFpC5sHcveAXSFdUIqcXel6v55Vfv8txDidZZ
-        6i7Js6KSBeXBHo/Xqdpne/s/ESirKvuAMPyT3Yxdie+Wtz6EG4RthKsKYLqmWUQEu1sdAe4shI6K
-        dhaCvhOBYxn6R9KcavvGPtYR9PHiwCkDH3OxpPy2pbddvbsYXtbrNadytfM3pCavE/nMihfWNiIh
-        J8g3oref4+NxPJpOptFgEsiRmAViNh4ms0FyhHvcJtzwzDZJITGPY9yB+oZiFz98bCkCQCFZz3a9
-        Jld81E+9TcOU7bxCCYrH40EYHk3EdDIezSIRTQJcn3CZTMVJfKyl7I7mu8NP+Jhz3porC6+eZ16V
-        fl16DRzhDX2CbD+vo1UqyFNeznlJjsJ5XUFAEPF4iqTwc0U+73bQb1/jbgv+9jXutvBvXWNgVGza
-        VEsCTxH64DBJUguR6gQiPDdNo0G4a9BAbDyriyyXh9fAHrH8nWk0QsKqS126wU7UtjPHsA9Xw752
-        MnTtZGHx/R1GXi1g3mHkNTR+h5EtMNKFgT6mFjpC5vgKzLk1SfmDZt32OYAmWcXtCL8rpZd59eJS
-        3+AnGG5Hvl5m1mtZL2VzJncWRn0nRo7kSXWXFpkyLM+8imv7/5H5+i/eu8uq/zfHNMKcUNyENu1b
-        pqc8m2EqUsCo/GPzaOvLixXQ/7UdbuQe7Kz5/YUs6xUJbhmr5zNFNa+M4TQlphkOme7ePz08fHLa
-        HtDaPj4+/gIAAP//AwA5yv8JrhwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18165","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18165","key":"NTEST-1835","fields":{"statuscategorychangedate":"2025-04-30T18:24:07.850+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1835/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:07.543+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sy7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:07.631+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/238]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/238 (238)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/91]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1835/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18165/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - b5b24833-c41e-44be-a7ff-bd186b716c5c
+      - 9ef9bf46-caaf-4981-9092-d16b608c52fd
       Atl-Traceid:
-      - b5b24833c41e44bea7ffbd186b716c5c
+      - 9ef9bf46caaf49819092d16b608c52fd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:24 GMT
+      - Wed, 30 Apr 2025 16:24:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=268,atl-edge-internal;dur=17,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=19,cdn-upstream-fbl;dur=401,atl-edge;dur=320,atl-edge-internal;dur=23,atl-edge-upstream;dur=297,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="MDtGnyzNdpoBPu65TWDfqnlowoKYSaumwawA7Z8HL6OaXKNMl22VLg==",cdn-downstream-fbl;dur=405
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 596b1ac54ac9ee415236dc72536ba33a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MDtGnyzNdpoBPu65TWDfqnlowoKYSaumwawA7Z8HL6OaXKNMl22VLg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 93b8123f8545611270677c009a9f8d91
+      - dafa96e4d53ce51f35cee9aee8bb7a0e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2bfm25oSExEAykdhcQQmnqiEKaVE06aZr230nEBDsCN8t+
-        Xj+WD6ThFrejIoy8OTdYNp+3KFG41rybmDvFre24jjU6MiNtZwfF9//gKxx3ncAW7cca1bBC7XD8
-        65KV0VJNqAX+LrnD0XZGezgBSGKIIao2l4/V+qH+mW6mvvEVYc8BmsEMXrwTB2X2vb+y3g/BtlJm
-        an2omTrVfkUI8wFalqfmFXcBpEDzCJIIljWlLEtZ5sUAF+Bhn7f+DzjWXX/OJlBTYEnOaBaXRfrN
-        iv5GS+PBLCkWggPmKEWSlsgzKTMJQtJlmi8aWWRICwn0TOBUMNx2Iw8vRMkn5e6M4KF9IOpUEdSv
-        24oczw97MjpMru9rcvwEAAD//wMAxjiaSiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:09.212+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 89368160-b61a-489f-b34a-d47aa3a0dca0
+      - 4735be7f-fb50-4b30-991b-506d111d230a
       Atl-Traceid:
-      - 89368160b61a489fb34ad47aa3a0dca0
+      - 4735be7ffb504b30991b506d111d230a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:24 GMT
+      - Wed, 30 Apr 2025 16:24:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=163,atl-edge-internal;dur=12,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="LScbeAN7QLWO5bjghDMCqqoSVJsFbSxyBxHO8yQzA2tL9eoRPnVCag==",cdn-downstream-fbl;dur=232,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=53,cdn-upstream-fbl;dur=229,atl-edge;dur=156,atl-edge-internal;dur=13,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b6805b08a4af317938604723e3f3424a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - LScbeAN7QLWO5bjghDMCqqoSVJsFbSxyBxHO8yQzA2tL9eoRPnVCag==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 467f57362a436179e80d254fc6922ba2
+      - 6d268e568a04dbd73dd2034c541c1492
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - d80c69c5-7a74-4b72-b297-470c9f6c8d63
+      - 7c92abbb-36ea-416f-bb55-54dc3d2b36d1
       Atl-Traceid:
-      - d80c69c57a744b72b297470c9f6c8d63
+      - 7c92abbb36ea416fbb5554dc3d2b36d1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:25 GMT
+      - Wed, 30 Apr 2025 16:24:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=313,atl-edge-internal;dur=14,atl-edge-upstream;dur=296,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=350,atl-edge;dur=318,atl-edge-internal;dur=14,atl-edge-upstream;dur=302,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="SjUDwPKka5NMXnewpOz46kwVu9MN3Ibvre9scKyKNssWzoDOKJRVHg==",cdn-downstream-fbl;dur=354
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - SjUDwPKka5NMXnewpOz46kwVu9MN3Ibvre9scKyKNssWzoDOKJRVHg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a558139e265f7f681a4e7946e579ad81
+      - c1262029397303e05c7cd92ba1e7c434
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/239]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/239 (239)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/91]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1297'
+      - '1317'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16080","key":"NTEST-1596","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16080"}'
+      string: '{"id":"18167","key":"NTEST-1836","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18167"}'
     headers:
       Atl-Request-Id:
-      - ec176758-554a-42de-9fb4-4c3583837aa7
+      - f6640803-ba10-4e85-a062-8a84dece3712
       Atl-Traceid:
-      - ec176758554a42de9fb44c3583837aa7
+      - f6640803ba104e85a0628a84dece3712
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:25 GMT
+      - Wed, 30 Apr 2025 16:24:10 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=662,atl-edge-internal;dur=13,atl-edge-upstream;dur=650,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="M0ycRuQii18ZKjPtCb_-rAs7mzqgC9UF9wbspk5vVn1AwecoAmyEfw==",cdn-downstream-fbl;dur=829,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=60,cdn-upstream-fbl;dur=827,atl-edge;dur=747,atl-edge-internal;dur=17,atl-edge-upstream;dur=730,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c8780798b589dc6b55523ca0a9bc3c02.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - M0ycRuQii18ZKjPtCb_-rAs7mzqgC9UF9wbspk5vVn1AwecoAmyEfw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - f5e5c2891e49e56443a7c638878a456f
+      - 1a30a68e9ac3778f8982c98b9083fe1c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1596
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1836
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9pEHYaWqoiS0tJRGEEA6ipDZnWx88dpb20uScvzvHe8r
-        RyB3gqqnk7is5z3z+fM8OrDKqIid0FEgYlAQHzPgsW4JmoJu6WgOKW3JDBQ1TArdgpiZFAxtRXMq
-        EuAyaT2A0iiD+BwyBRqEqXSjXBuZzqzDO9/zfK+j4O8ctJmuM5goGhkWgdNymI3vD7yhhx8a+Aw/
-        58ZkOnTdGGYQmVh+lB1qONWaUdERYFyMZFyaMTdwmdY5uLWDBazR/mw6vpi2/f7BAI+KFLQTPjoa
-        c8t1RA0kUq3LGmL8QovAC/ptz2/73jTwQr8fBv3OsNf9AfO2bosgBhMv3LwzSWvvoj8vaMquPmLQ
-        kWKZbRyeHhKdUs5bJGbaMBEZkjGIgMgZWUq16FjrSIpLxd+YRS6YHRfld/SBGqrcBwZLt0hrk2Al
-        8r2uP/xJs3/gxxTHnqcY1cICQ06pXthZ5ffG/gpnlGtoOaXhCdZV2LacOUPgqGi+PoUHwFy9p5Zj
-        GCIrQ5Q4ocixRmcLJl2vFmRKfsSK3tnwyrpodzHAut1bINlUdSmYMehAO01si9TfC10tZ2ZJlcWr
-        ZmnGGSYcb1WO8yhQ1huuesM3pvuFydSVNHPpefuYRtBbBb3/N0o5/QKLGNAfrPzBtwi4qiN2g1U3
-        +BYRK4A/Pb2Eo78Lp0EtmLHVVcmBOP2b25ea3VqTJomCBPnmq5egXwuwMsnzkhdeVx3sEuzvEAQ7
-        BcNdgoOX6ZS0WZ5aUipeCCds+/hJDT4cJeG+/eKWdL4hcLd0p+y1LH4eydw2zrekfG0PmEic0Kgc
-        niqett4Ui8quPb44s5mhqp7LnMcjpjNO19VVxmNMy1whZuz1rrqhAIu1/PHaI9EP9utHYrttDZVt
-        C3aBKmhAlSkmFTPrdzaxNnd7b3srWEoT0K610LUThgdcLjv6IdmQ5alc1qTac15em6DBPKf3YGnx
-        lYth2eTVNvi7EOoPbT/mVI8zFp0ysTi2khFkdnsRUT3FYrbLQtacCCnGuLzQew7nQHWJDFX9cian
-        l7+cnN2dnhyNzy7Gd+Pz8z/PsT68pRobggrTOZAJ8r8wxMYlTBMp+JoglzBunRIjyW9MUTJRkCKZ
-        kFwjZjuvcYqP18nxPjHPy8R96JRvIs4Om7+5U8+4AseQMEH5tlK1e1XtLXDOMbvq2841EdBo55m9
-        tLtwPPD9GsflmvRO6JXGzbv7fLN5Gxo3cPuZRgtcNmvI1c7LWEfVPvefEq6XQrfezYJ6TRBgoR5J
-        LtVZmc09z6GdKGSNzUokyUiWw5ZphuuwMK+Dvt+QwpcGu23UEMbzdv4lNv/2psxw2AvJzQeaBSE5
-        knLBgFwzgzxnyAVEuQJyzGnyyXYHm8NlRPlcahMOcXd2Z0zESKVu0D24LRyOiuZhXR8lsbAK98hX
-        Lcl3+Of7wvwClz7LQWiGbFElOcqBjLBQPPyDronvtYgFY1PE0fUYRTf4X3vg94pM7RyjJXRSZhR0
-        pEpchDG1o2W4sVn4u6jamZuUF3mXfq6sn0uxEHL5eZMmSsY57gBjkeDFTnFM7hSbb2MWHcJ8ya9y
-        2TZyR5eyykFwS1xyswRYIAtA422H1UbB7RaGHw4n5CKiYoe+3UPdA7+p57MKLtbaQKqxgjiTDGG2
-        FxbnxWxsr1LKhGYGOohEbJWe30uq4l0aL/yPNgizng9JJP8FAAD//+xZUUvcQBD+K4sgKJiYu8v1
-        7gpiD7HQB2lRqCDCsUk2XujdJmQTo1j/e7/Z3dvG9GKLFPFB8CFmd2dnJjPffDOnAwmoyyIhJFOi
-        Yo2NqgqwqExkpYisA9Yss3jJ1oJLhUVudlgJMPdaRoLxOAauioTdZpzVSJW4vC8ATNgnpTAl2m9p
-        dIavfKObSlLocikkRRbjTm6OnhMWQRMyC/yPZTLNy7U+w/KS0JpjVRFYAqh/CHlAikF4VjHDAxhf
-        NfyeTGQF19rVCjHNuGQtBdExSrHy2alUZLOz0PjgWpIT6DbyETSwGqqNiiRQ1XDQVk1bNresP0cW
-        ou7AZWS9DZemafy84arQ+YD0E3d+sSx0LOOSBWQu7N0LXoH4RDVCarH39XJ+8c27OPNQonWWukuK
-        vKxESXmwx5N1JvfZ3v5PBMqqyj8iDP9kN2NX4rvlrY/2DMI29FUlMF1TNyJj3a2OAHcWgr6F0HHU
-        7gnHMvRH0pxq+8Y+1hH08eLA3fmkWnfBHB+Ax0tKflMRVL1ecypXO39DavI6kc+8fGFtIxJyjHwj
-        yvwlORono+lkGg0mgRjFsyCejYfpbJDSkMRtwg3PbBMUEvMkwR2obyh2yf2nliIAFJL1bDtscsVH
-        /dTbNEzZliwUoHg8GYThh0k8nYxHsyiOJgGuT7lIp/FxcqSl7I7mu8PP+DPnvDWXFl49z7xSfq28
-        Bo7whj5Btl/U0SqLyVNewbkiR+G8riAgiHg8QVL4hSSfd1vrt69xtzd/+xp3e/u3rjEwKjGtoiWB
-        Jwh9cJg0reM40wlEeG4aUYNwV6CB2Hhal3khDq+APfHyd6bRbAmrLnXpBjtR284cwz5cDfvaydC1
-        k6XF93cYebWAeYeR19D4HUa2wEgXBvqYWugImeMvMOfGJOUDDcHtcwBN8orbEX5XSh8lC/pwKRhu
-        B7i+eVDQa0AvZXOWdU/0cblR74IjeULeZmUuDZEzr5La/n5k/v0X793m1f+bjRphTihuQpv2PddT
-        ns1AEylgVH7YPNr68mIF9G9thxu5BztrfncuVL0iwS1j9XymrOaVMZymxDTDIdPd+6eHh09O2wNa
-        28fHx18AAAD//wMAeLjZBa4cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18167","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18167","key":"NTEST-1836","fields":{"statuscategorychangedate":"2025-04-30T18:24:10.506+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1836/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:10.174+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00syf:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:10.268+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/239]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/239 (239)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/91]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1836/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18167/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - b3ef8a5d-dba7-4a85-8435-71ab58f47310
+      - 86e4a95c-b0e2-4340-81ad-de546895363d
       Atl-Traceid:
-      - b3ef8a5ddba74a85843571ab58f47310
+      - 86e4a95cb0e2434081adde546895363d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:26 GMT
+      - Wed, 30 Apr 2025 16:24:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=295,atl-edge-internal;dur=14,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="f_2DabVRKzxQFg0bEeMS5dcY1RwH2ZcPPkubVSrn4iAEVSnHFh5OPw==",cdn-downstream-fbl;dur=368,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=366,atl-edge;dur=278,atl-edge-internal;dur=14,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0730d54c3f7ca2a2e0c1b4cda1ebc0aa.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - f_2DabVRKzxQFg0bEeMS5dcY1RwH2ZcPPkubVSrn4iAEVSnHFh5OPw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - f6ae5f32f1521b6e2aa91a47a43877aa
+      - 605179318249af034eabf5bf5c7a0226
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16080
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18167
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvfiljoBhyGJn65ZlQeI0QLMgYKSzzJoiNZKK7bX97ztS
-        ltw6UYtkWFEgtXi89+ce3nsP1gUVqRd7CkQKCtITBjzVHUFz0B2dLCCnHVmAooZJoTuQMpODoZ1k
-        QUUGXGadB1AaZZBeQKFAgzDbu0mpjczn1uBdGARh0FPwdwnazDYFnCuaGJaA1/GY9R+OgnGAHxr4
-        HD8XxhQ69v0U5pCYVL6TPWo41ZpR0RNgfPRkfFowP/KZ1iX4tYElbFD/bDa9nHXD4eEIj1wI2ovf
-        expjK3VCDWRSbaocUvxCjSiIht0g7IbBLAricBhHw9540P8B47ZmnRODgTszLwzS6vtoL4iatLcf
-        KehEscIWDk+PiM4p5x2SMm2YSAwpGCRA5JyspFr2rHYixZXiz4yiFMy2i/I7+kANVf4Dg5XvwtoF
-        uBWFQT8c/6TZP/Bjjm0vc/RqYYEuZ1Qvba/Ke2N/xXPKNXS8SvE15uV0O96CIXBUsticwgNgrMHH
-        jmcYIqtAlHixKDFHbw8m/aAWFEq+w4xeWPCttiu3a2Bd7j2Q7LK6EswYNKC9xrdF6u/urpZzs6LK
-        4lWzvOAMA073Msd+OJQNxuvB+JnhfqEzdSZNXwbBKwwjGqyjwf/rpeq+wyI6DEfrcPQtHK5rj/1o
-        3Y++hcctwD9+fAzHsA2nUZugXwvmbP2mIkeExc0twiTLFGTIN18dgmEtwMwkLyteePrqqE3wqkUQ
-        tQrGbYLDx+FUtFmdWlJyL4QXd0P8pAYfjopwnz+4FZ3vCNyvzCk7lu7nsSxt4UJLytf2gInMi40q
-        AduHRs0b7Lgdzio4Z8/aVyyp6vj+0ZmNFZX1QpY8nTBdcLrZDreFhAJM1vLHU4/EMHpVPxL7ZWuo
-        bF/QBqqoAVWhmFTMbF5YxFrdHzzvrWA5zUD7VkPXRhgecLnq6YdsR5anclWT6sB7PDZRMwSc3oOl
-        RYv//Y2gDbphG0LDsa3HguppwZJTJpYnVjKBwm4vIql75jq5crLmREgxxeWF3nO4AKorHKjtL+/8
-        9OqX12d3p6+Pp2eX07vpxcWfF5gfTqnGguCF2QLIOfK/MMT6JUwTKfiGIJcwbo0SI8lvTFFyriBH
-        MiGlRsz2nuKUEMfJCz6wICjEfexVbyL2Dou/m6nPuALbkDFB+f6l7e61La9DNcfoarrBvmYCmttl
-        YYe2DcejMKxxXK1JL4Repdy8u59vNs9D4w5uP9NkictmDbnaeOXreLvP/aeA66XQr3ezqF4TBFio
-        J5JLdVZFc89L6GYKOWK3EkkykVWzZV7gOizM06AftpHCsCGFL3X883L+JXb/DmbMcDiIyc1bWkQx
-        OZZyyYBcM4OsZsglJKUCcsJp9sFWB4vDZUL5QmoTj3F39udMpEilftQ/vHUGJ654mNc7SSys4gPy
-        VU3yHf753qlf4tJnOQjVkC22QU5KIBPMBw//oBsSBh1iwdgkcXw9RdEN/tcdhQMXqe1jsoJezoyC
-        nlSZjzCmtrUMNzYLfx+v9hYm5y7uys4ba+dKLIVcfVqkcyXTEneAqchwsHNskz/DGlufrkIYL/lV
-        rrpGtlSp2BqIbolPblYAS2QBaKy1aO0u+H2n+PbonFwmVLTct3uofxg2+XySweVGG8g1ZpAWkiHM
-        DmJ37npja5VTJjQz0EMkYqn04l5SlbbdeGR/skOYtXxEEvkvAAAA///sWW1r2zAQ/iuiUGihdp3E
-        WZJB6ULpYB/KRgsrlEKQZbkxi2Xjl7ql63/fc5KipV7cjTJKPxTywYmku9P57rnnLjqQgLosklKx
-        StastVFVAxYrE1kJIuuAtctULFkmuaqwyM0OKwHXvVaRZFwI4KqM2W3KWYNUEeV9AWDCPqWkKcj+
-        hkVneMs3uqkkgy6XUlFkMe7k5ug5cSNYQtcC/2OpSvIy02dYXhJac6xWBJYA6h9SHZBhEJ7WzFR9
-        xlctv6crsoJr65oKMc24YhsGomNUcuWzU1XRnd0NjQ+uFTmBtJGPYIG1sFqbSAKrBg7aaunGnTdu
-        f44sRN2By+j2NlzatvXzlleFzgekn7zzi2WhYxlKFpC5sLoXvAbNiRqE1GLv6+X84pt3ceahROss
-        dUqKvKxlSXmwx+MsVftsb/8nAmVV5x8Rhn+ym7Er8d3y1odwg7BvwdFdgr66BNhrTkecrLM1dFS0
-        sxA4Gd2FPpYROJah354mW9s39vHiwBnzpFp3MRsvgIslJb+pCFWTZZzK1c7fkJq8TuQzL19Y24iE
-        HCPfiDJ/iY/G8Wg6mUaDSSBHYhaI2XiYzAYJDUncJmh4ZpukkJjHMXSgvqHYxfefNgwBoJCsZ9th
-        kys+6qfepmHKtmShBMXj8SAMP0zEdDIezSIRTQKoT7hMpuI4PtJSdkfz3eFnfMw5L+PKwqvnmZ8q
-        v6m8Fo7whj5Btl800SoV5Cmv4LwiR+G8riAgiHg8QVL4hSKfd1vrt29xtzd/+xZ3e/u3bjGgKDaN
-        oSWBJwh9cJgkaYRIdQIRnptG1ADZFWggNp42ZV7IwytAjFj+zjSaLWHVpS5psBO17cwx7MPVsK+d
-        DPtmFKHD7tIC/zu+vFokvePLa1j8ji9b8KULA46QOf4Cq29M7j3QENw+B1CY19yO8LtSeplXLy71
-        UrLhduTrmwcFfRyUAGHrQtDHQUd9J0aO5El1m5a5MkTO/BQ39v8j8/WfvJdnRsLD+tHC/Qvgd+Ov
-        r8O13IOdjN+dy6pZkeAN3XpcUtbz2thxm9f/b0ZrhDmh0IV28Xuup03rMSpNiWmGQyqdIU+tHT4x
-        1x7Q7nl8fPwFAAD//wMAhUhHPa4cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18167","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18167","key":"NTEST-1836","fields":{"statuscategorychangedate":"2025-04-30T18:24:10.506+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1836/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:10.174+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00syf:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:10.268+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/239]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/239 (239)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/91]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1836/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18167/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f9cd5f0b-bd67-44ad-84da-21374f6d71e1
+      - d09eb5b5-84e7-4576-b995-be6c89d28618
       Atl-Traceid:
-      - f9cd5f0bbd6744ad84da21374f6d71e1
+      - d09eb5b584e74576b995be6c89d28618
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:26 GMT
+      - Wed, 30 Apr 2025 16:24:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=274,atl-edge-internal;dur=23,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=294,atl-edge;dur=261,atl-edge-internal;dur=14,atl-edge-upstream;dur=247,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="9190YbP9Hst6-5L5ZZs4N_cnssJO-p8J3lFs67INcMtKZ-Bxp_-Ssg==",cdn-downstream-fbl;dur=298
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 9190YbP9Hst6-5L5ZZs4N_cnssJO-p8J3lFs67INcMtKZ-Bxp_-Ssg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 53e759d3c399f035830f7d48533e4200
+      - 957c91d105e2aeea2c5b209dccd718f4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -881,7 +863,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -895,9 +877,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"828\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:35240\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:34156\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: weekly engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\":
@@ -933,7 +915,111 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:15:26 GMT
+      - Wed, 30 Apr 2025 16:24:11 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: weekly engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/91", "url_api": "http://localhost:8080/api/v2/tests/91/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "weekly
+      engagement", "id": 3, "url_ui": "http://localhost:8080/engagement/3", "url_api":
+      "http://localhost:8080/api/v2/engagements/3/"}, "test": {"title": null, "id":
+      91, "url_ui": "http://localhost:8080/test/91", "url_api": "http://localhost:8080/api/v2/tests/91/"},
+      "finding_count": 2, "findings": {"new": [{"id": 238, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/238",
+      "url_api": "http://localhost:8080/api/v2/findings/238/"}, {"id": 239, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/239",
+      "url_api": "http://localhost:8080/api/v2/findings/239/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1300'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1300\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:34164\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: weekly engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/91\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/91/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"weekly engagement\\\", \\\"id\\\": 3, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/3\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/3/\\\"}, \\\"test\\\":
+        {\\\"title\\\": null, \\\"id\\\": 91, \\\"url_ui\\\": \\\"http://localhost:8080/test/91\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/91/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 238, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/238\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/238/\\\"},
+        {\\\"id\\\": 239, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/239\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/239/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 3,\n      \"name\": \"weekly
+        engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/3/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/3\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 238,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/238/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/238\"\n        },\n
+        \       {\n          \"id\": 239,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/239/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/239\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        91,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/91/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/91\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: weekly engagement: ZAP Scan\",\n
+        \   \"url_api\": \"http://localhost:8080/api/v2/tests/91/\",\n    \"url_ui\":
+        \"http://localhost:8080/test/91\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:24:11 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -958,26 +1044,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2T9WPLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPARYUZyaV8JHkAHLpkCnsKwY4+mcp0EMcAEBDnkX/oBD1XbnLIWKAacZZ0UCef7N
-        yu7GKBvAlOYLKQAzVJLOCxSpUqkCqdhyni1qlafIcgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMA2R0cXSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:11.817+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 236ef8fa-9627-4821-b799-b43502c0220d
+      - c976bb35-5e09-4b44-a0fe-3d18864a1a25
       Atl-Traceid:
-      - 236ef8fa96274821b799b43502c0220d
+      - c976bb355e094b44a0fe3d18864a1a25
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:27 GMT
+      - Wed, 30 Apr 2025 16:24:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -987,7 +1069,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=150,atl-edge-internal;dur=13,atl-edge-upstream;dur=136,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=206,atl-edge;dur=173,atl-edge-internal;dur=14,atl-edge-upstream;dur=159,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="MMw3melzr9famCvpBrWPXy0pqO2jQq7pyBtOVqCVRnpVeJvrtRswJA==",cdn-downstream-fbl;dur=210
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -996,10 +1078,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8139bc666c011a53bdc5037ba6d5931e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MMw3melzr9famCvpBrWPXy0pqO2jQq7pyBtOVqCVRnpVeJvrtRswJA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 807b585631f90cdaa143da838491f5f0
+      - 8629b8ad729f98dfd2ebbe11109c29eb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1026,26 +1116,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmB5AjSBZcUYz2Y8C2KACwhwyLvwBxyqtjtnKVQMOM05K9KMLr5Z
-        2d0YZQOY0flCCsAclaSzAkWmVKZAKrac5YtazTNkcwXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAlmYPJiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:12.130+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 5279709e-d145-4ce4-95cd-00f10a408744
+      - 2a9de0e1-f066-41f9-adac-e6c0f6243e9e
       Atl-Traceid:
-      - 5279709ed1454ce495cd00f10a408744
+      - 2a9de0e1f06641f9adace6c0f6243e9e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:27 GMT
+      - Wed, 30 Apr 2025 16:24:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1055,7 +1141,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=186,atl-edge-internal;dur=33,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=214,atl-edge;dur=181,atl-edge-internal;dur=23,atl-edge-upstream;dur=158,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="kZgSC-T9A5xFNwvidPnOlNtEAbBzpiBmsOw_wHtf78WD8F2PGzjDYA==",cdn-downstream-fbl;dur=218
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1064,10 +1150,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - kZgSC-T9A5xFNwvidPnOlNtEAbBzpiBmsOw_wHtf78WD8F2PGzjDYA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 49acac42b05000c1b5882849c8b9d031
+      - 9bf4805d4cb5912610d0ae822648ed42
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1094,97 +1188,135 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/field
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7RWS27bMBS8iqC1F+6iG+8KuwGKBm2RItkYRkFLTwobiTJIKo0R5DS9T89UUqTI
-        R4VSBMfe2ODwUTPzPhK3zynN01UqJJGtyIiEsuHH7J6wEnK1ShfpAxynAxipQUX87CKStQ1J1iZG
-        BWStkE2drgpSCVikDc+Bk30FDmHkkZYGkbxVgADCFQdCsoq0Ar4pKpGutlZOz2WpNlrPTp3O7qEm
-        6eo5lceDlqaFSlprseIoJNRThl5eFjYpB8KBSZcCt7SGf/Tr9/mzMQODlmznxBT06Q64oA0TTlGI
-        WVlX9Cl59Oi4OCNlUls09541mmzCOTkqYqryrOJTqwXnHuv26Q5rOug8BMf7bdLqnDpEvQ7IfTk4
-        iKZqpTFmhAaQFXmDsXF9p5YCUcZKEShy2UeoT35FhLyj8KcbWOMngKyfa4UlDhw3NCfh8cZHrDFL
-        sVFGR9DwctpwKn0fIaAfYI+MOzm1NI4u5gJpcS4chouyh8qPu1u6Ytj1+dVbqpj24XwLySkrw3p0
-        h70PXTAQ6hd/UQagG5iaUKYemHz2e+P+Tu8z3hMhnkBSzDtr6z1w7DU44h2TsuRQ2l5VZS0pI9Wr
-        FLwVZXPy72/y3W5eOCvzPE/L9klAXyHjFwHW2qeigEyKy36wSEcC+Tu/Wk6jd0iFaKGi7MF7DKB+
-        UNUS8uSL3rqMxY5V08wyF2h0/hCKGlkIWjJAPeuBvoYeOb8xRxfzpQLDxuyDh5cKp94trXZziZhU
-        PmeYotItV0y4kzG4jiLhWVMfGqbugF58AFkDa4yNmzg1/Y4yamPYVz4aOUOqB4OjXQVjYwDr7Gu3
-        GLc0py7Rl5xWsDCE/b9X4m94hrmgUOW/PiyXH5e+DpEdK3oD+lWzaX43ybqLSm5vrpMrHaqCWiY5
-        YaJSr8lcq3nzQO/eODtHPYttp3inHj5NPbG7vf0PAAD//7xZTW+CQBD9K6Sn9gCpiiZ6NU1jLzXV
-        9EJ6QKQWRSB8mP787izLuiwzFYN4UWB2Z2bf251hhurqC90W8o2gch/2gOXmIZxPN7L2QepaSViw
-        vGGV28RSIAUl2axIQ6lgwejgXiunQ6NgQJIDEpocFkCMZeAd2N91JCET+yJrQJCFuNBilKM+ecwY
-        UaFvQCB9wskUMbYLlUxDwu01GB3QjA5JRkEiGF0cE9eDaIOQJmV98TIEXqSV8sJZ/cRpbuT+by7g
-        jAFFieby4/3tZb5m45M03jOuQMbXzzQOnyFCNim4xXkCj/htg4MhzcGI5AAk8lRB0sU5kLK+OBiV
-        Z4NbwXavnqG2fKjFF2LxBbRBNeM35tY/+WGcHFkuM4Mo93epC1W0WQ6albq97wbCIxphm0QYJALh
-        zyKMAK8gLEtGBGh9SF9424B33RgKe6Q60RXYk2oPwdem8R2T+IJE4LtidgMwjmOrivvCdQy4ng2h
-        mOp199bMEM80sFnsPQWez/bmwZLDZ+jcCs4xDeeEhBMkAs7X2OVdCQTKStQXjBOAsTLC/x3+i6c2
-        HVHdO3rfkmF2V1NRITohEbWnFKJcIkOsntbLNLNmQf269xZkXk9c2FP8tQXx4PKgZlq9Z4q0p0Rj
-        5/+GDtrIuVd/CwPpQicH6eB4qe/mMUwRe1TeixXN5YNua8A3klCOrUW8lp6rTDFWqfyLTe5mSmdG
-        eVAF/mJjVo+6+Y9ycLaIrUCPPnhTRqqgQwhZmHIJGULga1lZBjy0DB61GX2FDaI0rdn+T+zAJR4k
-        xPfKDiECNOCljE0XpzZZnHIJRRArz2ApxpodTVGvtSQKn3lLwv4AAAD//0KOMOzdU+xuIEZZNJhd
-        XJKYW4A7GkHlFeVRiWIKLCJx90lNcPZJwTK4IlIBPk9DTOQhVNMqwsD9Vqi9AAAAAP//tFrBcoMg
-        EP0Vj+3BU53Rc9Nj28kkRw4Zamx1xgZHTfz9wmpRcdeA0ZPKArvwHrC7iOmlRKx94KCYu9kaB7K+
-        7xoDRAesARmwgoQE6BMORjdPymizFVhdgHtH+3wF1n7gwGmn4AGgvnPBJ3FEMAh7y6SQ/huoaeEZ
-        FHSoHPqSf0umR/HSydTqsBkwXQldGfH6ilLIt6p3KjBJNyLp7e37QnpQi/0LbDADM6ZenhbSK4hM
-        SICEWkEqo8hLLuP2InVaRmjDrdYSJC/sTLCoxfQ3vrDW2AFVSMKlZztZW3TKIyBTHiChEPQO/JwJ
-        7/Va1+JSOWFINN0KRUiV2BphVY+NynA0RWH8xLMAzVKp+Wq1TBClsy4BmXUBCYnoMcllifeeVbX3
-        tONVLNVffp7dsL3XyVYoQybH3RzHFmwkjbV0jgN+k9WpH6fZaPwL6KDVVWDEhBEzWaOQZISS2DHi
-        45rX2S4VWZw8wgm0m61YEVqwAjXIuc2YGb9KXuSJF0OdiiCI6QSvsWmAaoIhIc2QiGSIktgx5AiX
-        g+ZUulME72crjkQWHMEtcm/E3kpRnEVzwfmwBv4E9BEJ/csA+pE2eAOdp1N3++ib/8Ps23JP3NS9
-        QdKoOLytALD/AQAA///EWz1WwzAMvkovYBZvjLCylQdDpzT9AZrUvCZQOA/34UzEshzZteQ+SvyY
-        GkuuJX1WZFuK42mXOxeaWw1zK4nlZiDdhA27qZUy++ZTOZ6CvJsC+E5R1hmUxcQ9cMQX7PZpXe9u
-        zMdawPTMP0oBKyTrI9k59gIel/aRfxWKhcZ6FJzMXpC2T85t6XGt7FmNBHLocKc25rD2bnow05ng
-        W6j/AzZLKO9EcZp7JUa1HYF0PprDrjH2FXRaUxv1vjPb2eNAzKqeuDd2OeffnMqnrkgajUZ4EpkB
-        UQIG8IaEFDQFPvCc3TvaL4xJp4GzJZIIP5x1YafRHiKSRTb52b26ArCzKKSgRZCLnSNNtuhyzyKZ
-        nDFpxYr6y6FZLIgABy2bvy3b534IvLONObRCNE47lQrAUPY4FZeF5Hzg7K6GGGJHqlRb7avteuWW
-        ue4ahledF+fIqt6g38RhNKhs4LZhxJfaFESR8DdnYaHy0jhYSJMwgAJJdhSxMAOcMT7V9uPtjJec
-        9CjlIlBoiWRxQEzoHw3IyjuHXC3RYrUEOD7AmL5qcuDGHUphCzWRUFRhaHsrKo+sXObQWkTWchDZ
-        4GIcAytzbW4yTP3YC/9gwUWgNb89nGI7+HJslb/PmaAZFCOijx7iFZBlIZ7fX65KWXA15JBJl0BG
-        SdlVxGwwcNA0fzGG9RRiTu4o6BOQ0SUx+PQ/VSst52G1mIcFDmLpTkl+E8jgGXcohWmQP/Wigtal
-        eYsfAAAA//8iIXSxj1sY4x7UNEYa1CQ4bgFSh97oQAwIQGSxhD0OlbSKBPBwJVY7sYU6hWMVuAcD
-        jXAOFxsBAAAA///MXMFOwzAM/ZX+wDjkuBtCmuCENHZDOxTUbUXQVmmFxt/jOG6dNHYrpEXigLTa
-        7Ry/1ybuw1kgFx9Ke64GJ6ZYR5uA3uyMTKgZRC2KJaG10szTtVv423g3LbRvZe8arCqnegUZEIBm
-        AUBVTUVPDGDVKCpp5M8FHipkQaRbQxeOfgROV8mMqpKhh4B7hjVsqQSM/LmAQwUsiCQB94dVZ60A
-        bCESYSvXfyZQr3jHPlHnIU3MhOfe2b9vsENfxCuJigYXToIsaLOaCpjZN8RaEbb+TymGFsrOaUXF
-        nmwZ8uOQUj5pOcbnB4mUA1zIUh0fj0mgwebS63w8K9/FPBjOgUycAa40QBSsO+9UDPhUBAffdmgs
-        hmVmkgeVTlljRspFGE0seoU+zm64AI1NWbs9hj6t0EL5PH3BY5uJoSPPmK5xOfjVDT6mYWCLda6H
-        maPRJ9eNKd410oM8Xq3P/6oUhx7K8KWD4kapOSZfrnnfC28+ipT3XC3+6NPKuPu51v0dvJVVzaXt
-        usriSrA9XzZ9PPxxbtebhY2qSaGHENt9wksg0iZAxs5cmKESxWHo03/8H5DR9Smj6lPoIaRfHx7v
-        94ej71JuT8Wutv1QwFTXtU2vvOGtXnNzXlYjLp+APfPOfEKzJTPLNsbIjCZN1DKH1XW4g/HbAd5h
-        thhjDBGVoiNnuvJlVOULPTPOUK6pm2L6kYcFrpJzs3GURJIdvg1+Ogy4UCS09T2XEQ2ONihT43RH
-        BuY7Vn8BAAD//8ScTVODMBCG/wrjnUMcT17Vu+PHD3AoB7QzILXWny/ZbJIN7EsBm/FWsqGbPOTr
-        XUgEZxgEIYsf0b/sCXCPbePOpVC4j3JcnDazojDIyJe8/J8g0zWOghjIlywJ385WoRDbzCDnSc5M
-        vI3gPfK5HDCYTd8Pp0G4D/9c0j9PGq2ZgQoDIGRhqO7tbdXuaT+bwjLNkAshhT+kK43cNFZ0hpyL
-        HKVl9+Bw4MPAwAdZGJw7CLGg44dUcGmGXODcx0HClQZufpTUQh/h2McUGg56GBj0IAtDe3pDtNiS
-        CxMFOsjHQj6gVQ2r233905a9LK6nI4IXx85O8lHgxGsm8RoSvNsLCpzojX+tEjj+bqEcG+XIsyAi
-        dSPXM5zhpozD22qsSssrXwKxwVgtmAZhGt5Qb408dvWh6hu/kHcY0jSu/X2SiOu9tXVLp1rNwogZ
-        aibvwJ0ZKliy+M5cfx4HODNvfUY5cnVuUrOJL5XFjoe4uu9dXjLAcVEcInH73ZWuOYTsvs9jUWug
-        qCULQ3zomqogXCpBac6Fj4RtdKSyWzPzDmOk3S9c0k7GCTCsTQ3UpmSRwObETZohFzT6dkK60rDp
-        Wv8MNl2dGKwPDdSHZJHc7vA6L7HnokYbO4UnDdqmtqav8bCiMzeQmbVIZniFJ825iNH2vehIA7Zq
-        9eJ6piyzhyV219npb6ht9eEeRJznRSIjerGCXST7YiyY4/4QAR+VJZm3Qzp++PD7ELJwzZ5/AQAA
-        //8CzZcqQMdqsMQ+ijytoh9yRBKyTQjOAB36YIh7sYgBzoAFy0AD1hl87LwCtPbFErKoCqgftAAA
-        AAD//8Rdy26DMBD8lf5AJPcTKvVYqZfeerIimiCFBPG4VOq/Fy+2u2vvUEetxSWJdxfWjAcMg7Uh
-        aA1BK1Ox1m6LRcwGvFAmIY+Ed2hHcNmSAbXgJVFEpmKt/eDFgomBggl5Engbu74T2QA4hNSCmEST
-        NJlo7wczk1fG5jiLovTMEK613vLw4orisQ4VTCOFmF1ozxoKoTtrBJtNYj8xZaBURB5JGVqAszGh
-        aGG1qEOykZYws+1cmcYwyclOkz2effm+FXVh8nA/cdsdRCq8H2E59bv+9I2f6GMkF7NiekFRjTyS
-        Xgvm/aVxJ/TvHMtjaxGNhDeYVXfsTTmm441z11n+vyyxHa5c0XAH0wohDMk0CHJlJ0RjNkFVhzz+
-        gJ5/ypLqFGJ1SyvyhjQdnkoDQXnyUSlQVnF1cXsM83KrBus8Buo85PGwvjW20/H0nlpAkrrjc7iv
-        d/ehn1aT7AnGE55SMfog9hVAfFwMt+tHe5pX5F3uPyeho//CwwNVJfL44XkdTvbaflKvgK6UhtQa
-        MFKWZDJtsNJZhsmbN7YxHk+ub7KND3zrTIYyWIYyUIYiT5ic+35wi8IByNz97wDzncffsjS8W1nz
-        DQAA//8Cn3kB1FcEOvFCBxYtuBYgoEUDSB/uMCcmeYOdADIGe/fbAPeglgHOQS2wDDQGBvL4eAPw
-        cBb68fED1klBGvJKzSvLLMrPQ2lcoopBg88VRRDmJupV+siWYgsOzIofWQfCQymlqHcZIvhQj7iU
-        pqI3/qjnixTwNSMwO7H5A2o1YmIKqhYpdefnokQHgg/1gTNcgAQPENvKh9mGze1QuWLdgsR0FE/A
-        NNXWxgIAAAD//wMADdrZt2VyAAA=
+      string: "[{\"id\":\"statuscategorychangedate\",\"key\":\"statuscategorychangedate\",\"name\":\"Status
+        Category Changed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"statusCategoryChangedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"statuscategorychangedate\"}},{\"id\":\"fixVersions\",\"key\":\"fixVersions\",\"name\":\"Fix
+        versions\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"fixVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"fixVersions\"}},{\"id\":\"statusCategory\",\"key\":\"statusCategory\",\"name\":\"Status
+        Category\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"statusCategory\"],\"schema\":{\"type\":\"statusCategory\",\"system\":\"statusCategory\"}},{\"id\":\"parent\",\"key\":\"parent\",\"name\":\"Parent\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"parent\"]},{\"id\":\"resolution\",\"key\":\"resolution\",\"name\":\"Resolution\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolution\"],\"schema\":{\"type\":\"resolution\",\"system\":\"resolution\"}},{\"id\":\"lastViewed\",\"key\":\"lastViewed\",\"name\":\"Last
+        Viewed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"lastViewed\"],\"schema\":{\"type\":\"datetime\",\"system\":\"lastViewed\"}},{\"id\":\"priority\",\"key\":\"priority\",\"name\":\"Priority\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"priority\"],\"schema\":{\"type\":\"priority\",\"system\":\"priority\"}},{\"id\":\"labels\",\"key\":\"labels\",\"name\":\"Labels\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"labels\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"system\":\"labels\"}},{\"id\":\"timeestimate\",\"key\":\"timeestimate\",\"name\":\"Remaining
+        Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"remainingEstimate\",\"timeestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeestimate\"}},{\"id\":\"aggregatetimeoriginalestimate\",\"key\":\"aggregatetimeoriginalestimate\",\"name\":\"\u03A3
+        Original Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeoriginalestimate\"}},{\"id\":\"versions\",\"key\":\"versions\",\"name\":\"Affects
+        versions\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectedVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"versions\"}},{\"id\":\"issuelinks\",\"key\":\"issuelinks\",\"name\":\"Linked
+        Issues\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issueLink\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"issuelinks\"}},{\"id\":\"assignee\",\"key\":\"assignee\",\"name\":\"Assignee\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"assignee\"],\"schema\":{\"type\":\"user\",\"system\":\"assignee\"}},{\"id\":\"status\",\"key\":\"status\",\"name\":\"Status\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"status\"],\"schema\":{\"type\":\"status\",\"system\":\"status\"}},{\"id\":\"components\",\"key\":\"components\",\"name\":\"Components\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"component\"],\"schema\":{\"type\":\"array\",\"items\":\"component\",\"system\":\"components\"}},{\"id\":\"issuekey\",\"key\":\"issuekey\",\"name\":\"Key\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"id\",\"issue\",\"issuekey\",\"key\"]},{\"id\":\"customfield_10050\",\"key\":\"customfield_10050\",\"name\":\"DefectDojo
+        Custom URL Field\",\"untranslatedName\":\"DefectDojo Custom URL Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10050]\",\"DefectDojo
+        Custom URL Field\",\"DefectDojo Custom URL Field[URL Field]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":10050}},{\"id\":\"customfield_10051\",\"key\":\"customfield_10051\",\"name\":\"DefectDojo
+        Custom User Picker Field\",\"untranslatedName\":\"DefectDojo Custom User Picker
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10051]\",\"DefectDojo
+        Custom User Picker Field\",\"DefectDojo Custom User Picker Field[User Picker
+        (single user)]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":10051}},{\"id\":\"customfield_10052\",\"key\":\"customfield_10052\",\"name\":\"Impact\",\"untranslatedName\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10052]\",\"Impact\",\"Impact[Short
+        text]\"],\"scope\":{\"type\":\"PROJECT\",\"project\":{\"id\":\"10020\"}},\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":10052}},{\"id\":\"customfield_10053\",\"key\":\"customfield_10053\",\"name\":\"Design\",\"untranslatedName\":\"Design\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10053]\",\"Design\"],\"schema\":{\"type\":\"array\",\"items\":\"design.field.name\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:designcf\",\"customId\":10053}},{\"id\":\"customfield_10054\",\"key\":\"customfield_10054\",\"name\":\"Vulnerability\",\"untranslatedName\":\"Vulnerability\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10054]\",\"Vulnerability\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:vulnerabilitycf\",\"customId\":10054}},{\"id\":\"customfield_10055\",\"key\":\"customfield_10055\",\"name\":\"Sentiment\",\"untranslatedName\":\"Sentiment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10055]\",\"Sentiment\"],\"schema\":{\"type\":\"array\",\"items\":\"sd-sentiment\",\"custom\":\"com.atlassian.servicedesk.sentiment:sd-sentiment\",\"customId\":10055}},{\"id\":\"customfield_10056\",\"key\":\"customfield_10056\",\"name\":\"Goals\",\"untranslatedName\":\"Goals\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10056]\",\"Goals\",\"Goals[Goals]\"],\"schema\":{\"type\":\"array\",\"items\":\"Goals\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:goals\",\"customId\":10056}},{\"id\":\"customfield_10049\",\"key\":\"customfield_10049\",\"name\":\"DefectDojo
+        Custom Short Text Field\",\"untranslatedName\":\"DefectDojo Custom Short Text
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10049]\",\"DefectDojo
+        Custom Short Text Field\",\"DefectDojo Custom Short Text Field[Short text]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":10049}},{\"id\":\"aggregatetimeestimate\",\"key\":\"aggregatetimeestimate\",\"name\":\"\u03A3
+        Remaining Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeestimate\"}},{\"id\":\"creator\",\"key\":\"creator\",\"name\":\"Creator\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"creator\"],\"schema\":{\"type\":\"user\",\"system\":\"creator\"}},{\"id\":\"subtasks\",\"key\":\"subtasks\",\"name\":\"Sub-tasks\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"subtasks\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"subtasks\"}},{\"id\":\"customfield_10040\",\"key\":\"customfield_10040\",\"name\":\"DefectDojo
+        Custom DatePicker\",\"untranslatedName\":\"DefectDojo Custom DatePicker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10040]\",\"DefectDojo
+        Custom DatePicker\",\"DefectDojo Custom DatePicker[Date]\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":10040}},{\"id\":\"customfield_10041\",\"key\":\"customfield_10041\",\"name\":\"DefectDojo
+        Customer Date Time Picker\",\"untranslatedName\":\"DefectDojo Customer Date
+        Time Picker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10041]\",\"DefectDojo
+        Customer Date Time Picker\",\"DefectDojo Customer Date Time Picker[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10041}},{\"id\":\"customfield_10042\",\"key\":\"customfield_10042\",\"name\":\"DefectDojo
+        Custom Labels\",\"untranslatedName\":\"DefectDojo Custom Labels\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10042]\",\"DefectDojo
+        Custom Labels\",\"DefectDojo Custom Labels[Labels]\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":10042}},{\"id\":\"reporter\",\"key\":\"reporter\",\"name\":\"Reporter\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"reporter\"],\"schema\":{\"type\":\"user\",\"system\":\"reporter\"}},{\"id\":\"customfield_10043\",\"key\":\"customfield_10043\",\"name\":\"DefectDojo
+        Custom Number Field\",\"untranslatedName\":\"DefectDojo Custom Number Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10043]\",\"DefectDojo
+        Custom Number Field\",\"DefectDojo Custom Number Field[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10043}},{\"id\":\"aggregateprogress\",\"key\":\"aggregateprogress\",\"name\":\"\u03A3
+        Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"progress\",\"system\":\"aggregateprogress\"}},{\"id\":\"customfield_10044\",\"key\":\"customfield_10044\",\"name\":\"DefectDojo
+        Customer Paragraph Field\",\"untranslatedName\":\"DefectDojo Customer Paragraph
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10044]\",\"DefectDojo
+        Customer Paragraph Field\",\"DefectDojo Customer Paragraph Field[Paragraph]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":10044}},{\"id\":\"customfield_10045\",\"key\":\"customfield_10045\",\"name\":\"DefectDojo
+        Custom Radio Buttons Field\",\"untranslatedName\":\"DefectDojo Custom Radio
+        Buttons Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10045]\",\"DefectDojo
+        Custom Radio Buttons Field\",\"DefectDojo Custom Radio Buttons Field[Radio
+        Buttons]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":10045}},{\"id\":\"customfield_10046\",\"key\":\"customfield_10046\",\"name\":\"DefectDojo
+        Custom Select List (Cascading) Field\",\"untranslatedName\":\"DefectDojo Custom
+        Select List (Cascading) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10046]\",\"DefectDojo
+        Custom Select List (Cascading) Field\",\"DefectDojo Custom Select List (Cascading)
+        Field[Select List (cascading)]\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":10046}},{\"id\":\"customfield_10047\",\"key\":\"customfield_10047\",\"name\":\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"untranslatedName\":\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10047]\",\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"DefectDojo Custom Select List (MultiChoice)
+        Field[Select List (multiple choices)]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":10047}},{\"id\":\"customfield_10048\",\"key\":\"customfield_10048\",\"name\":\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"untranslatedName\":\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10048]\",\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"DefectDojo Custom Select List
+        (SingleChoice) Field[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10048}},{\"id\":\"customfield_10038\",\"key\":\"com.atlassian.atlas.jira__project-status\",\"name\":\"Project
+        overview status\",\"untranslatedName\":\"Project overview status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10038]\",\"Project
+        overview status\"],\"schema\":{\"type\":\"string\",\"custom\":\"read-only-string-issue-field\",\"customId\":10038}},{\"id\":\"customfield_10039\",\"key\":\"customfield_10039\",\"name\":\"DefectDojo
+        Custom CheckBoxes\",\"untranslatedName\":\"DefectDojo Custom CheckBoxes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10039]\",\"DefectDojo
+        Custom CheckBoxes\",\"DefectDojo Custom CheckBoxes[Checkboxes]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":10039}},{\"id\":\"progress\",\"key\":\"progress\",\"name\":\"Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"progress\"],\"schema\":{\"type\":\"progress\",\"system\":\"progress\"}},{\"id\":\"votes\",\"key\":\"votes\",\"name\":\"Votes\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"votes\"],\"schema\":{\"type\":\"votes\",\"system\":\"votes\"}},{\"id\":\"worklog\",\"key\":\"worklog\",\"name\":\"Log
+        Work\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"array\",\"items\":\"worklog\",\"system\":\"worklog\"}},{\"id\":\"issuetype\",\"key\":\"issuetype\",\"name\":\"Issue
+        Type\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issuetype\",\"type\"],\"schema\":{\"type\":\"issuetype\",\"system\":\"issuetype\"}},{\"id\":\"timespent\",\"key\":\"timespent\",\"name\":\"Time
+        Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"timespent\"],\"schema\":{\"type\":\"number\",\"system\":\"timespent\"}},{\"id\":\"customfield_10030\",\"key\":\"customfield_10030\",\"name\":\"Submitted
+        forms\",\"untranslatedName\":\"Submitted forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10030]\",\"Submitted
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-submitted-field-cftype\",\"customId\":10030}},{\"id\":\"project\",\"key\":\"project\",\"name\":\"Project\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"project\"],\"schema\":{\"type\":\"project\",\"system\":\"project\"}},{\"id\":\"customfield_10031\",\"key\":\"customfield_10031\",\"name\":\"Locked
+        forms\",\"untranslatedName\":\"Locked forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10031]\",\"Locked
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-locked-field-cftype\",\"customId\":10031}},{\"id\":\"customfield_10032\",\"key\":\"customfield_10032\",\"name\":\"Total
+        forms\",\"untranslatedName\":\"Total forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10032]\",\"Total
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-total-field-cftype\",\"customId\":10032}},{\"id\":\"customfield_10033\",\"key\":\"customfield_10033\",\"name\":\"Category\",\"untranslatedName\":\"Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Category[Category]\",\"cf[10033]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:jwm-category\",\"customId\":10033}},{\"id\":\"aggregatetimespent\",\"key\":\"aggregatetimespent\",\"name\":\"\u03A3
+        Time Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimespent\"}},{\"id\":\"customfield_10035\",\"key\":\"customfield_10035\",\"name\":\"Version\",\"untranslatedName\":\"Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10035]\",\"Version\",\"Version[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10035}},{\"id\":\"customfield_10036\",\"key\":\"customfield_10036\",\"name\":\"Defect
+        Type\",\"untranslatedName\":\"Defect Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10036]\",\"Defect
+        Type\",\"Defect Type[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10036}},{\"id\":\"customfield_10037\",\"key\":\"com.atlassian.atlas.jira__project-key\",\"name\":\"Project
+        overview key\",\"untranslatedName\":\"Project overview key\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10037]\",\"Project
+        overview key\"],\"schema\":{\"type\":\"string\",\"custom\":\"read-only-string-issue-field\",\"customId\":10037}},{\"id\":\"customfield_10027\",\"key\":\"customfield_10027\",\"name\":\"Target
+        start\",\"untranslatedName\":\"Target start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10027]\",\"Target
+        start\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-start\",\"customId\":10027}},{\"id\":\"customfield_10028\",\"key\":\"customfield_10028\",\"name\":\"Target
+        end\",\"untranslatedName\":\"Target end\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10028]\",\"Target
+        end\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-end\",\"customId\":10028}},{\"id\":\"customfield_10029\",\"key\":\"customfield_10029\",\"name\":\"Open
+        forms\",\"untranslatedName\":\"Open forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10029]\",\"Open
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-open-field-cftype\",\"customId\":10029}},{\"id\":\"resolutiondate\",\"key\":\"resolutiondate\",\"name\":\"Resolved\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolutiondate\",\"resolved\"],\"schema\":{\"type\":\"datetime\",\"system\":\"resolutiondate\"}},{\"id\":\"workratio\",\"key\":\"workratio\",\"name\":\"Work
+        Ratio\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"workratio\"],\"schema\":{\"type\":\"number\",\"system\":\"workratio\"}},{\"id\":\"watches\",\"key\":\"watches\",\"name\":\"Watchers\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"watchers\"],\"schema\":{\"type\":\"watches\",\"system\":\"watches\"}},{\"id\":\"issuerestriction\",\"key\":\"issuerestriction\",\"name\":\"Restrict
+        to\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"issuerestriction\",\"system\":\"issuerestriction\"}},{\"id\":\"thumbnail\",\"key\":\"thumbnail\",\"name\":\"Images\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[]},{\"id\":\"created\",\"key\":\"created\",\"name\":\"Created\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"created\",\"createdDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"created\"}},{\"id\":\"customfield_10020\",\"key\":\"customfield_10020\",\"name\":\"Sprint\",\"untranslatedName\":\"Sprint\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10020]\",\"Sprint\"],\"schema\":{\"type\":\"array\",\"items\":\"json\",\"custom\":\"com.pyxis.greenhopper.jira:gh-sprint\",\"customId\":10020}},{\"id\":\"customfield_10021\",\"key\":\"customfield_10021\",\"name\":\"Flagged\",\"untranslatedName\":\"Flagged\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10021]\",\"Flagged\",\"Flagged[Checkboxes]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":10021}},{\"id\":\"customfield_10022\",\"key\":\"customfield_10022\",\"name\":\"[CHART]
+        Date of First Response\",\"untranslatedName\":\"[CHART] Date of First Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[CHART]
+        Date of First Response\",\"[CHART] Date of First Response[Date of first response]\",\"cf[10022]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.ext.charting:firstresponsedate\",\"customId\":10022}},{\"id\":\"customfield_10023\",\"key\":\"customfield_10023\",\"name\":\"[CHART]
+        Time in Status\",\"untranslatedName\":\"[CHART] Time in Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[CHART]
+        Time in Status\",\"[CHART] Time in Status[Time in Status]\",\"cf[10023]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.ext.charting:timeinstatus\",\"customId\":10023}},{\"id\":\"customfield_10026\",\"key\":\"customfield_10026\",\"name\":\"Story
+        Points\",\"untranslatedName\":\"Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10026]\",\"Story
+        Points\",\"Story Points[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10026}},{\"id\":\"customfield_10016\",\"key\":\"customfield_10016\",\"name\":\"Story
+        point estimate\",\"untranslatedName\":\"Story point estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10016]\",\"Story
+        point estimate\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.pyxis.greenhopper.jira:jsw-story-points\",\"customId\":10016}},{\"id\":\"customfield_10017\",\"key\":\"customfield_10017\",\"name\":\"Issue
+        color\",\"untranslatedName\":\"Issue color\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10017]\",\"Issue
+        color\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:jsw-issue-color\",\"customId\":10017}},{\"id\":\"customfield_10018\",\"key\":\"customfield_10018\",\"name\":\"Parent
+        Link\",\"untranslatedName\":\"Parent Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10018]\",\"Parent
+        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-parent\",\"customId\":10018}},{\"id\":\"customfield_10019\",\"key\":\"customfield_10019\",\"name\":\"Rank\",\"untranslatedName\":\"Rank\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10019]\",\"Rank\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-lexo-rank\",\"customId\":10019}},{\"id\":\"updated\",\"key\":\"updated\",\"name\":\"Updated\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"updated\",\"updatedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"updated\"}},{\"id\":\"timeoriginalestimate\",\"key\":\"timeoriginalestimate\",\"name\":\"Original
+        estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"originalEstimate\",\"timeoriginalestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeoriginalestimate\"}},{\"id\":\"description\",\"key\":\"description\",\"name\":\"Description\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"description\"],\"schema\":{\"type\":\"string\",\"system\":\"description\"}},{\"id\":\"customfield_10010\",\"key\":\"customfield_10010\",\"name\":\"Request
+        Type\",\"untranslatedName\":\"Request Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10010]\",\"Request
+        Type\"],\"schema\":{\"type\":\"sd-customerrequesttype\",\"custom\":\"com.atlassian.servicedesk:vp-origin\",\"customId\":10010}},{\"id\":\"customfield_10011\",\"key\":\"customfield_10011\",\"name\":\"Epic
+        Name\",\"untranslatedName\":\"Epic Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10011]\",\"Epic
+        Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-label\",\"customId\":10011}},{\"id\":\"customfield_10012\",\"key\":\"customfield_10012\",\"name\":\"Epic
+        Status\",\"untranslatedName\":\"Epic Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10012]\",\"Epic
+        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-status\",\"customId\":10012}},{\"id\":\"customfield_10013\",\"key\":\"customfield_10013\",\"name\":\"Epic
+        Color\",\"untranslatedName\":\"Epic Color\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10013]\",\"Epic
+        Color\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-color\",\"customId\":10013}},{\"id\":\"customfield_10014\",\"key\":\"customfield_10014\",\"name\":\"Epic
+        Link\",\"untranslatedName\":\"Epic Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10014]\",\"Epic
+        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-link\",\"customId\":10014}},{\"id\":\"timetracking\",\"key\":\"timetracking\",\"name\":\"Time
+        tracking\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"timetracking\",\"system\":\"timetracking\"}},{\"id\":\"customfield_10015\",\"key\":\"customfield_10015\",\"name\":\"Start
+        date\",\"untranslatedName\":\"Start date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10015]\",\"Start
+        date\",\"Start date[Date]\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":10015}},{\"id\":\"customfield_10005\",\"key\":\"customfield_10005\",\"name\":\"Change
+        type\",\"untranslatedName\":\"Change type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10005]\",\"Change
+        type\",\"Change type[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10005}},{\"id\":\"customfield_10006\",\"key\":\"customfield_10006\",\"name\":\"Change
+        risk\",\"untranslatedName\":\"Change risk\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10006]\",\"Change
+        risk\",\"Change risk[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10006}},{\"id\":\"security\",\"key\":\"security\",\"name\":\"Security
+        Level\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"level\"],\"schema\":{\"type\":\"securitylevel\",\"system\":\"security\"}},{\"id\":\"customfield_10007\",\"key\":\"customfield_10007\",\"name\":\"Change
+        reason\",\"untranslatedName\":\"Change reason\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10007]\",\"Change
+        reason\",\"Change reason[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10007}},{\"id\":\"customfield_10008\",\"key\":\"customfield_10008\",\"name\":\"Change
+        start date\",\"untranslatedName\":\"Change start date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10008]\",\"Change
+        start date\",\"Change start date[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10008}},{\"id\":\"attachment\",\"key\":\"attachment\",\"name\":\"Attachment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"attachments\"],\"schema\":{\"type\":\"array\",\"items\":\"attachment\",\"system\":\"attachment\"}},{\"id\":\"customfield_10009\",\"key\":\"customfield_10009\",\"name\":\"Change
+        completion date\",\"untranslatedName\":\"Change completion date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10009]\",\"Change
+        completion date\",\"Change completion date[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10009}},{\"id\":\"summary\",\"key\":\"summary\",\"name\":\"Summary\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"summary\"],\"schema\":{\"type\":\"string\",\"system\":\"summary\"}},{\"id\":\"customfield_10000\",\"key\":\"customfield_10000\",\"name\":\"Development\",\"untranslatedName\":\"development\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10000]\",\"development\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:devsummarycf\",\"customId\":10000}},{\"id\":\"customfield_10001\",\"key\":\"customfield_10001\",\"name\":\"Team\",\"untranslatedName\":\"Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10001]\",\"Team\",\"Team[Team]\"],\"schema\":{\"type\":\"team\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team\",\"customId\":10001,\"configuration\":{\"com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team\":true}}},{\"id\":\"customfield_10002\",\"key\":\"customfield_10002\",\"name\":\"Organizations\",\"untranslatedName\":\"Organizations\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10002]\",\"Organizations\"],\"schema\":{\"type\":\"array\",\"items\":\"sd-customerorganization\",\"custom\":\"com.atlassian.servicedesk:sd-customer-organizations\",\"customId\":10002}},{\"id\":\"customfield_10003\",\"key\":\"customfield_10003\",\"name\":\"Approvers\",\"untranslatedName\":\"Approvers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approvers\",\"Approvers[User
+        Picker (multiple users)]\",\"cf[10003]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":10003}},{\"id\":\"customfield_10004\",\"key\":\"customfield_10004\",\"name\":\"Impact\",\"untranslatedName\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10004]\",\"Impact\",\"Impact[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10004}},{\"id\":\"environment\",\"key\":\"environment\",\"name\":\"Environment\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"environment\"],\"schema\":{\"type\":\"string\",\"system\":\"environment\"}},{\"id\":\"duedate\",\"key\":\"duedate\",\"name\":\"Due
+        date\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"due\",\"duedate\"],\"schema\":{\"type\":\"date\",\"system\":\"duedate\"}},{\"id\":\"comment\",\"key\":\"comment\",\"name\":\"Comment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"comment\"],\"schema\":{\"type\":\"comments-page\",\"system\":\"comment\"}}]"
     headers:
       Atl-Request-Id:
-      - 75c79b95-f690-42be-be58-f074db2d26ee
+      - c62a04e0-38c9-410f-b84f-1bfae91aafb9
       Atl-Traceid:
-      - 75c79b95f69042bebe58f074db2d26ee
+      - c62a04e038c9410fb84f1bfae91aafb9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:27 GMT
+      - Wed, 30 Apr 2025 16:24:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1194,7 +1326,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=252,atl-edge-internal;dur=26,atl-edge-upstream;dur=227,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=262,atl-edge;dur=228,atl-edge-internal;dur=17,atl-edge-upstream;dur=211,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="fOovOn_58A7fHJO3uJeyDzgMy85RMMjFSNbMrgMvaw4PIyH0VcgGYw==",cdn-downstream-fbl;dur=266
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1203,10 +1335,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 4bbf91f2f9edc22eb68408b6405ae452.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - fOovOn_58A7fHJO3uJeyDzgMy85RMMjFSNbMrgMvaw4PIyH0VcgGYw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 35114da9d153f235aec57409aa9fa58b
+      - 76b5b48abbeea911f398d4ba18bad51e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1230,61 +1370,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1595
+    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1835
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXa2/bNhT9K4Q+bZltPfyoI2AYutjdsmVZkDgt0KwIGOlaZk2RKknF9tr+911S
-        D7dx1CEdVgRIxMd9n3t4896DbUFF6sWeApGCgvQFA57qnqA56J5OVpDTnixAUcOk0D1ImcnB0F6y
-        oiIDLrPePSiNZ5BeQqFAgzD13aTURuZLq/A2DIIwGCh4V4I2i10BF4omhiXg9Txm7YeT4NkxLjTw
-        JS5XxhQ69v0UlpCYVL6VA2o41ZpRMRBgfLRkfFown1NjP5nWJfiNljXsUMn5Yn616Ifj4zFuOT+0
-        F7/3NDpY6gTlMql2VSAprlAiCqJxPwj7YbCIgjgcx9FwMJmOf0DnA+upNWLQe6fmqZ5GlZNW3kd9
-        QdTGXi9S0Ilihc0e7j4nOqec90jKtGEiMaRgkACRS7KRaj2w0okU14o/0YtSMFszym/pPTVU+fcM
-        Nr5za+9gfRQGw3D6k2Z/w4851r7M0arFBppcUL22BSvvjP2Kl5Rr6HmV4CnG5WR73oohelSy2p3B
-        PaCvwceeZxjCq0CoeLEoMUbvAVaGQXNQKPkWI/rKhNfSLt2ugE267eITkOyjuhbMWEBpr7Vt4fq7
-        u6vl0myosqDVLC84Q4fTB5FjPRzKRtPtaPpEd79QmSaSti6j4Bm6EY220ej/tVJV32ERDYaTbTj5
-        Fga3jcVhtB1G38JiDfCPHw/hGHbhNGoOlmz7siJCrP7Nm8Obw+YmzTIFGfLNQRNgAJKXVfs/bm7c
-        dTDpOnjWcRB1Hky7Do4P/axos9q1pOSeCS/uhzVX2pIollQhvT/Ys42C2dYrWfJ0xnTB6a5uJ9ze
-        UIPvT0XZT2/96kHYPwF+pU7ZxnafJ7K0qXeuvrIbTGRebFRpbaNS8xIxY9u7zoYCDNbyx2OPxHAa
-        No/Ew7S1VPbwoAtUUQuqQjGpmNl9ZQoacX/0tLeC5TQD7VsJ3ShhuMHlZqDvsz1ZnslNQ6oj77Bt
-        ohbznN6BpcVHGsOyyaNpCLsQGk5tPlZUzwuWnDGxfmFPZlDYEUYkDYIcrjburN0RUsxxgqF3HC6B
-        6gqVqv7yLs6ufzk9vz07PZmfX81v55eXf15ifNilGhOCFxYrIBfI/8IQa5cwTaTgO4JcwrhVSowk
-        vzFFyYWCHMmElBoRN3iMU0JsJy/4wIKgEMPYq95ErB0mf99Tn3EFliFjgvKHl+oBrE6vwz1H7+q1
-        rWsmoL1dFrZpu3A8mowaHFdj0ldCrxJu393PJ5unoXEPt59pssaJs4Fco7yydVLPc//J4WYo9JvZ
-        LGrGBAEW6onkUp1X3tzxEvqZQsbaj0SSzGRVbJkXOBML8zjoxy0pfKmwD4Vawvg8nX+J/c/RghkO
-        RzG5eU2LMCYnUq4ZkFfMIMcacgVJqYC84DT7YLODyeEyoXwltYmnwTTwl0ykSIR+NJy+cQpnLnkY
-        11tJLKziI/KvkuQ7/PW9E7/Coc9yEIohW9ROzkogMwwUN/+gOxIGPWLB2AZx8mqORzf4pz8JR85T
-        W8dkA4OcGQUDqTIfYUxtaRlObBb+Pl4drEzOnd+VnpdWz7VYC7n5NEkXSqYlzgBzkWFj51gmf4HJ
-        tzZdhtBf8qvc9I3syFJRK4jeEJ/cbADWyALQauuQ2l/wh07w9fMLcpVQ0XHf/WNzHLbxfBLB1U4b
-        yDVGkBaSIcyOYrfvamNzlVMmNDMwQCRiqvTqTlKVdt040D9rEPYPAAAA///sWW1L40AQ/iuLICiY
-        mLapbQ/EK+LBfZA7FE4QoWw2Gxuu3YS8GOXO/37P7G73Yq7xDjnED4IfarI7b5155plppkjynAmT
-        SEBdFkmpWCkr1tisqgCLpcmsBJl1wJplKpZsLbkq8ZKbE1YC3L1RkWRcCOCqjNldylmNUhHFQw5g
-        wjmlpKEHfsuic3zLt3qyJIOullJRZjHu5GYYPOERLCG3wP9YqpKsWOs7LCsIrTnelgSWAOrvUh2Q
-        YRCeVsxwEMZXDX8gF1nOtXV1iZxmXLGWgZgYlVz57EyV5LPz0MTgRlEQSBvFCBZYC8uNiSSwrBGg
-        rZa2fG55f4EqRN9ByMh7my5N0/hZw8tc1wPKT977+TLXuQwlC8hcWN0LXoF0RTVSarH35Wp++dW7
-        PPfQonWVOiV5VlSyoDrY4/E6Vftsb/8nEmVVZR+Qhn+ym7Fr8d321kd7BmEb+qoCmK6JFxHB7tE+
-        uhv0vQgdR+3ecCxDf0maU20/2Mc6gj5eHDidiDEXS6pv23rb3bsL7mW9XnNqVzt/Q2qKOpHPrHhh
-        byMScoJ6I8L7OT4ex6PpZBoNJoEciVkgZuNhMhskR9DjDkHDM8ckpcQ8jqED/Q3NLn742DIEgEKy
-        nh2HTa346J/6mIYpO5KFEhSPx4MwPJqI6WQ8mkUimgRQn3CZTMVJfKyl7I7mu8NP+DP3vDVXFl49
-        zzwq/br0GgTCG/oE2X5eR6tUUKS8nPOSAoX7uoOAIOLjKYrCzxXFvDtav32Lu7P527e4O9u/dYuB
-        UbEZUy0JPEXqg8MkSS1EqguI8NyMkQbhrkEDcfCsLrJcHl4De8Tyd6XRbglvXemSBrtR284cwz5c
-        DfvGydCNk4XF93cYebWEeYeR17D4HUa2wEgXBvqYWugImeMrcOfWFOUPWoLbzwEsySpuV/hdKX2U
-        LOjDpWC4HeD69kFBrwO9lM151r3Rx+VGvS8cyZPqLi0yZVieeRTX9vcj8++/RO8uq/7fZtMIc0Kh
-        CWPat0xveTbLVJSAMfnH5qPtLy82QP/WdriRe7Cz5vcXsqxXJLjlrN7PFNW8Mo7Tlph2OOS6e/70
-        8vDJbXtBW/v4+PgLAAD//wMA2CtU+bMcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18165","self":"https://defectdojo.atlassian.net/rest/api/latest/issue/18165","key":"NTEST-1835","fields":{"statuscategorychangedate":"2025-04-30T18:24:07.850+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1835/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:07.543+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sy7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:07.631+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/238]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/238 (238)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/91]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1835/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18165/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 83672fcd-ef84-401e-818a-7a522e23df16
+      - cd494b77-ad53-4807-9a26-d7adb7d44781
       Atl-Traceid:
-      - 83672fcdef84401e818a7a522e23df16
+      - cd494b77ad5348079a26d7adb7d44781
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:28 GMT
+      - Wed, 30 Apr 2025 16:24:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1294,7 +1417,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=265,atl-edge-internal;dur=27,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="3uzqS2AkqqENqUP-EH6V9oAsluk8kbgz5xtsnqyHkLR00wTtkGyyaA==",cdn-downstream-fbl;dur=371,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=368,atl-edge;dur=290,atl-edge-internal;dur=16,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1303,10 +1426,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 82e46a17c2e4998f87de230e61a57612.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 3uzqS2AkqqENqUP-EH6V9oAsluk8kbgz5xtsnqyHkLR00wTtkGyyaA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 83b4769e837e4791d86bd0817e033929
+      - 6748f53a296dc41829a794fe108f8a41
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_disabled_no_epic_and_push_findings.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_disabled_no_epic_and_push_findings.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrlm5d3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCGcAWQopJOXm8rFcP1Q/083Q1rEi/HmEJjCBl+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0XxHCY4AuFqfmlQgjSIHmCWQJLCtKOZtxFsUAFxDhmPfxD9hXuj1nM6go8CzntEhzVnyz
-        sr2xykWQZfNCCsAclcxmCxRMKaZAKrqc5UWt5gzpXAE9EwQzGm51L8YXohKDCXdOirF9IOZUEbSv
-        25Iczw97cnacXN9X5PgJAAD//wMAPYVe2iACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:13.415+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 00ef21ad-ea8e-44f3-8d37-d1c9e34edee6
+      - f4e327b8-e272-422e-8a41-ece40a57c89e
       Atl-Traceid:
-      - 00ef21adea8e44f38d37d1c9e34edee6
+      - f4e327b8e272422e8a41ece40a57c89e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:28 GMT
+      - Wed, 30 Apr 2025 16:24:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=184,atl-edge-internal;dur=34,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="He_iGTjUdclFE3SmB1oQ8zIq06wZ82vCD5c1JbGcHal4wq7acnPZPA==",cdn-downstream-fbl;dur=229,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=227,atl-edge;dur=144,atl-edge-internal;dur=15,atl-edge-upstream;dur=129,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - He_iGTjUdclFE3SmB1oQ8zIq06wZ82vCD5c1JbGcHal4wq7acnPZPA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - acc32f387ca7006f18507736fc5c9c29
+      - cbe88b42a0dac451fa64bac06e0c9dfc
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 1bd27322-1e80-41ac-a432-e5f798fa172b
+      - 321d18aa-a2a2-44e5-9df7-3a13845b77d1
       Atl-Traceid:
-      - 1bd273221e8041aca432e5f798fa172b
+      - 321d18aaa2a244e59df73a13845b77d1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:28 GMT
+      - Wed, 30 Apr 2025 16:24:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=286,atl-edge-internal;dur=28,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=315,atl-edge;dur=283,atl-edge-internal;dur=17,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="1L1e4kBoGaFSrwTq25EXW2kP4GwkLYJywHEfyfS-yvMt0L-aXJw2dg==",cdn-downstream-fbl;dur=319
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5ea7f8bcbac3004590a821cdd0466e1c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 1L1e4kBoGaFSrwTq25EXW2kP4GwkLYJywHEfyfS-yvMt0L-aXJw2dg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 37ecf761094a1371ff3b4db7fbb5f9eb
+      - c0103a7218b4731a7a0ebdb0b1faca2d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/240]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/240 (240)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/92]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1297'
+      - '1317'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16081","key":"NTEST-1597","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16081"}'
+      string: '{"id":"18169","key":"NTEST-1837","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18169"}'
     headers:
       Atl-Request-Id:
-      - 95ed29bb-ecbf-4ba4-aff7-af4ad71e6249
+      - a0f1dc9b-e0ff-442f-ad91-c95560edeb57
       Atl-Traceid:
-      - 95ed29bbecbf4ba4aff7af4ad71e6249
+      - a0f1dc9be0ff442fad91c95560edeb57
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:29 GMT
+      - Wed, 30 Apr 2025 16:24:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=695,atl-edge-internal;dur=18,atl-edge-upstream;dur=678,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=694,atl-edge;dur=662,atl-edge-internal;dur=15,atl-edge-upstream;dur=648,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="9ydMySbMpaaSC-qFu-UnpgLm7mgUjmj9iJ4_sVwgDKMfZJd3Z8PpKA==",cdn-downstream-fbl;dur=699
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a78d8f4a6ccd81221651cd6112d5330a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 9ydMySbMpaaSC-qFu-UnpgLm7mgUjmj9iJ4_sVwgDKMfZJd3Z8PpKA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - aaee454e13e0950d44460f8601baa870
+      - 14a3468de87e75a47437baa9aab39812
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1597
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1837
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeSRhw0hVRUm2paUUQQBpKUJm5mZi4rFnbQ9JyvLfez2v
-        AGG2gqorpDB+3Pe5x/fBgVVGReyEjgIRg4L4IwMe646gKeiOjuaQ0o7MQFHDpNAdiJlJwdBONKci
-        AS6Tzj0ojWcQn0KmQIMw1d0o10amM6vwxvc83+sp+JyDNtN1BieKRoZF4HQcZu37u97Ix4UGPsPl
-        3JhMh64bwwwiE8s72aOGU60ZFT0BxkVLxqUZcwOXaZ2DWytYwBrlj6eTs2nXH+59wK3CBe2ED45G
-        33IdUQOJVOsyhhhXKBF4wbDr+V3fmwZe6A/DYK+3Oxj9gH571klrxKDjhZp3OmnlXdTnBU3Y1SIG
-        HSmW2cTh7j7RKeW8Q2KmDRORIRmDCIickaVUi56VjqQ4V/yNXuSC2XJRfkPvqaHKvWewdAu3Ng5W
-        R77X90c/afY3/Jhi2fMUrVpYoMkp1Qtbq/zW2K9wRrmGjlMKHmJchWzHmTMEjorm6yO4B/TVe+w4
-        hiGyMkSJE4ocY3RewKTv1QeZkncY0TsTXkkX6S4KWKfbLp6AZBPVuWDGoALtNLYtUn8v7mo5M0uq
-        LF41SzPO0OH4ReRYjwJlg9FqMHqju1+pTB1JU5eBZ1EdDFbB4P+1Ula/wCIa9HdX/u63MLiqLfaD
-        VT/4FhYrgD8+bsPRb8NpUB/M2Oqi5ECs/tX19s1+fZMmiYIE+WarCTAAyfOy/V83N2w72G07+NBy
-        ELQejNoO9rb9LGmz3LWkVLwQTtj1cUkNPhwl4b69cUs63xC4W6pTti2LzwOZ28T5lpQv7QYTiRMa
-        lQOWD5WaC6y4bc7SuUKf1a9YVCb4YWvP+orCei5zHo+ZzjhdV81tIaEAg7X88doj0ff69SPxMm0N
-        lb08aANV0IAqU0wqZtbvTGIt7g7e9lawlCagXSuhayUMN7hc9vR9siHLI7msSXXgbLdN0GCe01uw
-        tPhKY1g2eTUNfhtC/ZHNx5zqScaiIyYWH+3JGDI7vYiorllRyWVx1uwIKSY4vNBbDqdAdYkDVX05
-        J0fnvxwe3xwdHkyOzyY3k9PTP08xPuxSjQnBC9M5kBPkf2GItUuYJlLwNUEuYdwqJUaS35ii5ERB
-        imRCco2Y7b3GKT62k+N9YZ6XibvQKd9ErB0mf9NTz7gCy5AwQfnLS9XsVaW3QDVH76q1rWsioLmd
-        Z7ZpW3G81+C4HJPeCb1SuHl3n082b0PjBm4/02iBw2YNuVp5aeugmuf+k8P1UOjWs1lQjwkCLNQj
-        yaU6Lr255Tl0E4UcsRmJJBnLstgyzXAcFuZ10A/bSGHYkMLXKv48nX+Jzd/OlBkOOyG5+kQzPyQH
-        Ui4YkEtmkNUMOYMoV0A+cpp8sdnB5HAZUT6X2oQjb+S5MyZipFI3GHjXhcJxkTyM604SC6twh/yr
-        JPkOf74vxM9w6LMchGLIFpWT4xzIGOPBzT/omvheh1gwNkEcXE7w6Ar/dXf9QeGprWO0hF7KjIKe
-        VImLMKa2tAwnNgt/F6/25iblhd+lngur51wshFw+TdKJknGOM8BEJNjYKZbJnWKOrc0iQ+gv+VUu
-        u0a2ZCmrFATXxCVXS4AFsgA02lqkNhfcfiH4af+EnEVUtNy3c6i7FzTxPIngbK0NpBojiDPJEGY7
-        YbFf1MbmKqVMaGagh0jEVOn5raQqbruxpX+8QZjVvE8i+Q8AAAD//+xZUWvbMBD+K6JQaKF2ncRp
-        kkHpQulgD2WjhRVKIci23JjFsrHsumXrf993kqKlXtyNMkofCnlwIunudL777ruLDiSgLouEkEyJ
-        mrU2qmrAojKRlSKyDli7zOIlywWXCovc7LAScN0bGQnG4xi4KhJ2l3HWIFXi6qEEMGGflMIUZH/D
-        onO85VvdVJJBV0shKbIYd3IL9Jy4ESyha4H/sUymRZXrM6yoCK05VhWBJYD6u5AHZBiEZzUzVZ/x
-        Vcsf6Iqs5Nq6RiGmGZdsw0B0jFKsfHYmFd3Z3dD44EaSE0gb+QgWWAvV2kQSqBo4aKulG3feuP0F
-        shB1By6j29twadvWL1quSp0PSD9x75fLUscylCwgc2F1L3gNmhM1CKnF3per+eVX7/LcQ4nWWeqU
-        lEVVi4ryYI8neSb32d7+TwTKqi4+IAz/ZDdjV+K75a0P4QZh34IjtwR9dQWw15yOOFlna+ioaGch
-        6CPIQR/LCBzL0G9Pk63tG/t4ceCMeVKtu5iNF8DjJSW/qQiqyXNO5Wrnb0hNXifyWVQvrG1EQk6Q
-        b0SZPyfH42Q0nUyjwSQQo3gWxLPxMJ0N0iPocZug4ZltgkJiniTQgfqGYpc8fNwwBIBCsp5th02u
-        +KifepuGKduShQIUjyeDMDyaxNPJeDSL4mgSQH3KRTqNT5JjLWV3NN8dfsLHnPNyLi28ep75SfmN
-        8lo4whv6BNl+2USrLCZPeSXnihyF87qCgCDi8RRJ4ZeSfN5trd++xd3e/O1b3O3t37rFgKLENIaW
-        BJ4i9MFh0rSJ40wnEOG5aUQNkF2DBmLjWVMVpTi8BsTEy9+ZRrMlrLrUJQ12oradOYZ9uBr2tZOh
-        aye7Cw67Kwv87/jyapH0ji+vYfE7vmzBly4MOELm+AusvjW594OG4PY5gMKi5naE35XSy7x6camX
-        kg23I1/fPCjo46AECFsXgj4OOuo7MXIkT8i7rCqkIXLmp6Sx/x+Zr//kvSI3En6sHy3cvwB+N/76
-        OlzLPdjJ+f2FUM2KBG/o1uOSqp7Xxo67ov5/M1ojzAmFLrSL3wo9bVqPUWlKTDMcUukMeWrt8Im5
-        9oB2z+Pj4y8AAAD//wMAykKLdK4cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18169","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18169","key":"NTEST-1837","fields":{"statuscategorychangedate":"2025-04-30T18:24:14.691+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1837/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:14.432+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00syn:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:14.506+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/240]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/240 (240)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/92]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1837/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18169/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 55120d50-7f98-4d90-a806-aeee684ea719
+      - 9823d323-f5f5-4ee9-9f0f-e428feec8f7d
       Atl-Traceid:
-      - 55120d507f984d90a806aeee684ea719
+      - 9823d323f5f54ee99f0fe428feec8f7d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:30 GMT
+      - Wed, 30 Apr 2025 16:24:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=301,atl-edge-internal;dur=13,atl-edge-upstream;dur=289,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="WJ7P4vFUpfnx42II245GfH_Gfs2bdZwvxba33teL2qOSRqXuMrlr2g==",cdn-downstream-fbl;dur=500,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=497,atl-edge;dur=411,atl-edge-internal;dur=23,atl-edge-upstream;dur=389,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 72fcd81c14e3eb0facf41fedad65e9e4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - WJ7P4vFUpfnx42II245GfH_Gfs2bdZwvxba33teL2qOSRqXuMrlr2g==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 6f27900716f15fae8c396d8594ca634b
+      - 3650df92ead64242cfe1d04368faead5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16081
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18169
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeSRkw0hVRUm2paUUQQBpKUJm5mZi4rGntockZfnvvZ5X
-        IDC7gqorpDD29X0fH98HB1YZFbETOgpEDArijwx4rDuCpqA7OppDSjsyA0UNk0J3IGYmBUM70ZyK
-        BLhMOvegNMogPoVMgQZhqrNRro1MZ9bgje95vtdT8HcO2kzXGZwoGhkWgdNxmPXvD72RjwsNfIbL
-        uTGZDl03hhlEJpZ3skcNp1ozKnoCjIuejEsz5gYu0zoHtzawgDXqH08nZ9Ouv7v3AbeKELQTPjga
-        Y8t1RA0kUq3LHGJcoUbgBbtdz+/63jTwQn83DPZ6w8HoB4zbs0FaJwYDL8y8M0ir76I9L2jSrhYx
-        6EixzBYOd/eJTinnHRIzbZiIDMkYREDkjCylWvSsdiTFueJvjCIXzLaL8ht6Tw1V7j2DpVuEtQmw
-        Evle3x/9pNk/8GOKbc9T9GphgS6nVC9sr/JbY7/CGeUaOk6peIh5FbodZ84QOCqar4/gHjBW77Hj
-        GIbIyhAlTihyzNHZgknfqwWZkneY0TsLXmkX5S4aWJfbLp6AZJPVuWDGoAHtNL4tUn8vzmo5M0uq
-        LF41SzPOMOB4K3PsR4GywWg1GL0x3C90ps6k6cvAs6gOBqtg8P96KbtfYBEd+sOVP/wWDle1x36w
-        6gffwmMF8MfHl3D023AatAn6tWDGVhclOSIsrq4RJkmiIEG++eol2K0FmJnkeckLrx8dtgk+tAiC
-        VsGoTbD3MpySNstdS0rFC+GEXR+X1ODDURLu2y9uSecbAndLc8pey+LzQOa2cL4l5Uu7wUTihEbl
-        8FjxtLWmWFRW7eHFno0Mj+q5zHk8ZjrjdF1dZdzGsMwFYsZe76oaCjBZyx+vPRJ9r18/Ettla6hs
-        W9AGqqABVaaYVMys31nEWt0dvO2tYClNQLtWQ9dGGG5wuezp+2RDlkdyWZPqwHl5bYLmEnB6C5YW
-        Lf63J4I26PptCPVHth5zqicZi46YWHy0kjFkdnoRUd3ForfLQtbsCCkmOLzQWw6nQHWJDFV9OSdH
-        578cHt8cHR5Mjs8mN5PT0z9PMT+8pRoLggemcyAnyP/CEOuXME2k4GuCXMK4NUqMJL8xRcmJghTJ
-        hOQaMdt7jVN8vE6O95l5XibuQqd8E7F3WPzNnXrGFdiGhAnKtw9Vs1dV3gLnHKOr6Qb7mghoTueZ
-        vbStON5rcFyOSe+EXqncvLvPJ5u3oXEDt59ptMBhs4Zcbbz0dVDNc/8p4HoodOvZLKjHBAEW6pHk
-        Uh2X0dzyHLqJQtbYjESSjGXZbJlmOA4L8zrodxtS+FJjt5Uawnhezr/E5m9nygyHnZBcfaKZH5ID
-        KRcMyCUzyHOGnEGUKyAfOU0+2+pgcbiMKJ9LbcKRN/LcGRMxUqkbDLzrwuC4KB7mdSeJhVW4Q76q
-        Sb7Dn+8L9TMc+iwHoRqyRRXkOAcyxkRx8w+6Jr7XIRaMTRIHlxMUXeG/7tAfFJHaPkZL6KXMKOhJ
-        lbgIY2pby3Bis/B38WhvblJexF3aubB2zsVCyOXTIp0oGec4A0xEghc7xTa5Uyy+9VlUCOMlv8pl
-        18iWKmWVgeCauORqCbBAFoDGWovW5oDbLxQ/7Z+Qs4iKlvN2DnX3giafJxmcrbWBVGMGcSYZwmwn
-        LPaL3thapZQJzQz0EIlYKj2/lVTFbSde2B9vEGYt75NI/gsAAP//7FlRa9swEP4rolBooXadxGmS
-        QelC6WAPZaOFFUohyLbcmMWysey6Zet/33eSoqVe3I0ySh8KeXAi6e50vvvuu4sOJKAui4SQTIma
-        tTaqasCiMpGVIrIOWLvM4iXLBZcKi9zssBJw3RsZCcbjGLgqEnaXcdYgVeLqoQQwYZ+UwpRof8Oi
-        c7zlW91UkkFXSyEpshh3cgv0nLgRLKFrgf+xTKZFleszrKgIrTlWFYElgPq7kAdkGIRnNTM8gPFV
-        yx/oiqzk2rpGIaYZl2zDQHSMUqx8diYV3dnd0PjgRpITSBv5CBZYC9XaRBKoGjhoq6Ubd964/QWy
-        EHUHLqPb23Bp29YvWq5KnQ9IP3Hvl8tSxzKULCBzYXUveA3iEzUIqcXel6v55Vfv8txDidZZ6pSU
-        RVWLivJgjyd5JvfZ3v5PBMqqLj4gDP9kN2NX4rvlrY/2DMK+BUd3CRPrCmCvOR2xtM7W0FHRzkLg
-        ZHQX+lhG4FiGfnuabG3f2MeLA2fMk2rdBXO8AB4vKflNRVBNnnMqVzt/Q2ryOpHPonphbSMScoJ8
-        I8r8OTkeJ6PpZBoNJoEYxbMgno2H6WyQHkGP2wQNz2wTFBLzJIEO1DcUu+Th44YhABSS9Ww7bHLF
-        R/3U2zRM2ZYsFKB4PBmE4dEknk7Go1kUR5MA6lMu0ml8khxrKbuj+e7wEz7mnJdzaeHV88xPym+U
-        18IR3tAnyPbLJlplMXnKKzlX5Cic1xUEBBGPp0gKv5Tk825r/fYt7vbmb9/ibm//1i0GFCWmVbQk
-        8BShDw6Tpk0cZzqBCM9NI2qA7Bo0EBvPmqooxeE1ICZe/s40mi1h1aUuabATte3MMezD1bCvnQz7
-        ZhShw+7KAv87vrxaJL3jy2tY/I4vW/ClCwOOkDn+AqtvTe79oCG4fQ6gsKi5HeF3pfQyr15c6qVk
-        w+3I1zcPCvo4KAHC1oWgj4OO+k6MHMkT8i6rCmmInPkpaez/R+brP3mvyI2EH+tHC/cvgN+Nv74O
-        13IPdnJ+fyFUsyLBG7r1uKSq57Wx466o/9+M1ghzQqEL7eK3Qk+b1oNVmhLTDIdUOkOeWjt8Yq49
-        oN3z+Pj4CwAA//8DAKyUJpOuHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18169","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18169","key":"NTEST-1837","fields":{"statuscategorychangedate":"2025-04-30T18:24:14.691+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1837/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:14.432+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00syn:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:14.506+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/240]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/240 (240)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/92]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1837/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18169/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a45e116f-1754-4ff7-ba7a-d77988de3bf6
+      - 82a63f21-bab6-46a7-86a5-7ac054360dc1
       Atl-Traceid:
-      - a45e116f17544ff7ba7ad77988de3bf6
+      - 82a63f21bab646a786a57ac054360dc1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:30 GMT
+      - Wed, 30 Apr 2025 16:24:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=249,atl-edge-internal;dur=14,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=284,atl-edge;dur=251,atl-edge-internal;dur=16,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="H8s8_LTbVd3TwK53G2InIXACt9vw2pMT4AWlZB2euffeqiAAI4DcSA==",cdn-downstream-fbl;dur=289
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 aa3674a12327640af71c59263be8ffc6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - H8s8_LTbVd3TwK53G2InIXACt9vw2pMT4AWlZB2euffeqiAAI4DcSA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a8017b24590faed1f9e8d565c5a68a4d
+      - 6ff862883a27cfefb47ce94e6e479caf
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2TtvvIDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8em0QYXSN/bdpsJr4VwrTGrQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgKaQQlJuLh/L9UP1M92MXR0qwp8jNIEJvAQn9truu3Blte+jbaXt
-        2IRQPba6+YoQHgJsPj81r4SPIANWJEATWFaM8TzjeRADXECAQ96FP+BQtd05S6FiwGnBM0gXUHyz
-        srsxygYwp7OFFIAFKkmzOYpcqVyBVGyZFYtazXJkMwXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAnN7O/SACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:16.187+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 35d94742-ee2d-4832-a61b-474880bb73c1
+      - d615212c-5917-48c3-ae1f-80a59e316334
       Atl-Traceid:
-      - 35d94742ee2d4832a61b474880bb73c1
+      - d615212c591748c3ae1f80a59e316334
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:30 GMT
+      - Wed, 30 Apr 2025 16:24:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=14,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="wS7ztRuoaGBKDQ2j_sbvurS7vTMxIFp2VytYTrkv0uwoReXe4m98Pw==",cdn-downstream-fbl;dur=267,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=265,atl-edge;dur=181,atl-edge-internal;dur=14,atl-edge-upstream;dur=167,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a63f854fb49823d899d920c07df1bcae.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - wS7ztRuoaGBKDQ2j_sbvurS7vTMxIFp2VytYTrkv0uwoReXe4m98Pw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 209e4975a8dc8fb16e0c6decefbd34b6
+      - 23105cf5d7e7ba7a7c037e2584b208ee
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 9bf76a0b-737e-4dfe-8fdf-6190875a3102
+      - 45d763fd-6c70-4229-bcdb-e85ad48e052c
       Atl-Traceid:
-      - 9bf76a0b737e4dfe8fdf6190875a3102
+      - 45d763fd6c704229bcdbe85ad48e052c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:31 GMT
+      - Wed, 30 Apr 2025 16:24:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=311,atl-edge-internal;dur=12,atl-edge-upstream;dur=299,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=345,atl-edge;dur=313,atl-edge-internal;dur=16,atl-edge-upstream;dur=297,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="A0DicNCmNB4ZdDVHSY_eOeR4YmsKLJyT6VMY8aBAfJb_bc0B3HhX-w==",cdn-downstream-fbl;dur=350
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8139bc666c011a53bdc5037ba6d5931e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - A0DicNCmNB4ZdDVHSY_eOeR4YmsKLJyT6VMY8aBAfJb_bc0B3HhX-w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - fbcf1c12f051ee2f691fe5947f313fd9
+      - 5b0c5bc507e487652c5b4a5d5a6ffe55
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/241]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/241 (241)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/92]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1297'
+      - '1317'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16082","key":"NTEST-1598","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16082"}'
+      string: '{"id":"18171","key":"NTEST-1838","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18171"}'
     headers:
       Atl-Request-Id:
-      - 649cc27b-e3ef-46b9-b151-74de00292ab4
+      - 2aeb4061-1051-477c-9b86-9862212d4258
       Atl-Traceid:
-      - 649cc27be3ef46b9b15174de00292ab4
+      - 2aeb40611051477c9b869862212d4258
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:31 GMT
+      - Wed, 30 Apr 2025 16:24:17 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=689,atl-edge-internal;dur=14,atl-edge-upstream;dur=676,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=754,atl-edge;dur=720,atl-edge-internal;dur=18,atl-edge-upstream;dur=703,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="pIXLWCesH_0v8SwlTp0f1-wFTvEVMHlJM3lY0qBNpAfqDdUllE-qPA==",cdn-downstream-fbl;dur=760
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9fe7d47ea2a815113a41181f1d63f69e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - pIXLWCesH_0v8SwlTp0f1-wFTvEVMHlJM3lY0qBNpAfqDdUllE-qPA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4163b1aa819ac64c81c797c6b1505749
+      - a288cf829760816ff9024b2374a71644
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1598
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1838
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxtXlqgRJomRsvGxhiCAtJlCJnkNDV17Mx2aDsu/33HeSsU
-        cq9g2hVSiX183h8/Po8OLDMqYid0FIgYFMSHDHisO4KmoDs6mkFKOzIDRQ2TQncgZiYFQzvRjIoE
-        uEw6D6A0yiA+g0yBBmGqs1GujUyn1uCt73m+11Pwdw7aTFYZnCoaGRaB03GY9e/veMMAFxr4FJcz
-        YzIdum4MU4hMLO9ljxpOtWZU9AQYFz0Zl2bMDVymdQ5ubWAOK9Q/mYzPJ11/e2+IW0UI2gkfHY2x
-        5TqiBhKpVmUOMa5QI/CC7a7nd31vEnihvx32/d6eH/yAcXs2SOvEYOCFmQ8GafVdtOfZQMu0q0UM
-        OlIss4XD3X2iU8p5h8RMGyYiQzIGERA5JQup5j2rHUlxofg7o8gFs+2i/JY+UEOV+8Bg4RZhrQOs
-        RL7X94c/afYP/Jhi2/MUvVpYoMsJ1XPbq/zO2K9wSrmGjlMqHmFehW7HmTEEjopmq2N4AIzVe+o4
-        hiGyMkSJE4occ3Q2YNL3akGm5D1m9MGCV9pFuYsG1uW2i2cgWWd1IZgxaEA7jW+L1N+Ls1pOzYIq
-        i1fN0owzDDjeyBz7UaBsMFwOhu8M9wudqTNp+jLwdjGMYLAMBv+vl7L7BRbRob+z9He+hcNl7bEf
-        LPvBt/BYAfzp6TUc/TacBm2Cfi2YsuVlSY4Ii+sbhEmSKEiQb756CbZrAWYmeV7ywttHd9oEuy2C
-        oFUwbBPsvQ6npM1y15JS8UI4YdfHJTX4cJSE+/6LW9L5msDd0pyy17L4PJC5LZxvSfnKbjCROKFR
-        OTxVPG2tKRaVVXt8tWcjw6N6JnMej5jOOF1VVxm3MSxziZix17uqhgJM1vLHW4/EjrdbPxKbZWuo
-        bFPQBqqgAVWmmFTMrD5YxFrdHbzvrWApTUC7VkPXRhhucLno6YdkTZbHclGT6sB5fW2C5hJwegeW
-        Fi3+NyeCNuj6bQj1h7YeM6rHGYuOmZgfWskIMju9iKjuYtHbRSFrdoQUYxxe6B2HM6C6RIaqvpzT
-        44tfjk5uj48Oxifn49vx2dmfZ5gf3lKNBcEDkxmQU+R/YYj1S5gmUvAVQS5h3BolRpLfmKLkVEGK
-        ZEJyjZjtvcUpPl4nx/vMPC8TKnTKNxF7h8Vf36kXXIFtSJigfPNQNXtV5S1wzjG6mm6wr4mA5nSe
-        2UvbiuPdvRrH5Zj0QeiVys27+3KyeR8a13D7mUZzHDZryNXGS18H1Tz3nwKuh0K3ns2CekwQYKEe
-        SS7VSRnNHc+hmyhkjfVIJMlIls2WaYbjsDBvg367IYUvNXZTqSGMl+X8S6z/tibMcNgKyfUnmgUh
-        OZByzoBcMYM8Z8g5RLkCcshp8tlWB4vDZUT5TGoTDr2h506ZiJFK3WDg3xQGR0XxMK97SSyswi3y
-        VU3yHf58X6if49BnOQjVkC2qIEc5kBEmipt/0BXxvQ6xYGySOLgao+ga/3V3/EERqe1jtIBeyoyC
-        nlSJizCmtrUMJzYLfxeP9mYm5UXcpZ1La+dCzIVcPC/SqZJxjjPAWCR4sVNskzvB4lufRYUwXvKr
-        XHSNbKlSVhkIbohLrhcAc2QBaKy1aK0PuP1C8dP+KTmPqGg5b+dQdy9o8nmWwflKG0g1ZhBnkiHM
-        tsJiv+iNrVVKmdDMQA+RiKXSsztJVdx24pX90Rph1vI+ieS/AAAA///sWVFr2zAQ/iuiUGihdp3E
-        aZJB6ULpYA9lo4UVSiHIttyYxbKx7Lpl63/fd5KipV7cjTJKHwp5cCLp7nS+++67iw4koC6LhJBM
-        iZq1NqpqwKIykZUisg5Yu8ziJcsFlwqL3OywEnDdGxkJxuMYuCoSdpdx1iBV4uqhBDBhn5TClGh/
-        w6JzvOVb3VSSQVdLISmyGHdyC/ScuBEsoWuB/7FMpkWV6zOsqAitOVYVgSWA+ruQB2QYhGc1MzyA
-        8VXLH+iKrOTaukYhphmXbMNAdIxSrHx2JhXd2d3Q+OBGkhNIG/kIFlgL1dpEEqgaOGirpRt33rj9
-        BbIQdQcuo9vbcGnb1i9arkqdD0g/ce+Xy1LHMpQsIHNhdS94DeITNQipxd6Xq/nlV+/y3EOJ1lnq
-        lJRFVYuK8mCPJ3km99ne/k8EyqouPiAM/2Q3Y1fiu+Wtj/YMwr4FR3cJE+sKYK85HbG0ztbQUdHO
-        QuBkdBf6WEbgWIZ+e5psbd/Yx4sDZ8yTat0Fc7wAHi8p+U1FUE2ecypXO39DavI6kc+iemFtIxJy
-        gnwjyvw5OR4no+lkGg0mgRjFsyCejYfpbJAeQY/bBA3PbBMUEvMkgQ7UNxS75OHjhiEAFJL1bDts
-        csVH/dTbNEzZliwUoHg8GYTh0SSeTsajWRRHkwDqUy7SaXySHGspu6P57vATPuacl3Np4dXzzE/K
-        b5TXwhHe0CfI9ssmWmUxecorOVfkKJzXFQQEEY+nSAq/lOTzbmv99i3u9uZv3+Jub//WLQYUJaZV
-        tCTwFKEPDpOmTRxnOoEIz00jaoDsGjQQG8+aqijF4TUgJl7+zjSaLWHVpS5psBO17cwx7MPVsK+d
-        DPtmFKHD7soC/zu+vFokvePLa1j8ji9b8KULA46QOf4Cq29N7v2gIbh9DqCwqLkd4Xel9DKvXlzq
-        pWTD7cjXNw8K+jgoAcLWhaCPg476TowcyRPyLqsKaYic+Slp7P9H5us/ea/IjYQf60cL9y+A342/
-        vg7Xcg92cn5/IVSzIsEbuvW4pKrntbHjrqj/34zWCHNCoQvt4rdCT5vWg1WaEtMMh1Q6Q55aO3xi
-        rj2g3fP4+PgLAAD//wMAJIjnZq4cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18171","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18171","key":"NTEST-1838","fields":{"statuscategorychangedate":"2025-04-30T18:24:17.405+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1838/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:17.100+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00syv:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:17.197+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/241]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/241 (241)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/92]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1838/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18171/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f22aecf0-a02d-47c6-a67d-5ea502494ba9
+      - 1db88122-4396-40df-af76-2a4da1b6fcce
       Atl-Traceid:
-      - f22aecf0a02d47c6a67d5ea502494ba9
+      - 1db88122439640dfaf762a4da1b6fcce
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:32 GMT
+      - Wed, 30 Apr 2025 16:24:17 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=237,atl-edge-internal;dur=19,atl-edge-upstream;dur=213,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=362,atl-edge;dur=274,atl-edge-internal;dur=17,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="SBnTfAI3Ffryaw97TRknPi9RwFRjJWf_uSi_FaKpQeOmtTMLNAg_-A==",cdn-downstream-fbl;dur=365
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0835ebd52ef8594cd8aa4dac9cfbd9a8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - SBnTfAI3Ffryaw97TRknPi9RwFRjJWf_uSi_FaKpQeOmtTMLNAg_-A==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 5c4f27a088a6eca6369a94ddfd114229
+      - e54c94e2a16f7e12cdb79e3c237768c8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16082
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18171
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9pEEwkpVRUloaSlFJIB0FCGzO9mYeO2t7SVJOf73jveR
-        8MjeCaqeTuKyHs/7m8/z6MAyoyJ2QkeBiEFBfMSAx7olaAq6paMZpLQlM1DUMCl0C2JmUjC0Fc2o
-        SIDLpPUASqMM4nPIFGgQprob5drIdGoN3vqe53sdBX/noM1klcGZopFhETgth1n//q43CPBDA5/i
-        58yYTIeuG8MUIhPLe9mhhlOtGRUdAcZFT8alGXMDl2mdg1sbmMMK9U8no/Gk7ff3B3hUhKCd8NHR
-        GFuuI2ogkWpV5hDjF2oEXtBve37b9yaBF/r9sOt39v3gB4zbs0FaJwYDL8x8MEir76I9zwZapl19
-        xKAjxTJbODw9IDqlnLdIzLRhIjIkYxABkVOykGresdqRFBeKvzOKXDDbLspv6QM1VLkPDBZuEdYm
-        wErke11/8JNm/8CPKbY9T9GrhQW6nFA9t73K74z9FU4p19BySsVjzKvQbTkzhsBR0Wx1Ag+AsXpP
-        LccwRFaGKHFCkWOOziuYdL1akCl5jxl9sOCVdlHuooF1ue3HM5BssroQzBg0oJ21b4vU34u7Wk7N
-        giqLV83SjDMMOH6VOfajQFlvsOwN3hnuFzpTZ7LuS8/bwzCC3jLo/b9eyu4XWESH/u7S3/0WDpe1
-        x26w7AbfwmMF8Kent3D0m3Aa1IIpW16WHIjdv755e7Nb36RJoiBBvvnqEPRrAWYmeV7ywvaru02C
-        vQZB0CgYNAn234ZT0mZ5akmpeCGcsO1XXGlbolhURv745swOClZbz2TO4yHTGaerapzweEENPj0l
-        Zb9/9MsHYfMEuKU5ZQe7+Hkoc1v6ItQre8BE4oRG5dY3GjWXiBk73lU1FGCylj+2PRK73l79SLwu
-        25rKXguaQBWsQZUpJhUzqw+WoFZ3e+97K1hKE9Cu1dC1EYYHXC46+iHZkOWJXNSk2nPejk2wxjyn
-        d2BpcctgWDbZWga/CaH+wNZjRvUoY9EJE/MjKxlCZrcXEdUIKnC1KGTrEyHFCJcXesfhHKguUamq
-        X87ZycUvx6e3J8eHo9Px6HZ0fv7nOeaHU6qxIHhhMgNyhvwvDLF+CdNECr4iyCWMW6PESPIbU5Sc
-        KUiRTEiuEXGdbZzi4zg53mfmeZlQoVO+idg7LP5mpl5wBbYhYYLy15eq3asqb4F7jtFV37aviYD1
-        7TyzQ9uI4739GsflmvRB6JXK63f35WbzPjRu4PYzjea4bNaQq42Xvg6rfe4/BVwvhW69mwX1miDA
-        Qj2SXKrTMpo7nkM7UchYm5VIkqEsmy3TDNdhYbaDvt9ECv01KXyp4y/L+ZfY/NuZMMNhJyTXn2gW
-        hORQyjkDcsUMcqwhY4hyBeSI0+SzrQ4Wh8uI8pnUJhx4A8+dMhEjEbpBz78pDA6L4mFe95JYWIU7
-        5Kua5Dv8832hPsalz3IQqiFbVEEOcyBDzAcP/6Ar4nstYsG4TuLwaoSia/yvvev3ikhtH6MFdFJm
-        FHSkSlyEMbWtZbixWfi7eLUzMykv4i7tXFo7F2Iu5OJ5kc6UjHPcAUYiwcFOsU3uBGtsfRYVwnjJ
-        r3LRNrKhSlllILghLrleAMyRBWBtrUFrc8HtFoqfDs7IOKKi4b7dQ939YJ3PswzGK20g1ZhBnEmG
-        MNsJi/OiN7ZWKWVCMwMdRCKWSs/uJFVx04039ocbhFnLBySS/wIAAP//7Flta9swEP4rolBooXad
-        xGmSQelC6WAfykYLK5RCkGW5MUtk45e6Zet/33OSorle3I0ySj8U8sGxpNPd5e655y46kIC6LJJS
-        sVJWrLFRVQEWSxNZCSLrgDXLVCzZWnJVYpGbHVYCzL1RkWRcCOCqjNldylmNVBHFQw5gwj6lpKEH
-        fkujc/zKt7qpJIWullJRZDHu5GboOWERNCGzwP9YqpKsWOszLCsIrTlWSwJLAPV3qQ5IMQhPK2Y4
-        COOrhj+QiSznWru6REwzrlhLQXSMSq58dqZKstlZaHxwo8gJdBv5CBpYDcuNiiSwrOGgrZq2bG5Z
-        f4EsRN2By8h6Gy5N0/hZw8tc5wPST977+TLXsYxLFpC5sHcveAXSFdUIqcXel6v55Vfv8txDidZZ
-        6i7Js6KSBeXBHo/Xqdpne/s/ESirKvuAMPyT3Yxdie+Wtz6EG4RthKsKYLomXkQEu1sdAe4shI6K
-        dhaCvhOBYxn6R9KcavvGPtYR9PHiwCkDH3OxpPy2pbddvbsYXtbrNadytfM3pCavE/nMihfWNiIh
-        J8g3Iryf4+NxPJpOptFgEsiRmAViNh4ms0FyhHvcJtzwzDZJITGPY9yB+oZiFz98bCkCQCFZz7bD
-        Jld81E+9TcOUbclCCYrH40EYHk3EdDIezSIRTQJcn3CZTMVJfKyl7I7mu8NP+Jhz3porC6+eZ16V
-        fl16DRzhDX2CbD+vo1UqyFNeznlJjsJ5XUFAEPF4iqTwc0U+77bWb1/jbm/+9jXu9vZvXWNgVGza
-        VEsCTxH64DBJUguR6gQiPDdtpEG4a9BAbDyriyyXh9fAHrH8nWk0W8KqS126wU7UtjPHsA9Xw752
-        MnTtZGHx/R1GXi1g3mHkNTR+h5EtMNKFgT6mFjpC5vgKzLk1SfmDhuD2OYAmWcXtCL8rpZd59eJS
-        3+AnGG5Hvl5m1mtZL2VzJncWRn0nRo7kSXWXFpkyLM+8imv7/5H5+i/eu8uq/zfZNMKcUNyENu1b
-        pqc8m2EqUsCo/GPzaOvLixXQ/7UdbuQe7Kz5/YUs6xUJbhmr5zNFNa+M4TQlphkOme7ePz08fHLa
-        HtDaPj4+/gIAAP//AwA1SgTwrhwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18171","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18171","key":"NTEST-1838","fields":{"statuscategorychangedate":"2025-04-30T18:24:17.405+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1838/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:17.100+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00syv:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:17.197+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/241]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/241 (241)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/92]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1838/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18171/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 1201167c-f2b2-458d-b1bb-8346a05bdb8e
+      - ca67633e-9ad3-4637-93de-cfddefea1471
       Atl-Traceid:
-      - 1201167cf2b2458db1bb8346a05bdb8e
+      - ca67633e9ad3463793decfddefea1471
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:32 GMT
+      - Wed, 30 Apr 2025 16:24:18 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=255,atl-edge-internal;dur=15,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="PLrw7tgO4XIY5Ch-u4655UGns_qkGl01gGQ4EeUxvU94znjCVf3Nmg==",cdn-downstream-fbl;dur=386,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=383,atl-edge;dur=300,atl-edge-internal;dur=15,atl-edge-upstream;dur=285,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 82e46a17c2e4998f87de230e61a57612.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - PLrw7tgO4XIY5Ch-u4655UGns_qkGl01gGQ4EeUxvU94znjCVf3Nmg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - ab28ad5b60090ca03380d479dd6e36dd
+      - 1dc3dca94cd8671ba26362fb4c6dfd45
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -881,7 +863,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -895,9 +877,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"828\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:54836\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:44580\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: weekly engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\":
@@ -933,7 +915,111 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:15:32 GMT
+      - Wed, 30 Apr 2025 16:24:18 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: weekly engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/92", "url_api": "http://localhost:8080/api/v2/tests/92/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "weekly
+      engagement", "id": 3, "url_ui": "http://localhost:8080/engagement/3", "url_api":
+      "http://localhost:8080/api/v2/engagements/3/"}, "test": {"title": null, "id":
+      92, "url_ui": "http://localhost:8080/test/92", "url_api": "http://localhost:8080/api/v2/tests/92/"},
+      "finding_count": 2, "findings": {"new": [{"id": 240, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/240",
+      "url_api": "http://localhost:8080/api/v2/findings/240/"}, {"id": 241, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/241",
+      "url_api": "http://localhost:8080/api/v2/findings/241/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1300'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1300\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:44588\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: weekly engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/92\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/92/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"weekly engagement\\\", \\\"id\\\": 3, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/3\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/3/\\\"}, \\\"test\\\":
+        {\\\"title\\\": null, \\\"id\\\": 92, \\\"url_ui\\\": \\\"http://localhost:8080/test/92\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/92/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 240, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/240\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/240/\\\"},
+        {\\\"id\\\": 241, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/241\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/241/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 3,\n      \"name\": \"weekly
+        engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/3/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/3\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 240,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/240/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/240\"\n        },\n
+        \       {\n          \"id\": 241,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/241/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/241\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        92,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/92/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/92\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: weekly engagement: ZAP Scan\",\n
+        \   \"url_api\": \"http://localhost:8080/api/v2/tests/92/\",\n    \"url_ui\":
+        \"http://localhost:8080/test/92\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:24:18 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -958,26 +1044,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2m5r3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwG2WJyaV8JHkAHLp0CnUFSM8SzlWRADXECAQ96FP+BQtd05S6FiwGnOU5YUy+Kb
-        ld2NUTaAGZ0vpQDMUUmaLlBkSmUKpGJFmi9rNc+QzRWwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAuqTVxSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:19.114+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 90fc1249-c9a7-4fb9-93ed-5d3942089731
+      - 08a34387-e1e1-413c-ad52-6ff90dbae894
       Atl-Traceid:
-      - 90fc1249c9a74fb993ed5d3942089731
+      - 08a34387e1e1413cad526ff90dbae894
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:33 GMT
+      - Wed, 30 Apr 2025 16:24:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -987,7 +1069,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=177,atl-edge-internal;dur=14,atl-edge-upstream;dur=163,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="IkIcZfoqtC20ByNuuPuvhxOdMC7RQDSze7DoC8DX-AVX80a5RRWJHw==",cdn-downstream-fbl;dur=441,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=439,atl-edge;dur=351,atl-edge-internal;dur=15,atl-edge-upstream;dur=336,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -996,10 +1078,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 3cab2977109e9e185607e6a3005951e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - IkIcZfoqtC20ByNuuPuvhxOdMC7RQDSze7DoC8DX-AVX80a5RRWJHw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - fe3e76a45f78a834c5ec54748b083b08
+      - 748abac7e6adefd4babe5f9dde52d411
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1026,26 +1116,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TfmzLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPATYfH5qXgkfQQYsnwKdwrJijGcpz4IY4AICHPIu/AGHqu3OWQoVA05znqZJCsU3
-        K7sbo2wAM1ospADMUUmazlFkSmUKpGLLNF/UqsiQFQrYmcDraLhtBxFfiEqM2t9ZKWL7QPSpImhe
-        tyU5nh/2ZE2cXN9X5PgJAAD//wMAcgnqCSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:19.487+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 4038d299-6fc7-48d5-9569-d11cddb0512e
+      - b6f20024-9924-484a-98b0-61894ebbbdee
       Atl-Traceid:
-      - 4038d2996fc748d59569d11cddb0512e
+      - b6f200249924484a98b061894ebbbdee
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:33 GMT
+      - Wed, 30 Apr 2025 16:24:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1055,7 +1141,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=146,atl-edge-internal;dur=19,atl-edge-upstream;dur=128,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="f3lmmgdodjRDRK5DnsrJyfcdPwepfjmGtEJrpn1lyxE4DsIz4GbYig==",cdn-downstream-fbl;dur=258,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=72,cdn-upstream-fbl;dur=256,atl-edge;dur=159,atl-edge-internal;dur=15,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1064,10 +1150,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 05df0d22c8cc3d4b946b6f2dc43d6b9c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - f3lmmgdodjRDRK5DnsrJyfcdPwepfjmGtEJrpn1lyxE4DsIz4GbYig==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 7a8f98c95ad45e93f17d2099d90e7156
+      - ebb86984e7bdb28dfc606326b2ea5e45
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1094,97 +1188,135 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/field
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7RWS27bMBS8iqC1F+6iG+8KuwGKBm2RItkYRkFLTwobiTJIKo0R5DS9T89UUqTI
-        R4VSBMfe2ODwUTPzPhK3zynN01UqJJGtyIiEsuHH7J6wEnK1ShfpAxynAxipQUX87CKStQ1J1iZG
-        BWStkE2drgpSCVikDc+Bk30FDmHkkZYGkbxVgADCFQdCsoq0Ar4pKpGutlZOz2WpNlrPTp3O7qEm
-        6eo5lceDlqaFSlprseIoJNRThl5eFjYpB8KBSZcCt7SGf/Tr9/mzMQODlmznxBT06Q64oA0TTlGI
-        WVlX9Cl59Oi4OCNlUls09541mmzCOTkqYqryrOJTqwXnHuv26Q5rOug8BMf7bdLqnDpEvQ7IfTk4
-        iKZqpTFmhAaQFXmDsXF9p5YCUcZKEShy2UeoT35FhLyj8KcbWOMngKyfa4UlDhw3NCfh8cZHrDFL
-        sVFGR9DwctpwKn0fIaAfYI+MOzm1NI4u5gJpcS4chouyh8qPu1u6Ytj1+dVbqpj24XwLySkrw3p0
-        h70PXTAQ6hd/UQagG5iaUKYemHz2e+P+Tu8z3hMhnkBSzDtr6z1w7DU44h2TsuRQ2l5VZS0pI9Wr
-        FLwVZXPy72/y3W5eOCvzPE/L9klAXyHjFwHW2qeigEyKy36wSEcC+Tu/Wk6jd0iFaKGi7MF7DKB+
-        UNUS8uSL3rqMxY5V08wyF2h0/hCKGlkIWjJAPeuBvoYeOb8xRxfzpQLDxuyDh5cKp94trXZziZhU
-        PmeYotItV0y4kzG4jiLhWVMfGqbugF58AFkDa4yNmzg1/Y4yamPYVz4aOUOqB4OjXQVjYwDr7Gu3
-        GLc0py7Rl5xWsDCE/b9X4m94hrmgUOW/PiyXH5e+DpEdK3oD+lWzaX43ybqLSm5vrpMrHaqCWiY5
-        YaJSr8lcq3nzQO/eODtHPYttp3inHj5NPbG7vf0PAAD//7xZTW+CQBD9K6Sn9gCpiiZ6NU1jLzXV
-        9EJ6QKQWRSB8mP787izLuiwzFYN4UWB2Z2bf251hhurqC90W8o2gch/2gOXmIZxPN7L2QepaSViw
-        vGGV28RSIAUl2axIQ6lgwejgXiunQ6NgQJIDEpocFkCMZeAd2N91JCET+yJrQJCFuNBilKM+ecwY
-        UaFvQCB9wskUMbYLlUxDwu01GB3QjA5JRkEiGF0cE9eDaIOQJmV98TIEXqSV8sJZ/cRpbuT+by7g
-        jAFFieby4/3tZb5m45M03jOuQMbXzzQOnyFCNim4xXkCj/htg4MhzcGI5AAk8lRB0sU5kLK+OBiV
-        Z4NbwXavnqG2fKjFF2LxBbRBNeM35tY/+WGcHFkuM4Mo93epC1W0WQ6albq97wbCIxphm0QYJALh
-        zyKMAK8gLEtGBGh9SF9424B33RgKe6Q60RXYk2oPwdem8R2T+IJE4LtidgMwjmOrivvCdQy4ng2h
-        mOp199bMEM80sFnsPQWez/bmwZLDZ+jcCs4xDeeEhBMkAs7X2OVdCQTKStQXjBOAsTLC/x3+i6c2
-        HVHdO3rfkmF2V1NRITohEbWnFKJcIkOsntbLNLNmQf269xZkXk9c2FP8tQXx4PKgZlq9Z4q0p0Rj
-        5/+GDtrIuVd/CwPpQicH6eB4qe/mMUwRe1TeixXN5YNua8A3klCOrUW8lp6rTDFWqfyLTe5mSmdG
-        eVAF/mJjVo+6+Y9ycLaIrUCPPnhTRqqgQwhZmHIJGULga1lZBjy0DB61GX2FDaI0rdn+T+zAJR4k
-        xPfKDiECNOCljE0XpzZZnHIJRRArz2ApxpodTVGvtSQKn3lLwv4AAAD//0KOMOzdU+xuIEZZNJhd
-        XJKYW4A7GkHlFeVRiWIKLCJx90lNcPZJwTK4IlIBPk9DTOQhVNMqwsD9Vqi9AAAAAP//tFrBcoMg
-        EP0Vj+3BU53Rc9Nj28kkRw4Zamx1xgZHTfz9wmpRcdeA0ZPKArvwHrC7iOmlRKx94KCYu9kaB7K+
-        7xoDRAesARmwgoQE6BMORjdPymizFVhdgHtH+3wF1n7gwGmn4AGgvnPBJ3FEMAh7y6SQ/huoaeEZ
-        FHSoHPqSf0umR/HSydTqsBkwXQldGfH6ilLIt6p3KjBJNyLp7e37QnpQi/0LbDADM6ZenhbSK4hM
-        SICEWkEqo8hLLuP2InVaRmjDrdYSJC/sTLCoxfQ3vrDW2AFVSMKlZztZW3TKIyBTHiChEPQO/JwJ
-        7/Va1+JSOWFINN0KRUiV2BphVY+NynA0RWH8xLMAzVKp+Wq1TBClsy4BmXUBCYnoMcllifeeVbX3
-        tONVLNVffp7dsL3XyVYoQybH3RzHFmwkjbV0jgN+k9WpH6fZaPwL6KDVVWDEhBEzWaOQZISS2DHi
-        45rX2S4VWZw8wgm0m61YEVqwAjXIuc2YGb9KXuSJF0OdiiCI6QSvsWmAaoIhIc2QiGSIktgx5AiX
-        g+ZUulME72crjkQWHMEtcm/E3kpRnEVzwfmwBv4E9BEJ/csA+pE2eAOdp1N3++ib/8Ps23JP3NS9
-        QdKoOLytALD/AQAA///EWz1WwzAMvkovYBZvjLCylQdDpzT9AZrUvCZQOA/34UzEshzZteQ+SvyY
-        GkuuJX1WZFuK42mXOxeaWw1zK4nlZiDdhA27qZUy++ZTOZ6CvJsC+E5R1hmUxcQ9cMQX7PZpXe9u
-        zMdawPTMP0oBKyTrI9k59gIel/aRfxWKhcZ6FJzMXpC2T85t6XGt7FmNBHLocKc25rD2bnow05ng
-        W6j/AzZLKO9EcZp7JUa1HYF0PprDrjH2FXRaUxv1vjPb2eNAzKqeuDd2OeffnMqnrkgajUZ4EpkB
-        UQIG8IaEFDQFPvCc3TvaL4xJp4GzJZIIP5x1YafRHiKSRTb52b26ArCzKKSgRZCLnSNNtuhyzyKZ
-        nDFpxYr6y6FZLIgABy2bvy3b534IvLONObRCNE47lQrAUPY4FZeF5Hzg7K6GGGJHqlRb7avteuWW
-        ue4ahledF+fIqt6g38RhNKhs4LZhxJfaFESR8DdnYaHy0jhYSJMwgAJJdhSxMAOcMT7V9uPtjJec
-        9CjlIlBoiWRxQEzoHw3IyjuHXC3RYrUEOD7AmL5qcuDGHUphCzWRUFRhaHsrKo+sXObQWkTWchDZ
-        4GIcAytzbW4yTP3YC/9gwUWgNb89nGI7+HJslb/PmaAZFCOijx7iFZBlIZ7fX65KWXA15JBJl0BG
-        SdlVxGwwcNA0fzGG9RRiTu4o6BOQ0SUx+PQ/VSst52G1mIcFDmLpTkl+E8jgGXcohWmQP/Wigtal
-        eYsfAAAA//8iIXSxj1sY4x7UNEYa1CQ4bgFSh97oQAwIQGSxhD0OlbSKBPBwJVY7sYU6hWMVuAcD
-        jXAOFxsBAAAA///MXMFOwzAM/ZX+wDjkuBtCmuCENHZDOxTUbUXQVmmFxt/jOG6dNHYrpEXigLTa
-        7Ry/1ybuw1kgFx9Ke64GJ6ZYR5uA3uyMTKgZRC2KJaG10szTtVv423g3LbRvZe8arCqnegUZEIBm
-        AUBVTUVPDGDVKCpp5M8FHipkQaRbQxeOfgROV8mMqpKhh4B7hjVsqQSM/LmAQwUsiCQB94dVZ60A
-        bCESYSvXfyZQr3jHPlHnIU3MhOfe2b9vsENfxCuJigYXToIsaLOaCpjZN8RaEbb+TymGFsrOaUXF
-        nmwZ8uOQUj5pOcbnB4mUA1zIUh0fj0mgwebS63w8K9/FPBjOgUycAa40QBSsO+9UDPhUBAffdmgs
-        hmVmkgeVTlljRspFGE0seoU+zm64AI1NWbs9hj6t0EL5PH3BY5uJoSPPmK5xOfjVDT6mYWCLda6H
-        maPRJ9eNKd410oM8Xq3P/6oUhx7K8KWD4kapOSZfrnnfC28+ipT3XC3+6NPKuPu51v0dvJVVzaXt
-        usriSrA9XzZ9PPxxbtebhY2qSaGHENt9wksg0iZAxs5cmKESxWHo03/8H5DR9Smj6lPoIaRfHx7v
-        94ej71JuT8Wutv1QwFTXtU2vvOGtXnNzXlYjLp+APfPOfEKzJTPLNsbIjCZN1DKH1XW4g/HbAd5h
-        thhjDBGVoiNnuvJlVOULPTPOUK6pm2L6kYcFrpJzs3GURJIdvg1+Ogy4UCS09T2XEQ2ONihT43RH
-        BuY7Vn8BAAD//8ScTVODMBCG/wrjnUMcT17Vu+PHD3AoB7QzILXWny/ZbJIN7EsBm/FWsqGbPOTr
-        XUgEZxgEIYsf0b/sCXCPbePOpVC4j3JcnDazojDIyJe8/J8g0zWOghjIlywJ385WoRDbzCDnSc5M
-        vI3gPfK5HDCYTd8Pp0G4D/9c0j9PGq2ZgQoDIGRhqO7tbdXuaT+bwjLNkAshhT+kK43cNFZ0hpyL
-        HKVl9+Bw4MPAwAdZGJw7CLGg44dUcGmGXODcx0HClQZufpTUQh/h2McUGg56GBj0IAtDe3pDtNiS
-        CxMFOsjHQj6gVQ2r233905a9LK6nI4IXx85O8lHgxGsm8RoSvNsLCpzojX+tEjj+bqEcG+XIsyAi
-        dSPXM5zhpozD22qsSssrXwKxwVgtmAZhGt5Qb408dvWh6hu/kHcY0jSu/X2SiOu9tXVLp1rNwogZ
-        aibvwJ0ZKliy+M5cfx4HODNvfUY5cnVuUrOJL5XFjoe4uu9dXjLAcVEcInH73ZWuOYTsvs9jUWug
-        qCULQ3zomqogXCpBac6Fj4RtdKSyWzPzDmOk3S9c0k7GCTCsTQ3UpmSRwObETZohFzT6dkK60rDp
-        Wv8MNl2dGKwPDdSHZJHc7vA6L7HnokYbO4UnDdqmtqav8bCiMzeQmbVIZniFJ825iNH2vehIA7Zq
-        9eJ6piyzhyV219npb6ht9eEeRJznRSIjerGCXST7YiyY4/4QAR+VJZm3Qzp++PD7ELJwzZ5/AQAA
-        //8CzZcqQMdqsMQ+ijytoh9yRBKyTQjOAB36YIh7sYgBzoAFy0AD1hl87LwCtPbFErKoCqgftAAA
-        AAD//8Rdy26DMBD8lf5AJPcTKvVYqZfeerIimiCFBPG4VOq/Fy+2u2vvUEetxSWJdxfWjAcMg7Uh
-        aA1BK1Ox1m6LRcwGvFAmIY+Ed2hHcNmSAbXgJVFEpmKt/eDFgomBggl5Engbu74T2QA4hNSCmEST
-        NJlo7wczk1fG5jiLovTMEK613vLw4orisQ4VTCOFmF1ozxoKoTtrBJtNYj8xZaBURB5JGVqAszGh
-        aGG1qEOykZYws+1cmcYwyclOkz2effm+FXVh8nA/cdsdRCq8H2E59bv+9I2f6GMkF7NiekFRjTyS
-        Xgvm/aVxJ/TvHMtjaxGNhDeYVXfsTTmm441z11n+vyyxHa5c0XAH0wohDMk0CHJlJ0RjNkFVhzz+
-        gJ5/ypLqFGJ1SyvyhjQdnkoDQXnyUSlQVnF1cXsM83KrBus8Buo85PGwvjW20/H0nlpAkrrjc7iv
-        d/ehn1aT7AnGE55SMfog9hVAfFwMt+tHe5pX5F3uPyeho//CwwNVJfL44XkdTvbaflKvgK6UhtQa
-        MFKWZDJtsNJZhsmbN7YxHk+ub7KND3zrTIYyWIYyUIYiT5ic+35wi8IByNz97wDzncffsjS8W1nz
-        DQAA//8Cn3kB1FcEOvFCBxYtuBYgoEUDSB/uMCcmeYOdADIGe/fbAPeglgHOQS2wDDQGBvL4eAPw
-        cBb68fED1klBGvJKzSvLLMrPQ2lcoopBg88VRRDmJupV+siWYgsOzIofWQfCQymlqHcZIvhQj7iU
-        pqI3/qjnixTwNSMwO7H5A2o1YmIKqhYpdefnokQHgg/1gTNcgAQPENvKh9mGze1QuWLdgsR0FE/A
-        NNXWxgIAAAD//wMADdrZt2VyAAA=
+      string: "[{\"id\":\"statuscategorychangedate\",\"key\":\"statuscategorychangedate\",\"name\":\"Status
+        Category Changed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"statusCategoryChangedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"statuscategorychangedate\"}},{\"id\":\"fixVersions\",\"key\":\"fixVersions\",\"name\":\"Fix
+        versions\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"fixVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"fixVersions\"}},{\"id\":\"statusCategory\",\"key\":\"statusCategory\",\"name\":\"Status
+        Category\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"statusCategory\"],\"schema\":{\"type\":\"statusCategory\",\"system\":\"statusCategory\"}},{\"id\":\"parent\",\"key\":\"parent\",\"name\":\"Parent\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"parent\"]},{\"id\":\"resolution\",\"key\":\"resolution\",\"name\":\"Resolution\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolution\"],\"schema\":{\"type\":\"resolution\",\"system\":\"resolution\"}},{\"id\":\"lastViewed\",\"key\":\"lastViewed\",\"name\":\"Last
+        Viewed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"lastViewed\"],\"schema\":{\"type\":\"datetime\",\"system\":\"lastViewed\"}},{\"id\":\"priority\",\"key\":\"priority\",\"name\":\"Priority\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"priority\"],\"schema\":{\"type\":\"priority\",\"system\":\"priority\"}},{\"id\":\"labels\",\"key\":\"labels\",\"name\":\"Labels\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"labels\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"system\":\"labels\"}},{\"id\":\"timeestimate\",\"key\":\"timeestimate\",\"name\":\"Remaining
+        Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"remainingEstimate\",\"timeestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeestimate\"}},{\"id\":\"aggregatetimeoriginalestimate\",\"key\":\"aggregatetimeoriginalestimate\",\"name\":\"\u03A3
+        Original Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeoriginalestimate\"}},{\"id\":\"versions\",\"key\":\"versions\",\"name\":\"Affects
+        versions\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectedVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"versions\"}},{\"id\":\"issuelinks\",\"key\":\"issuelinks\",\"name\":\"Linked
+        Issues\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issueLink\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"issuelinks\"}},{\"id\":\"assignee\",\"key\":\"assignee\",\"name\":\"Assignee\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"assignee\"],\"schema\":{\"type\":\"user\",\"system\":\"assignee\"}},{\"id\":\"status\",\"key\":\"status\",\"name\":\"Status\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"status\"],\"schema\":{\"type\":\"status\",\"system\":\"status\"}},{\"id\":\"components\",\"key\":\"components\",\"name\":\"Components\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"component\"],\"schema\":{\"type\":\"array\",\"items\":\"component\",\"system\":\"components\"}},{\"id\":\"issuekey\",\"key\":\"issuekey\",\"name\":\"Key\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"id\",\"issue\",\"issuekey\",\"key\"]},{\"id\":\"customfield_10050\",\"key\":\"customfield_10050\",\"name\":\"DefectDojo
+        Custom URL Field\",\"untranslatedName\":\"DefectDojo Custom URL Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10050]\",\"DefectDojo
+        Custom URL Field\",\"DefectDojo Custom URL Field[URL Field]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":10050}},{\"id\":\"customfield_10051\",\"key\":\"customfield_10051\",\"name\":\"DefectDojo
+        Custom User Picker Field\",\"untranslatedName\":\"DefectDojo Custom User Picker
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10051]\",\"DefectDojo
+        Custom User Picker Field\",\"DefectDojo Custom User Picker Field[User Picker
+        (single user)]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":10051}},{\"id\":\"customfield_10052\",\"key\":\"customfield_10052\",\"name\":\"Impact\",\"untranslatedName\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10052]\",\"Impact\",\"Impact[Short
+        text]\"],\"scope\":{\"type\":\"PROJECT\",\"project\":{\"id\":\"10020\"}},\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":10052}},{\"id\":\"customfield_10053\",\"key\":\"customfield_10053\",\"name\":\"Design\",\"untranslatedName\":\"Design\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10053]\",\"Design\"],\"schema\":{\"type\":\"array\",\"items\":\"design.field.name\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:designcf\",\"customId\":10053}},{\"id\":\"customfield_10054\",\"key\":\"customfield_10054\",\"name\":\"Vulnerability\",\"untranslatedName\":\"Vulnerability\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10054]\",\"Vulnerability\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:vulnerabilitycf\",\"customId\":10054}},{\"id\":\"customfield_10055\",\"key\":\"customfield_10055\",\"name\":\"Sentiment\",\"untranslatedName\":\"Sentiment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10055]\",\"Sentiment\"],\"schema\":{\"type\":\"array\",\"items\":\"sd-sentiment\",\"custom\":\"com.atlassian.servicedesk.sentiment:sd-sentiment\",\"customId\":10055}},{\"id\":\"customfield_10056\",\"key\":\"customfield_10056\",\"name\":\"Goals\",\"untranslatedName\":\"Goals\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10056]\",\"Goals\",\"Goals[Goals]\"],\"schema\":{\"type\":\"array\",\"items\":\"Goals\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:goals\",\"customId\":10056}},{\"id\":\"customfield_10049\",\"key\":\"customfield_10049\",\"name\":\"DefectDojo
+        Custom Short Text Field\",\"untranslatedName\":\"DefectDojo Custom Short Text
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10049]\",\"DefectDojo
+        Custom Short Text Field\",\"DefectDojo Custom Short Text Field[Short text]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":10049}},{\"id\":\"aggregatetimeestimate\",\"key\":\"aggregatetimeestimate\",\"name\":\"\u03A3
+        Remaining Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeestimate\"}},{\"id\":\"creator\",\"key\":\"creator\",\"name\":\"Creator\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"creator\"],\"schema\":{\"type\":\"user\",\"system\":\"creator\"}},{\"id\":\"subtasks\",\"key\":\"subtasks\",\"name\":\"Sub-tasks\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"subtasks\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"subtasks\"}},{\"id\":\"customfield_10040\",\"key\":\"customfield_10040\",\"name\":\"DefectDojo
+        Custom DatePicker\",\"untranslatedName\":\"DefectDojo Custom DatePicker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10040]\",\"DefectDojo
+        Custom DatePicker\",\"DefectDojo Custom DatePicker[Date]\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":10040}},{\"id\":\"customfield_10041\",\"key\":\"customfield_10041\",\"name\":\"DefectDojo
+        Customer Date Time Picker\",\"untranslatedName\":\"DefectDojo Customer Date
+        Time Picker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10041]\",\"DefectDojo
+        Customer Date Time Picker\",\"DefectDojo Customer Date Time Picker[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10041}},{\"id\":\"customfield_10042\",\"key\":\"customfield_10042\",\"name\":\"DefectDojo
+        Custom Labels\",\"untranslatedName\":\"DefectDojo Custom Labels\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10042]\",\"DefectDojo
+        Custom Labels\",\"DefectDojo Custom Labels[Labels]\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":10042}},{\"id\":\"reporter\",\"key\":\"reporter\",\"name\":\"Reporter\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"reporter\"],\"schema\":{\"type\":\"user\",\"system\":\"reporter\"}},{\"id\":\"customfield_10043\",\"key\":\"customfield_10043\",\"name\":\"DefectDojo
+        Custom Number Field\",\"untranslatedName\":\"DefectDojo Custom Number Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10043]\",\"DefectDojo
+        Custom Number Field\",\"DefectDojo Custom Number Field[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10043}},{\"id\":\"aggregateprogress\",\"key\":\"aggregateprogress\",\"name\":\"\u03A3
+        Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"progress\",\"system\":\"aggregateprogress\"}},{\"id\":\"customfield_10044\",\"key\":\"customfield_10044\",\"name\":\"DefectDojo
+        Customer Paragraph Field\",\"untranslatedName\":\"DefectDojo Customer Paragraph
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10044]\",\"DefectDojo
+        Customer Paragraph Field\",\"DefectDojo Customer Paragraph Field[Paragraph]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":10044}},{\"id\":\"customfield_10045\",\"key\":\"customfield_10045\",\"name\":\"DefectDojo
+        Custom Radio Buttons Field\",\"untranslatedName\":\"DefectDojo Custom Radio
+        Buttons Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10045]\",\"DefectDojo
+        Custom Radio Buttons Field\",\"DefectDojo Custom Radio Buttons Field[Radio
+        Buttons]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":10045}},{\"id\":\"customfield_10046\",\"key\":\"customfield_10046\",\"name\":\"DefectDojo
+        Custom Select List (Cascading) Field\",\"untranslatedName\":\"DefectDojo Custom
+        Select List (Cascading) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10046]\",\"DefectDojo
+        Custom Select List (Cascading) Field\",\"DefectDojo Custom Select List (Cascading)
+        Field[Select List (cascading)]\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":10046}},{\"id\":\"customfield_10047\",\"key\":\"customfield_10047\",\"name\":\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"untranslatedName\":\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10047]\",\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"DefectDojo Custom Select List (MultiChoice)
+        Field[Select List (multiple choices)]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":10047}},{\"id\":\"customfield_10048\",\"key\":\"customfield_10048\",\"name\":\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"untranslatedName\":\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10048]\",\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"DefectDojo Custom Select List
+        (SingleChoice) Field[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10048}},{\"id\":\"customfield_10038\",\"key\":\"com.atlassian.atlas.jira__project-status\",\"name\":\"Project
+        overview status\",\"untranslatedName\":\"Project overview status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10038]\",\"Project
+        overview status\"],\"schema\":{\"type\":\"string\",\"custom\":\"read-only-string-issue-field\",\"customId\":10038}},{\"id\":\"customfield_10039\",\"key\":\"customfield_10039\",\"name\":\"DefectDojo
+        Custom CheckBoxes\",\"untranslatedName\":\"DefectDojo Custom CheckBoxes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10039]\",\"DefectDojo
+        Custom CheckBoxes\",\"DefectDojo Custom CheckBoxes[Checkboxes]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":10039}},{\"id\":\"progress\",\"key\":\"progress\",\"name\":\"Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"progress\"],\"schema\":{\"type\":\"progress\",\"system\":\"progress\"}},{\"id\":\"votes\",\"key\":\"votes\",\"name\":\"Votes\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"votes\"],\"schema\":{\"type\":\"votes\",\"system\":\"votes\"}},{\"id\":\"worklog\",\"key\":\"worklog\",\"name\":\"Log
+        Work\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"array\",\"items\":\"worklog\",\"system\":\"worklog\"}},{\"id\":\"issuetype\",\"key\":\"issuetype\",\"name\":\"Issue
+        Type\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issuetype\",\"type\"],\"schema\":{\"type\":\"issuetype\",\"system\":\"issuetype\"}},{\"id\":\"timespent\",\"key\":\"timespent\",\"name\":\"Time
+        Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"timespent\"],\"schema\":{\"type\":\"number\",\"system\":\"timespent\"}},{\"id\":\"customfield_10030\",\"key\":\"customfield_10030\",\"name\":\"Submitted
+        forms\",\"untranslatedName\":\"Submitted forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10030]\",\"Submitted
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-submitted-field-cftype\",\"customId\":10030}},{\"id\":\"project\",\"key\":\"project\",\"name\":\"Project\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"project\"],\"schema\":{\"type\":\"project\",\"system\":\"project\"}},{\"id\":\"customfield_10031\",\"key\":\"customfield_10031\",\"name\":\"Locked
+        forms\",\"untranslatedName\":\"Locked forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10031]\",\"Locked
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-locked-field-cftype\",\"customId\":10031}},{\"id\":\"customfield_10032\",\"key\":\"customfield_10032\",\"name\":\"Total
+        forms\",\"untranslatedName\":\"Total forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10032]\",\"Total
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-total-field-cftype\",\"customId\":10032}},{\"id\":\"customfield_10033\",\"key\":\"customfield_10033\",\"name\":\"Category\",\"untranslatedName\":\"Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Category[Category]\",\"cf[10033]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:jwm-category\",\"customId\":10033}},{\"id\":\"aggregatetimespent\",\"key\":\"aggregatetimespent\",\"name\":\"\u03A3
+        Time Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimespent\"}},{\"id\":\"customfield_10035\",\"key\":\"customfield_10035\",\"name\":\"Version\",\"untranslatedName\":\"Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10035]\",\"Version\",\"Version[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10035}},{\"id\":\"customfield_10036\",\"key\":\"customfield_10036\",\"name\":\"Defect
+        Type\",\"untranslatedName\":\"Defect Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10036]\",\"Defect
+        Type\",\"Defect Type[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10036}},{\"id\":\"customfield_10037\",\"key\":\"com.atlassian.atlas.jira__project-key\",\"name\":\"Project
+        overview key\",\"untranslatedName\":\"Project overview key\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10037]\",\"Project
+        overview key\"],\"schema\":{\"type\":\"string\",\"custom\":\"read-only-string-issue-field\",\"customId\":10037}},{\"id\":\"customfield_10027\",\"key\":\"customfield_10027\",\"name\":\"Target
+        start\",\"untranslatedName\":\"Target start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10027]\",\"Target
+        start\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-start\",\"customId\":10027}},{\"id\":\"customfield_10028\",\"key\":\"customfield_10028\",\"name\":\"Target
+        end\",\"untranslatedName\":\"Target end\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10028]\",\"Target
+        end\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-end\",\"customId\":10028}},{\"id\":\"customfield_10029\",\"key\":\"customfield_10029\",\"name\":\"Open
+        forms\",\"untranslatedName\":\"Open forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10029]\",\"Open
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-open-field-cftype\",\"customId\":10029}},{\"id\":\"resolutiondate\",\"key\":\"resolutiondate\",\"name\":\"Resolved\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolutiondate\",\"resolved\"],\"schema\":{\"type\":\"datetime\",\"system\":\"resolutiondate\"}},{\"id\":\"workratio\",\"key\":\"workratio\",\"name\":\"Work
+        Ratio\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"workratio\"],\"schema\":{\"type\":\"number\",\"system\":\"workratio\"}},{\"id\":\"watches\",\"key\":\"watches\",\"name\":\"Watchers\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"watchers\"],\"schema\":{\"type\":\"watches\",\"system\":\"watches\"}},{\"id\":\"issuerestriction\",\"key\":\"issuerestriction\",\"name\":\"Restrict
+        to\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"issuerestriction\",\"system\":\"issuerestriction\"}},{\"id\":\"thumbnail\",\"key\":\"thumbnail\",\"name\":\"Images\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[]},{\"id\":\"created\",\"key\":\"created\",\"name\":\"Created\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"created\",\"createdDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"created\"}},{\"id\":\"customfield_10020\",\"key\":\"customfield_10020\",\"name\":\"Sprint\",\"untranslatedName\":\"Sprint\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10020]\",\"Sprint\"],\"schema\":{\"type\":\"array\",\"items\":\"json\",\"custom\":\"com.pyxis.greenhopper.jira:gh-sprint\",\"customId\":10020}},{\"id\":\"customfield_10021\",\"key\":\"customfield_10021\",\"name\":\"Flagged\",\"untranslatedName\":\"Flagged\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10021]\",\"Flagged\",\"Flagged[Checkboxes]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":10021}},{\"id\":\"customfield_10022\",\"key\":\"customfield_10022\",\"name\":\"[CHART]
+        Date of First Response\",\"untranslatedName\":\"[CHART] Date of First Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[CHART]
+        Date of First Response\",\"[CHART] Date of First Response[Date of first response]\",\"cf[10022]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.ext.charting:firstresponsedate\",\"customId\":10022}},{\"id\":\"customfield_10023\",\"key\":\"customfield_10023\",\"name\":\"[CHART]
+        Time in Status\",\"untranslatedName\":\"[CHART] Time in Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[CHART]
+        Time in Status\",\"[CHART] Time in Status[Time in Status]\",\"cf[10023]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.ext.charting:timeinstatus\",\"customId\":10023}},{\"id\":\"customfield_10026\",\"key\":\"customfield_10026\",\"name\":\"Story
+        Points\",\"untranslatedName\":\"Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10026]\",\"Story
+        Points\",\"Story Points[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10026}},{\"id\":\"customfield_10016\",\"key\":\"customfield_10016\",\"name\":\"Story
+        point estimate\",\"untranslatedName\":\"Story point estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10016]\",\"Story
+        point estimate\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.pyxis.greenhopper.jira:jsw-story-points\",\"customId\":10016}},{\"id\":\"customfield_10017\",\"key\":\"customfield_10017\",\"name\":\"Issue
+        color\",\"untranslatedName\":\"Issue color\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10017]\",\"Issue
+        color\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:jsw-issue-color\",\"customId\":10017}},{\"id\":\"customfield_10018\",\"key\":\"customfield_10018\",\"name\":\"Parent
+        Link\",\"untranslatedName\":\"Parent Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10018]\",\"Parent
+        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-parent\",\"customId\":10018}},{\"id\":\"customfield_10019\",\"key\":\"customfield_10019\",\"name\":\"Rank\",\"untranslatedName\":\"Rank\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10019]\",\"Rank\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-lexo-rank\",\"customId\":10019}},{\"id\":\"updated\",\"key\":\"updated\",\"name\":\"Updated\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"updated\",\"updatedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"updated\"}},{\"id\":\"timeoriginalestimate\",\"key\":\"timeoriginalestimate\",\"name\":\"Original
+        estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"originalEstimate\",\"timeoriginalestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeoriginalestimate\"}},{\"id\":\"description\",\"key\":\"description\",\"name\":\"Description\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"description\"],\"schema\":{\"type\":\"string\",\"system\":\"description\"}},{\"id\":\"customfield_10010\",\"key\":\"customfield_10010\",\"name\":\"Request
+        Type\",\"untranslatedName\":\"Request Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10010]\",\"Request
+        Type\"],\"schema\":{\"type\":\"sd-customerrequesttype\",\"custom\":\"com.atlassian.servicedesk:vp-origin\",\"customId\":10010}},{\"id\":\"customfield_10011\",\"key\":\"customfield_10011\",\"name\":\"Epic
+        Name\",\"untranslatedName\":\"Epic Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10011]\",\"Epic
+        Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-label\",\"customId\":10011}},{\"id\":\"customfield_10012\",\"key\":\"customfield_10012\",\"name\":\"Epic
+        Status\",\"untranslatedName\":\"Epic Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10012]\",\"Epic
+        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-status\",\"customId\":10012}},{\"id\":\"customfield_10013\",\"key\":\"customfield_10013\",\"name\":\"Epic
+        Color\",\"untranslatedName\":\"Epic Color\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10013]\",\"Epic
+        Color\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-color\",\"customId\":10013}},{\"id\":\"customfield_10014\",\"key\":\"customfield_10014\",\"name\":\"Epic
+        Link\",\"untranslatedName\":\"Epic Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10014]\",\"Epic
+        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-link\",\"customId\":10014}},{\"id\":\"timetracking\",\"key\":\"timetracking\",\"name\":\"Time
+        tracking\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"timetracking\",\"system\":\"timetracking\"}},{\"id\":\"customfield_10015\",\"key\":\"customfield_10015\",\"name\":\"Start
+        date\",\"untranslatedName\":\"Start date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10015]\",\"Start
+        date\",\"Start date[Date]\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":10015}},{\"id\":\"customfield_10005\",\"key\":\"customfield_10005\",\"name\":\"Change
+        type\",\"untranslatedName\":\"Change type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10005]\",\"Change
+        type\",\"Change type[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10005}},{\"id\":\"customfield_10006\",\"key\":\"customfield_10006\",\"name\":\"Change
+        risk\",\"untranslatedName\":\"Change risk\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10006]\",\"Change
+        risk\",\"Change risk[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10006}},{\"id\":\"security\",\"key\":\"security\",\"name\":\"Security
+        Level\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"level\"],\"schema\":{\"type\":\"securitylevel\",\"system\":\"security\"}},{\"id\":\"customfield_10007\",\"key\":\"customfield_10007\",\"name\":\"Change
+        reason\",\"untranslatedName\":\"Change reason\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10007]\",\"Change
+        reason\",\"Change reason[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10007}},{\"id\":\"customfield_10008\",\"key\":\"customfield_10008\",\"name\":\"Change
+        start date\",\"untranslatedName\":\"Change start date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10008]\",\"Change
+        start date\",\"Change start date[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10008}},{\"id\":\"attachment\",\"key\":\"attachment\",\"name\":\"Attachment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"attachments\"],\"schema\":{\"type\":\"array\",\"items\":\"attachment\",\"system\":\"attachment\"}},{\"id\":\"customfield_10009\",\"key\":\"customfield_10009\",\"name\":\"Change
+        completion date\",\"untranslatedName\":\"Change completion date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10009]\",\"Change
+        completion date\",\"Change completion date[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10009}},{\"id\":\"summary\",\"key\":\"summary\",\"name\":\"Summary\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"summary\"],\"schema\":{\"type\":\"string\",\"system\":\"summary\"}},{\"id\":\"customfield_10000\",\"key\":\"customfield_10000\",\"name\":\"Development\",\"untranslatedName\":\"development\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10000]\",\"development\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:devsummarycf\",\"customId\":10000}},{\"id\":\"customfield_10001\",\"key\":\"customfield_10001\",\"name\":\"Team\",\"untranslatedName\":\"Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10001]\",\"Team\",\"Team[Team]\"],\"schema\":{\"type\":\"team\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team\",\"customId\":10001,\"configuration\":{\"com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team\":true}}},{\"id\":\"customfield_10002\",\"key\":\"customfield_10002\",\"name\":\"Organizations\",\"untranslatedName\":\"Organizations\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10002]\",\"Organizations\"],\"schema\":{\"type\":\"array\",\"items\":\"sd-customerorganization\",\"custom\":\"com.atlassian.servicedesk:sd-customer-organizations\",\"customId\":10002}},{\"id\":\"customfield_10003\",\"key\":\"customfield_10003\",\"name\":\"Approvers\",\"untranslatedName\":\"Approvers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approvers\",\"Approvers[User
+        Picker (multiple users)]\",\"cf[10003]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":10003}},{\"id\":\"customfield_10004\",\"key\":\"customfield_10004\",\"name\":\"Impact\",\"untranslatedName\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10004]\",\"Impact\",\"Impact[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10004}},{\"id\":\"environment\",\"key\":\"environment\",\"name\":\"Environment\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"environment\"],\"schema\":{\"type\":\"string\",\"system\":\"environment\"}},{\"id\":\"duedate\",\"key\":\"duedate\",\"name\":\"Due
+        date\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"due\",\"duedate\"],\"schema\":{\"type\":\"date\",\"system\":\"duedate\"}},{\"id\":\"comment\",\"key\":\"comment\",\"name\":\"Comment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"comment\"],\"schema\":{\"type\":\"comments-page\",\"system\":\"comment\"}}]"
     headers:
       Atl-Request-Id:
-      - f9e70baf-63e1-460c-9904-9b585e009a9a
+      - b1ad90d9-c96b-41ad-a5a3-b6a29031338b
       Atl-Traceid:
-      - f9e70baf63e1460c99049b585e009a9a
+      - b1ad90d9c96b41ada5a3b6a29031338b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:33 GMT
+      - Wed, 30 Apr 2025 16:24:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1194,7 +1326,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=211,atl-edge-internal;dur=24,atl-edge-upstream;dur=189,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=288,atl-edge;dur=254,atl-edge-internal;dur=16,atl-edge-upstream;dur=239,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="jcLUzSJJcH2lr4rI_RAjoh7N5WBJCqvAR-pS1fKOGVbtjdrZtZvkyA==",cdn-downstream-fbl;dur=292
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1203,10 +1335,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - jcLUzSJJcH2lr4rI_RAjoh7N5WBJCqvAR-pS1fKOGVbtjdrZtZvkyA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 148c105042c508202b8504b5793184d8
+      - b85f9b0fb6d13d09aaf12cebba07fbe9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1230,61 +1370,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1597
+    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1837
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXa08bRxT9K6P91FLb+7AhZqWqSrFp01KKwCRSKELD7vV68OzMZmYW203y33tn
-        9mGC2VRQNUKCncd9n3vm8tGDdUFF6sWeApGCgvSYAU91T9AcdE8nC8hpTxagqGFS6B6kzORgaC9Z
-        UJEBl1nvHpTGM0jPoVCgQZj6blJqI/O5VXgTBkEYDBR8KEGb2aaAM0UTwxLweh6z9sODYBziQgOf
-        43JhTKFj309hDolJ5Z0cUMOp1oyKgQDjoyXj04L5nBr7ybQuwW+0LGGDSk5n04tZP9w/fIVbzg/t
-        xR89jQ6WOkG5TKpNFUiKK5SIgmi/H4T9MJhFQRzux9Hh4GA0/gGdD6yn1ohB752a53oaVU5aeR/1
-        BVEbe71IQSeKFTZ7uPua6Jxy3iMp04aJxJCCQQJEzslKquXASidSXCr+TC9KwWzNKL+h99RQ5d8z
-        WPnOra2D9VEYDMPxT5r9DT/mWPsyR6sWG2hyRvXSFqy8NfYrnlOuoedVgm8wLifb8xYM0aOSxeYE
-        7gF9DT73PMMQXgVCxYtFiTF6j7AyDJqDQsk7jOiFCa+lXbpdAZt028UDkGyjuhTMWEBpr7Vt4fq7
-        u6vl3KyosqDVLC84Q4fTR5FjPRzKRuP1aPxMd79SmSaSti6jwKI6Gq2j0f9rpaq+wyIaDA/W4cG3
-        MLhuLA6j9TD6FhZrgH/+vAvHsAunUXMwZ+u3FRFi9a+ud28Om5s0yxRkyDc7TYABSF5W7f+0uf2u
-        g4Oug1cdB1Hnwbjr4HDXz4o2q11LSu6Z8OJ+WHOlLYliSRXSx5092yiYbb2QJU8nTBecbup2wu0V
-        Nfj+VJT9/NavHoTtE+BX6pRtbPd5JEubeufqO7vBRObFRpXWNio1bxEztr3rbCjAYC1/PPVIDINh
-        80g8TltLZY8PukAVtaAqFJOKmc0LU9CI+6PnvRUspxlo30roRgnDDS5XA32fbcnyRK4aUh15u20T
-        tZjn9BYsLT7RGJZNnkxD2IXQcGzzsaB6WrDkhInlsT2ZQGFHGJE0CHK4WrmzdkdIMcUJht5yOAeq
-        K1Sq+ss7O7n85c3pzcmbo+npxfRmen7+5znGh12qMSF4YbYAcob8LwyxdgnTRAq+IcgljFulxEjy
-        G1OUnCnIkUxIqRFxg6c4JcR28oJPLAgKcRd71ZuItcPkb3vqC67AMmRMUP74Uj2A1el1uOfoXb22
-        dc0EtLfLwjZtJ44PWxxXY9ILoVcJt+/ul5PN89C4hdvPNFnixNlArlFe2Tqq57n/5HAzFPrNbBY1
-        Y4IAC/VEcqlOK29ueQn9TCFjbUciSSayKrbMC5yJhXka9PstKXytsI+FWsL4Mp1/ie3P3owZDnsx
-        uXpPizAmR1IuGZB3zCDHGnIBSamAHHOafbLZweRwmVC+kNrE42Ac+HMmUiRCPxoF107hxCUP47qT
-        xMIq3iP/Kkm+w1/fO/ELHPosB6EYskXt5KQEMsFAcfMPuiFh0CMWjG0QR++meHSFf/oH4ch5auuY
-        rGCQM6NgIFXmI4ypLS3Dic3C38erg4XJufO70vPW6rkUSyFXD5N0pmRa4gwwFRk2do5l8meYfGvT
-        ZQj9Jb/KVd/IjiwVtYLomvjkagWwRBaAVluH1PaCP3SC71+fkYuEio777h+bw6iN50EEFxttINcY
-        QVpIhjDbi92+q43NVU6Z0MzAAJGIqdKLW0lV2nVjR/+kQdg/AAAA///sWW1L40AQ/iuLICiYmLap
-        bQ/EK+LBfZA7FE4QoWw2Gxuu3YS8GOXO/37P7G73Yq7xDjnED4IfarI7b5155plppkjynAmTSEBd
-        FkmpWCkr1tisqgCLpcmsBJl1wJplKpZsLbkq8ZKbE1YC3L1RkWRcCOCqjNldylmNUhHFQw5gwjml
-        pKEHfsuic3zLt3qyJIOullJRZjHu5GYYPOERLCG3wP9YqpKsWOs7LCsIrTnelgSWAOrvUh2QYRCe
-        VsxwEMZXDX8gF1nOtXV1iZxmXLGWgZgYlVz57EyV5LPz0MTgRlEQSBvFCBZYC8uNiSSwrBGgrZa2
-        fG55f4EqRN9ByMh7my5N0/hZw8tc1wPKT977+TLXuQwlC8hcWN0LXoF0RTVSarH35Wp++dW7PPfQ
-        onWVOiV5VlSyoDrY4/E6Vftsb/8nEmVVZR+Qhn+ym7Fr8d321kd7BmEb+qoCmK6JFxHB7tE+uhv0
-        vQgdR+3ecCxDf0maU20/2Mc6gj5eHDidiDEXS6pv23rb3bsL7mW9XnNqVzt/Q2qKOpHPrHhhbyMS
-        coJ6I8L7OT4ex6PpZBoNJoEciVkgZuNhMhskR9DjDkHDM8ckpcQ8jqED/Q3NLn742DIEgEKynh2H
-        Ta346J/6mIYpO5KFEhSPx4MwPJqI6WQ8mkUimgRQn3CZTMVJfKyl7I7mu8NP+DP3vDVXFl49zzwq
-        /br0GgTCG/oE2X5eR6tUUKS8nPOSAoX7uoOAIOLjKYrCzxXFvDtav32Lu7P527e4O9u/dYuBUbEZ
-        Uy0JPEXqg8MkSS1EqguI8NyMkQbhrkEDcfCsLrJcHl4De8Tyd6XRbglvXemSBrtR284cwz5cDfvG
-        ydCNk4XF93cYebWEeYeR17D4HUa2wEgXBvqYWugImeMrcOfWFOUPWoLbzwEsySpuV/hdKX2ULOjD
-        pWC4HeD69kFBrwO9lM151r3Rx+VGvS8cyZPqLi0yZVieeRTX9vcj8++/RO8uq/7fZtMIc0KhCWPa
-        t0xveTbLVJSAMfnH5qPtLy82QP/WdriRe7Cz5vcXsqxXJLjlrN7PFNW8Mo7Tlph2OOS6e/708vDJ
-        bXtBW/v4+PgLAAD//wMAPW1gvLMcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18169","self":"https://defectdojo.atlassian.net/rest/api/latest/issue/18169","key":"NTEST-1837","fields":{"statuscategorychangedate":"2025-04-30T18:24:14.691+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1837/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:14.432+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00syn:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:14.506+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/240]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/240 (240)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/92]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1837/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18169/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 27ceba83-00cf-4907-a8c6-ba8a177d5d0f
+      - 9945b432-ca55-43df-a1d5-b7f96990c088
       Atl-Traceid:
-      - 27ceba8300cf4907a8c6ba8a177d5d0f
+      - 9945b432ca5543dfa1d5b7f96990c088
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:33 GMT
+      - Wed, 30 Apr 2025 16:24:20 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1294,7 +1417,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=268,atl-edge-internal;dur=20,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=356,atl-edge;dur=270,atl-edge-internal;dur=16,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="tR9q07J3-NFstnx8WIkmCjB5u9t9eWorAIE7VTxh2U6imF2a3iZDNw==",cdn-downstream-fbl;dur=360
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1303,10 +1426,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 124fcc45b0cac625cd0077abe70a7c60.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - tR9q07J3-NFstnx8WIkmCjB5u9t9eWorAIE7VTxh2U6imF2a3iZDNw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 0898f4e9be990f69c2d22103746a6080
+      - 90564deaf14b017f27106e8d44307237
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_enabled_create_epic_and_push_findings.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_enabled_create_epic_and_push_findings.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1tKZN5ngFJ1CuxdFJE0uWE2T0qSDMfbdTXDofFPfjrvf
-        /37H7UkjPG4GQzh5DaH3fDZTqFEG5d5cJoIR3rfCZhYDmRDV+t6I3T/4CodtK1Ghf1+h6ZdoAw5/
-        XbJ0VpsRrcTfJbc4+NbZCFMAmkEG02p98VCt7uvv6XrsmlgR/pSgCUzgOTqxN27XxSvrXZ9sS+NG
-        FUPN2Br1GSE8BlhZHpuXIiSQASumQKdsUdOc55TPFxkAnEGEY97HP+BQt90P9rxmlOcFhyKDkn2x
-        sru22kVQFwVFLOe0UShzKQWioM1CaXpeCk3zKNBNgexEEEwy3LSDSC9ELUYTbp0Uqb0n5lgRtC+b
-        ihxOD3t0Nk2u7mpy+AAAAP//AwDjs6gYIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:20.812+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - dc2fdac2-6ca6-4d66-a1fa-7b7a8151f2c8
+      - fb9d84f8-7fcc-47a0-b2a8-f2f7396e55e5
       Atl-Traceid:
-      - dc2fdac26ca64d66a1fa7b7a8151f2c8
+      - fb9d84f87fcc47a0b2a8f2f7396e55e5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:05 GMT
+      - Wed, 30 Apr 2025 16:24:20 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=228,atl-edge-internal;dur=29,atl-edge-upstream;dur=200,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="yyzQRfvG1YUIFJoAlc1gSgVoGoH_xV8hAi8kHuFCzrjMJCKPMyvp7w==",cdn-downstream-fbl;dur=239,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=236,atl-edge;dur=160,atl-edge-internal;dur=14,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 6bddabf0adf0131ec8169647c939d30c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - yyzQRfvG1YUIFJoAlc1gSgVoGoH_xV8hAi8kHuFCzrjMJCKPMyvp7w==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 18474af2b7f4a69211e1b5cfeeef83a6
+      - 55682b18813025571db780c514ab7fce
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,42 +90,31 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Epic&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xWW0/bMBT+K1aeS0JLxVClaZqASWwTmsTlZULIbU5bg2NnttMmQ/3vO6e5OKVs
-        S9nGXshTfHIu37G/88UPAeQpV3EwClKj72DibNDzr6OvD95BWJuBK1IgFwtyira5c6kdRVEMUwyI
-        9Z0OuZPcWsFVqMBFBqyLeCqiQVRljfr7+GAKQUnrxT0UuDq/PL24xJXiCeDySgnnMAEV5AvuuLky
-        ElE9BMOjfHi0Y/1MiQUYy+VtmStaCFhG1FADrfrQ3x/uv8Gag2E+GP7bKu+s+A5vbcKlxIL9w7x/
-        +BIF87riwSA/GLxExQRikSXBqtfmEfHrGUxqMjzNpRjsxIjUCa3Q+p6NxYxlFgyzTpuCuTl3TAHE
-        ljnNxsDGRt+DYrFeqpAdG+AOYjYu2EdhOLvQU7fkBtgeOjClHcNGHNOGxSDBQUjVJ1ohM7t0IRI+
-        AxtRhPV92AhSMQntYubJf4oWXGXKGa6sJFDnG19sNnbc3gejKZcWesFcgOFmMi8+wwIQTL/nZ3cq
-        QMY0RtULjpDNkoSbgl4NfMuEAXR0JsNMdjKHhNMXAofh1hmhCJstrIOELFX0qsF7UVnqWa49EBi3
-        JzDlmXTXXGbQANYpAqZTIiIgD1xw06ZHJ2TeuwXOGz28M7Kxy9KzRNiO7YTxBmVISr2EeO30yt8O
-        /P0tS1d06BOdpFqBon9O+9SroK1j58ZwopbAA8cQH9+mQSup58GxN9Y8aPl1JELA45gqAdUzkOgF
-        BE+QgzrbOMwurW3PWjuFb+SkZa07aXt2baWeu0q6O01d7dsCWZs8wC+NUwnOB+0AbHtTnzVxf3b3
-        qKJJPD6V2lYNFW2ASFIpUFb9kb5eVf5mwf93VSmVKUPVTda/zVskTL+/4xSX8cFaZcK0yIUNZwZA
-        zXWKbA/vUKNHs/ke6eee5GOgTsuYM0y/ruhHijSVrW8BjXZtwdtpvFZ0I8ivcYtKc5fWHmsvbXAp
-        OI0YtHN69B9EzipnL75t112g9yoN/rX6pkZoI9yjW87POmu8N3StsrWFrXGrla0xbDVQKug2/icA
-        P1PZhP4BAAD//7xYwW6DMAz9lx16XLaWHhHabZOYVKm79kAZAlQGGxBVPfTfZ8cJOINJlKAea7Dz
-        Yr/afuDZAis/d5DrIDkYsjzNILo9y1/JiCeoxgnJcAO7Xg7sEKmBuXaGuVkGJjUUG+g7NRkNdeMM
-        1VsGKjDSxhlWZwPScwa5XQzkgKKhshmo24frAXcv/k90g35PKoyMHW9aB4tKbEI3zZy8PHUuZuR4
-        f0ZOSC+Njxxk3qDt/du3sSurOTdz2gzXYx2thxySweDVz6HfyrbC9R9lz8Qydkx4fnwSFEg0MoXS
-        tsGPTOqLP/nyY5IBMEdtG8XZF0qXWflg/iwnzNrn5YW/SrmxvKfdg24QV9+XXq4jiWbWk/kz/MzK
-        6gq/QdkqJd+X1wrgUmKtywUQ/pTUQSzrGvKiVczbp79qsuq8l8cPkLO7CJ/5ONy5uSGLdlVAQTD4
-        pSyK1Sy6dGlGwCmI/mlJxq8FFh2MNyODMXVU6A1uWcTDBUWLjkUimgT1fqD3bV/prFuzQZ0DN/LD
-        9RcAAP//AwBwEqjntBYAAA==
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","untranslatedName":"Epic","subtask":false,"hierarchyLevel":1,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1}]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"customfield_10011":{"required":false,"schema":{"type":"string","custom":"com.pyxis.greenhopper.jira:gh-epic-label","customId":10011},"name":"Epic
+        Name","key":"customfield_10011","hasDefaultValue":false,"operations":["set"]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - b87ab541-9873-4bcb-b4d0-171962f3a902
+      - ebee5922-17a6-4f23-8a3a-cd163ae56d4b
       Atl-Traceid:
-      - b87ab54198734bcbb4d0171962f3a902
+      - ebee592217a64f238a3acd163ae56d4b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:05 GMT
+      - Wed, 30 Apr 2025 16:24:21 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -131,7 +124,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=362,atl-edge-internal;dur=15,atl-edge-upstream;dur=348,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="OHJeWAoLBhuwMDeZammSQ2vZAx64GEeSyHS9bVma74Ex3WSWcu5xpA==",cdn-downstream-fbl;dur=391,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=369,atl-edge;dur=293,atl-edge-internal;dur=17,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -140,13 +133,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ed78483d37e5338746e5a4b545e5818e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - OHJeWAoLBhuwMDeZammSQ2vZAx64GEeSyHS9bVma74Ex3WSWcu5xpA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 123eca3c50496b773a888435b9d54f08
+      - 90d02fc5520cdc1fd545d54bdaf82924
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -177,18 +178,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16607","key":"NTEST-1824","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16607"}'
+      string: '{"id":"18173","key":"NTEST-1839","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18173"}'
     headers:
       Atl-Request-Id:
-      - 35a69b3f-045c-438b-bf97-7d1ae935c2bb
+      - e43a62ad-ef63-4348-b97b-d973f459f771
       Atl-Traceid:
-      - 35a69b3f045c438bbf977d1ae935c2bb
+      - e43a62adef634348b97bd973f459f771
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:06 GMT
+      - Wed, 30 Apr 2025 16:24:22 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -198,7 +201,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=884,atl-edge-internal;dur=13,atl-edge-upstream;dur=871,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=771,atl-edge;dur=738,atl-edge-internal;dur=17,atl-edge-upstream;dur=722,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="cy1eDE6dESIcmSm6h1QfSkfTm2LYlkAtBY0eGaYTjeKVecwzThdhDg==",cdn-downstream-fbl;dur=775
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -207,10 +210,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 848ee9f48eafd6caa6bf5371a2f79f28.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - cy1eDE6dESIcmSm6h1QfSkfTm2LYlkAtBY0eGaYTjeKVecwzThdhDg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 8d6e3026c6ae2627c31fe90f2e23886b
+      - 659a8fce2b32c5858f581c0c0ffb7028
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -234,52 +245,36 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1824
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1839
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4S+zrZeLLuOgWHYUnfolqZB4nQfhiGgpbPEmiI1kortZfnvO+rN
-        iy0NjYv1m8Uj7/W5585PDuxyKmJn7igQMSiI3zHgsR4ImoEe6CiFjA5kDooaJoUeQMxMBoYOopSK
-        BLhMBo+gNMogvoVcgQZh6rtRoY3M1lbhg+95vjdS8GcB2iz3OdwoGhkWgTNwmLXvT6feG/zQwNf4
-        mRqT67nrxrCGyMTysxxRw6nWjIqRAOOiJePSnLmBy7QuwG0UbGCP76+Xi7vl0J8FIR6VLmhn/uRo
-        9K3QETWQSLWvYojxC18EXjAZev4wuFgG/jyczL3pKBwH36HfnnXSGjHoeKnmTCftexf1VRrLsOuP
-        GHSkWG4Th6c/khVLSKFBEUyh2hOTUkMEQKyJkWQFZKXkBgSJ5VaMyKUCjCEmqz35hSlK7uTabKkC
-        MsQLREhDbNmIVCQGDgZG1nokxb3iXxIFy2gC2rUv9CEO7ULOopF+TFCbhQuqWuCJrWGxMlRvnPma
-        cg0DJ2WIHxWl+yt4BDTpPw8cwxBgOYLFmYuC84FzhJax1whyJT+jY2fmvX7dnfV/YeUQxL1gxqAC
-        7bS2LWB/Le/qOrU2SpblnKHDcRsofaSGKkxrCbZwtgtnr3S3EMz2E+UPlS73kcHWLXHTRFILfC8s
-        8R6EOwT5/2rlB83+gu91RjlHg/5050+/hcFdY3Ec7MbBt7CYYZ8UmfP8fApHvw+nQSNYs92nigqx
-        +r//cXpz3NykSaIgwZY9aQIMQPKiYoFuc5M+wbRP8KZHEPQKZn2Ci1M/K/asTrdSbcpB4cyHPn5S
-        g/Oj4t3XN27F6gcedyt1yrZl+fNSFjZxvuXm3+wBE4kzN6oALB8qNZ+w4rY561gqkuxk+snoYhY2
-        TH8cdEtEx4I+SAQtJHLFpGJmf2YKmufu+CsIu1bC8KCC90vK/lBBvibGsXMK/aDF7bGghRynK7Cc
-        14F6SxWdr32En4N9sD9NuT+zCUuptvPkionNOyt5C7ndUUS0b/lWp3JbytoTIcUCZx1dcbgFqm0f
-        PSFaq1/OzdX9z++vH67eXy6u7xYPi9vbj7doHptQY8bwwjIFcoP0LgyxdgnTRAq+J0gVjFuldvyW
-        M/ZGQYaJK4e0HnVRho/d4nh/M89T6/HcqUYeFherc2iZF1SAdUqYoPz4Ur1h1QkuG4Ojd/W3LXyC
-        u0Fzu8htT3YDfTryw0kD9GoZOhOb1eN2rL7cX14H1wMYf6LRBlfKBo2N8srWZb21fZXDzernBrWR
-        oNkCBGwtEiWX6rryZsULGCaKWoTWDi4leSurYsssx6VXmG7YT/pYY9Kyxn9V/GU6twAbBCGIBFGa
-        2XFxqravSf0+R3z/yzT7wZkJr/SU7fmxjMSCBekA8Uwxs202D8VGYUcbYWROku6GJckMfVu44yth
-        X4zttLTJNviXY1MOiadTM17fYA3boXf8omU2DVFR0Xz3xb5B6/UNWq+1+YIfjlFCjaFRWpatxKAu
-        sozaBumuqx2AUp1TzX8AAAD//+xYPW+DMBD9K10yQh0gBYYojaJW6pClQ4dsxoYGiQDiI20U8d/7
-        bBM3jXBUVVWUIRKDwfbdcXDv3rPgU8C5GWVMNN0XPp1wN/CDaOyT2GUhYeHEScJxIr6uXgQPZ5ZB
-        WKbZnHP4QAmhnvju8SgQ1JewdZZQy7zHNkpULhN7DqTOi9FFKB973oPPAn/ihhGLfAL3CY2TgM34
-        VFoZufOR84xL7bM2NO8zZlnqUW23tfWBRFiODebI7bKNMggfZMoqKa1ForA/hWpI0YMwXCwtYpe5
-        gLFTcn79EZ+y++uP+FQdXHvEwB6e1mVGd32fWeDXv1vSJGkZS2UBNdAuisoq5Fqh02DhU1sV0C8r
-        gA1bf1eaUKeY1aUrPPQSfLg5eaae4JkoracpbRWXRdXENxi53A9zg5FLRHyDkQEYOYUBE8v0NAPT
-        hAWv866Kci+O0foxQSRFQ6ELyIB5EwcjJlwizjDAmUQnMb6AkaOZuKWAkMEJ1zihWV2cb9OqyBVz
-        U4942x9Eq9tfZa/YKAv7w7CH+z/g8tEZ+v3BLoQx/XyN6zYTho98S0VWNfNGxbEtmv875VHGtFH4
-        WtP6rZCCVmr8Tp0zCZkoXOpAfkbr/Ai33yDT03XdFwAAAP//AwCr0ocf9xgAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18173","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18173","key":"NTEST-1839","fields":{"statuscategorychangedate":"2025-04-30T18:24:22.230+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1},"timespent":null,"customfield_10030":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10031":null,"customfield_10032":null,"fixVersions":[],"customfield_10033":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"aggregatetimespent":null,"resolution":null,"customfield_10035":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"lastViewed":null,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1839/watchers","watchCount":1,"isWatching":true},"created":"2025-04-30T18:24:21.906+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},"customfield_10023":null,"labels":[],"customfield_10026":null,"customfield_10016":null,"customfield_10017":"grey","customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00sz3:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:22.031+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"weekly
+        engagement","customfield_10010":null,"customfield_10055":null,"customfield_10011":"weekly
+        engagement","customfield_10056":null,"customfield_10012":{"self":"https://defectdojo.atlassian.net/rest/api/2/customFieldOption/10016","value":"To
+        Do","id":"10016"},"customfield_10013":"ghx-label-12","customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10049":null,"customfield_10005":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"aggregatetimeestimate":null,"attachment":[],"customfield_10009":null,"summary":"weekly
+        engagement","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10047":null,"customfield_10003":null,"customfield_10048":null,"customfield_10004":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1839/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18173/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3d4d84c7-56aa-4efc-9c2c-49e5c17f852b
+      - bf834164-e6e6-436b-9ce7-a70d0e1a7450
       Atl-Traceid:
-      - 3d4d84c756aa4efc9c2c49e5c17f852b
+      - bf834164e6e6436b9ce7a70d0e1a7450
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:06 GMT
+      - Wed, 30 Apr 2025 16:24:22 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -289,7 +284,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=260,atl-edge-internal;dur=19,atl-edge-upstream;dur=241,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=389,atl-edge;dur=262,atl-edge-internal;dur=15,atl-edge-upstream;dur=247,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="hhKmRUcMXPoxVEV4bBOJ7LNj6ZAKYnBYol1TkWQhRzShUlVgvwOOuw==",cdn-downstream-fbl;dur=394
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -298,10 +293,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 800cba2437ee092ab9e4755c65d34a72.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - hhKmRUcMXPoxVEV4bBOJ7LNj6ZAKYnBYol1TkWQhRzShUlVgvwOOuw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - b21a099f1b3c205cf3170a7d4e62a792
+      - 03f8f438152b04671c169298b7eb14d2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -328,26 +331,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQ30vDMBDH/5e8unVJf9AubzLBKTqFdi8TkTS5YDRNSpMOytj/boJD55v6dtx9
-        vvc57oBa5mA7aETRq/e9o4uFAAncC/tmE+Y1c04xkxjwaIaEcr1m0z/4Goa94iDAva9B9yswHoa/
-        LllZI/UIhsPvknsYnLImwARjkuAEz+vN5WO9fmi+p5uxa0OF6FOEZniGn4MTem2nLlzZTH20rbQd
-        RQi1o9LiM4JoCKRleWpeMR/BFKfFHJN5WjUkpzmhWZVgjC9wgEPehT/A0KjuB7tsUkLzguIyyarq
-        i+XdjZE2gLIoCECZkVYAzzlnAIy0lZBkWTJJ8iCQbQHpmcDraLhVA4svBMlG7e8sZ7F9QPpUITAv
-        2xodzw/bWRMn1/cNOn4AAAD//wMA82+DqSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:23.133+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 3dbaf052-0574-4271-99d0-0ec013e2c8dc
+      - 5334420d-caee-46cb-af6c-5783ead6bf6f
       Atl-Traceid:
-      - 3dbaf0520574427199d00ec013e2c8dc
+      - 5334420dcaee46cbaf6c5783ead6bf6f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:07 GMT
+      - Wed, 30 Apr 2025 16:24:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -357,7 +356,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=152,atl-edge-internal;dur=13,atl-edge-upstream;dur=139,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=196,atl-edge;dur=164,atl-edge-internal;dur=19,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="FFvO2BfIzaI5-hCH9Q4OaizVufkPbSp-NnVhQkwakptjQI43oUei2A==",cdn-downstream-fbl;dur=200
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -366,10 +365,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 edb5724c2fa0963fde9c6c5089b747ce.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - FFvO2BfIzaI5-hCH9Q4OaizVufkPbSp-NnVhQkwakptjQI43oUei2A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - cd80cd9f60d98728446e60efee24320f
+      - e5e253fa1b704676a5fbf3ed758a7b9d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -396,41 +403,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 9ed7915e-d5aa-4323-a982-c6d13885ecce
+      - 181a198d-fc88-4276-b1a5-68c577ecf5eb
       Atl-Traceid:
-      - 9ed7915ed5aa4323a982c6d13885ecce
+      - 181a198dfc884276b1a568c577ecf5eb
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:07 GMT
+      - Wed, 30 Apr 2025 16:24:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -440,7 +434,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=270,atl-edge-internal;dur=15,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=395,atl-edge;dur=310,atl-edge-internal;dur=18,atl-edge-upstream;dur=292,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="GX5_CczcRMu-KgCDD4L5l4FEn-iET7n46WNKcbbWO378ID4HbuqNFA==",cdn-downstream-fbl;dur=399
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -449,13 +443,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 57f0537bdb26692a5be92bbbe93e4ea2.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - GX5_CczcRMu-KgCDD4L5l4FEn-iET7n46WNKcbbWO378ID4HbuqNFA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 95c3692dea6dac5b3ca1f5b2a5424029
+      - 42c77c88b3faf78eb9ebfca7d24c11cc
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -466,17 +468,17 @@ interactions:
 - request:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
-      [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/232]\n\n*Defect
-      Dojo link:* http://localhost:8080/finding/232 (232)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 29, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/242]\n\n*Defect
+      Dojo link:* http://localhost:8080/finding/242 (242)\n\n*Severity:* Low\n\n\n*Due
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
-      / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+      / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
       cookie has been set without the secure flag, which means that the cookie can\nbe
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -488,7 +490,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1297'
+      - '1317'
       Content-Type:
       - application/json
       User-Agent:
@@ -497,18 +499,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16608","key":"NTEST-1825","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16608"}'
+      string: '{"id":"18175","key":"NTEST-1840","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18175"}'
     headers:
       Atl-Request-Id:
-      - 77d664d0-36fc-4d13-ad09-dfc1fc543df8
+      - 6d1c437f-b4b2-432f-a6d7-1365b28dcec4
       Atl-Traceid:
-      - 77d664d036fc4d13ad09dfc1fc543df8
+      - 6d1c437fb4b2432fa6d71365b28dcec4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:08 GMT
+      - Wed, 30 Apr 2025 16:24:24 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -518,7 +522,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=643,atl-edge-internal;dur=16,atl-edge-upstream;dur=628,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="VuShks7FXZ3lWDjyBTPYbjnzStskAcqt_zlbQlBz4i3jqCP5JX-ENQ==",cdn-downstream-fbl;dur=886,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=883,atl-edge;dur=796,atl-edge-internal;dur=47,atl-edge-upstream;dur=749,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -527,10 +531,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f6567fa2210130239a3a2c737c9517ac.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - VuShks7FXZ3lWDjyBTPYbjnzStskAcqt_zlbQlBz4i3jqCP5JX-ENQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - a782d3a8371f1e6328f557ca39f53571
+      - 07cec8f0c91a0cc3c78798763f2ca939
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -554,61 +566,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1825
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1840
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+2/bNhD+Vwj9tGWy9fCjjoBh6BJ365ZlQeK0QLMioKWzxJoiVZKK7aX533fU
-        y20SdUiGFQVSk8d7f/fpbh3YFlQkTuQoEAkoSF4x4Il2Bc1BuzrOIKeuLEBRw6TQLiTM5GCoG2dU
-        pMBl6t6A0iiD5BwKBRqEad7GpTYyX1mD14HvB/5QwccStFnsCjhTNDYsBsd1mPUfTKf+DA8a+AqP
-        mTGFjjwvgRXEJpEf5JAaTrVmVAwFGA89GY8WzAs9pnUJXmtgDTvUP13MLxaDYBZO8KoKQTvRraMx
-        tlLH1EAq1a7OIcETaoR+OBn4wSA8XIRBNJ5E/mw4Dg5/wLh9G6R1YjDwyswzg7T6Htrzwy7t5pCA
-        jhUrbOHw9iXROeXcJQnThonYkIJBDESuyEaq9dBqx1JcKv7EKErBbLsov6Y31FDl3TDYeFVY+wAb
-        UeCPgtlPmv0NP+bY9jJHrxYW6HJB9dr2qlwa+ytaUa7BdWrF15hXpes6GUPgqDjbncANYKz+nesY
-        hsgqECVOJErM0bkHk5HfCgolP2BGzyx4o12Vu2pgW257+Awk+6wuBTMGDWin822R+nv1VsuV2VBl
-        8apZXnCGASf3Msd+VCgbz7bj2RPD/Upn2ky6voz9FxhGON6G4//XS939CovoMJhug+m3cLhtPY7C
-        7Sj8Fh4bgN/dPYRj0IfTsBWs2PZNzYHY/av3D1+O2pc0TRWkyDcPhgATkLysx/9xd5M+wbRP8KJH
-        EPYKZn2Cw4dx1rRZ31pSqr4QTjQI8EgNfjhqwn364NZ0vidwrzan7FhWP49kaQsXWFJ+ay+YSJ3I
-        qBKwfWjUvMGO2+FsclGAodrpf4zi/WnYUvz9pDsiui/og0TYQaJQTCpmds8sQavujZ/G9CynKWjP
-        aujWCMMLLjdDfZPuqe5EblpKHDsPQR92iOV0CZbUHoG15YJHyxD04SuY2XpkVM8LFp8wsX5lJcdQ
-        2N1DxLuOTnUmN5WsuxFSzHH1oEsO50C1HZNbBGP9yzk7ufzl9en1yeuj+enF/Hp+fv7nOeaHM6ax
-        IPhgkQE5Q/YWhli/hGkiBd8RZALGrVFiJPmNKUrOFORIBaTUiLjhY4wQ4DA4/ifm+2q1jJz6i4a9
-        w+LvJ+KLScc2pExQfv9Rszk15a1wzzG65mz7mgroXpeFHbk+HAeTFy2O6yXnmdCrlbuv5pd7ydPQ
-        uIfbzzRe46rYQq41Xvs6arax/xRwu9J57WYVth95ARbqseRSndbRLHkJg1TR3T7AhSTHsm62zAtc
-        ZoV5HPSTPlKYdKTwtY5/Wc6/xP7fwYIZDgcRuXpHiyAiR1KuGZC3zGSyNOQC4lIBecVp+slWB4vD
-        ZUx5JrWJZv7M91ZMJEiEXjgK31cGj6viYV4fJLGwig7Iv2qS7/DP95X6Ba5sloNQDdmiCfK4BHKM
-        +eDlH3RHwkOXWDB2SRy9naPoCv8bTINxFantY7yBYc6MgqFUqYcwpra1DPctC38Pnw4zk/Mq7trO
-        G2vnUqyF3HxepDMlkxK/4HOR4mDn2CZvgTW2PqsKYbzkV7kZGNlTpaIxEL4nHrnaAKyRBaCz1qO1
-        f+CNKsV3L8/IRUxFz3u7RXqHfpfPZxlc7LSBXGMGSSEZwuwgqu6r3tha5ZQJzQwMEYlYKp0tJVVJ
-        34sH9o/3CLOWX5K4BhKyLlkCCKLBkE2DKoO0qGtkrRBZLtlkLM5IDlRoFNL6RSz/AQAA///sWV1L
-        40AU/StBEBRMTNvUtgviFnFhH2QXhRVEKNPJxAbTSciHtbj973vuzDgbs4m7yCJ9KPgQMzP3K3PP
-        PfdWSYC7d3IuHMY5cFWEzmPMnAqpwvN1BmDCPilx4+iTejWLLvGV71VLSAbdLISkm+UwKzdFxwiP
-        YAm5BfbmxDJK86U646Q5oTXDakFgCaB+EPKIDIPwuHRQK6okdFiyYmty0cmYsq4qcKcdJp2agej3
-        pEg850IW5LP1UMfgTlIQSBvFCBYYC4sXE0lgUSFArZbWfK55f4UsRN1ByMh7c11Wq5WXrliRqXxA
-        +oknL1tk6i5DyQwyZ0b3jJVlHs8rXKnZwbeb6fV39/rSRYlWWWqVZGleipzy4ICFy1geOgeHP3FR
-        kjL9hGv4J7sZ2hLfLG9dCNcL6ghXon9/UMTruaVEdpHVwBLJxoLfdcLvYhm+ZRnq6ymy1b6xi9X6
-        1hjEmPEF5bcpvfXq3cTwolouGZWrvb8hNUWdyGeav7O2EQk5Q74R4f0ang7DwXg0nvdGvhjwic8n
-        w3406UUn0GM3QcMb2wRdiWkYQgfqG4pduP5cMwSAQrLebGZ1rnion2qbginTUAUCFI+FvSA4GfHx
-        aDiYzPl85EN9xEQ05mfhqZKyP5ju97/gT59zl0waeHVd/arwqsJdIRBu3yPI9rJqnsScIuVmjBUU
-        KJxXFQQEEY/nSAovkxTzZmO8/RY3O+vtt7jZmW+7xcCoMC6yhK0NCTzH1QeHiaKK81glEOG5biM1
-        wt2CBmLjRZWnmTi+BcTwxe9Mo8kQVm3qkgYzD2tnjkEXrgZd7WRg28nmgsXu3AD/Dl8+7Cbt8OUj
-        LN7hSwu+NGHAEjLLV2D1vc69Zxphm2cfCtOSmQF8U0on8+rEpU5K1m9Hvq55kN/FQQkQWhd863Jj
-        YdB1YmBJnpCPcZ5KzfL0q7Ayv/7of/8leo9p+f8mm1qYFQpNaNN+pGrKowZfeiChTX5+eTT15d0G
-        qF/Kjl/kHu0t2dOVKKqEBNecVfOZvJyW2nGa8dIMh1y3718f7r86bQ4oazebzS8AAAD//wMATn/G
-        nGwcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18175","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18175","key":"NTEST-1840","fields":{"statuscategorychangedate":"2025-04-30T18:24:24.572+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1840/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:24.264+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szb:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:24.369+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/242]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/242 (242)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1840/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18175/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - bd1888e8-37a6-4dbe-a30e-345772f7ac9e
+      - 8028a642-1162-47f2-b5b6-7ea7ac887516
       Atl-Traceid:
-      - bd1888e837a64dbea30e345772f7ac9e
+      - 8028a642116247f2b5b67ea7ac887516
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:08 GMT
+      - Wed, 30 Apr 2025 16:24:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -618,7 +613,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=378,atl-edge-internal;dur=14,atl-edge-upstream;dur=364,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=20,cdn-upstream-fbl;dur=343,atl-edge;dur=261,atl-edge-internal;dur=16,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="BAF8i7sEHRFnMlaaEOL7U8FMP4KLRzPO-7ymqzfNjGPgS8BFV2O1mg==",cdn-downstream-fbl;dur=347
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -627,10 +622,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2bdfafaaaec33c116889588ecd9de280.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - BAF8i7sEHRFnMlaaEOL7U8FMP4KLRzPO-7ymqzfNjGPgS8BFV2O1mg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 6d194404d9abd49996e32a1c3405dbb9
+      - e45067186e2515b7e4d253d152228711
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -654,61 +657,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16608
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18175
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZlsvdhxHAHD0CXuli3LgsRJgWZFQEtniTVFqiQV20vz33eU
-        LLlxog7JsKJAavF47889vHsHVgUViRM5CkQCCpK3DHiiXUFz0K6OM8ipKwtQ1DAptAsJMzkY6sYZ
-        FSlwmbp3oDTKILmAQoEGYTZ341Ibmc+twdvA9wO/r+BTCdpM1wWcKxobFoPjOsz6D0Yjf4wfGvgc
-        PzNjCh15XgJziE0iP8o+NZxqzajoCzAeejIeLZgXekzrErzGwALWqH82nVxOe8E43MejKgTtRPeO
-        xthKHVMDqVTrOocEv1Aj9MP9nh/0wsNpGETD/cgf94fB4Q8Yt2+DtE4MBl6ZeWWQVt9De37Ypr35
-        SEDHihW2cHj6huiccu6ShGnDRGxIwSAGIudkKdWib7VjKa4Uf2EUpWC2XZTf0jtqqPLuGCy9Kqxt
-        gBtR4A+C8U+a/Q0/5tj2MkevFhbockr1wvaqnBn7K5pTrsF1asUTzKvSdZ2MIXBUnK1P4Q4wVv/B
-        dQxDZBWIEicSJebo7MBk4DeCQsmPmNErC77RrspdNbApt/34AiTbrK4EMwYNaKf1bZH6e3VXy7lZ
-        UmXxqllecIYBJzuZYz8qlA3Hq+H4heF+pTNNJm1fhv4BhhEOV+Hw//VSd7/CIjoMRqtg9C0crhqP
-        g3A1CL+Fxw3AHx6ewjHowmnYJRg0gjlbXdfkiLC4+YAwSVMFKfLNkyHABCQv6/F/3up+l2DUJTjo
-        EISdgnGX4PBpnDVt1qeWlKoXwol6AX5Sgw9HTbgvH9yazrcE7tXmlB3L6ueRLG3hAkvK7+wBE6kT
-        GVUCtg+NmmvsuB3OTS4KMFQ7/c9RvD8KG4rfTbolol1BFyTCFhKFYlIxs35lCRp1b/gypmc5TUF7
-        VkM3RhgecLns67t0S3WnctlQ4tB5CvqwhTCnM7CkZtG7+553AS/owlcwtvXIqJ4ULD5lYvHWSo6h
-        sLuHiNctnepMLitZeyKkmODqQWccLoBqOyb3CMb6l3N+evXLydnt6cnR5Oxycju5uPjzAvPDGdNY
-        ELwwzYCcI3sLQ6xfwjSRgq8JMgHj1igxkvzGFCXnCnKkAlJqRFz/OUYIcBgc/zPzfTWfRU79omHv
-        sPjbiXg06diGlAnKdy9tNqdNeSvcc4yuIQvsayqgvV0WduS6cBzsHzQ4rpecV0KvVm5fzcd7ycvQ
-        uIXbzzRe4KrYQK4xXvs62mxj/yngZqXzms0qbB55ARbqseRSndXRzHgJvVTR9TbAqSTHsm62zAtc
-        ZoV5HvT7LSl8rbG7Si1hPC7nX2L7b2/KDIe9iNy8p0UQkSMpFwzIO2YyWRpyCXGpgLzlNP1sq4PF
-        4TKmPJPaRGN/7HtzJhIkQi8chB8qg8dV8TCvj5JYWEV75F81yXf45/tK/RJXNstBqIZssQnyuARy
-        jIni4R90TcJDl1gwtkkcvZug6Ab/642CYRWp7WO8hH7OjIK+VKmHMKa2tQz3LQt/D6/2M5PzKu7a
-        zrW1cyUWQi6/LNK5kkmJL/hEpDjYObbJm2Lxrc+qQhgv+VUue0Z2VKnYGAg/EI/cLAEWyALQWuvQ
-        2l7wBpXi+zfn5DKmouO+3SK9Q7/N54sMLtfaQK4xg6SQDGG2F1XnVW9srXLKhGYG+ohELJXOZpKq
-        pOvGE/vHW4RZy29IXAMJWZfMAATRYMhygyqDtKhrZM0RWS5ZZizOSA5UaBTS+kYs/wEAAP//7Flt
-        S+NAEP4rQRAUTEzb1LYH4hXx4D7IHQoniFC2ycYGk92QF2vx+t99Zjfdi7HrHXKIH4R+SJvNvGXm
-        mWemSgLcvRFz7rAwBK7yyLlPmFOjVMJilQOYcE4IZBy9Uq9l0Tne8q0aCcmgqwUXlFkOM3IlJkZ4
-        BEvILbA3JxGxLDL1jCMLQmuGuyWBJYD6josDMgzCk8pBr6jTyGHpkq3IRSdnyrq6RE47TDgtAzHv
-        CZ56zpkoyWfjoY7BjaAgkDaKESxoLCw3JpLAskaAtlra8rnl/QWqEH0HISPvm3RZLpeeXLIyV/WA
-        8uMPXr7IVS5DyQwyZ43uGauqIpnXSKnZ3o+r6eVP9/LcRYtWVWqU5LKoeEF1sMeiLBH7zt7+byRK
-        WskvSMOX7GZoWny3vdloTy+w3TDUlDCxwmB/pxjZ48veGRgi2bnh2+itb1iGekmKU20/aGMdvo3V
-        +sYYxJiFC6rvLTy9C+5lnWWM2tXO35Caok7kUxZv7G1EQk5Qb0R4v0fHw2gwHo3nvZHPB+HEDyfD
-        fjzpxUfQYw5BwyvHOKXENIqgA/0NzS5afW0ZAkAhWa8Os7pWPPRPdUzBVDNQBRwUj0W9IDgahePR
-        cDCZh/ORD/Ux4/E4PImOlZTdwXS3/w0f/ZybMdHAq+vqn0qvLt0lAuH2PYJsL6/naRJSpNycsZIC
-        hedVBwFBxOUpisLLBcW8Oxh/fIu7k/XHt7g7mX90iwFFUVLmKVs1JPAUqQ8OE8d1GCaqgAjP9Rip
-        gewaNBAHz+pC5vzwGtgTLv5UGm2GcNeULmlo9mHbmWNgw9XANk4GZpwsGnz/hJF3S5hPGHkPiz9h
-        ZAuMdGHAxtQCQ8gMX4E7t7ooH2mF3Vz7sERWrFnAd6VYmZcVl2yLH7+/HfmszMzqmZWy2TjowPbE
-        wJA8Lu6TQgrN8vRPUd38+6O//lP0ZKYlPG4uG7h/Ay63/rg63Mg92MnYwwUv65QEt3SrdUlRTStt
-        x72s/t+GVQszQqEL4+IvqbZNagG31jte2uGQSmPIc2v7z8xtHlDhWa/XTwAAAP//AwCKUuOjbBwA
-        AA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18175","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18175","key":"NTEST-1840","fields":{"statuscategorychangedate":"2025-04-30T18:24:24.572+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1840/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:24.264+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szb:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:24.369+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/242]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/242 (242)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1840/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18175/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 0f5b7b79-1cd3-4b6d-bf34-0a0e87a8f0c5
+      - bcf59cd6-aeaa-4968-b62b-eec3decbe4e7
       Atl-Traceid:
-      - 0f5b7b791cd34b6dbf340a0e87a8f0c5
+      - bcf59cd6aeaa4968b62beec3decbe4e7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:09 GMT
+      - Wed, 30 Apr 2025 16:24:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -718,7 +704,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=247,atl-edge-internal;dur=13,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="h9ovZ_dgBz0RTixcgLbVINKl4QAg0_Hu3sswm82J3_hmULlVoBSzRQ==",cdn-downstream-fbl;dur=330,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=327,atl-edge;dur=243,atl-edge-internal;dur=17,atl-edge-upstream;dur=227,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -727,10 +713,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b1383a69c949c8987c982636bd26b4f2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - h9ovZ_dgBz0RTixcgLbVINKl4QAg0_Hu3sswm82J3_hmULlVoBSzRQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 697fb4618e6c4d62015bdd36a63d4548
+      - 398d5988d15e26858991ea16f73ddddd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -739,7 +733,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"issues": ["16608"]}'
+    body: '{"issues": ["18175"]}'
     headers:
       Accept:
       - application/json,*/*;q=0.9
@@ -756,21 +750,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/16607/issue
+    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/18173/issue
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 4d8d8178-6de0-4e14-85a2-f909d716eb0f
+      - 51755e0b-aaa4-4a77-8a94-8fec20bc5c40
       Atl-Traceid:
-      - 4d8d81786de04e1485a2f909d716eb0f
+      - 51755e0baaa44a778a948fec20bc5c40
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:09 GMT
+      - Wed, 30 Apr 2025 16:24:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -780,17 +776,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=565,atl-edge-internal;dur=15,atl-edge-upstream;dur=551,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="yUm08xc-DSCjKhOYW0xwkM3p4CFPGu3sK2RIzcDfti5IJYWbNa0YFA==",cdn-downstream-fbl;dur=559,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=557,atl-edge;dur=481,atl-edge-internal;dur=16,atl-edge-upstream;dur=466,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 087e16218fcf1ccb7472a2c9f6a4cbe2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - yUm08xc-DSCjKhOYW0xwkM3p4CFPGu3sK2RIzcDfti5IJYWbNa0YFA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 025a1155b4e5baa6fb4758386409ef52
+      - 2b660ecc0576b31f20e735a5eb21d679
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -817,26 +821,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQ30vDMBDH/5e8unVJf9AubzLBKTqFdi8TkTS5YDRNSpMOytj/boJD55v6dtx9
-        vvc57oBa5mA7aETRq/e9o4uFAAncC/tmE+Y1c04xkxjwaIaEcr1m0z/4Goa94iDAva9B9yswHoa/
-        LllZI/UIhsPvknsYnLImwARjkuAEz+vN5WO9fmi+p5uxa0OF6FOEZniGn4MTem2nLlzZTH20rbQd
-        RQi1o9LiM4JoCKRleWpeMR/BFKfFHJN5WjUkpzmhWZVgjC9wgEPehT/A0KjuB7tsUkLzIixM8qz6
-        Ynl3Y6QNoCwKAlBmpBXAc84ZACNtJSRZlkySPAhkW0B6JvA6Gm7VwOILQbJR+zvLWWwfkD5VCMzL
-        tkbH88N21sTJ9X2Djh8AAAD//wMAgMpZMSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:26.653+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - d752dd56-7df1-4465-a712-0e3c8eba73cb
+      - 86b0ada6-4bae-4182-a934-8ffa6c933b77
       Atl-Traceid:
-      - d752dd567df14465a7120e3c8eba73cb
+      - 86b0ada64bae4182a9348ffa6c933b77
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:10 GMT
+      - Wed, 30 Apr 2025 16:24:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -846,7 +846,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=182,atl-edge-internal;dur=14,atl-edge-upstream;dur=169,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="DDJ_i95FgG_REM4FvOzgzvY6c5TZkyddikx-TC64VDjN8W-G7hsd5A==",cdn-downstream-fbl;dur=226,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=223,atl-edge;dur=145,atl-edge-internal;dur=15,atl-edge-upstream;dur=131,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -855,10 +855,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 471c951325b4c2c11c6c583a1d28e92a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - DDJ_i95FgG_REM4FvOzgzvY6c5TZkyddikx-TC64VDjN8W-G7hsd5A==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 820dc70ae834b2bdda75d5ebd71e7c56
+      - 3e2d7d62a2b6edd873157d27846019f5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -885,41 +893,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - e7295481-3fe6-463d-9954-d68587c44c11
+      - af975a6d-fa5b-4fb9-8c75-ff50f78ab4b6
       Atl-Traceid:
-      - e72954813fe6463d9954d68587c44c11
+      - af975a6dfa5b4fb98c75ff50f78ab4b6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:10 GMT
+      - Wed, 30 Apr 2025 16:24:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -929,7 +924,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=255,atl-edge-internal;dur=17,atl-edge-upstream;dur=238,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=335,atl-edge;dur=303,atl-edge-internal;dur=17,atl-edge-upstream;dur=285,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="lVRNXvjF5mmrqMAkN7wUHFSXPVMRDyJGaUfWOqH_3CgntPUvBNPjbw==",cdn-downstream-fbl;dur=339
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -938,13 +933,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 771067dca4682f83a6c9963c412d66cc.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - lVRNXvjF5mmrqMAkN7wUHFSXPVMRDyJGaUfWOqH_3CgntPUvBNPjbw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 646b22644e43607aaf975a6bd07be075
+      - 98a8c783a5a6907be2a7b9038b546aed
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -955,17 +958,17 @@ interactions:
 - request:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
-      [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/233]\n\n*Defect
-      Dojo link:* http://localhost:8080/finding/233 (233)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 29, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/243]\n\n*Defect
+      Dojo link:* http://localhost:8080/finding/243 (243)\n\n*Severity:* Low\n\n\n*Due
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
-      / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/90]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+      / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
       cookie has been set without the secure flag, which means that the cookie can\nbe
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -977,7 +980,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1297'
+      - '1317'
       Content-Type:
       - application/json
       User-Agent:
@@ -986,18 +989,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16609","key":"NTEST-1826","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16609"}'
+      string: '{"id":"18177","key":"NTEST-1841","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18177"}'
     headers:
       Atl-Request-Id:
-      - 02ef8b2c-291a-465c-9a3b-f2f2109609c7
+      - d5e4719b-f89d-4a43-874b-633a1cf15015
       Atl-Traceid:
-      - 02ef8b2c291a465c9a3bf2f2109609c7
+      - d5e4719bf89d4a43874b633a1cf15015
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:11 GMT
+      - Wed, 30 Apr 2025 16:24:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1007,7 +1012,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=778,atl-edge-internal;dur=12,atl-edge-upstream;dur=766,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="A3jzDAVujahCROGSWXr83UGejnh0ixHpejJzsCEXFz3BI2wxgh8ciQ==",cdn-downstream-fbl;dur=795,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=95,cdn-upstream-fbl;dur=793,atl-edge;dur=665,atl-edge-internal;dur=15,atl-edge-upstream;dur=650,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1016,10 +1021,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 edb5724c2fa0963fde9c6c5089b747ce.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - A3jzDAVujahCROGSWXr83UGejnh0ixHpejJzsCEXFz3BI2wxgh8ciQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e82e2ff5a18a14506c7e6f3ac6c6353d
+      - 52f8e2bd1432d244620481d4c776e84e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1043,61 +1056,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1826
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1841
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/jRhD+Kyt/aqkTvyTkgqWqopBraSlFEA7pKEKLPbGXrHd9u2uS9O7+e2f9
-        Fg7wVVD1dBKX3dl5f+bxfHRgXVCROJGjQCSgIHnLgCfaFTQH7eo4g5y6sgBFDZNCu5Awk4OhbpxR
-        kQKXqXsPSqMMkjMoFGgQpnkbl9rIfGEN3gS+H/hDBR9K0Ga+KeBU0diwGBzXYdZ/MJn4e3jQwBd4
-        zIwpdOR5CSwgNom8k0NqONWaUTEUYDz0ZDxaMC/0mNYleK2BJWxQ/2Q+O58Pgmk4wasqBO1EHx2N
-        sZU6pgZSqTZ1DgmeUCP0w92BHwzCvXkYROPdKAiGk9HuDxi3b4O0TgwGXpl5ZZBW30N7ftil3RwS
-        0LFihS0c3u4TnVPOXZIwbZiIDSkYxEDkgqykWg6tdizFheIvjKIUzLaL8ht6Tw1V3j2DlVeFtQ2w
-        EQX+KJj+pNnf8GOObS9z9GphgS7nVC9tr8pbY39FC8o1uE6teIR5VbqukzEEjoqzzTHcA8bqf3Yd
-        wxBZBaLEiUSJOTqPYDLyW0Gh5B1m9MqCN9pVuasGtuW2hwcg2WZ1IZgxaEA7nW+L1N+rt1ouzIoq
-        i1fN8oIzDDh5lDn2o0LZeLoeT18Y7lc602bS9WXsv8EwwvE6HP+/XuruV1hEh8FkHUy+hcN163EU
-        rkfht/DYAPzz56dwDPpwGraCBVu/qzkQu391/fTlqH1J01RBinzzZAgwAcnLevyfd7fbJ5j0Cd70
-        CMJewbRPsPc0zpo261tLStUXwokGAR6pwQ9HTbgvH9yazrcE7tXmlB3L6ueBLG3hAkvKl/aCidSJ
-        jCoB24dGzTvsuB3OJhcFGKqd/ucoPhyPW4p/nHRHRI8FfZAIO0gUiknFzOaVJWjVvfHLmJ7lNAXt
-        WQ3dGmF4weVqqO/TLdUdy1VLiWPnKejDDrGc3oIltWdgbbng2TIEffgKprYeGdWzgsXHTCzfWskh
-        FHb3EPGmo1OdyVUl626EFDNcPegthzOg2o7JRwRj/cs5Pb745ejk5vjoYHZyPruZnZ39eYb54Yxp
-        LAg+mGdATpG9hSHWL2GaSME3BJmAcWuUGEl+Y4qSUwU5UgEpNSJu+BwjBDgMjv+J+b5a3EVO/UXD
-        3mHxtxPxxaRjG1ImKH/8qNmcmvJWuOcYXXO2fU0FdK/Lwo5cH45Ho6DFcb3kvBJ6tXL31fxyL3kZ
-        Grdw+5nGS1wVW8i1xmtfB8029p8Cblc6r92swvYjL8BCPZZcqpM6mltewiBVdLMNcC7JoaybLfMC
-        l1lhngf9bkcKX2vsY6WOML4s519i+29nzgyHnYhcvadFGJEDKZcMyCUzmSwNOYe4VEDecpp+stXB
-        4nAZU55JbaKpP/W9BRMJEqEXjkbXlcHDqniY150kFlbRDvlXTfId/vm+Uj/Hlc1yEKohWzRBHpZA
-        DjFRvPyDbki45xILxi6Jg8sZiq7wv8EkGFeR2j7GKxjmzCgYSpV6CGNqW8tw37Lw9/DpMDM5r+Ku
-        7byzdi7EUsjVwyKdKpmU+AWfiRQHO8c2eXMsvvVZVQjjJb/K1cDInioVjYHwmnjkagWwRBaAzlqP
-        1vaBN6oU3++fkvOYip73dov09vwunwcZnG+0gVxjBkkhGcJsJ6ruq97YWuWUCc0MDBGJWCqd3Uqq
-        kr4XT+wfbhFmLe+TuAYSsi65BRBEgyGrBlUGaVHXyFogslyyylickRyo0Cik9YtY/gMAAP//7Flt
-        S+NAEP4rQRAUTEzb9NoeiFfEg/sgdyicIELZbjY2mGxCXqzF63+/Z3bjXhq73iGH+KHQD2mzmbfM
-        PPPMVEmAu7dyLhzGOXBVhM5DzJwapcKLVQ5gwjkpkXH0Sr2WRRd4y3dqJCSDrhdCUmY5zMjNMDHC
-        I1hCboG9ObGMsiJVzzhZQWjNcLcksARQ3wt5RIZBeFw56BV1EjosWbIVuejkTFlXl8hph0mnZSDm
-        PSkSzzmXJflsPNQxuJUUBNJGMYIFjYXls4kksKwRoK2WtnxueX+JKkTfQcjI+yZdlsully1Zmat6
-        QPmJRy9f5CqXoWQGmbNG94xVVRHPa6TU7OD79fTqh3t14aJFqyo1SvKsqERBdXDAwjSWh87B4S8k
-        SlJln5GGL9nN0LT4bnuz0Z5eYLthqClhYoXB/l4xsqeXvdO3sdjAMMzuE4ZlqJekONX2gzbW4dtY
-        rW90bnTrLpjjBTC+oOLXHaGs05RRu9r7G1JT1Il8ZsUbexuRkFPUGxHeb+HJMByMR+N5b+SLAZ/4
-        fDLsR5NeRCsOcwgaXjkmKCWmYQgd6G9oduHqS8sQAArJenWY1bXioX+qYwqmmoEqEKB4LOwFwacR
-        H4+Gg8mcz0c+1EdMRGN+Gp4oKfuD6X7/Kz76OTdlsoFX19U/lV5duksEwu17BNleXs+TmFOk3Jyx
-        kgKF51UHAUHE5RmKwsslxbw7GH98i7uT9ce3uDuZf3SLAUVhXOYJWzUk8AypDw4TRTXnsSogwnM9
-        RmoguwENxMHzushycXwD7OGLP5VGmyHcNaVLGpp92HbmGNhwNbCNk4EZJ4sG33cw8m4Js4OR97B4
-        ByNbYKQLAzamFhhCZvgL3LnTRflEK+zm2oclWcWaBXxXio2S+TZc8vvbAc62D/KtDlgpm41qEoRs
-        vTGw3jAkT8iHuMikJnL6p7Bu/v3RX/8pelmqJTw9XzZw/wZcbv1xdfws92gvZY+XoqwTEtzSrdYl
-        RTWttB0PWfX/NqxamBEKXRgXf2Zq26QWcGu946UdDqk0hmxa298wt3lAhWe9Xv8GAAD//wMA3LOe
-        qmwcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18177","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18177","key":"NTEST-1841","fields":{"statuscategorychangedate":"2025-04-30T18:24:27.900+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1841/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:27.607+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:27.693+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/243]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/243 (243)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1841/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18177/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 1a809b0b-bf28-4392-94a0-d0a6dec81d9a
+      - 17d724ea-fc67-4132-ada5-c7481d5b2808
       Atl-Traceid:
-      - 1a809b0bbf28439294a0d0a6dec81d9a
+      - 17d724eafc674132ada5c7481d5b2808
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:12 GMT
+      - Wed, 30 Apr 2025 16:24:28 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1107,7 +1103,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=276,atl-edge-internal;dur=15,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=322,atl-edge;dur=289,atl-edge-internal;dur=18,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="JeLpKEdBNF7wRraM9HSj-H8FemLZ-6WOGl8r3Rr4oQHZA3GYW337Bw==",cdn-downstream-fbl;dur=326
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1116,10 +1112,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 60b2b330807c6611e06e3923c8e315cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JeLpKEdBNF7wRraM9HSj-H8FemLZ-6WOGl8r3Rr4oQHZA3GYW337Bw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 9fb4fed285f3e04d08489bccc85ade8d
+      - eb0833743e7d9ebe88f64862319a7103
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1143,61 +1147,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16609
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18177
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/jRhD+Kyt/aqkTvyTkgqWqopBraSlFEDjpKEKLPbGXrHfd3TVJyvHfO2vH
-        DhfwnaDq6SQu3tl5f+bZeXBgWVCROJGjQCSgIHnPgCfaFTQH7eo4g5y6sgBFDZNCu5Awk4OhbpxR
-        kQKXqXsPSqMMkjMoFGgQZn03LrWR+cwavAl8P/D7Cv4uQZvpqoBTRWPDYnBch1n/wWjk7+GHBj7D
-        z8yYQkeel8AMYpPIO9mnhlOtGRV9AcZDT8ajBfNCj2ldgtcYmMMK9U+mk/NpLxiHIzyqQtBO9OBo
-        jK3UMTWQSrWqc0jwCzVCP9zt+UEv3JuGQTTcjYKgPxrs/oBx+zZI68Rg4JWZNwZp9T2054dt2uuP
-        BHSsWGELh6f7ROeUc5ckTBsmYkMKBjEQOSMLqeZ9qx1LcaH4K6MoBbPtovyG3lNDlXfPYOFVYW0C
-        XIsCfxCMf9LsH/gxx7aXOXq1sECXU6rntlflrbG/ohnlGlynVjzCvCpd18kYAkfF2eoY7gFj9R9d
-        xzBEVoEocSJRYo7OFkwGfpcgaASFkneY6hs7sdau+lB1tumD/XiCnk26F4IZgwa00/q2EP69uqvl
-        zCyoskDWLC84w4CTrZJgoyr4DcfL4fiV4X6hZU0mbcOG/jsMIxwuw+H/66WGRQVSdBiMlsHoWzhc
-        Nh4H4XIQfguPa+Q/Pj6HY9iF00EjmLHlZU2O2P2ra0RDmipIkW++OgS7jQATkLyseeHlq6MuwbsO
-        QdgpGHcJ9p6HU9NmfWpJqXohnKgX4Cc1+HDUhPv6+azpfEPgXm1O2emrfh7I0hYusKT8wR4wkTqR
-        USVgl9CoucTG2hlc56IAQ7VD/hLFh8NhQ/HbSXcRUdgS0baghUShmFTMrN5YgkbdG76O6VlOU9Ce
-        1dCNEYYHXC76+j7dMNqxXDTMN3SeYztsIczpLVjusujdfs+7gBd04SsY23pkVE8KFh8zMX9vJYdQ
-        2N1DxKuWNXUmF5WsPRFSTHD1oLcczoBqOw0PCMb6l3N6fPHL0cnN8dHB5OR8cjM5O/vzDPPDGdNY
-        ELwwzYCcIkkLQ6xfwjSRgq8IDjzj1igxkvzGFCWnCnKceFJqRFz/pcEPcBgc/xPzfTW7i5z6RcPe
-        YfE3E/HZpGMbUiYo37603pzW5a1wzzG6hiywr6mA9nZZ2JHrwvFgEDQ4rpecN0KvVm4fx8/3kteh
-        cQO3n2k8x1WxgVxjvPZ1sN7G/lPAzUrnNZtV2LzlAizUY8mlOqmjueUl9FJFV5sAp5IcyrrZMi9w
-        mRXmZdDvtqTwpcZuK7WE8Xk5/xKbfztTZjjsROTqIy3CiBxIOWdAPjCTydKQc4hLBeQ9p+knWx0s
-        Dpcx5ZnUJhr7Y9+bMZEgEXrhYHBdGTysiod53UliYRXtkK9qku/wz/eV+jmubJaDUA3ZYh3kYQnk
-        EBPFwz/oioR7LrFgbJM4+DBB0RX+1xsFwypS28d4Af2cGQV9qVIPYUxtaxmuVRb+Hl7tZybnVdy1
-        nUtr50LMhVw8LdKpkkmJD/VEpDjYObbJm2Lxrc+qQhgv+VUuekZ2VKlYGwiviUeuFgBzZAForXVo
-        bS54g0rx4/4pOY+p6Lhvl0Vvz2/zeZLB+UobyDVmkBSSIcx2ouq86o2tVU6Z0MxAH5GIpdLZraQq
-        6brxzP7hBmHW8j6JayAh65JbAEE0GLJYo8ogLeoaWTNElksWGYszkgMVGoW0vhHLfwEAAP//7Flt
-        S+NAEP4rQRAUTEzb9NoeiFfEg/sgdyicIELZbjY2mG5CXqzF63+/Z3bXvRqz3iGH+EHwQ8zuzs5M
-        Zp55ZqokwNxrORce4xy4KmLvLmVeg1Th5boAMGGflIg4+qTBlkZn+Mo3qiUkhS4XQlJkeczKzdEx
-        wiJoQmaBpHmpTPJyqc54eUlozbBaEVgCqG+FPCDFIDytPdSKJos9lq3Ymkz0Cqa0ayrEtMekt6Ug
-        +j0pssA7lRXZbC3UPriW5AS6jXwEDYyG1aOKJLBq4KBOTbds3rL+HFmIugOXkfUmXFarVZCvWFWo
-        fED6ifugWBQqlnHJDDJn5u4Zq+synTcIqdne98vpxQ//4sxHiVZZai8p8rIWJeXBHouXqdz39vZ/
-        IVCyOv+MMHzOboa2xLfLm4v29CLXgiWrhIk1GvtbxcgentfOyBLJ1kJoZbQXXCwjtCxDfT1Ftro3
-        ulhtaJWBjxlfUH538PQ2uFfNcsmoXO38DanJ60Q+8/KVtY1IyDHyjQjvt/hoGA/Go/G8NwrFgE9C
-        Phn2k0kvoRGH3YQbXtgmKCSmcYw7UN9Q7OL1ly1FACgk68WeVedKgPqptimYMn1TJEDxWNyLok8j
-        Ph4NB5M5n49CXJ8wkYz5cXykpOwOprv9r/jT5/wlkwZefV+/qoKm8ldwhN8PCLKDoplnKSdP+QVj
-        FTkK51UFAUHE4wmSIigk+bzd/75/jdsN9PvXuN2Av3eNAUVxWhUZWxsSeILQB4dJkobzVCUQ4blu
-        IzWQXYEGYuNpU+aFOLwCxPDFn0yjARBWberSDWYe1s0cIxeuRq52MnJNGCKL3aUB/g98ebNI+sCX
-        t9D4A1868KUNA5aQWb4CrW907j3QpNo8h7gwr5kZwLelOJmXE5eclKzfjXyueVDo4qAECJ0LoYuD
-        DlwnBpbkCXmXlrnULE+/ihvz64/+91+8d5fX/2+yqYVZobgJbdrPXE151OBLDyS0yg+Pj6a+vFoB
-        9UvZ4aPcg50luz8XVZOR4C1j1XymrKe1NpxmvDTDIdPt+6eH+09OmwNK281m8xsAAP//AwB8FoVT
-        bBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18177","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18177","key":"NTEST-1841","fields":{"statuscategorychangedate":"2025-04-30T18:24:27.900+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1841/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:27.607+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:27.693+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/243]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/243 (243)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1841/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18177/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 8d665a4d-ac63-432b-b5ef-bca6b1880049
+      - 072d6799-cc4c-4d67-957f-3e861e16f690
       Atl-Traceid:
-      - 8d665a4dac63432bb5efbca6b1880049
+      - 072d6799cc4c4d67957f3e861e16f690
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:12 GMT
+      - Wed, 30 Apr 2025 16:24:28 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1207,7 +1194,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=290,atl-edge-internal;dur=14,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="_q5OOeXVKn81MIgV3h4cp4BGSgKAa6BNBh9YNAG-lJZI0JYYOO4agg==",cdn-downstream-fbl;dur=344,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=341,atl-edge;dur=262,atl-edge-internal;dur=16,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1216,10 +1203,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0835ebd52ef8594cd8aa4dac9cfbd9a8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - _q5OOeXVKn81MIgV3h4cp4BGSgKAa6BNBh9YNAG-lJZI0JYYOO4agg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - ccf764aeb6daa09afe8d5e767a89806c
+      - 246a91926239818147f9ee07920c41c7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1228,7 +1223,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"issues": ["16609"]}'
+    body: '{"issues": ["18177"]}'
     headers:
       Accept:
       - application/json,*/*;q=0.9
@@ -1245,21 +1240,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/16607/issue
+    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/18173/issue
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - f775a80a-f906-49d9-87a2-4e95b9927b64
+      - c329894a-a51d-4802-94bc-c2f385ae98fa
       Atl-Traceid:
-      - f775a80af90649d987a24e95b9927b64
+      - c329894aa51d480294bcc2f385ae98fa
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:13 GMT
+      - Wed, 30 Apr 2025 16:24:29 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1269,17 +1266,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=461,atl-edge-internal;dur=15,atl-edge-upstream;dur=444,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="QTXHtZCGejRsEG4UOsSCNHhoAezqkxDj5H9kzGzcbqDUOWCY4rSk8w==",cdn-downstream-fbl;dur=478,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=476,atl-edge;dur=390,atl-edge-internal;dur=16,atl-edge-upstream;dur=374,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 35f3ad5aa26e63a13ffedf420998e698.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QTXHtZCGejRsEG4UOsSCNHhoAezqkxDj5H9kzGzcbqDUOWCY4rSk8w==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - d1b63777dda0ac9ac859eccdef696c77
+      - 9417bedc97ff40d9458ea21c38078a3f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1289,14 +1294,14 @@ interactions:
       message: No Content
 - request:
     body: '{"description": "Event test_added has occurred.", "title": "Test created
-      for Security How-to: weekly engagement: ZAP Scan", "user": null, "url_ui": "http://localhost:8080/test/90",
-      "url_api": "http://localhost:8080/api/v2/tests/90/", "product_type": {"name":
+      for Security How-to: weekly engagement: ZAP Scan", "user": null, "url_ui": "http://localhost:8080/test/93",
+      "url_api": "http://localhost:8080/api/v2/tests/93/", "product_type": {"name":
       "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2", "url_api":
       "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name": "Security
       How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api": "http://localhost:8080/api/v2/products/2/"},
       "engagement": {"name": "weekly engagement", "id": 3, "url_ui": "http://localhost:8080/engagement/3",
       "url_api": "http://localhost:8080/api/v2/engagements/3/"}, "test": {"title":
-      null, "id": 90, "url_ui": "http://localhost:8080/test/90", "url_api": "http://localhost:8080/api/v2/tests/90/"}}'
+      null, "id": 93, "url_ui": "http://localhost:8080/test/93", "url_api": "http://localhost:8080/api/v2/tests/93/"}}'
     headers:
       Accept:
       - application/json
@@ -1311,7 +1316,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.3
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1325,13 +1330,13 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"828\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:48442\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:55190\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: weekly engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\":
-        \\\"http://localhost:8080/test/90\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/90/\\\",
+        \\\"http://localhost:8080/test/93\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/93/\\\",
         \\\"product_type\\\": {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\":
         \\\"http://localhost:8080/product/type/2\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"},
         \\\"product\\\": {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\":
@@ -1339,8 +1344,8 @@ interactions:
         \\\"engagement\\\": {\\\"name\\\": \\\"weekly engagement\\\", \\\"id\\\":
         3, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/3\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/engagements/3/\\\"}, \\\"test\\\": {\\\"title\\\":
-        null, \\\"id\\\": 90, \\\"url_ui\\\": \\\"http://localhost:8080/test/90\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/90/\\\"}}\",\n  \"files\":
+        null, \\\"id\\\": 93, \\\"url_ui\\\": \\\"http://localhost:8080/test/93\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/93/\\\"}}\",\n  \"files\":
         {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event test_added
         has occurred.\",\n    \"engagement\": {\n      \"id\": 3,\n      \"name\":
         \"weekly engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/3/\",\n
@@ -1350,10 +1355,10 @@ interactions:
         \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
         \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
         \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
-        90,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/90/\",\n
-        \     \"url_ui\": \"http://localhost:8080/test/90\"\n    },\n    \"title\":
+        93,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/93/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/93\"\n    },\n    \"title\":
         \"Test created for Security How-to: weekly engagement: ZAP Scan\",\n    \"url_api\":
-        \"http://localhost:8080/api/v2/tests/90/\",\n    \"url_ui\": \"http://localhost:8080/test/90\",\n
+        \"http://localhost:8080/api/v2/tests/93/\",\n    \"url_ui\": \"http://localhost:8080/test/93\",\n
         \   \"user\": null\n  }\n}\n"
     headers:
       Access-Control-Allow-Credentials:
@@ -1363,7 +1368,111 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 29 Jan 2025 20:45:13 GMT
+      - Wed, 30 Apr 2025 16:24:29 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: weekly engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/93", "url_api": "http://localhost:8080/api/v2/tests/93/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "weekly
+      engagement", "id": 3, "url_ui": "http://localhost:8080/engagement/3", "url_api":
+      "http://localhost:8080/api/v2/engagements/3/"}, "test": {"title": null, "id":
+      93, "url_ui": "http://localhost:8080/test/93", "url_api": "http://localhost:8080/api/v2/tests/93/"},
+      "finding_count": 2, "findings": {"new": [{"id": 242, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/242",
+      "url_api": "http://localhost:8080/api/v2/findings/242/"}, {"id": 243, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/243",
+      "url_api": "http://localhost:8080/api/v2/findings/243/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1300'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1300\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:55200\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: weekly engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/93\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/93/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"weekly engagement\\\", \\\"id\\\": 3, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/3\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/3/\\\"}, \\\"test\\\":
+        {\\\"title\\\": null, \\\"id\\\": 93, \\\"url_ui\\\": \\\"http://localhost:8080/test/93\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/93/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 242, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/242\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/242/\\\"},
+        {\\\"id\\\": 243, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/243\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/243/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 3,\n      \"name\": \"weekly
+        engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/3/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/3\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 242,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/242/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/242\"\n        },\n
+        \       {\n          \"id\": 243,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/243/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/243\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        93,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/93/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/93\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: weekly engagement: ZAP Scan\",\n
+        \   \"url_api\": \"http://localhost:8080/api/v2/tests/93/\",\n    \"url_ui\":
+        \"http://localhost:8080/test/93\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:24:29 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1388,26 +1497,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3boka+mWN6ngFJ1Cu5eJSJpcMJompUkHY+y7m+Bg8019O+5+
-        //sdd0At97AZDGLoPYTes9lMggIRpPtwGQ+Ge6+5zSwENEFS+97w/T/4GoadFiDBf67A9BXYAMNf
-        l1TOKjOCFfC75A4Gr52NMMGYZDjD03p9/VyvnprzdD12bawQe0nQBE/wa3RCb9y+i1c2+z7ZKuNG
-        GUPtqI38jiAWA7QsT80bHhJIMS2mmEzpoiE5ywmbLzKM8RWOcMz7+AcYGt39YJcNJSwvGJlnBT2z
-        oruzykVQFQUBKOeklSByITgAJ+1CKrIsuSJ5FKi2AHohCCYZ7vXA0wtB8dGEByd4ah+QOVUI7Num
-        RsfLw7bOpsntY4OOXwAAAP//AwBukVcqIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:29.894+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 63c87549-8e2c-4cbf-8ecf-d90285decde7
+      - f4d1d2a1-f67d-41d3-848e-9094c845f57b
       Atl-Traceid:
-      - 63c875498e2c4cbf8ecfd90285decde7
+      - f4d1d2a1f67d41d3848e9094c845f57b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:13 GMT
+      - Wed, 30 Apr 2025 16:24:29 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1417,7 +1522,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=167,atl-edge-internal;dur=15,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=193,atl-edge;dur=160,atl-edge-internal;dur=14,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="xYUCneea-joioc43qnjgyhIVv7_WEkGZeHhR6O019v4ViEDiId4J7w==",cdn-downstream-fbl;dur=197
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1426,10 +1531,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b3ac893abff0a2c3dda216fe4cd9157a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - xYUCneea-joioc43qnjgyhIVv7_WEkGZeHhR6O019v4ViEDiId4J7w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 33a508a0dfc8263889715abe736ba6b0
+      - c4710fa45092f2e4b0580f4144a02fde
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1453,71 +1566,73 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/NTEST-1824/issue
+    uri: https://defectdojo.atlassian.net/rest/agile/1.0/epic/NTEST-1839/issue
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW8iNxD+K9Z+LbAvkBxZqaquCVelTdMTIdcPVRWZ3QF87Nor2xugUf57Z7wv
-        EAInkab3DXvWM8/MM288ebAuuEy92DPJAnLekTwH43U8Y7m2H60XBx0v5+sxmDKzxovP8GyV5ZkX
-        Rx1PGFPi5/FfT1tFqgDNrVDSdB5BG/wB6RgKDQakrQWQCpuD5Z1kweUcMjXvaJApaEg/CchSQiBI
-        WXh+HgwJDmQzPC6sLUzs+ynMILGp+qp63GbcGMFlT4L10Yr1+Vxk4Ie9wHf4/EbJEjao43Yyupt0
-        w2F0hlezylr8RA7b0iTcwlzpTYUrxRO+iILorBuE3ehiEoXx4CwOhr1BePFDEAYBASUjdlOAU3MS
-        0EL4UQWS3vuoL4ha1+tDCibRoqDA4e1HZnKeZR2WCmOFTCwrBCTA1IytlF726HWi5L3OTkRRSkF0
-        8eyBP3Ik338UsPIdrC3AWhQG/XD4kxH/wI85UlnmaJUSB01OuFkSX+XU0q94xjMDHa96eI1+ubcd
-        byEwS3Sy2NzAIyDW4LnjFRyTwFIUW+4/vKZtcHI6bKPsUoF07vBe5jnXZGEFsMw2DOSczyEnJK4M
-        MCveSGz12LFKefKSyNOI2gb4Z54ssV52s4SUV7Yu6/T9T4CbGvCbVIwaDiSs8CpRmdK3FZppVkJ3
-        rvlmJwMUu1LeM/GphdLCvhVN89zvnxYrkSN/xqcXplEi8KJK1Z55pODVYH9v0tcFs+89v3c5uwax
-        S9R+OU/FnJUGNDMWY87sglsmAVLDrGJTYFOtliBZqlayxy41IDkpm27Yr0JzdqdmdoVVw7r4AZPK
-        MuqsTGmWQgYWTmwHLyLX+mF8KETyMm4jvKGs2yvz/aoOnykPrMCZUrjSliX2Ls8gK9tTUqLruavI
-        B4xSP2gEhVZfEegbeahfH2Zhp6dsnbqXwlpUQNOnfj1B/39z35o61OS1yItMIOB0r79hmF2vGAzX
-        g+GJcL/RfxtP2u47cD0sGqyxGf6vVqoe7yYOGgzP1+H59zC4biz2o3U/+h4W6zFG2bqfjuGxPI0a
-        wUysv1SbDq1Cf7/+st98yedzDXMs4VclgQ6orKy6wmFzZ8cE58cEH44IoqOC4THBxWuc1XJU3dLq
-        4ZY+L+6GdQslSrRIKpeeXt1RoWC0zUKVWXolTJHhEKnKCa+RW/sFeaMSq01wixvqW0dxNf23q59f
-        qdNU6u7npSqJDAf+T7oQcu7FVpeEJqnarnd4FQzOo2YV3A9b28r2BW1SUWttNh63nLzDvtOuv6S8
-        XXnqJndwy/nmDuTmPWGsgLnjQxi1s/LypbwodZEBSVNc/beU7oegLZ/3WhMoUG8ddjtrQqZWL2fd
-        jaKtx42PAbm170hb3RmfAg2AAy2A+ubBTAiP1WI4pHgsuKFReyPk8hNJrqCg/0kyaWrFVdDKydob
-        qeQI1wA+zWAM3FT1p+tf3ueb+1+ubx9uri9Ht3ejh9F4/McY/cN+ZDAg+MFkAeyzW8XZvwAAAP//
-        7FhrT9tIFP0rI6RKgLDjvMhDqtoIqHY/oEVNu0hAhSbjcezWnrE89rqR+PE9d2yc4MZ0tStVfEBE
-        QOyZ+5p7zz13SC+LDNMKSQHUjGISSszE0o+rTCaATctfjLsPPfsAjgPvIfK8LFjNDyougLND8Lfo
-        8QQVcQzrSPG4vaieJevw2sSLYV39nc51Ddr0uLpICZ72V+zMPZ1OHiv2leD/D4IvdJKixhVdDOxJ
-        +nEDf88dbHtTA41Pw3mntj/Hn6I8lsdzdnvD0/6cnWn9LZLsOsrRTXK2lKIAJ/4Q8/UDRQfBibXg
-        cahNPp96U68XRMoHwPcGw8EXK/DcBg9+fdWM0mp+zH65kx3i15HdvgTdJQzCNqBFbeR5Idk5HMXD
-        S75hg9kJo2RsnDi7vsCrW/xxTvsjaymdoyilm0R5Jl2drXtIY05HG4GbUvr3sNQN8yS2dldy/iY5
-        n9U3hRlhJ0hXmfYLsJ2LBsx7nxB80mkjBHvZH7p0ct0RpbQWMPjCeuz2p9bQsWu7oDe0G28WV2wp
-        uOpYT4y7N/Maf3Y8WG5MLhMDD/xUY2Iwx3P73J4NxSrhkTIR5hxkIkJlwpXmmd+14if559sMI8kL
-        JqpEAupi9MLUZWTOyjqrcsCiqTIrQGadsDKMRMgSyZWpxjZaUUuAu3cK0xsXAriKie2fiLMCpSKy
-        TUoTHJBByYoIuTsWXeKU1/aSjAy6DqWizGK8katVTh7BEnILTJdFKtBZYvfQ4Ae05nhrCCwB1Jgd
-        T8gwCMdgWLEtxuOSb8hFlnJrXWGQ04wrtmNgyGFh7LILZcjnxsMqBneKgkDaKEawoLbQPJpIAk2B
-        AO21dMfnHe8/ogrRdxAy8r5Ol7IsXV1yk9p6QPnJ724apjaXoeQeMu9r3fc8B71cFUip+8O/rhfL
-        K2d56aBF2yptlKQ6y2VGdXDI/SRSR+zw6AGJEud6jjQkBGxhUtPi2+2ti+CNu9j6uJMI0Cj3hPQR
-        aOYZuoGlokSW21u6lHhdL0YNj2/vaMyyx2vZ2P6FXXzF65odvEbnkz7fbgM4Oi5CSzltL6H0Wu9M
-        2FuO+ivMp/Mjwl6R0v/QJYnOvEPl0kjwp/927A+nk+mqP/HkUMw8MRsPglk/OIWeZhE0PLNMUnIt
-        fB860CnRNv3N+x1DAE0k69krhKrqXHRiu8wCXj3GjiTIIvf7o9HpREwn4+FsJVYTD+oDLoOpeOe/
-        tVLeDBdvBh/wqfY5CVc1UDtO9ci4hXFKBMIZuAT+blqs4khQpJyUc0OBwn7bi3Aq+PcM5eWmimLe
-        vo54+Ra37zNevsXt+5CXbjENgdVoX9PJM6Q+2FAQFEJEtoCoM1SDdoV4N3ZoPLgoMp3K3g2wSITb
-        SqP7OLxtSpc01JeQ+znoqAuhR133OqNmMM3qTvEKI78tYV5h5HdY/K9h5AcAAAD//xokLqZLMYJe
-        DOBq85mYYLRngN5Jh2TKatDEAZSNmCkHTW6im4KriWaAs1zC1XI0MMJe8uFsqSF8BgAAAP//QtOB
-        swkH9zKahDEuHcbwRl9qXllmUX4epGEHEUophc6sQ7jEhF5Zfgn1xn4hhsENBdoE7PCF5YPHi+Cj
-        lfm5ECdXw5jQ+oVsB4BXIejDzEVdVYHkWfBID3TpRS1kZB00GgTyOlwcVbMRim6oBrBrQbNvtFyZ
-        YalEanhgWZkBMgRtyBtU2YGTEiTKSViZYWioZ2ZsOroyY3RlBl4rR/rALbWmXEZXZoyuzCA9HmDT
-        8FhjYXRlBlG2jK7MGF2ZAZaAN7QR7hzKKzPMqLYyA9gUNDIxGV2ZgZAnfmUGAAAA//+CF/PUaSaM
-        rswY3CszsgbHygxDIz0LY4vRlRlUaOAPipUZRvhm6XCsBkCsrzAme2WGMWhlhvHoygx0XaMrM0ZX
-        ZoyuzMDVWh9dmQGt59GrAZJWZuAt80HxN7oyg86TZ5jDEYPfxejjGYPfxejjIYPdxaBOIM2nVEdX
-        ZgzRYgQAAAD//8KSYEaLEXq4mM7FCAAAAP//otjFdClG0IsBXG2+0ZUZCAm6rcygzUIJS5IXSlBx
-        hYgZUStEKF2ZEVsLAAAA//8DAB+M+iV+QwAA
+      string: '{"expand":"schema,names","startAt":0,"maxResults":50,"total":2,"issues":[{"expand":"operations,versionedRepresentations,editmeta,changelog,renderedFields","id":"18175","self":"https://defectdojo.atlassian.net/rest/agile/1.0/issue/18175","key":"NTEST-1840","fields":{"statuscategorychangedate":"2025-04-30T18:24:24.572+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"parent":{"id":"18173","key":"NTEST-1839","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18173","fields":{"summary":"weekly
+        engagement","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},"issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1}}},"timespent":null,"sprint":null,"customfield_10030":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10031":null,"customfield_10032":null,"fixVersions":[],"customfield_10033":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"aggregatetimespent":null,"resolution":null,"customfield_10035":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"lastViewed":null,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1840/watchers","watchCount":1,"isWatching":true},"created":"2025-04-30T18:24:24.264+0200","customfield_10020":null,"customfield_10021":null,"epic":{"id":18173,"key":"NTEST-1839","self":"https://defectdojo.atlassian.net/rest/agile/1.0/epic/18173","name":"weekly
+        engagement","summary":"weekly engagement","color":{"key":"color_12"},"issueColor":{"key":"purple"},"done":false},"customfield_10022":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"customfield_10023":null,"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szb:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:26.079+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"timeoriginalestimate":null,"customfield_10051":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/242]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/242 (242)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":"NTEST-1839","timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"security":null,"customfield_10007":null,"customfield_10008":null,"customfield_10009":null,"aggregatetimeestimate":null,"attachment":[],"flagged":false,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"customfield_10044":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10047":null,"customfield_10003":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1840/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18175/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}},{"expand":"operations,versionedRepresentations,editmeta,changelog,renderedFields","id":"18177","self":"https://defectdojo.atlassian.net/rest/agile/1.0/issue/18177","key":"NTEST-1841","fields":{"statuscategorychangedate":"2025-04-30T18:24:27.900+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"parent":{"id":"18173","key":"NTEST-1839","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18173","fields":{"summary":"weekly
+        engagement","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},"issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1}}},"timespent":null,"sprint":null,"customfield_10030":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10031":null,"customfield_10032":null,"fixVersions":[],"customfield_10033":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"aggregatetimespent":null,"resolution":null,"customfield_10035":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"lastViewed":null,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1841/watchers","watchCount":1,"isWatching":true},"created":"2025-04-30T18:24:27.607+0200","customfield_10020":null,"customfield_10021":null,"epic":{"id":18173,"key":"NTEST-1839","self":"https://defectdojo.atlassian.net/rest/agile/1.0/epic/18173","name":"weekly
+        engagement","summary":"weekly engagement","color":{"key":"color_12"},"issueColor":{"key":"purple"},"done":false},"customfield_10022":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"customfield_10023":null,"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:29.335+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"timeoriginalestimate":null,"customfield_10051":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/243]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/243 (243)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":"NTEST-1839","timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"security":null,"customfield_10007":null,"customfield_10008":null,"customfield_10009":null,"aggregatetimeestimate":null,"attachment":[],"flagged":false,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"customfield_10044":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10047":null,"customfield_10003":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18177/comment","maxResults":0,"total":0,"startAt":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1841/votes","votes":0,"hasVoted":false},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}]}'
     headers:
       Atl-Request-Id:
-      - 1ab0c683-0f7f-4e43-8ad5-da93b3a539b1
+      - e6cb1789-3b05-4a4f-b487-8debc05e5c51
       Atl-Traceid:
-      - 1ab0c6830f7f4e438ad5da93b3a539b1
+      - e6cb17893b054a4fb4878debc05e5c51
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:14 GMT
+      - Wed, 30 Apr 2025 16:24:30 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1527,7 +1642,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=499,atl-edge-internal;dur=16,atl-edge-upstream;dur=483,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=488,atl-edge;dur=455,atl-edge-internal;dur=16,atl-edge-upstream;dur=439,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="6V1nbyPTc9N8A-I7m7P1T-uerPyqWKmFmxolT0vAH48R5BGVYvD1WQ==",cdn-downstream-fbl;dur=492
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1536,10 +1651,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5ea7f8bcbac3004590a821cdd0466e1c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 6V1nbyPTc9N8A-I7m7P1T-uerPyqWKmFmxolT0vAH48R5BGVYvD1WQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f8670a958f7cb0e80a132e5b4738e9e4
+      - e9cf62b32492074dd68e4f57d23c68c9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1566,26 +1689,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQwUoDMRCG3yVX222SZtmam1SwilZhtxdFJJtMMJpNlk22UErf3QSL1pt6G2a+
-        f75h9qgVATaDRRy9xtgHPpsp0CCj8m++ENGKEIxwhYOIJkiZ0Fux+wdfw7A1EhSE9xXYfgkuwvDX
-        JUvvtB3BSfhdcgtDMN4lmGBMClzgab2+eKhX9833dD12baoQf8rQBE/wc3JCb/2uS1c2uz7bltaP
-        KoXa0Vj1GUE8BWhVHZuXImaQYlpOMZnSRUMYZ4TPFwXG+AwnOOVD+gMMjel+sOcNJZyVnLCCYfrF
-        yu7aaZ9AXZYEoJqTVoFkUgoAQdqF0uS8EpqwJNBtCfREEG023JhB5BeCFqONt16K3N4je6wQuJdN
-        jQ6nhz16lydXdw06fAAAAP//AwBRCcFyIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:30.760+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 841216f7-032d-4cd3-ae33-004340c3ab0d
+      - e6bf17d6-aa16-4fe8-8c5e-fb8ffcb1d963
       Atl-Traceid:
-      - 841216f7032d4cd3ae33004340c3ab0d
+      - e6bf17d6aa164fe88c5efb8ffcb1d963
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:14 GMT
+      - Wed, 30 Apr 2025 16:24:30 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1595,7 +1714,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=151,atl-edge-internal;dur=14,atl-edge-upstream;dur=138,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=196,atl-edge;dur=164,atl-edge-internal;dur=13,atl-edge-upstream;dur=151,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="BKtP-0kTsEvxCM0ryi1v0vhZUsT1CnzAyYG5Nbzm0BgYLPptpdXTCg==",cdn-downstream-fbl;dur=201
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1604,10 +1723,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - BKtP-0kTsEvxCM0ryi1v0vhZUsT1CnzAyYG5Nbzm0BgYLPptpdXTCg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 353f3bf5f2ae590f0c1aee49961249e2
+      - e77b3415d3935b4e8d5c9730c41f57ad
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1634,97 +1761,135 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/field
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7RWS27bMBS8iqC1F+6iG+8KuwGKBm2RItkYRkFLTwobiTJIKo0R5DS9T89UUqTI
-        R4VSBMfe2ODwUTPzPhK3zynN01UqJJGtyIiEsuHH7J6wEnK1ShfpAxynAxipQUX87CKStQ1J1iZG
-        BWStkE2drgpSCVikDc+Bk30FDmHkkZYGkbxVgADCFQdCsoq0Ar4pKpGutlZOz2WpNlrPTp3O7qEm
-        6eo5lceDlqaFSlprseIoJNRThl5eFjYpB8KBSZcCt7SGf/Tr9/mzMQODlmznxBT06Q64oA0TTlGI
-        WVlX9Cl59Oi4OCNlUls09541mmzCOTkqYqryrOJTqwXnHuv26Q5rOug8BMf7bdLqnDpEvQ7IfTk4
-        iKZqpTFmhAaQFXmDsXF9p5YCUcZKEShy2UeoT35FhLyj8KcbWOMngKyfa4UlDhw3NCfh8cZHrDFL
-        sVFGR9DwctpwKn0fIaAfYI+MOzm1NI4u5gJpcS4chouyh8qPu1u6Ytj1+dVbqpj24XwLySkrw3p0
-        h70PXTAQ6hd/UQagG5iaUKYemHz2e+P+Tu8z3hMhnkBSzDtr6z1w7DU44h2TsuRQ2l5VZS0pI9Wr
-        FLwVZXPy72/y3W5eOCvzPE/L9klAXyHjFwHW2qeigEyKy36wSEcC+Tu/Wk6jd0iFaKGi7MF7DKB+
-        UNUS8uSL3rqMxY5V08wyF2h0/hCKGlkIWjJAPeuBvoYeOb8xRxfzpQLDxuyDh5cKp94trXZziZhU
-        PmeYotItV0y4kzG4jiLhWVMfGqbugF58AFkDa4yNmzg1/Y4yamPYVz4aOUOqB4OjXQVjYwDr7Gu3
-        GLc0py7Rl5xWsDCE/b9X4m94hrmgUOW/PiyXH5e+DpEdK3oD+lWzaX43ybqLSm5vrpMrHaqCWiY5
-        YaJSr8lcq3nzQO/eODtHPYttp3inHj5NPbG7vf0PAAD//7xZTW+CQBD9K6Sn9gCpiiZ6NU1jLzXV
-        9EJ6QKQWRSB8mP787izLuiwzFYN4UWB2Z2bf251hhurqC90W8o2gch/2gOXmIZxPN7L2QepaSViw
-        vGGV28RSIAUl2axIQ6lgwejgXiunQ6NgQJIDEpocFkCMZeAd2N91JCET+yJrQJCFuNBilKM+ecwY
-        UaFvQCB9wskUMbYLlUxDwu01GB3QjA5JRkEiGF0cE9eDaIOQJmV98TIEXqSV8sJZ/cRpbuT+by7g
-        jAFFieby4/3tZb5m45M03jOuQMbXzzQOnyFCNim4xXkCj/htg4MhzcGI5AAk8lRB0sU5kLK+OBiV
-        Z4NbwXavnqG2fKjFF2LxBbRBNeM35tY/+WGcHFkuM4Mo93epC1W0WQ6albq97wbCIxphm0QYJALh
-        zyKMAK8gLEtGBGh9SF9424B33RgKe6Q60RXYk2oPwdem8R2T+IJE4LtidgMwjmOrivvCdQy4ng2h
-        mOp199bMEM80sFnsPQWez/bmwZLDZ+jcCs4xDeeEhBMkAs7X2OVdCQTKStQXjBOAsTLC/x3+i6c2
-        HVHdO3rfkmF2V1NRITohEbWnFKJcIkOsntbLNLNmQf269xZkXk9c2FP8tQXx4PKgZlq9Z4q0p0Rj
-        5/+GDtrIuVd/CwPpQicH6eB4qe/mMUwRe1TeixXN5YNua8A3klCOrUW8lp6rTDFWqfyLTe5mSmdG
-        eVAF/mJjVo+6+Y9ycLaIrUCPPnhTRqqgQwhZmHIJGULga1lZBjy0DB61GX2FDaI0rdn+T+zAJR4k
-        xPfKDiECNOCljE0XpzZZnHIJRRArz2ApxpodTVGvtSQKn3lLwv4AAAD//0KOMOzdU+xuIEZZNJhd
-        XJKYW4A7GkHlFeVRiWIKLCJx90lNcPZJwTK4IlIBPk9DTOQhVNMqwsD9Vqi9AAAAAP//tFrBcoMg
-        EP0Vj+3BU53Rc9Nj28kkRw4Zamx1xgZHTfz9wmpRcdeA0ZPKArvwHrC7iOmlRKx94KCYu9kaB7K+
-        7xoDRAesARmwgoQE6BMORjdPymizFVhdgHtH+3wF1n7gwGmn4AGgvnPBJ3FEMAh7y6SQ/huoaeEZ
-        FHSoHPqSf0umR/HSydTqsBkwXQldGfH6ilLIt6p3KjBJNyLp7e37QnpQi/0LbDADM6ZenhbSK4hM
-        SICEWkEqo8hLLuP2InVaRmjDrdYSJC/sTLCoxfQ3vrDW2AFVSMKlZztZW3TKIyBTHiChEPQO/JwJ
-        7/Va1+JSOWFINN0KRUiV2BphVY+NynA0RWH8xLMAzVKp+Wq1TBClsy4BmXUBCYnoMcllifeeVbX3
-        tONVLNVffp7dsL3XyVYoQybH3RzHFmwkjbV0jgN+k9WpH6fZaPwL6KDVVWDEhBEzWaOQZISS2DHi
-        45rX2S4VWZw8wgm0m61YEVqwAjXIuc2YGb9KXuSJF0OdiiCI6QSvsWmAaoIhIc2QiGSIktgx5AiX
-        g+ZUulME72crjkQWHMEtcm/E3kpRnEVzwfmwBv4E9BEJ/csA+pE2eAOdp1N3++ib/8Ps23JP3NS9
-        QdKoOLytALD/AQAA///EWz1WwzAMvkovYBZvjLCylQdDpzT9AZrUvCZQOA/34UzEshzZteQ+SvyY
-        GkuuJX1WZFuK42mXOxeaWw1zK4nlZiDdhA27qZUy++ZTOZ6CvJsC+E5R1hmUxcQ9cMQX7PZpXe9u
-        zMdawPTMP0oBKyTrI9k59gIel/aRfxWKhcZ6FJzMXpC2T85t6XGt7FmNBHLocKc25rD2bnow05ng
-        W6j/AzZLKO9EcZp7JUa1HYF0PprDrjH2FXRaUxv1vjPb2eNAzKqeuDd2OeffnMqnrkgajUZ4EpkB
-        UQIG8IaEFDQFPvCc3TvaL4xJp4GzJZIIP5x1YafRHiKSRTb52b26ArCzKKSgRZCLnSNNtuhyzyKZ
-        nDFpxYr6y6FZLIgABy2bvy3b534IvLONObRCNE47lQrAUPY4FZeF5Hzg7K6GGGJHqlRb7avteuWW
-        ue4ahledF+fIqt6g38RhNKhs4LZhxJfaFESR8DdnYaHy0jhYSJMwgAJJdhSxMAOcMT7V9uPtjJec
-        9CjlIlBoiWRxQEzoHw3IyjuHXC3RYrUEOD7AmL5qcuDGHUphCzWRUFRhaHsrKo+sXObQWkTWchDZ
-        4GIcAytzbW4yTP3YC/9gwUWgNb89nGI7+HJslb/PmaAZFCOijx7iFZBlIZ7fX65KWXA15JBJl0BG
-        SdlVxGwwcNA0fzGG9RRiTu4o6BOQ0SUx+PQ/VSst52G1mIcFDmLpTkl+E8jgGXcohWmQP/Wigtal
-        eYsfAAAA//8iIXSxj1sY4x7UNEYa1CQ4bgFSh97oQAwIQGSxhD0OlbSKBPBwJVY7sYU6hWMVuAcD
-        jXAOFxsBAAAA///MXMFOwzAM/ZX+wDjkuBtCmuCENHZDOxTUbUXQVmmFxt/jOG6dNHYrpEXigLTa
-        7Ry/1ybuw1kgFx9Ke64GJ6ZYR5uA3uyMTKgZRC2KJaG10szTtVv423g3LbRvZe8arCqnegUZEIBm
-        AUBVTUVPDGDVKCpp5M8FHipkQaRbQxeOfgROV8mMqpKhh4B7hjVsqQSM/LmAQwUsiCQB94dVZ60A
-        bCESYSvXfyZQr3jHPlHnIU3MhOfe2b9vsENfxCuJigYXToIsaLOaCpjZN8RaEbb+TymGFsrOaUXF
-        nmwZ8uOQUj5pOcbnB4mUA1zIUh0fj0mgwebS63w8K9/FPBjOgUycAa40QBSsO+9UDPhUBAffdmgs
-        hmVmkgeVTlljRspFGE0seoU+zm64AI1NWbs9hj6t0EL5PH3BY5uJoSPPmK5xOfjVDT6mYWCLda6H
-        maPRJ9eNKd410oM8Xq3P/6oUhx7K8KWD4kapOSZfrnnfC28+ipT3XC3+6NPKuPu51v0dvJVVzaXt
-        usriSrA9XzZ9PPxxbtebhY2qSaGHENt9wksg0iZAxs5cmKESxWHo03/8H5DR9Smj6lPoIaRfHx7v
-        94ej71JuT8Wutv1QwFTXtU2vvOGtXnNzXlYjLp+APfPOfEKzJTPLNsbIjCZN1DKH1XW4g/HbAd5h
-        thhjDBGVoiNnuvJlVOULPTPOUK6pm2L6kYcFrpJzs3GURJIdvg1+Ogy4UCS09T2XEQ2ONihT43RH
-        BuY7Vn8BAAD//8ScTVODMBCG/wrjnUMcT17Vu+PHD3AoB7QzILXWny/ZbJIN7EsBm/FWsqGbPOTr
-        XUgEZxgEIYsf0b/sCXCPbePOpVC4j3JcnDazojDIyJe8/J8g0zWOghjIlywJ385WoRDbzCDnSc5M
-        vI3gPfK5HDCYTd8Pp0G4D/9c0j9PGq2ZgQoDIGRhqO7tbdXuaT+bwjLNkAshhT+kK43cNFZ0hpyL
-        HKVl9+Bw4MPAwAdZGJw7CLGg44dUcGmGXODcx0HClQZufpTUQh/h2McUGg56GBj0IAtDe3pDtNiS
-        CxMFOsjHQj6gVQ2r233905a9LK6nI4IXx85O8lHgxGsm8RoSvNsLCpzojX+tEjj+bqEcG+XIsyAi
-        dSPXM5zhpozD22qsSssrXwKxwVgtmAZhGt5Qb408dvWh6hu/kHcY0jSu/X2SiOu9tXVLp1rNwogZ
-        aibvwJ0ZKliy+M5cfx4HODNvfUY5cnVuUrOJL5XFjoe4uu9dXjLAcVEcInH73ZWuOYTsvs9jUWug
-        qCULQ3zomqogXCpBac6Fj4RtdKSyWzPzDmOk3S9c0k7GCTCsTQ3UpmSRwObETZohFzT6dkK60rDp
-        Wv8MNl2dGKwPDdSHZJHc7vA6L7HnokYbO4UnDdqmtqav8bCiMzeQmbVIZniFJ825iNH2vehIA7Zq
-        9eJ6piyzhyV219npb6ht9eEeRJznRSIjerGCXST7YiyY4/4QAR+VJZm3Qzp++PD7ELJwzZ5/AQAA
-        //8CzZcqQMdqsMQ+ijytoh9yRBKyTQjOAB36YIh7sYgBzoAFy0AD1hl87LwCtPbFErKoCqgftAAA
-        AAD//8Rdy26DMBD8lf5AJPcTKvVYqZfeerIimiCFBPG4VOq/Fy+2u2vvUEetxSWJdxfWjAcMg7Uh
-        aA1BK1Ox1m6LRcwGvFAmIY+Ed2hHcNmSAbXgJVFEpmKt/eDFgomBggl5Engbu74T2QA4hNSCmEST
-        NJlo7wczk1fG5jiLovTMEK613vLw4orisQ4VTCOFmF1ozxoKoTtrBJtNYj8xZaBURB5JGVqAszGh
-        aGG1qEOykZYws+1cmcYwyclOkz2effm+FXVh8nA/cdsdRCq8H2E59bv+9I2f6GMkF7NiekFRjTyS
-        Xgvm/aVxJ/TvHMtjaxGNhDeYVXfsTTmm441z11n+vyyxHa5c0XAH0wohDMk0CHJlJ0RjNkFVhzz+
-        gJ5/ypLqFGJ1SyvyhjQdnkoDQXnyUSlQVnF1cXsM83KrBus8Buo85PGwvjW20/H0nlpAkrrjc7iv
-        d/ehn1aT7AnGE55SMfog9hVAfFwMt+tHe5pX5F3uPyeho//CwwNVJfL44XkdTvbaflKvgK6UhtQa
-        MFKWZDJtsNJZhsmbN7YxHk+ub7KND3zrTIYyWIYyUIYiT5ic+35wi8IByNz97wDzncffsjS8W1nz
-        DQAA//8Cn3kB1FcEOvFCBxYtuBYgoEUDSB/uMCcmeYOdADIGe/fbAPeglgHOQS2wDDQGBvL4eAPw
-        cBb68fED1klBGvJKzSvLLMrPQ2lcoopBg88VRRDmJupV+siWYgsOzIofWQfCQymlqHcZIvhQj7iU
-        pqI3/qjnixTwNSMwO7H5A2o1YmIKqhYpdefnokQHgg/1gTNcgAQPENvKh9mGze1QuWLdgsR0FE/A
-        NNXWxgIAAAD//wMADdrZt2VyAAA=
+      string: "[{\"id\":\"statuscategorychangedate\",\"key\":\"statuscategorychangedate\",\"name\":\"Status
+        Category Changed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"statusCategoryChangedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"statuscategorychangedate\"}},{\"id\":\"fixVersions\",\"key\":\"fixVersions\",\"name\":\"Fix
+        versions\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"fixVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"fixVersions\"}},{\"id\":\"statusCategory\",\"key\":\"statusCategory\",\"name\":\"Status
+        Category\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"statusCategory\"],\"schema\":{\"type\":\"statusCategory\",\"system\":\"statusCategory\"}},{\"id\":\"parent\",\"key\":\"parent\",\"name\":\"Parent\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"parent\"]},{\"id\":\"resolution\",\"key\":\"resolution\",\"name\":\"Resolution\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolution\"],\"schema\":{\"type\":\"resolution\",\"system\":\"resolution\"}},{\"id\":\"lastViewed\",\"key\":\"lastViewed\",\"name\":\"Last
+        Viewed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"lastViewed\"],\"schema\":{\"type\":\"datetime\",\"system\":\"lastViewed\"}},{\"id\":\"priority\",\"key\":\"priority\",\"name\":\"Priority\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"priority\"],\"schema\":{\"type\":\"priority\",\"system\":\"priority\"}},{\"id\":\"labels\",\"key\":\"labels\",\"name\":\"Labels\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"labels\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"system\":\"labels\"}},{\"id\":\"timeestimate\",\"key\":\"timeestimate\",\"name\":\"Remaining
+        Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"remainingEstimate\",\"timeestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeestimate\"}},{\"id\":\"aggregatetimeoriginalestimate\",\"key\":\"aggregatetimeoriginalestimate\",\"name\":\"\u03A3
+        Original Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeoriginalestimate\"}},{\"id\":\"versions\",\"key\":\"versions\",\"name\":\"Affects
+        versions\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectedVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"versions\"}},{\"id\":\"issuelinks\",\"key\":\"issuelinks\",\"name\":\"Linked
+        Issues\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issueLink\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"issuelinks\"}},{\"id\":\"assignee\",\"key\":\"assignee\",\"name\":\"Assignee\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"assignee\"],\"schema\":{\"type\":\"user\",\"system\":\"assignee\"}},{\"id\":\"status\",\"key\":\"status\",\"name\":\"Status\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"status\"],\"schema\":{\"type\":\"status\",\"system\":\"status\"}},{\"id\":\"components\",\"key\":\"components\",\"name\":\"Components\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"component\"],\"schema\":{\"type\":\"array\",\"items\":\"component\",\"system\":\"components\"}},{\"id\":\"issuekey\",\"key\":\"issuekey\",\"name\":\"Key\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"id\",\"issue\",\"issuekey\",\"key\"]},{\"id\":\"customfield_10050\",\"key\":\"customfield_10050\",\"name\":\"DefectDojo
+        Custom URL Field\",\"untranslatedName\":\"DefectDojo Custom URL Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10050]\",\"DefectDojo
+        Custom URL Field\",\"DefectDojo Custom URL Field[URL Field]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":10050}},{\"id\":\"customfield_10051\",\"key\":\"customfield_10051\",\"name\":\"DefectDojo
+        Custom User Picker Field\",\"untranslatedName\":\"DefectDojo Custom User Picker
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10051]\",\"DefectDojo
+        Custom User Picker Field\",\"DefectDojo Custom User Picker Field[User Picker
+        (single user)]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":10051}},{\"id\":\"customfield_10052\",\"key\":\"customfield_10052\",\"name\":\"Impact\",\"untranslatedName\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10052]\",\"Impact\",\"Impact[Short
+        text]\"],\"scope\":{\"type\":\"PROJECT\",\"project\":{\"id\":\"10020\"}},\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":10052}},{\"id\":\"customfield_10053\",\"key\":\"customfield_10053\",\"name\":\"Design\",\"untranslatedName\":\"Design\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10053]\",\"Design\"],\"schema\":{\"type\":\"array\",\"items\":\"design.field.name\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:designcf\",\"customId\":10053}},{\"id\":\"customfield_10054\",\"key\":\"customfield_10054\",\"name\":\"Vulnerability\",\"untranslatedName\":\"Vulnerability\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10054]\",\"Vulnerability\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:vulnerabilitycf\",\"customId\":10054}},{\"id\":\"customfield_10055\",\"key\":\"customfield_10055\",\"name\":\"Sentiment\",\"untranslatedName\":\"Sentiment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10055]\",\"Sentiment\"],\"schema\":{\"type\":\"array\",\"items\":\"sd-sentiment\",\"custom\":\"com.atlassian.servicedesk.sentiment:sd-sentiment\",\"customId\":10055}},{\"id\":\"customfield_10056\",\"key\":\"customfield_10056\",\"name\":\"Goals\",\"untranslatedName\":\"Goals\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10056]\",\"Goals\",\"Goals[Goals]\"],\"schema\":{\"type\":\"array\",\"items\":\"Goals\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:goals\",\"customId\":10056}},{\"id\":\"customfield_10049\",\"key\":\"customfield_10049\",\"name\":\"DefectDojo
+        Custom Short Text Field\",\"untranslatedName\":\"DefectDojo Custom Short Text
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10049]\",\"DefectDojo
+        Custom Short Text Field\",\"DefectDojo Custom Short Text Field[Short text]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":10049}},{\"id\":\"aggregatetimeestimate\",\"key\":\"aggregatetimeestimate\",\"name\":\"\u03A3
+        Remaining Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeestimate\"}},{\"id\":\"creator\",\"key\":\"creator\",\"name\":\"Creator\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"creator\"],\"schema\":{\"type\":\"user\",\"system\":\"creator\"}},{\"id\":\"subtasks\",\"key\":\"subtasks\",\"name\":\"Sub-tasks\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"subtasks\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"subtasks\"}},{\"id\":\"customfield_10040\",\"key\":\"customfield_10040\",\"name\":\"DefectDojo
+        Custom DatePicker\",\"untranslatedName\":\"DefectDojo Custom DatePicker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10040]\",\"DefectDojo
+        Custom DatePicker\",\"DefectDojo Custom DatePicker[Date]\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":10040}},{\"id\":\"customfield_10041\",\"key\":\"customfield_10041\",\"name\":\"DefectDojo
+        Customer Date Time Picker\",\"untranslatedName\":\"DefectDojo Customer Date
+        Time Picker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10041]\",\"DefectDojo
+        Customer Date Time Picker\",\"DefectDojo Customer Date Time Picker[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10041}},{\"id\":\"customfield_10042\",\"key\":\"customfield_10042\",\"name\":\"DefectDojo
+        Custom Labels\",\"untranslatedName\":\"DefectDojo Custom Labels\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10042]\",\"DefectDojo
+        Custom Labels\",\"DefectDojo Custom Labels[Labels]\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":10042}},{\"id\":\"reporter\",\"key\":\"reporter\",\"name\":\"Reporter\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"reporter\"],\"schema\":{\"type\":\"user\",\"system\":\"reporter\"}},{\"id\":\"customfield_10043\",\"key\":\"customfield_10043\",\"name\":\"DefectDojo
+        Custom Number Field\",\"untranslatedName\":\"DefectDojo Custom Number Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10043]\",\"DefectDojo
+        Custom Number Field\",\"DefectDojo Custom Number Field[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10043}},{\"id\":\"aggregateprogress\",\"key\":\"aggregateprogress\",\"name\":\"\u03A3
+        Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"progress\",\"system\":\"aggregateprogress\"}},{\"id\":\"customfield_10044\",\"key\":\"customfield_10044\",\"name\":\"DefectDojo
+        Customer Paragraph Field\",\"untranslatedName\":\"DefectDojo Customer Paragraph
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10044]\",\"DefectDojo
+        Customer Paragraph Field\",\"DefectDojo Customer Paragraph Field[Paragraph]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":10044}},{\"id\":\"customfield_10045\",\"key\":\"customfield_10045\",\"name\":\"DefectDojo
+        Custom Radio Buttons Field\",\"untranslatedName\":\"DefectDojo Custom Radio
+        Buttons Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10045]\",\"DefectDojo
+        Custom Radio Buttons Field\",\"DefectDojo Custom Radio Buttons Field[Radio
+        Buttons]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":10045}},{\"id\":\"customfield_10046\",\"key\":\"customfield_10046\",\"name\":\"DefectDojo
+        Custom Select List (Cascading) Field\",\"untranslatedName\":\"DefectDojo Custom
+        Select List (Cascading) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10046]\",\"DefectDojo
+        Custom Select List (Cascading) Field\",\"DefectDojo Custom Select List (Cascading)
+        Field[Select List (cascading)]\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":10046}},{\"id\":\"customfield_10047\",\"key\":\"customfield_10047\",\"name\":\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"untranslatedName\":\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10047]\",\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"DefectDojo Custom Select List (MultiChoice)
+        Field[Select List (multiple choices)]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":10047}},{\"id\":\"customfield_10048\",\"key\":\"customfield_10048\",\"name\":\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"untranslatedName\":\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10048]\",\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"DefectDojo Custom Select List
+        (SingleChoice) Field[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10048}},{\"id\":\"customfield_10038\",\"key\":\"com.atlassian.atlas.jira__project-status\",\"name\":\"Project
+        overview status\",\"untranslatedName\":\"Project overview status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10038]\",\"Project
+        overview status\"],\"schema\":{\"type\":\"string\",\"custom\":\"read-only-string-issue-field\",\"customId\":10038}},{\"id\":\"customfield_10039\",\"key\":\"customfield_10039\",\"name\":\"DefectDojo
+        Custom CheckBoxes\",\"untranslatedName\":\"DefectDojo Custom CheckBoxes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10039]\",\"DefectDojo
+        Custom CheckBoxes\",\"DefectDojo Custom CheckBoxes[Checkboxes]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":10039}},{\"id\":\"progress\",\"key\":\"progress\",\"name\":\"Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"progress\"],\"schema\":{\"type\":\"progress\",\"system\":\"progress\"}},{\"id\":\"votes\",\"key\":\"votes\",\"name\":\"Votes\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"votes\"],\"schema\":{\"type\":\"votes\",\"system\":\"votes\"}},{\"id\":\"worklog\",\"key\":\"worklog\",\"name\":\"Log
+        Work\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"array\",\"items\":\"worklog\",\"system\":\"worklog\"}},{\"id\":\"issuetype\",\"key\":\"issuetype\",\"name\":\"Issue
+        Type\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issuetype\",\"type\"],\"schema\":{\"type\":\"issuetype\",\"system\":\"issuetype\"}},{\"id\":\"timespent\",\"key\":\"timespent\",\"name\":\"Time
+        Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"timespent\"],\"schema\":{\"type\":\"number\",\"system\":\"timespent\"}},{\"id\":\"customfield_10030\",\"key\":\"customfield_10030\",\"name\":\"Submitted
+        forms\",\"untranslatedName\":\"Submitted forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10030]\",\"Submitted
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-submitted-field-cftype\",\"customId\":10030}},{\"id\":\"project\",\"key\":\"project\",\"name\":\"Project\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"project\"],\"schema\":{\"type\":\"project\",\"system\":\"project\"}},{\"id\":\"customfield_10031\",\"key\":\"customfield_10031\",\"name\":\"Locked
+        forms\",\"untranslatedName\":\"Locked forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10031]\",\"Locked
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-locked-field-cftype\",\"customId\":10031}},{\"id\":\"customfield_10032\",\"key\":\"customfield_10032\",\"name\":\"Total
+        forms\",\"untranslatedName\":\"Total forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10032]\",\"Total
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-total-field-cftype\",\"customId\":10032}},{\"id\":\"customfield_10033\",\"key\":\"customfield_10033\",\"name\":\"Category\",\"untranslatedName\":\"Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Category[Category]\",\"cf[10033]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:jwm-category\",\"customId\":10033}},{\"id\":\"aggregatetimespent\",\"key\":\"aggregatetimespent\",\"name\":\"\u03A3
+        Time Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimespent\"}},{\"id\":\"customfield_10035\",\"key\":\"customfield_10035\",\"name\":\"Version\",\"untranslatedName\":\"Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10035]\",\"Version\",\"Version[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10035}},{\"id\":\"customfield_10036\",\"key\":\"customfield_10036\",\"name\":\"Defect
+        Type\",\"untranslatedName\":\"Defect Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10036]\",\"Defect
+        Type\",\"Defect Type[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10036}},{\"id\":\"customfield_10037\",\"key\":\"com.atlassian.atlas.jira__project-key\",\"name\":\"Project
+        overview key\",\"untranslatedName\":\"Project overview key\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10037]\",\"Project
+        overview key\"],\"schema\":{\"type\":\"string\",\"custom\":\"read-only-string-issue-field\",\"customId\":10037}},{\"id\":\"customfield_10027\",\"key\":\"customfield_10027\",\"name\":\"Target
+        start\",\"untranslatedName\":\"Target start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10027]\",\"Target
+        start\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-start\",\"customId\":10027}},{\"id\":\"customfield_10028\",\"key\":\"customfield_10028\",\"name\":\"Target
+        end\",\"untranslatedName\":\"Target end\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10028]\",\"Target
+        end\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-end\",\"customId\":10028}},{\"id\":\"customfield_10029\",\"key\":\"customfield_10029\",\"name\":\"Open
+        forms\",\"untranslatedName\":\"Open forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10029]\",\"Open
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-open-field-cftype\",\"customId\":10029}},{\"id\":\"resolutiondate\",\"key\":\"resolutiondate\",\"name\":\"Resolved\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolutiondate\",\"resolved\"],\"schema\":{\"type\":\"datetime\",\"system\":\"resolutiondate\"}},{\"id\":\"workratio\",\"key\":\"workratio\",\"name\":\"Work
+        Ratio\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"workratio\"],\"schema\":{\"type\":\"number\",\"system\":\"workratio\"}},{\"id\":\"watches\",\"key\":\"watches\",\"name\":\"Watchers\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"watchers\"],\"schema\":{\"type\":\"watches\",\"system\":\"watches\"}},{\"id\":\"issuerestriction\",\"key\":\"issuerestriction\",\"name\":\"Restrict
+        to\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"issuerestriction\",\"system\":\"issuerestriction\"}},{\"id\":\"thumbnail\",\"key\":\"thumbnail\",\"name\":\"Images\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[]},{\"id\":\"created\",\"key\":\"created\",\"name\":\"Created\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"created\",\"createdDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"created\"}},{\"id\":\"customfield_10020\",\"key\":\"customfield_10020\",\"name\":\"Sprint\",\"untranslatedName\":\"Sprint\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10020]\",\"Sprint\"],\"schema\":{\"type\":\"array\",\"items\":\"json\",\"custom\":\"com.pyxis.greenhopper.jira:gh-sprint\",\"customId\":10020}},{\"id\":\"customfield_10021\",\"key\":\"customfield_10021\",\"name\":\"Flagged\",\"untranslatedName\":\"Flagged\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10021]\",\"Flagged\",\"Flagged[Checkboxes]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":10021}},{\"id\":\"customfield_10022\",\"key\":\"customfield_10022\",\"name\":\"[CHART]
+        Date of First Response\",\"untranslatedName\":\"[CHART] Date of First Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[CHART]
+        Date of First Response\",\"[CHART] Date of First Response[Date of first response]\",\"cf[10022]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.ext.charting:firstresponsedate\",\"customId\":10022}},{\"id\":\"customfield_10023\",\"key\":\"customfield_10023\",\"name\":\"[CHART]
+        Time in Status\",\"untranslatedName\":\"[CHART] Time in Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[CHART]
+        Time in Status\",\"[CHART] Time in Status[Time in Status]\",\"cf[10023]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.ext.charting:timeinstatus\",\"customId\":10023}},{\"id\":\"customfield_10026\",\"key\":\"customfield_10026\",\"name\":\"Story
+        Points\",\"untranslatedName\":\"Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10026]\",\"Story
+        Points\",\"Story Points[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10026}},{\"id\":\"customfield_10016\",\"key\":\"customfield_10016\",\"name\":\"Story
+        point estimate\",\"untranslatedName\":\"Story point estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10016]\",\"Story
+        point estimate\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.pyxis.greenhopper.jira:jsw-story-points\",\"customId\":10016}},{\"id\":\"customfield_10017\",\"key\":\"customfield_10017\",\"name\":\"Issue
+        color\",\"untranslatedName\":\"Issue color\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10017]\",\"Issue
+        color\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:jsw-issue-color\",\"customId\":10017}},{\"id\":\"customfield_10018\",\"key\":\"customfield_10018\",\"name\":\"Parent
+        Link\",\"untranslatedName\":\"Parent Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10018]\",\"Parent
+        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-parent\",\"customId\":10018}},{\"id\":\"customfield_10019\",\"key\":\"customfield_10019\",\"name\":\"Rank\",\"untranslatedName\":\"Rank\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10019]\",\"Rank\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-lexo-rank\",\"customId\":10019}},{\"id\":\"updated\",\"key\":\"updated\",\"name\":\"Updated\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"updated\",\"updatedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"updated\"}},{\"id\":\"timeoriginalestimate\",\"key\":\"timeoriginalestimate\",\"name\":\"Original
+        estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"originalEstimate\",\"timeoriginalestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeoriginalestimate\"}},{\"id\":\"description\",\"key\":\"description\",\"name\":\"Description\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"description\"],\"schema\":{\"type\":\"string\",\"system\":\"description\"}},{\"id\":\"customfield_10010\",\"key\":\"customfield_10010\",\"name\":\"Request
+        Type\",\"untranslatedName\":\"Request Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10010]\",\"Request
+        Type\"],\"schema\":{\"type\":\"sd-customerrequesttype\",\"custom\":\"com.atlassian.servicedesk:vp-origin\",\"customId\":10010}},{\"id\":\"customfield_10011\",\"key\":\"customfield_10011\",\"name\":\"Epic
+        Name\",\"untranslatedName\":\"Epic Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10011]\",\"Epic
+        Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-label\",\"customId\":10011}},{\"id\":\"customfield_10012\",\"key\":\"customfield_10012\",\"name\":\"Epic
+        Status\",\"untranslatedName\":\"Epic Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10012]\",\"Epic
+        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-status\",\"customId\":10012}},{\"id\":\"customfield_10013\",\"key\":\"customfield_10013\",\"name\":\"Epic
+        Color\",\"untranslatedName\":\"Epic Color\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10013]\",\"Epic
+        Color\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-color\",\"customId\":10013}},{\"id\":\"customfield_10014\",\"key\":\"customfield_10014\",\"name\":\"Epic
+        Link\",\"untranslatedName\":\"Epic Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10014]\",\"Epic
+        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-link\",\"customId\":10014}},{\"id\":\"timetracking\",\"key\":\"timetracking\",\"name\":\"Time
+        tracking\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"timetracking\",\"system\":\"timetracking\"}},{\"id\":\"customfield_10015\",\"key\":\"customfield_10015\",\"name\":\"Start
+        date\",\"untranslatedName\":\"Start date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10015]\",\"Start
+        date\",\"Start date[Date]\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":10015}},{\"id\":\"customfield_10005\",\"key\":\"customfield_10005\",\"name\":\"Change
+        type\",\"untranslatedName\":\"Change type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10005]\",\"Change
+        type\",\"Change type[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10005}},{\"id\":\"customfield_10006\",\"key\":\"customfield_10006\",\"name\":\"Change
+        risk\",\"untranslatedName\":\"Change risk\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10006]\",\"Change
+        risk\",\"Change risk[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10006}},{\"id\":\"security\",\"key\":\"security\",\"name\":\"Security
+        Level\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"level\"],\"schema\":{\"type\":\"securitylevel\",\"system\":\"security\"}},{\"id\":\"customfield_10007\",\"key\":\"customfield_10007\",\"name\":\"Change
+        reason\",\"untranslatedName\":\"Change reason\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10007]\",\"Change
+        reason\",\"Change reason[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10007}},{\"id\":\"customfield_10008\",\"key\":\"customfield_10008\",\"name\":\"Change
+        start date\",\"untranslatedName\":\"Change start date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10008]\",\"Change
+        start date\",\"Change start date[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10008}},{\"id\":\"attachment\",\"key\":\"attachment\",\"name\":\"Attachment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"attachments\"],\"schema\":{\"type\":\"array\",\"items\":\"attachment\",\"system\":\"attachment\"}},{\"id\":\"customfield_10009\",\"key\":\"customfield_10009\",\"name\":\"Change
+        completion date\",\"untranslatedName\":\"Change completion date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10009]\",\"Change
+        completion date\",\"Change completion date[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10009}},{\"id\":\"summary\",\"key\":\"summary\",\"name\":\"Summary\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"summary\"],\"schema\":{\"type\":\"string\",\"system\":\"summary\"}},{\"id\":\"customfield_10000\",\"key\":\"customfield_10000\",\"name\":\"Development\",\"untranslatedName\":\"development\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10000]\",\"development\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:devsummarycf\",\"customId\":10000}},{\"id\":\"customfield_10001\",\"key\":\"customfield_10001\",\"name\":\"Team\",\"untranslatedName\":\"Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10001]\",\"Team\",\"Team[Team]\"],\"schema\":{\"type\":\"team\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team\",\"customId\":10001,\"configuration\":{\"com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team\":true}}},{\"id\":\"customfield_10002\",\"key\":\"customfield_10002\",\"name\":\"Organizations\",\"untranslatedName\":\"Organizations\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10002]\",\"Organizations\"],\"schema\":{\"type\":\"array\",\"items\":\"sd-customerorganization\",\"custom\":\"com.atlassian.servicedesk:sd-customer-organizations\",\"customId\":10002}},{\"id\":\"customfield_10003\",\"key\":\"customfield_10003\",\"name\":\"Approvers\",\"untranslatedName\":\"Approvers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approvers\",\"Approvers[User
+        Picker (multiple users)]\",\"cf[10003]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":10003}},{\"id\":\"customfield_10004\",\"key\":\"customfield_10004\",\"name\":\"Impact\",\"untranslatedName\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10004]\",\"Impact\",\"Impact[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10004}},{\"id\":\"environment\",\"key\":\"environment\",\"name\":\"Environment\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"environment\"],\"schema\":{\"type\":\"string\",\"system\":\"environment\"}},{\"id\":\"duedate\",\"key\":\"duedate\",\"name\":\"Due
+        date\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"due\",\"duedate\"],\"schema\":{\"type\":\"date\",\"system\":\"duedate\"}},{\"id\":\"comment\",\"key\":\"comment\",\"name\":\"Comment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"comment\"],\"schema\":{\"type\":\"comments-page\",\"system\":\"comment\"}}]"
     headers:
       Atl-Request-Id:
-      - d6ed07fd-4a02-4f87-b6aa-be078e2352fe
+      - a415949e-5bb0-45fe-93c6-64a4e7a14d46
       Atl-Traceid:
-      - d6ed07fd4a024f87b6aabe078e2352fe
+      - a415949e5bb045fe93c664a4e7a14d46
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:14 GMT
+      - Wed, 30 Apr 2025 16:24:31 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1734,7 +1899,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=240,atl-edge-internal;dur=15,atl-edge-upstream;dur=226,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=18,cdn-upstream-fbl;dur=313,atl-edge;dur=239,atl-edge-internal;dur=18,atl-edge-upstream;dur=222,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="gHJLczD53NCDNH-n8EyHzBVVp36dkbAUggSCbtW5xhKQsrhtad32WQ==",cdn-downstream-fbl;dur=317
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1743,10 +1908,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 452324c4cfd54555e3a2d8c074edaf78.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - gHJLczD53NCDNH-n8EyHzBVVp36dkbAUggSCbtW5xhKQsrhtad32WQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 6d01592ec71d5dd2e52ff8c9ee34d256
+      - 067ea7c9e084501f4058b3d624d41bfb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1770,64 +1943,48 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1825
+    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1840
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXW3PqNhD+Kxq/1uALhEOY6XTaHE4nbZpmEnL60OlkhL0YHWTJleQATfPfu+sL
-        IQQ6Az3Nm6WVtLdvv10/ebAquEq9kWdApWAg/SRAptZXPAfr22QOOfd1AYY7oZX1IRUuB8f9ZM5V
-        BlJn/iMYizJIb6EwYEG55mxSWqfzGT34EIVhFHYN/FmCdZN1ATeGJ04k4PmeIP3RYBAOcWFBznA5
-        d66woyBIYQaJS/UX3eVOcmsFV10FLkBNLuCFCCR39CmsLSFoX1nAGh+5nozvJp1oGJ/hVmWH9UZP
-        nkUDS5vgvUybde1Iiiu8EYfxWSeMOvH5JI5G/bNROOz2o/Nv0PiQLCUlDq2vnjnW0rg2ku4H+F4Y
-        b3xvFinYxIiCooe73zObcyl9lgrrhEocKwQkwPSMLbVZdOl2otW9kUdaUSpBOePygT9yx03wKGAZ
-        VGa9GNiIorAXDb+z4i/4NsfclzlqJWygygm3C0pYOXX0NZpxacH36ouX6Fd11/fmAtFjkvn6Ch4B
-        bQ2ffa/giDdHUdwk/8PbtPVPwUMT5QoK9OZW3ss854Y0LAEWcs1AZTyDnCzxG1ScmNj6cpVVwsnr
-        RB6XqJcA/8CTBRbYNkro8VrXRQPf/2RwWwNBC8W4zYGCJW4lWmpzXVszlSV0MsPXWwjQ7KP2nimf
-        Rmgj3KnWtNeD3nGxEjnmzwZ0w7aPCNyoodq1jxS8xthfWvhWwex5z1+7nCuC2E7UbjlPRcZKC4Yh
-        LZo1c3PumAJILXOaTYFNjV6AYqleqi67MIDJSdl0zX4ShrM7PXNLrBrWwQNMaceIipk2LAUJDo6k
-        g1eR2/hhAyhE8jpuY9wh1O2U+W5VR8+EAyewbRRVaasSucvb6QG9sBUURn9B006MfHN7f9y3WOTF
-        jXslHDUK6210Uxv6uTprm+CSnyIvpECD0x1Gw8BW7NAfrvrDI839F8ZtPdnwbb9irbi/Qvr7X7XU
-        rF71GFQYDVbR4D0UrlqNvXjVi99DY9O4CJ+7cIwO4TRuBTOx+lwPOJj93/94e7LXnuRZZiDDon1T
-        BOiAlmXNA/vVnR0SDA4JPhwQxAcFw0OC87d21uNQvUvDRjX+eaNOhEvucCo8tVHWvfllMAvq5wyV
-        ZfV5oUsKXETs/BttCJV5I2dKwPTho+4zZpyKs/Glpklv/+gWDuJ2dNt1ekNEu4JDkIg3kPhazY7G
-        m1Mpe6vZSb18zdhXmnp3RYl9anO7jmwQK/kUiNT2wJq4YG8YokP4ioYUjzm31DCuhFp8IslHKOjH
-        QiXrDZ3auV5Wss2O0mqMzYxPJdwCt1QmTwjG+su7ubr/8fL64eryYnx9N34Y397+eov+YY1ZDAge
-        mMyB3VQDJSO9TFimFY53yARC0qPUX6smemMgRyqourDt7mOECIvBC/8WYWhm05FXdzTMHQb/pSJe
-        VTqmIROKy91DzW9RE94K9xKta9aU1wybf3u6LKjk9uP4vDsYfmhx/N5j6j8AAAD//+xZbWvbSBD+
-        K/ulkIRIlm05foHSmiTl7kNoOPcukKSE9UqK1Eq7QruqzrQ//p5Z6WRHtlK4DyUHISE20uzszOzM
-        M89s+rRu0+1/RFOFynJMqtIcTvpJCwrPHWx3UQsYT8N5L7c/J58Sk4YnC3Z3y/Phgp0r9TUJ2U1i
-        YlUatgpFCWb3IeWPPyg6CE6qBE9jpc1i5s28QZTIAEA4GI1Hn63CCxs8+PVFMUqrxQn76Up2hD/H
-        dvkKpI0wCMuAFo2RF2XILuAoHl7xDRvNTxklY+vE+c0lXt3hwzkb+tZSOkdRhW6WmCJ0VfE4QBpz
-        OtoEfIvSfwBRNzZZau2u9fxFev6UXyWY7k6QrgsVlOjgl+1YNviE4NOeNkKwl/2mKseonijljYLR
-        ZzZgd3tDXs+qrcBgbBfeLq/ZSnDZI2+vG+Ze68+OB6uNNmGm4UGQqwRpdrKwz+3ZUKwynkidgK0j
-        ExEqHa8VL4I+iT39F9sMI81LJupEAupigMDsoEPDqiarDGBR15kVIbNOWRUnImZZyKWuhw+SaDTA
-        3XuJGYQLAVzF3PEt4axEqYhik9McAmSQyDg6UnfHoiuc8qO97yGDbuJQUmYx3upV0pBHsITcAntj
-        iYxUkdk1NL4ArTneagJLADUmoFMyDMox3qBXlGnAeFrxDbnIcm6tKzVymnHJdgyMOSxMXXYpNfnc
-        eljH4F5SEGg3ihEsaCzU/5pICnWJAB20dMfnHe//QBWi7yBk5H2TLlVVuariOrf1gPIL/3bzOLe5
-        jE0eoPOh2fuBG1Mk6xIp9XD08Wa5unZWVw5atK3SdpNcFSYsqA6OeJAl8pgdHf9AoqRGLZCG++xm
-        0rb4bnvroz1DGjaeXLx0BVqKSthoCoC+ZWbf93uo18dm/ZZpdle0bMMeluVWhwX72IfXx269ds8n
-        XbsL6jgILmJ7FWQ7w/au6GeITaEiEqqK/9jjiIy8Q90R8f09eDsJxrPpbD2ceuFYzD0xn4yi+TA6
-        wz6tEHZ4Riyk1FgGAfZAn0PTCzbvdwwBsJCuZ4faumZc9FErZuGqGaz8EFSPB0PfP5uK2XQynq/F
-        euph+4iH0Uy8C95aLW/GyzejD/it1zkZlw3MOk79SLuldioEwhm5BN1uXq7TRFCknJxzTYHCettJ
-        QBTx9RzF4eaSYt4dkF++xd0J++Vb3J3QX7rFgKIg0XnKNw0ZPEfqg8tEUSlEYguIcL0eJ2sguwUd
-        hOBlWag8HNwCe0S8rTS6IcLbtnRph+Yi7DCD9Pvw1e8bK/12rCwanH+FkV+WMK8w8issfoWRAzDS
-        hYE+xub7e/wF7jzWRfmdrrKb7x4sUYY3/2DraumjZF4fLnmjGuD+AQAA//9CNwjXuJABTg/gbLLB
-        fYauA1dbzhinBLyRl5pXllmUnwdpyEGEUkqhs7sQLlGhl58LMaEaxoQW92SUy0gT0/owc3WUchMr
-        glKLS3NABiPZDR42KSpxLIG4oyy/hHojrRDD4IYC7coAAAAA//9KLA7LB486gQfiaiFjvaCxHJCV
-        cIegutYIxblQDeDgqa2tBQAAAP//AwDenZgOUSAAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18175","self":"https://defectdojo.atlassian.net/rest/api/latest/issue/18175","key":"NTEST-1840","fields":{"statuscategorychangedate":"2025-04-30T18:24:24.572+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"parent":{"id":"18173","key":"NTEST-1839","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18173","fields":{"summary":"weekly
+        engagement","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},"issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1}}},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1840/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:24.264+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szb:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:26.079+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/242]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/242 (242)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/93]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":"NTEST-1839","timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1840/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18175/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - bab75e9e-a5fe-47ea-a26d-f5ab3c9c24d4
+      - f0f3413f-4ed7-4bac-958c-0f88c4b26d15
       Atl-Traceid:
-      - bab75e9ea5fe47eaa26df5ab3c9c24d4
+      - f0f3413f4ed74bac958c0f88c4b26d15
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 29 Jan 2025 20:45:15 GMT
+      - Wed, 30 Apr 2025 16:24:31 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1837,7 +1994,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=332,atl-edge-internal;dur=12,atl-edge-upstream;dur=320,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=321,atl-edge;dur=288,atl-edge-internal;dur=15,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="V3HDy13J7Li6R4hiLyawZyf2K7TOyokIpUw_sThNAswx4DM0zl2pew==",cdn-downstream-fbl;dur=324
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1846,10 +2003,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1b7fa09f50c08a88d619f90eef5ee94a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - V3HDy13J7Li6R4hiLyawZyf2K7TOyokIpUw_sThNAswx4DM0zl2pew==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f01a7f6b4b22ae7ed6cf29061a83ba29
+      - 2490bd8150b4255fe526320d6ef59121
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_enabled_no_epic_and_push_findings.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_engagement_epic_mapping_enabled_no_epic_and_push_findings.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2TtvvoDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCANd7gdNCnJm/e9K6fTFiUK39p3m3KvuXOKm9SgJxPSKtdrvv8HX+GwUwJbdB9r1P0Kjcfh
-        r0tW1kg9ohH4u+QOB6esCTAFoCmkkFSby8dq/VD/TDdj14SKlM8RmsAEXoITe233Xbiy3vfRttJ2
-        bEOoGZVuvyKkDAE2n5+aV9xHkAErEqAJLGvGyjwr8yAGuIAAh7wLf8ChVt05S6FmUNIi4GmW5d+s
-        6G6MtAHM6WwhOGCBUtBsjjyXMpcgJFtmxaKRsxzZTAI7E3gdDbdq4PGFKPmo/Z0VPLYPRJ8qguZ1
-        W5Hj+WFP1sTJ9X1Njp8AAAD//wMADzcVWiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:32.157+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 2d554bd8-aa48-451c-bc7e-85db47be12a4
+      - 0eabb628-169c-4772-adbb-27c5651adeb6
       Atl-Traceid:
-      - 2d554bd8aa48451cbc7e85db47be12a4
+      - 0eabb628169c4772adbb27c5651adeb6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:43 GMT
+      - Wed, 30 Apr 2025 16:24:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=147,atl-edge-internal;dur=17,atl-edge-upstream;dur=129,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=189,atl-edge;dur=157,atl-edge-internal;dur=15,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="JtmTv8z9anvfqf-huLNs3VdG4oGCpLXlv9AAVkaI2NEaTxvr-YUkPg==",cdn-downstream-fbl;dur=194
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JtmTv8z9anvfqf-huLNs3VdG4oGCpLXlv9AAVkaI2NEaTxvr-YUkPg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e4b903e5064401a156a40c481ad1586e
+      - e55afd2881afe3f291c2675b47b9dbe1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 1acd09f5-5e81-4c2d-afcc-a14bad6a273e
+      - 3dcbaee4-3644-4be3-a68c-df3639aba4d6
       Atl-Traceid:
-      - 1acd09f55e814c2dafcca14bad6a273e
+      - 3dcbaee436444be3a68cdf3639aba4d6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:43 GMT
+      - Wed, 30 Apr 2025 16:24:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=14,atl-edge-upstream;dur=281,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="NyphyzrQ_zatLJtxKMxIVaBaL5dxUGsw-RBZBJH3zTcDje5opgLJQQ==",cdn-downstream-fbl;dur=383,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=381,atl-edge;dur=295,atl-edge-internal;dur=16,atl-edge-upstream;dur=279,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f6567fa2210130239a3a2c737c9517ac.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - NyphyzrQ_zatLJtxKMxIVaBaL5dxUGsw-RBZBJH3zTcDje5opgLJQQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 662fa25a172c747f8dca4d01b88ded4c
+      - a75cddd7cce8c419f8afe3e068b05b30
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/244]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/244 (244)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/94]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1297'
+      - '1317'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16086","key":"NTEST-1602","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16086"}'
+      string: '{"id":"18179","key":"NTEST-1842","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18179"}'
     headers:
       Atl-Request-Id:
-      - eaf2bf3b-3564-4dfb-ae7c-d8a1b7a70b1b
+      - 4aa9e1ad-5284-4689-9b0e-29c95117f55f
       Atl-Traceid:
-      - eaf2bf3b35644dfbae7cd8a1b7a70b1b
+      - 4aa9e1ad528446899b0e29c95117f55f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:44 GMT
+      - Wed, 30 Apr 2025 16:24:33 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=621,atl-edge-internal;dur=13,atl-edge-upstream;dur=609,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="es53V5kXW031qAH73tq5CpX4-irKBHH5LRYKStywgY3zbHgczwrgDw==",cdn-downstream-fbl;dur=826,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=824,atl-edge;dur=750,atl-edge-internal;dur=18,atl-edge-upstream;dur=731,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5a3010bd9376613ba1249daca87b27a2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - es53V5kXW031qAH73tq5CpX4-irKBHH5LRYKStywgY3zbHgczwrgDw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 884f1dbdddf2365e6d9ae96ed5741933
+      - b1498f4688b2950048ba79013ded67ef
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1602
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1842
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW/0/jNhT/V6z8tLG2+dJQSqRputGysTGGoHDSMYRM8pr66tiZ7dB2d/e/79lp
-        2qOQO8G0UyWI/fy+f/zx++DBsqQi8xJPgchAQXbMgGe6I2gBuqPTGRS0I0tQ1DApdAcyZgowtJPO
-        qMiBy7zzAEqjDLILKBVoEGZ9Nq20kcXUGrwLgyAMegr+rkCbyaqEc0VTw1LwOh6z/sNBMBzgQgOf
-        4nJmTKkT389gCqnJ5HvZo4ZTrRkVPQHGR0/GpyXzI59pXYHfGJjDCvXPJuPLSRf3ItxyIWgv+eBp
-        jK3SKTWQS7Wqc8hwhRpREO13g7AbBpMoSML9JI57/UH8A8Yd2CCtE4OBOzOvDNLq+2jPRVWnvV5k
-        oFPFSls43H1DdEE575CMacNEakjJIAUip2Qh1bxntVMprhR/YRSVYLZdlN/RB2qo8h8YLHwX1jbA
-        tSgM+uHwJ83+gR8LbHtVoFcLC3Q5oXpue1XdG/uVTCnX0PFqxRPMy+l2vBlD4Kh0tjqFB8BYg08d
-        zzBEVoko8RJRYY7eDkz6QSMolXyPGb2y4GttV27XwKbcdvEZSLZZXQlmDBrQ3sa3Rerv7qyWU7Og
-        yuJVs6LkDAPOdjLHfjiUxcNlPHxhuF/oTJPJpi9xcIBhRPEyiv9fL3X3HRbRYThYhoNv4XDZeOxH
-        y370LTyuAf7p01M4hm04jdoE/UYwZcvrmhwRFje3CJM8V5Aj33z1Euw3AsxM8qrmheePDtoEBy2C
-        qFUwbBMcPg2nps1615KSeyG8pBvikhp8OGrCffnFrel8S+B+bU7Za+k+j2RlCxdaUn5rN5jIvcSo
-        CrB9aNRcY8ft5ayDc/asfcXSuo4fnuzZWFFZz2TFsxHTJaer9eW2kFCAyVr+eO6RCA77zSOxW7YN
-        le0K2kAVbUBVKiYVM6tXFrFR9+OXvRWsoDlo32roxgjDDS4XPf2Qb8nyVC4aUo29p9cm2lwCTu/B
-        0qLF/+5E0AbdsA2h4dDWY0b1uGTpKRPzYysZQWmnF5E2PXOdXDjZZkdIMcbhhd5zuACqaxyo9Zd3
-        fnr1y8nZ3enJ0fjscnw3vrj48wLzw1uqsSB4YDIDco78LwyxfgnTRAq+IsgljFujxEjyG1OUnCso
-        kExIpRGzvec4JcTr5AUfWRCUUiRe/SZi77D42zv1iCuwDTkTlO8eWs9e6/I6VHOMrqEb7GsuYHO6
-        Ku2lbcNxuH/Q4Lgek14JvVp58+4+nmxehsYt3H6m6RyHzQZyjfHa19F6nvtPATdDod/MZlEzJgiw
-        UE8ll+qsjuaeV9DNFXLEdiSSZCTrZssC24pAeR70+xtS+FJjd5U2hPG4nH+J7W9vwgyHvYTcvKNl
-        mJAjKecMyFtmkNUMuYS0UkCOOc0/2upgcbhMKZ9JbZJhMAz8KRMZUqkfxfGtMzhyxcO83ktiYZXs
-        ka9qku/wz/dO/RKHPstBqIZssQ5yVAEZYaK4+QddkTDoEAvGTRJHb8cousF/3UEYu0htH9MF9Apm
-        FPSkyn2EMbWtZTixWfj7eLQ3MwV3cdd2rq2dKzEXcvF5kc6VzCqcAcYix4tdYJv8CRbf+nQVwnjJ
-        r3LRNbKlSuXaQHRLfHKzAJgjC8DGWovW9oDfd4rv3pyTy5SKlvN2DvUP6z48/u1drrSBQmMGWSkZ
-        wmwvcfuuN7ZWBWVCMwM9RCKWSs/uJVVZ24kn9kdbhFnLb0gq/wUAAP//7Flta9swEP4rolBooXad
-        xFmSQelC6WAfykYLK5RCkGW5MYtl45e6pet/33OSoqVe3I0ySj8U8sGJpLvT+e655y46kIC6LJJS
-        sUrWrLVRVQMWKxNZCSLrgLXLVCxZJrmqsMjNDisB171WkWRcCOCqjNltylmDVBHlfQFgwj6lpCnI
-        /oZFZ3jLN7qpJIMul1JRZDHu5OboOXEjWELXAv9jqUryMtNnWF4SWnOsVgSWAOofUh2QYRCe1sxU
-        fcZXLb+nK7KCa+uaCjHNuGIbBqJjVHLls1NV0Z3dDY0PrhU5gbSRj2CBtbBam0gCqwYO2mrpxp03
-        bn+OLETdgcvo9jZc2rb185ZXhc4HpJ+884tloWMZShaQubC6F7wGzYkahNRi7+vl/OKbd3HmoUTr
-        LHVKirysZUl5sMfjLFX7bG//JwJlVecfEYZ/spuxK/Hd8tZHewZh34Kju4SJdQmw15yOOFlna+io
-        aGchcDK6C30sI3AsQ789Tba2b+zjxYEz5km17oI5XgAXS0p+UxGqJss4laudvyE1eZ3IZ16+sLYR
-        CTlGvhFl/hIfjePRdDKNBpNAjsQsELPxMJkNEpqbuE3Q8Mw2SSExj2PoQH1DsYvvP20YAkAhWc+2
-        wyZXfNRPvU3DlG3JQgmKx+NBGH6YiOlkPJpFIpoEUJ9wmUzFcXykpeyO5rvDz/iYc17GlYVXzzM/
-        VX5TeS0c4Q19gmy/aKJVKshTXsF5RY7CeV1BQBDxeIKk8AtFPu+21m/f4m5v/vYt7vb2b91iQFFs
-        GkNLAk8Q+uAwSdIIkeoEIjw3jagBsivQQGw8bcq8kIdXgBix/J1pNFvCqktd0mAnatuZY9iHq2Ff
-        Oxn2zShCh92lBf53fHm1SHrHl9ew+B1ftuBLFwYcIXP8BVbfmNx7oCG4fQ6gMK+5HeF3pfQyr15c
-        6qVkw+3I1zcPCvo4KAHC1oWgj4OO+k6MHMmT6jYtc2WInPkpbuz/R+brP3kvz4yEh/WjhfsXwO/G
-        X1+Ha7kHOxm/O5dVsyLBG7r1uKSs57Wx4zav/9+M1ghzQqEL7eL3XE+b1mNUmhLTDIdUOkOeWjt8
-        Yq49oN3z+Pj4CwAA//8DABfcOnSuHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18179","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18179","key":"NTEST-1842","fields":{"statuscategorychangedate":"2025-04-30T18:24:33.499+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1842/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:33.171+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szr:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:33.267+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/244]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/244 (244)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/94]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1842/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18179/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - fb690633-c424-44c7-a3bc-06ced1918ce5
+      - c248f949-fa73-4a20-a3e8-ed8fa2a0783c
       Atl-Traceid:
-      - fb690633c42444c7a3bc06ced1918ce5
+      - c248f949fa734a20a3e8ed8fa2a0783c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:44 GMT
+      - Wed, 30 Apr 2025 16:24:34 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=13,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=32,cdn-upstream-fbl;dur=401,atl-edge;dur=272,atl-edge-internal;dur=19,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="zN-NoGPBRSQ0WywjCE42QxdrpPkMlN0VOqtQYWZBsTfq3KMKcl-DWg==",cdn-downstream-fbl;dur=406
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 995d6494814d695ff2add6899f970080.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - zN-NoGPBRSQ0WywjCE42QxdrpPkMlN0VOqtQYWZBsTfq3KMKcl-DWg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 9ca055c17cf1295ba64aa147b8b535a2
+      - 767906c7f44a16b6544f620bbfeccf50
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16086
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18179
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeWQIYaSqoiS0tJRGEEBaipCZuZl447GntockZfnvvZ5H
-        spBkV1B1FQnG9n3f4+P75MAipyJxIkeBSEBBcsKAJ7olaAa6peMpZLQlc1DUMCl0CxJmMjC0FU+p
-        SIHLtPUISuMZJBeQK9AgTC0bF9rIbGIN3vue53sdBX8XoM14mcNI0diwGJyWw6x/v+f1e7jQwCe4
-        nBqT68h1E5hAbBL5UXao4VRrRkVHgHHRk3FpztzAZVoX4DYGZrBE/fPx8HLcxr0At8oQtBM9ORpj
-        K3RMDaRSLascElyhRuAF+23Pb/veOPAifz8Kw063F/6AcXs2SOvEYOClmXcGafVdtFdGVaVdLxLQ
-        sWK5LRzuHhGdUc5bJGHaMBEbkjOIgcgJmUs161jtWIorxd8YRSGYbRfl9/SRGqrcRwZztwxrHWB9
-        5Htdv/+TZv/Ajxm2vcjQq4UFuhxTPbO9Kh6M/YomlGtoOZXiKeZV6racKUPgqHi6PINHwFi955Zj
-        GCIrR5Q4kSgwR+cVTLrergO/OciV/IipvrMTtXbZh7KzTR/s4jP0rNO9EswYNKCdlW8L4d9LWS0n
-        Zk6VBbJmWc4ZBpy8Kgk2qoRf2F+E/TeG+4WWNZmsGhZ6BxhGEC6C8P/1UsGiBCk69HsLv/ctHC4a
-        j91g0Q2+hcca+c/Pm3AMGjhO2OK64kBs8u3dpmS3kaRpqiBFvvnqJdhvDjAByYuKF7aL9nYdHOw4
-        CHYe9HcdHG6GU9FmtWtJqXwhnKjt45IafDgqwn37/azofE3gbmVO2dtXfh7LwhbOt6R8YzeYSJ3I
-        qAKea5621hSLq6o9bezZyFBUT2XBkwHTOafL+sbiNoZlrhEa9hbX1VCAyVqa2PZIeIfd5pF4XbZd
-        VBasqOz1wQpUuWJSMbN8ZxEbdTd821vBMpqCdq2Gboww3OBy3tGP6ZoTz+S84c7Q2bwdwQrznD6A
-        Zb8tF8OSxtYy+LsQ6vdtPaZUD3MWnzExO7EnA8jt9CLipotlb+fl2WpHSDHE4YU+cLgAqitkqPrL
-        GZ1d/XJ6fn92ejw8vxzeDy8u/rzA/PCWaiwICoynQEZI88IQ65cwTaTgS4KUwbg1SowkvzFFyUhB
-        hpxBCo2Y7WyjDh+vk+N9Yp6XSxE51ZuIvcPir+/UC67ANqRMUP5aqJ696vKWOOcYXb22fU0FrKSL
-        3F7aXTj29w8aHFdj0juhVymvnteXk83b0LiG2880nuGw2UCuMV75Oq7nuf8UcDMUus1sFjTTgAAL
-        9Vhyqc6raB54Ae1UIWusRyJJBrJqtsywrQiU7aDfX5HClxr7WmlFGC/L+ZdY//bGzHDYi8jtB5r7
-        ETmWcsaA3DCDPGfIJcSFAnLCafrJVgeLw2VM+VRqE/W9vudOmEiQSt0gDO9Kg4OyeJjXR0ksrKI9
-        8lVN8h3++b5Uv8Shz3IQqiFb1EEOCiADTBQ3/6BL4nstYsG4SuL4ZohHt/iv3fPDMlLbx3gOnYwZ
-        BR2pUhdhTG1rGQ5mFv4uinamJuNl3JWda2vnSsyEnH9epJGSSYFP/VCkeLEzbJM7xuJbn2WFMF7y
-        q5y3jdxRpbw2ENwRl9zOAWbIArCytkNrLeB2S8UPRyNyGVOxQ96Om+5h1YeXv73LpTaQacwgySVD
-        mO1F5X7ZG1urjDKhmYEOIhFLpacPkqpkl8SG/cEaYdbyEYnlvwAAAP//7FlRS9xAEP4riyAomJi7
-        y/XuCmIPsdAHaVGoIMKxSTZe6N0mZBOjWP97v9nd28b0YosU8UHwIWZ3Z2cmM998M6cDCajLIiEk
-        U6JijY2qCrCoTGSliKwD1iyzeMnWgkuFRW52WAkw91pGgvE4Bq6KhN1mnNVIlbi8LwBM2CelMCXa
-        b2l0hq98o5tKUuhyKSRFFuNObo6eExZBEzILNI9lMs3LtT7D8pLQmmNVEVgCqH8IeUCKQXhWMcMD
-        GF81/J5MZAXX2tUKMc24ZC0F0TFKsfLZqVRks7PQ+OBakhPoNvIRNLAaqo2KJFDVcNBWTVs2t6w/
-        Rxai7sBlZL0Nl6Zp/LzhqtD5gPQTd36xLHQs45IFZC7s3QtegfhENUJqsff1cn7xzbs481CidZa6
-        S4q8rERJebDHk3Um99ne/k8EyqrKPyIM/2Q3Y1fiu+Wtj/YMwjb0VSUwXVM3ImPdrY4AdxaCvoXQ
-        cdTuCccy9EfSnGr7xj7WEfTx4sDd+aRad8EcH4DHS0p+UxFUvV5zKlc7f0Nq8jqRz7x8YW0jEnKM
-        fCPK/CU5Giej6WQaDSaBGMWzIJ6Nh+lskNLcxG3CDc9sExQS8yTBHahvKHbJ/aeWIgAUkvVs12ty
-        xUf91Ns0TNnOKxSgeDwZhOGHSTydjEezKI4mAa5PuUin8XFypKXsjua7w8/4M+e8NZcWXj3PvFJ+
-        rbwGjvCGPkG2X9TRKovJU17BuSJH4byuICCIeDxBUviFJJ93O+i3r3G3BX/7Gndb+LeuMTAqMa2i
-        JYEnCH1wmDSt4zjTCUR4bhpRg3BXoIHYeFqXeSEOr4A98fJ3ptEICasudekGO1HbzhzDPlwN+9rJ
-        0LWTpcX3dxh5tYB5h5HX0PgdRrbASBcG+pha6AiZ4y8w58Yk5QPNuu1zAE3yitsRfldKHyUL+nAp
-        GG4HuL55UNBrQC9lc5Z1T/RxuVHvgiN5Qt5mZS4NkTOvktr+fmT+/Rfv3ebV/5uNGmFOKG5Cm/Y9
-        11OezUATKWBUftg82vryYgX0b22HG7kHO2t+dy5UvSLBLWP1fKas5pUxnKbENMMh0937p4eHT07b
-        A1rbx8fHXwAAAP//AwA1HUiDrhwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18179","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18179","key":"NTEST-1842","fields":{"statuscategorychangedate":"2025-04-30T18:24:33.499+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1842/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:33.171+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szr:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:33.267+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/244]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/244 (244)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/94]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1842/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18179/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 299dc555-8813-41c5-bb8b-0ec83b007c05
+      - cf841099-e5c5-4456-b21a-eba0970716a6
       Atl-Traceid:
-      - 299dc555881341c5bb8b0ec83b007c05
+      - cf841099e5c54456b21aeba0970716a6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:45 GMT
+      - Wed, 30 Apr 2025 16:24:34 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=323,atl-edge-internal;dur=18,atl-edge-upstream;dur=305,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=303,atl-edge;dur=269,atl-edge-internal;dur=19,atl-edge-upstream;dur=250,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="XY3AjGfr7uYnDbbZXQy8Y2fcbzsSHnuNp9_q8uE9ofWyeioO1-H4gw==",cdn-downstream-fbl;dur=307
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c31337642f54c5bd34bb485701d02e8a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - XY3AjGfr7uYnDbbZXQy8Y2fcbzsSHnuNp9_q8uE9ofWyeioO1-H4gw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7ce425b4bac17e425e214d913856acbf
+      - cf2e170882b87e02faf2ae81da0f4588
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2bJfvIDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCCV9LjtDRHkLYTOi8mkRo0q1O7dZTIY6X0jbWYxkBGpG98Zuf8HX2C/axTW6D/WaLoV2oD9
-        X5esnNVmQKvwd8kd9r5xNsI5QJ5BBuNic/lYrB/Kn+lmaKtYEfGcoBGM4CU6sTNu38Yry32XbCvj
-        hjqGqqEx9VeEiBig8/mpeSVDAilQPoZ8DMuSUsGmgkUxwAVEOOZ9/AP2ZdOeszmUFETOBeMZ5/Sb
-        Ve2N1S6CLJ8tlATkqFU+naNkWjMNStPllC8qPWNIZxromSCYZLhtepleiFoOJtw5JVP7QMypImhf
-        twU5nh/25GyaXN+X5PgJAAD//wMA3lPbfiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:34.965+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 4193a936-26fc-479d-874d-921897cf1333
+      - b36a13de-5ec3-479e-8fb4-245f69d5f314
       Atl-Traceid:
-      - 4193a93626fc479d874d921897cf1333
+      - b36a13de5ec3479e8fb4245f69d5f314
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:45 GMT
+      - Wed, 30 Apr 2025 16:24:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=181,atl-edge-internal;dur=37,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="CTVTagMeCGyIPklg7YMeTn96HNNGKcy0Axik77_CxlpszfDMvP3WPw==",cdn-downstream-fbl;dur=250,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=248,atl-edge;dur=170,atl-edge-internal;dur=15,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c80d7d73c19744418338fdf12216d306.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - CTVTagMeCGyIPklg7YMeTn96HNNGKcy0Axik77_CxlpszfDMvP3WPw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 5de562dd321b164bfc61ad821de38c3f
+      - 8fe8df260dbc201bb93eabb2eefe7d75
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - c9a219b7-4f2a-4f80-8b8f-53a03fecb265
+      - 5ffff061-ce68-4c10-a6f3-9adb0acd624c
       Atl-Traceid:
-      - c9a219b74f2a4f808b8f53a03fecb265
+      - 5ffff061ce684c10a6f39adb0acd624c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:45 GMT
+      - Wed, 30 Apr 2025 16:24:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=302,atl-edge-internal;dur=16,atl-edge-upstream;dur=286,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="_8HNGv2DooXuFmsEJwnQu_QBNK_WFAIm93mI8mppgnLNDXCFpujAXw==",cdn-downstream-fbl;dur=367,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=364,atl-edge;dur=290,atl-edge-internal;dur=17,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a4888bfa57444daa340ca8dc53629170.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - _8HNGv2DooXuFmsEJwnQu_QBNK_WFAIm93mI8mppgnLNDXCFpujAXw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 2bde9c0cc13d58eccf8d6c0c60134f1f
+      - 08329a0462432c54173176fe8089dcee
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/245]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/245 (245)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/94]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1297'
+      - '1317'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16087","key":"NTEST-1603","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16087"}'
+      string: '{"id":"18181","key":"NTEST-1843","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18181"}'
     headers:
       Atl-Request-Id:
-      - 47da1da6-b1c9-4407-894a-9c5e0b65c6a2
+      - 104448a0-ca1b-46ec-a8b3-17d2331dd7bb
       Atl-Traceid:
-      - 47da1da6b1c94407894a9c5e0b65c6a2
+      - 104448a0ca1b46eca8b317d2331dd7bb
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:46 GMT
+      - Wed, 30 Apr 2025 16:24:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=692,atl-edge-internal;dur=15,atl-edge-upstream;dur=677,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=940,atl-edge;dur=813,atl-edge-internal;dur=19,atl-edge-upstream;dur=794,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="qyoMT6PLdH-MntELfOCPEww0nSqgcxJlgpo_nPtnhSAcDd7DHprq6Q==",cdn-downstream-fbl;dur=943
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qyoMT6PLdH-MntELfOCPEww0nSqgcxJlgpo_nPtnhSAcDd7DHprq6Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a11d9f814b343f4edb4fa7b26e2926aa
+      - f3bdc8e4ec90cc9fe426f74a299089c9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1603
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1843
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeWTIZkeqKkqy7baUIgggLUXIzNxMvPHYU9tDku7y33s9
-        r0BgdgVVV0hh7Ov7Pj6+nxxY51QkTuQoEAkoSN4x4InuCZqB7ul4ARntyRwUNUwK3YOEmQwM7cUL
-        KlLgMu3dgdIog+QUcgUahKnPxoU2Mptbgze+5/neQMHfBWgz2+RwomhsWAxOz2HWvz/yxm9woYHP
-        cbkwJteR6yYwh9gk8qMcUMOp1oyKgQDjoifj0py5gcu0LsBtDCxhg/rHs+nZrI97Q9wqQ9BO9MnR
-        GFuhY2oglWpT5ZDgCjUCL9jve37f92aBF/n7UTgajMLRDxi3Z4O0TgwGXpp5ZZBW30V7XtCmXS8S
-        0LFiuS0c7h4QnVHOeyRh2jARG5IziIHIOVlJtRxY7ViKc8VfGEUhmG0X5Tf0jhqq3DsGK7cMaxtg
-        LfK9oT/+SbN/4McM215k6NXCAl3OqF7aXhW3xn5Fc8o19JxK8T3mVer2nAVD4Kh4sTmCO8BYvfue
-        YxgiK0eUOJEoMEdnByZDrxHkSn7EjF5Z8Fq7LHfZwKbcdvEAJNuszgUzBg1op/Vtkfp7eVbLuVlR
-        ZfGqWZZzhgEnO5ljP0qUheN1OH5huF/oTJNJ25fQs0APwnUQ/r9equ6XWESH/mjtj76Fw3XjcRis
-        h8G38FgD/P7+KRz9LpwGXYJhI5iz9UVFjgiLq2uESZoqSJFvvnoJ9hsBZiZ5UfHC80dHXYI3HYKg
-        UzDuErx9Gk5Fm9WuJaXyhXCivo9LavDhqAj35Re3ovMtgbuVOWWvZfl5KAtbON+S8qXdYCJ1IqMK
-        uK952lpTLK6q9unJno0Mj+qFLHgyYTrndFNfZdzGsMwFYsZe77oaCjBZyx/PPRLDYftI7JatpbJd
-        QReoghZUuWJSMbN5ZREbdTd82VvBMpqCdq2Gboww3OByNdB36ZYsj+SqIdXQeXptgvYScHoLlhYt
-        /ncngi7o+l0I9ce2HguqpzmLj5hYvrOSCeR2ehFx08Wyt6tS1u4IKaY4vNBbDqdAdYUMVX85J0fn
-        v7w/vjl6fzg9PpveTE9P/zzF/PCWaiwIHpgtgJwg/wtDrF/CNJGCbwhyCePWKDGS/MYUJScKMiQT
-        UmjE7OA5TvHxOjneZ+Z5ubyLnOpNxN5h8bd36hFXYBtSJijfPVTPXnV5S5xzjK6hG+xrKqA9XeT2
-        0nbhOPT2GxxXY9IroVcpt+/u48nmZWjcwu1nGi9x2Gwg1xivfB3W89x/CrgZCt1mNguaMUGAhXos
-        uVTHVTS3vIB+qpA1tiORJBNZNVtmOY7DwjwP+v2WFL7U2F2lljAel/Mvsf3bmzHDYS8iVx9oHkTk
-        UMolA3LJDPKcIWcQFwrIO07Tz7Y6WBwuY8oXUpto7I09d85EglTqBuH+dWlwUhYP8/ooiYVVtEe+
-        qkm+w5/vS/UzHPosB6EaskUd5KQAMsFEcfMPuiG+1yMWjG0Sh5dTFF3hv/7ID8tIbR/jFQwyZhQM
-        pEpdhDG1rWU4sVn4u3h0sDAZL+Ou7FxYO+diKeTqYZFOlEwKnAGmIsWLnWGb3BkW3/osK4Txkl/l
-        qm9kR5Xy2kBwTVxytQJYIgtAa61Da3vAHZaKHw5OyFlMRcd5O4e6b8M2nwcZnG20gUxjBkkuGcJs
-        Lyr3y97YWmWUCc0MDBCJWCq9uJVUJV0nntifbBFmLR+QWP4LAAD//+xZUWvbMBD+K6JQaKF2ncRp
-        kkHpQulgD2WjhRVKIci23JjFsrHsumXrf993kqKlXtyNMkofCnlwIunudL777ruLDiSgLouEkEyJ
-        mrU2qmrAojKRlSKyDli7zOIlywWXCovc7LAScN0bGQnG4xi4KhJ2l3HWIFXi6qEEMGGflMKUaH/D
-        onO85VvdVJJBV0shKbIYd3IL9Jy4ESyha4H/sUymRZXrM6yoCK05VhWBJYD6u5AHZBiEZzUzPIDx
-        Vcsf6Iqs5Nq6RiGmGZdsw0B0jFKsfHYmFd3Z3dD44EaSE0gb+QgWWAvV2kQSqBo4aKulG3feuP0F
-        shB1By6j29twadvWL1quSp0PSD9x75fLUscylCwgc2F1L3gN4hM1CKnF3per+eVX7/LcQ4nWWeqU
-        lEVVi4ryYI8neSb32d7+TwTKqi4+IAz/ZDdjV+K75a2P9gzCvgVHdwkT6wpgrzkdsbTO1tBR0c5C
-        4GR0F/pYRuBYhn57mmxt39jHiwNnzJNq3QVzvAAeLyn5TUVQTZ5zKlc7f0Nq8jqRz6J6YW0jEnKC
-        fCPK/Dk5Hiej6WQaDSaBGMWzIJ6Nh+lskB5Bj9sEDc9sExQS8ySBDtQ3FLvk4eOGIQAUkvVsO2xy
-        xUf91Ns0TNmWLBSgeDwZhOHRJJ5OxqNZFEeTAOpTLtJpfJIcaym7o/nu8BM+5pyXc2nh1fPMT8pv
-        lNfCEd7QJ8j2yyZaZTF5yis5V+QonNcVBAQRj6dICr+U5PNua/32Le725m/f4m5v/9YtBhQlplW0
-        JPAUoQ8Ok6ZNHGc6gQjPTSNqgOwaNBAbz5qqKMXhNSAmXv7ONJotYdWlLmmwE7XtzDHsw9Wwr50M
-        +2YUocPuygL/O768WiS948trWPyOL1vwpQsDjpA5/gKrb03u/aAhuH0OoLCouR3hd6X0Mq9eXOql
-        ZMPtyNc3Dwr6OCgBwtaFoI+DjvpOjBzJE/IuqwppiJz5KWns/0fm6z95r8iNhB/rRwv3L4Dfjb++
-        DtdyD3Zyfn8hVLMiwRu69bikque1seOuqP/fjNYIc0KhC+3it0JPm9aDVZoS0wyHVDpDnlo7fGKu
-        PaDd8/j4+AsAAP//AwA0kcuhrhwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18181","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18181","key":"NTEST-1843","fields":{"statuscategorychangedate":"2025-04-30T18:24:36.431+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1843/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:36.062+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szz:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:36.196+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/245]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/245 (245)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/94]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1843/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18181/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - bc488f07-4cdc-4713-9776-340a7e51473b
+      - 03435e7c-e154-41d9-ae71-2241341c8d83
       Atl-Traceid:
-      - bc488f074cdc47139776340a7e51473b
+      - 03435e7ce15441d9ae712241341c8d83
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:47 GMT
+      - Wed, 30 Apr 2025 16:24:37 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=272,atl-edge-internal;dur=15,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="yuPelTiMWrU7Ws_KQEBxBizwJDwHNCf5P_6A_fU04XPtS9gD3vh4nA==",cdn-downstream-fbl;dur=354,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=352,atl-edge;dur=265,atl-edge-internal;dur=16,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 596b1ac54ac9ee415236dc72536ba33a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - yuPelTiMWrU7Ws_KQEBxBizwJDwHNCf5P_6A_fU04XPtS9gD3vh4nA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 8baa284c348980902b80121a26cac87f
+      - 9454a0fcf1d15e9cf68e58e372dd0b54
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16087
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18181
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+2/bNhD+Vwj9tGW29bDsugKGIYvdLVuWBYmTAM2CgJHOMmuK1Egqttf2f99R
-        L+elFsmwokBq8Xjv7z7eRwc2ORWJEzkKRAIKkncMeKJ7gmagezpeQkZ7MgdFDZNC9yBhJgNDe/GS
-        ihS4THt3oDTKIDmFXIEGYeq7caGNzBbW4I3veb43UPB3AdrMtzmcKBobFoPTc5j174+9yRv80MAX
-        +Lk0JteR6yawgNgk8oMcUMOp1oyKgQDjoifj0py5gcu0LsBtDKxgi/rH89nZvI9nQzwqQ9BO9NHR
-        GFuhY2oglWpb5ZDgF2oEXjDqe37f9+aBF/mjKBwPxuH4B4zbs0FaJwYDL828Mkir76I9L2jTrj8S
-        0LFiuS0cnu4TnVHOeyRh2jARG5IziIHIBVlLtRpY7ViKc8VfGEUhmG0X5Tf0jhqq3DsGa7cMaxdg
-        LfK9oT/5SbN/4McM215k6NXCAl3OqV7ZXhW3xv6KFpRr6DmV4iHmVer2nCVD4Kh4uT2CO8BYvc89
-        xzBEVo4ocSJRYI7OI5gMvS6B3whyJT9gqq/sRK1d9qHsbNMH+3EPPbt0zwUzBg1op/VtIfx7eVfL
-        hVlTZYGsWZZzhgEnj0qCjSrhF0424eSF4X6hZU0mbcNCz05AEG6C8P/1UsGiBCk69Mcbf/wtHG4a
-        j8NgMwy+hcca+Z8/P4Vj0MBxwTYXFQdik6+un94cNjdpmipIkW++OgSjRoAJSF5UvPD81XGX4E2H
-        IOgUTLoEb5+GU9FmdWpJqXwhnKjv11xpK69YXEX+8cmZnQcsql7KgidTpnNOt/XU4DG20Fxge+wk
-        1S6owceoIvGXz3z1ROweBbcyp+xElz8PZGGbUQZ/aQ+YSJ3IqMJGEyvAZC1NPPdIDIftI/G4bF1U
-        FrRU9ljQgipXTCpmtq9MuFF3w5e9FSyjKWjXaujGCMMDLtcDfZfuOPFIrhvuDJ2n0xG0mOf0Fiz7
-        PTMYljSeLYPfhVB/YuuxpHqWs/iIidU7K5lCbrcXETcIKnG1LmXtiZBihssLveVwClRXqFT1L+fk
-        6PyXw+Obo8OD2fHZ7GZ2evrnKeaHU6qxIHhhvgRygjQvDLF+CdNECr4lSBmMW6PESPIbU5ScKMiQ
-        M0ihEV+D56jDx3FyvE/M83J5FznVm4i9w+LvZuoBV2AbUiYof3yp3r3q8pYo5xhd/W37mgpobxe5
-        HdouHIfeqMFxtSa9EnqVcvu8PtxsXobGHdx+pvEKl80Gco3xytdBvc/9p4CbpdBtdrOg2QYEWKjH
-        kkt1XEVzywvopwoZa7cSSTKVVbNlluM6LMzzoB91kcKoJYUvdfxhOf8Su397c2Y47EXk6j3Ng4gc
-        SLliQC6ZQY415AziQgF5x2n6yVYHi8NlTPlSahNNvInnLphIkPbcIBxdlwanZfEwrw+SWFhFe+Sr
-        muQ7/PN9qX6GS5/lIFRDtqiDnBZAppgPHv5Bt8T3esSCsU3i4HKGoiv8rz/2wzJS28d4DYOMGQUD
-        qVIXYUxtaxkuZhb+Ll4dLE3Gy7grOxfWzrlYCbm+X6QTJZMCn/qZSHGwM2yTO8caW59lhTBe8qtc
-        943sqFJeGwiuiUuu1gArZAForXVo7S64w1Lx/f4JOYup6Lhv1033bdjmcy+Ds602kGnMIMklQ5jt
-        ReV52Rtbq4wyoZmBASIRS6WXt5KqpOvGE/vTHcKs5X0Sy38BAAD//+xZbWvbMBD+K6JQaKF2ncRp
-        kkHpQulgH8pGCyuUQpBluTFLZOOXumXrf99zkqK5XtyNMko/FPLBsaTT3eXuuecuOpCAuiySUrFS
-        VqyxUVUBFksTWQki64A1y1Qs2VpyVWKRmx1WAsy9UZFkXAjgqozZXcpZjVQRxUMOYMI+paShB35L
-        o3P8yre6qSSFrpZSUWQx7uRm6DlhETQhs0DzWKqSrFjrMywrCK05VksCSwD1d6kOSDEITytmOAjj
-        q4Y/kIks51q7ukRMM65YS0F0jEqufHamSrLZWWh8cKPICXQb+QgaWA3LjYoksKzhoK2atmxuWX+B
-        LETdgcvIehsuTdP4WcPLXOcD0k/e+/ky17GMSxaQubB3L3gF0hXVCKnF3per+eVX7/LcQ4nWWeou
-        ybOikgXlwR6P16naZ3v7PxEoqyr7gDD8k92MXYnvlrc+hBuEbYSrCmC6pllEBLtbHQHuLISOinYW
-        gr4TgWMZ+kfSnGr7xj7WEfTx4sApAx9zsaT8tqW3Xb27GF7W6zWncrXzN6QmrxP5zIoX1jYiISfI
-        N6K3n+PjcTyaTqbRYBLIkZgFYjYeJrNBcoR73Cbc8Mw2SSExj2PcgfqGYhc/fGwpAkAhWc92vSZX
-        fNRPvU3DlO28QgmKx+NBGB5NxHQyHs0iEU0CXJ9wmUzFSXyspeyO5rvDT/iYc96aKwuvnmdelX5d
-        eg0c4Q19gmw/r6NVKshTXs55SY7CeV1BQBDxeIqk8HNFPu920G9f424L/vY17rbwb11jYFRs2lRL
-        Ak8R+uAwSVILkeoEIjw3TaNBuGvQQGw8q4ssl4fXwB6x/J1pNELCqktdusFO1LYzx7APV8O+djJ0
-        7WRh8f0dRl4tYN5h5DU0foeRLTDShYE+phY6Qub4Csy5NUn5g2bd9jmAJlnF7Qi/K6WXefXiUt/g
-        JxhuR75eZtZrWS9lcyZ3FkZ9J0aO5El1lxaZMizPvIpr+/+R+fov3rvLqv83xzTCnFDchDbtW6an
-        PJthKlLAqPxj82jry4sV0P+1HW7kHuys+f2FLOsVCW4Zq+czRTWvjOE0JaYZDpnu3j89PHxy2h7Q
-        2j4+Pv4CAAD//wMAsjlviK4cAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18181","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18181","key":"NTEST-1843","fields":{"statuscategorychangedate":"2025-04-30T18:24:36.431+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1843/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:36.062+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szz:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:36.196+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/245]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/245 (245)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/94]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1843/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18181/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 7a8181ec-911b-4a49-a236-21ba64177fbe
+      - 343fe3af-8c43-4ffd-abca-411a8b3243f7
       Atl-Traceid:
-      - 7a8181ec911b4a49a23621ba64177fbe
+      - 343fe3af8c434ffdabca411a8b3243f7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:47 GMT
+      - Wed, 30 Apr 2025 16:24:37 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=15,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=286,atl-edge;dur=253,atl-edge-internal;dur=18,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="oqkpHMnVuduQe33BdyS4iUD_tZg_pGXmTcRV0AhjPcBLAou1PC881g==",cdn-downstream-fbl;dur=289
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 771067dca4682f83a6c9963c412d66cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - oqkpHMnVuduQe33BdyS4iUD_tZg_pGXmTcRV0AhjPcBLAou1PC881g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f8f83725fd91f36eb4e7159c83047fcf
+      - 3bb394f46cae0fa98c454532560add37
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -881,7 +863,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -895,9 +877,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"828\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:56244\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:33122\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: weekly engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\":
@@ -933,7 +915,111 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:15:47 GMT
+      - Wed, 30 Apr 2025 16:24:37 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: weekly engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/94", "url_api": "http://localhost:8080/api/v2/tests/94/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "weekly
+      engagement", "id": 3, "url_ui": "http://localhost:8080/engagement/3", "url_api":
+      "http://localhost:8080/api/v2/engagements/3/"}, "test": {"title": null, "id":
+      94, "url_ui": "http://localhost:8080/test/94", "url_api": "http://localhost:8080/api/v2/tests/94/"},
+      "finding_count": 2, "findings": {"new": [{"id": 244, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/244",
+      "url_api": "http://localhost:8080/api/v2/findings/244/"}, {"id": 245, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/245",
+      "url_api": "http://localhost:8080/api/v2/findings/245/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1300'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1300\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:33136\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: weekly engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/94\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/94/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"weekly engagement\\\", \\\"id\\\": 3, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/3\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/3/\\\"}, \\\"test\\\":
+        {\\\"title\\\": null, \\\"id\\\": 94, \\\"url_ui\\\": \\\"http://localhost:8080/test/94\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/94/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 244, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/244\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/244/\\\"},
+        {\\\"id\\\": 245, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/245\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/245/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 3,\n      \"name\": \"weekly
+        engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/3/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/3\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 244,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/244/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/244\"\n        },\n
+        \       {\n          \"id\": 245,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/245/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/245\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        94,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/94/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/94\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: weekly engagement: ZAP Scan\",\n
+        \   \"url_api\": \"http://localhost:8080/api/v2/tests/94/\",\n    \"url_ui\":
+        \"http://localhost:8080/test/94\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:24:37 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -958,26 +1044,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrlq5b3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCGcAWQopJOXm8rFcP1Q/083Q1rEi/HmEJjCBl+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0XxHCY4AWxal5JcIIUqB5AlkCy4pSzmacRTHABUQ45n38A/aVbs/ZDCoKPMs5K9JiQb9Z
-        2d5Y5SLIsvlCCsAclcxmBQqmFFMgFV3O8kWt5gzpXAE9EwQzGm51L8YXohKDCXdOirF9IOZUEbSv
-        25Iczw97cnacXN9X5PgJAAD//wMACBlBviACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:37.859+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 218c60a8-37e4-4f05-a3f3-e1506ffd3288
+      - 82fdce1c-eb80-4423-84b0-3b5e0507a963
       Atl-Traceid:
-      - 218c60a837e44f05a3f3e1506ffd3288
+      - 82fdce1ceb80442384b03b5e0507a963
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:47 GMT
+      - Wed, 30 Apr 2025 16:24:37 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -987,7 +1069,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=147,atl-edge-internal;dur=17,atl-edge-upstream;dur=131,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=20,cdn-upstream-fbl;dur=244,atl-edge;dur=159,atl-edge-internal;dur=16,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="FRCTLwOAGOhGJ_JrNuNVikDqmrIibKDBh-0ugr8bWlazWerafQGwNQ==",cdn-downstream-fbl;dur=247
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -996,10 +1078,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 05df0d22c8cc3d4b946b6f2dc43d6b9c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - FRCTLwOAGOhGJ_JrNuNVikDqmrIibKDBh-0ugr8bWlazWerafQGwNQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - e3a1406ded3945754ea73c4009cd7fb4
+      - 72aca69352138814a51844cfdedc0317
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1026,26 +1116,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2bpvvIDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04qJtgRuFn2
-        8/qxfCC18LjtDeHkLYTO8+m0QYUyNO7dpSIY4b0WNrUYyIQ02ndG7P/Bl9jvtMQG/ccaTbdCG7D/
-        65KVs8oMaCX+LrnD3mtnI5wBZCmkkJSby8dy/VD9TDdDW8eK8OcRmsAEXqITO+P2bbyy2nejbWXc
-        0MRQPWjTfEUIjwE6n5+aVyKMIAVaJJAlsKwo5SznLIoBLiDCMe/jH7CvdHvOZlBR4FnB2SKFZf7N
-        yvbGKhdBls0WUgAWqGSWz1EwpZgCqegyLxa1mjGkMwX0TBDMaLjVvRhfiEoMJtw5Kcb2gZhTRdC+
-        bktyPD/sydlxcn1fkeMnAAAA//8DABvMoU4gAgAA
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:38.259+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - d70d4734-72f4-414c-8eb6-6a35e1e4d0e3
+      - 2b149bb2-f614-4ea7-a755-c9b765940d20
       Atl-Traceid:
-      - d70d473472f4414c8eb66a35e1e4d0e3
+      - 2b149bb2f6144ea7a755c9b765940d20
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:48 GMT
+      - Wed, 30 Apr 2025 16:24:38 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1055,7 +1141,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=142,atl-edge-internal;dur=15,atl-edge-upstream;dur=127,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="nAlEd-4T4pQYbyTpm7F1SBoltty7Wlg2QXaRL24uibu2HGoMUmsENQ==",cdn-downstream-fbl;dur=310,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=95,cdn-upstream-fbl;dur=308,atl-edge;dur=181,atl-edge-internal;dur=25,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1064,10 +1150,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1b7fa09f50c08a88d619f90eef5ee94a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - nAlEd-4T4pQYbyTpm7F1SBoltty7Wlg2QXaRL24uibu2HGoMUmsENQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 41ff994ca269032b404e7ee0528239b0
+      - 1f89dd28f49216ded6a524994b009d8d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1094,97 +1188,135 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/field
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7RWS27bMBS8iqC1F+6iG+8KuwGKBm2RItkYRkFLTwobiTJIKo0R5DS9T89UUqTI
-        R4VSBMfe2ODwUTPzPhK3zynN01UqJJGtyIiEsuHH7J6wEnK1ShfpAxynAxipQUX87CKStQ1J1iZG
-        BWStkE2drgpSCVikDc+Bk30FDmHkkZYGkbxVgADCFQdCsoq0Ar4pKpGutlZOz2WpNlrPTp3O7qEm
-        6eo5lceDlqaFSlprseIoJNRThl5eFjYpB8KBSZcCt7SGf/Tr9/mzMQODlmznxBT06Q64oA0TTlGI
-        WVlX9Cl59Oi4OCNlUls09541mmzCOTkqYqryrOJTqwXnHuv26Q5rOug8BMf7bdLqnDpEvQ7IfTk4
-        iKZqpTFmhAaQFXmDsXF9p5YCUcZKEShy2UeoT35FhLyj8KcbWOMngKyfa4UlDhw3NCfh8cZHrDFL
-        sVFGR9DwctpwKn0fIaAfYI+MOzm1NI4u5gJpcS4chouyh8qPu1u6Ytj1+dVbqpj24XwLySkrw3p0
-        h70PXTAQ6hd/UQagG5iaUKYemHz2e+P+Tu8z3hMhnkBSzDtr6z1w7DU44h2TsuRQ2l5VZS0pI9Wr
-        FLwVZXPy72/y3W5eOCvzPE/L9klAXyHjFwHW2qeigEyKy36wSEcC+Tu/Wk6jd0iFaKGi7MF7DKB+
-        UNUS8uSL3rqMxY5V08wyF2h0/hCKGlkIWjJAPeuBvoYeOb8xRxfzpQLDxuyDh5cKp94trXZziZhU
-        PmeYotItV0y4kzG4jiLhWVMfGqbugF58AFkDa4yNmzg1/Y4yamPYVz4aOUOqB4OjXQVjYwDr7Gu3
-        GLc0py7Rl5xWsDCE/b9X4m94hrmgUOW/PiyXH5e+DpEdK3oD+lWzaX43ybqLSm5vrpMrHaqCWiY5
-        YaJSr8lcq3nzQO/eODtHPYttp3inHj5NPbG7vf0PAAD//7xZTW+CQBD9K6Sn9gCpiiZ6NU1jLzXV
-        9EJ6QKQWRSB8mP787izLuiwzFYN4UWB2Z2bf251hhurqC90W8o2gch/2gOXmIZxPN7L2QepaSViw
-        vGGV28RSIAUl2axIQ6lgwejgXiunQ6NgQJIDEpocFkCMZeAd2N91JCET+yJrQJCFuNBilKM+ecwY
-        UaFvQCB9wskUMbYLlUxDwu01GB3QjA5JRkEiGF0cE9eDaIOQJmV98TIEXqSV8sJZ/cRpbuT+by7g
-        jAFFieby4/3tZb5m45M03jOuQMbXzzQOnyFCNim4xXkCj/htg4MhzcGI5AAk8lRB0sU5kLK+OBiV
-        Z4NbwXavnqG2fKjFF2LxBbRBNeM35tY/+WGcHFkuM4Mo93epC1W0WQ6albq97wbCIxphm0QYJALh
-        zyKMAK8gLEtGBGh9SF9424B33RgKe6Q60RXYk2oPwdem8R2T+IJE4LtidgMwjmOrivvCdQy4ng2h
-        mOp199bMEM80sFnsPQWez/bmwZLDZ+jcCs4xDeeEhBMkAs7X2OVdCQTKStQXjBOAsTLC/x3+i6c2
-        HVHdO3rfkmF2V1NRITohEbWnFKJcIkOsntbLNLNmQf269xZkXk9c2FP8tQXx4PKgZlq9Z4q0p0Rj
-        5/+GDtrIuVd/CwPpQicH6eB4qe/mMUwRe1TeixXN5YNua8A3klCOrUW8lp6rTDFWqfyLTe5mSmdG
-        eVAF/mJjVo+6+Y9ycLaIrUCPPnhTRqqgQwhZmHIJGULga1lZBjy0DB61GX2FDaI0rdn+T+zAJR4k
-        xPfKDiECNOCljE0XpzZZnHIJRRArz2ApxpodTVGvtSQKn3lLwv4AAAD//0KOMOzdU+xuIEZZNJhd
-        XJKYW4A7GkHlFeVRiWIKLCJx90lNcPZJwTK4IlIBPk9DTOQhVNMqwsD9Vqi9AAAAAP//tFrBcoMg
-        EP0Vj+3BU53Rc9Nj28kkRw4Zamx1xgZHTfz9wmpRcdeA0ZPKArvwHrC7iOmlRKx94KCYu9kaB7K+
-        7xoDRAesARmwgoQE6BMORjdPymizFVhdgHtH+3wF1n7gwGmn4AGgvnPBJ3FEMAh7y6SQ/huoaeEZ
-        FHSoHPqSf0umR/HSydTqsBkwXQldGfH6ilLIt6p3KjBJNyLp7e37QnpQi/0LbDADM6ZenhbSK4hM
-        SICEWkEqo8hLLuP2InVaRmjDrdYSJC/sTLCoxfQ3vrDW2AFVSMKlZztZW3TKIyBTHiChEPQO/JwJ
-        7/Va1+JSOWFINN0KRUiV2BphVY+NynA0RWH8xLMAzVKp+Wq1TBClsy4BmXUBCYnoMcllifeeVbX3
-        tONVLNVffp7dsL3XyVYoQybH3RzHFmwkjbV0jgN+k9WpH6fZaPwL6KDVVWDEhBEzWaOQZISS2DHi
-        45rX2S4VWZw8wgm0m61YEVqwAjXIuc2YGb9KXuSJF0OdiiCI6QSvsWmAaoIhIc2QiGSIktgx5AiX
-        g+ZUulME72crjkQWHMEtcm/E3kpRnEVzwfmwBv4E9BEJ/csA+pE2eAOdp1N3++ib/8Ps23JP3NS9
-        QdKoOLytALD/AQAA///EWz1WwzAMvkovYBZvjLCylQdDpzT9AZrUvCZQOA/34UzEshzZteQ+SvyY
-        GkuuJX1WZFuK42mXOxeaWw1zK4nlZiDdhA27qZUy++ZTOZ6CvJsC+E5R1hmUxcQ9cMQX7PZpXe9u
-        zMdawPTMP0oBKyTrI9k59gIel/aRfxWKhcZ6FJzMXpC2T85t6XGt7FmNBHLocKc25rD2bnow05ng
-        W6j/AzZLKO9EcZp7JUa1HYF0PprDrjH2FXRaUxv1vjPb2eNAzKqeuDd2OeffnMqnrkgajUZ4EpkB
-        UQIG8IaEFDQFPvCc3TvaL4xJp4GzJZIIP5x1YafRHiKSRTb52b26ArCzKKSgRZCLnSNNtuhyzyKZ
-        nDFpxYr6y6FZLIgABy2bvy3b534IvLONObRCNE47lQrAUPY4FZeF5Hzg7K6GGGJHqlRb7avteuWW
-        ue4ahledF+fIqt6g38RhNKhs4LZhxJfaFESR8DdnYaHy0jhYSJMwgAJJdhSxMAOcMT7V9uPtjJec
-        9CjlIlBoiWRxQEzoHw3IyjuHXC3RYrUEOD7AmL5qcuDGHUphCzWRUFRhaHsrKo+sXObQWkTWchDZ
-        4GIcAytzbW4yTP3YC/9gwUWgNb89nGI7+HJslb/PmaAZFCOijx7iFZBlIZ7fX65KWXA15JBJl0BG
-        SdlVxGwwcNA0fzGG9RRiTu4o6BOQ0SUx+PQ/VSst52G1mIcFDmLpTkl+E8jgGXcohWmQP/Wigtal
-        eYsfAAAA//8iIXSxj1sY4x7UNEYa1CQ4bgFSh97oQAwIQGSxhD0OlbSKBPBwJVY7sYU6hWMVuAcD
-        jXAOFxsBAAAA///MXMFOwzAM/ZX+wDjkuBtCmuCENHZDOxTUbUXQVmmFxt/jOG6dNHYrpEXigLTa
-        7Ry/1ybuw1kgFx9Ke64GJ6ZYR5uA3uyMTKgZRC2KJaG10szTtVv423g3LbRvZe8arCqnegUZEIBm
-        AUBVTUVPDGDVKCpp5M8FHipkQaRbQxeOfgROV8mMqpKhh4B7hjVsqQSM/LmAQwUsiCQB94dVZ60A
-        bCESYSvXfyZQr3jHPlHnIU3MhOfe2b9vsENfxCuJigYXToIsaLOaCpjZN8RaEbb+TymGFsrOaUXF
-        nmwZ8uOQUj5pOcbnB4mUA1zIUh0fj0mgwebS63w8K9/FPBjOgUycAa40QBSsO+9UDPhUBAffdmgs
-        hmVmkgeVTlljRspFGE0seoU+zm64AI1NWbs9hj6t0EL5PH3BY5uJoSPPmK5xOfjVDT6mYWCLda6H
-        maPRJ9eNKd410oM8Xq3P/6oUhx7K8KWD4kapOSZfrnnfC28+ipT3XC3+6NPKuPu51v0dvJVVzaXt
-        usriSrA9XzZ9PPxxbtebhY2qSaGHENt9wksg0iZAxs5cmKESxWHo03/8H5DR9Smj6lPoIaRfHx7v
-        94ej71JuT8Wutv1QwFTXtU2vvOGtXnNzXlYjLp+APfPOfEKzJTPLNsbIjCZN1DKH1XW4g/HbAd5h
-        thhjDBGVoiNnuvJlVOULPTPOUK6pm2L6kYcFrpJzs3GURJIdvg1+Ogy4UCS09T2XEQ2ONihT43RH
-        BuY7Vn8BAAD//8ScTVODMBCG/wrjnUMcT17Vu+PHD3AoB7QzILXWny/ZbJIN7EsBm/FWsqGbPOTr
-        XUgEZxgEIYsf0b/sCXCPbePOpVC4j3JcnDazojDIyJe8/J8g0zWOghjIlywJ385WoRDbzCDnSc5M
-        vI3gPfK5HDCYTd8Pp0G4D/9c0j9PGq2ZgQoDIGRhqO7tbdXuaT+bwjLNkAshhT+kK43cNFZ0hpyL
-        HKVl9+Bw4MPAwAdZGJw7CLGg44dUcGmGXODcx0HClQZufpTUQh/h2McUGg56GBj0IAtDe3pDtNiS
-        CxMFOsjHQj6gVQ2r233905a9LK6nI4IXx85O8lHgxGsm8RoSvNsLCpzojX+tEjj+bqEcG+XIsyAi
-        dSPXM5zhpozD22qsSssrXwKxwVgtmAZhGt5Qb408dvWh6hu/kHcY0jSu/X2SiOu9tXVLp1rNwogZ
-        aibvwJ0ZKliy+M5cfx4HODNvfUY5cnVuUrOJL5XFjoe4uu9dXjLAcVEcInH73ZWuOYTsvs9jUWug
-        qCULQ3zomqogXCpBac6Fj4RtdKSyWzPzDmOk3S9c0k7GCTCsTQ3UpmSRwObETZohFzT6dkK60rDp
-        Wv8MNl2dGKwPDdSHZJHc7vA6L7HnokYbO4UnDdqmtqav8bCiMzeQmbVIZniFJ825iNH2vehIA7Zq
-        9eJ6piyzhyV219npb6ht9eEeRJznRSIjerGCXST7YiyY4/4QAR+VJZm3Qzp++PD7ELJwzZ5/AQAA
-        //8CzZcqQMdqsMQ+ijytoh9yRBKyTQjOAB36YIh7sYgBzoAFy0AD1hl87LwCtPbFErKoCqgftAAA
-        AAD//8Rdy26DMBD8lf5AJPcTKvVYqZfeerIimiCFBPG4VOq/Fy+2u2vvUEetxSWJdxfWjAcMg7Uh
-        aA1BK1Ox1m6LRcwGvFAmIY+Ed2hHcNmSAbXgJVFEpmKt/eDFgomBggl5Engbu74T2QA4hNSCmEST
-        NJlo7wczk1fG5jiLovTMEK613vLw4orisQ4VTCOFmF1ozxoKoTtrBJtNYj8xZaBURB5JGVqAszGh
-        aGG1qEOykZYws+1cmcYwyclOkz2effm+FXVh8nA/cdsdRCq8H2E59bv+9I2f6GMkF7NiekFRjTyS
-        Xgvm/aVxJ/TvHMtjaxGNhDeYVXfsTTmm441z11n+vyyxHa5c0XAH0wohDMk0CHJlJ0RjNkFVhzz+
-        gJ5/ypLqFGJ1SyvyhjQdnkoDQXnyUSlQVnF1cXsM83KrBus8Buo85PGwvjW20/H0nlpAkrrjc7iv
-        d/ehn1aT7AnGE55SMfog9hVAfFwMt+tHe5pX5F3uPyeho//CwwNVJfL44XkdTvbaflKvgK6UhtQa
-        MFKWZDJtsNJZhsmbN7YxHk+ub7KND3zrTIYyWIYyUIYiT5ic+35wi8IByNz97wDzncffsjS8W1nz
-        DQAA//8Cn3kB1FcEOvFCBxYtuBYgoEUDSB/uMCcmeYOdADIGe/fbAPeglgHOQS2wDDQGBvL4eAPw
-        cBb68fED1klBGvJKzSvLLMrPQ2lcoopBg88VRRDmJupV+siWYgsOzIofWQfCQymlqHcZIvhQj7iU
-        pqI3/qjnixTwNSMwO7H5A2o1YmIKqhYpdefnokQHgg/1gTNcgAQPENvKh9mGze1QuWLdgsR0FE/A
-        NNXWxgIAAAD//wMADdrZt2VyAAA=
+      string: "[{\"id\":\"statuscategorychangedate\",\"key\":\"statuscategorychangedate\",\"name\":\"Status
+        Category Changed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"statusCategoryChangedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"statuscategorychangedate\"}},{\"id\":\"fixVersions\",\"key\":\"fixVersions\",\"name\":\"Fix
+        versions\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"fixVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"fixVersions\"}},{\"id\":\"statusCategory\",\"key\":\"statusCategory\",\"name\":\"Status
+        Category\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"statusCategory\"],\"schema\":{\"type\":\"statusCategory\",\"system\":\"statusCategory\"}},{\"id\":\"parent\",\"key\":\"parent\",\"name\":\"Parent\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"parent\"]},{\"id\":\"resolution\",\"key\":\"resolution\",\"name\":\"Resolution\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolution\"],\"schema\":{\"type\":\"resolution\",\"system\":\"resolution\"}},{\"id\":\"lastViewed\",\"key\":\"lastViewed\",\"name\":\"Last
+        Viewed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"lastViewed\"],\"schema\":{\"type\":\"datetime\",\"system\":\"lastViewed\"}},{\"id\":\"priority\",\"key\":\"priority\",\"name\":\"Priority\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"priority\"],\"schema\":{\"type\":\"priority\",\"system\":\"priority\"}},{\"id\":\"labels\",\"key\":\"labels\",\"name\":\"Labels\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"labels\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"system\":\"labels\"}},{\"id\":\"timeestimate\",\"key\":\"timeestimate\",\"name\":\"Remaining
+        Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"remainingEstimate\",\"timeestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeestimate\"}},{\"id\":\"aggregatetimeoriginalestimate\",\"key\":\"aggregatetimeoriginalestimate\",\"name\":\"\u03A3
+        Original Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeoriginalestimate\"}},{\"id\":\"versions\",\"key\":\"versions\",\"name\":\"Affects
+        versions\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectedVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"versions\"}},{\"id\":\"issuelinks\",\"key\":\"issuelinks\",\"name\":\"Linked
+        Issues\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issueLink\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"issuelinks\"}},{\"id\":\"assignee\",\"key\":\"assignee\",\"name\":\"Assignee\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"assignee\"],\"schema\":{\"type\":\"user\",\"system\":\"assignee\"}},{\"id\":\"status\",\"key\":\"status\",\"name\":\"Status\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"status\"],\"schema\":{\"type\":\"status\",\"system\":\"status\"}},{\"id\":\"components\",\"key\":\"components\",\"name\":\"Components\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"component\"],\"schema\":{\"type\":\"array\",\"items\":\"component\",\"system\":\"components\"}},{\"id\":\"issuekey\",\"key\":\"issuekey\",\"name\":\"Key\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"id\",\"issue\",\"issuekey\",\"key\"]},{\"id\":\"customfield_10050\",\"key\":\"customfield_10050\",\"name\":\"DefectDojo
+        Custom URL Field\",\"untranslatedName\":\"DefectDojo Custom URL Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10050]\",\"DefectDojo
+        Custom URL Field\",\"DefectDojo Custom URL Field[URL Field]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":10050}},{\"id\":\"customfield_10051\",\"key\":\"customfield_10051\",\"name\":\"DefectDojo
+        Custom User Picker Field\",\"untranslatedName\":\"DefectDojo Custom User Picker
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10051]\",\"DefectDojo
+        Custom User Picker Field\",\"DefectDojo Custom User Picker Field[User Picker
+        (single user)]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":10051}},{\"id\":\"customfield_10052\",\"key\":\"customfield_10052\",\"name\":\"Impact\",\"untranslatedName\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10052]\",\"Impact\",\"Impact[Short
+        text]\"],\"scope\":{\"type\":\"PROJECT\",\"project\":{\"id\":\"10020\"}},\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":10052}},{\"id\":\"customfield_10053\",\"key\":\"customfield_10053\",\"name\":\"Design\",\"untranslatedName\":\"Design\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10053]\",\"Design\"],\"schema\":{\"type\":\"array\",\"items\":\"design.field.name\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:designcf\",\"customId\":10053}},{\"id\":\"customfield_10054\",\"key\":\"customfield_10054\",\"name\":\"Vulnerability\",\"untranslatedName\":\"Vulnerability\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10054]\",\"Vulnerability\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:vulnerabilitycf\",\"customId\":10054}},{\"id\":\"customfield_10055\",\"key\":\"customfield_10055\",\"name\":\"Sentiment\",\"untranslatedName\":\"Sentiment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10055]\",\"Sentiment\"],\"schema\":{\"type\":\"array\",\"items\":\"sd-sentiment\",\"custom\":\"com.atlassian.servicedesk.sentiment:sd-sentiment\",\"customId\":10055}},{\"id\":\"customfield_10056\",\"key\":\"customfield_10056\",\"name\":\"Goals\",\"untranslatedName\":\"Goals\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10056]\",\"Goals\",\"Goals[Goals]\"],\"schema\":{\"type\":\"array\",\"items\":\"Goals\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:goals\",\"customId\":10056}},{\"id\":\"customfield_10049\",\"key\":\"customfield_10049\",\"name\":\"DefectDojo
+        Custom Short Text Field\",\"untranslatedName\":\"DefectDojo Custom Short Text
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10049]\",\"DefectDojo
+        Custom Short Text Field\",\"DefectDojo Custom Short Text Field[Short text]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":10049}},{\"id\":\"aggregatetimeestimate\",\"key\":\"aggregatetimeestimate\",\"name\":\"\u03A3
+        Remaining Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeestimate\"}},{\"id\":\"creator\",\"key\":\"creator\",\"name\":\"Creator\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"creator\"],\"schema\":{\"type\":\"user\",\"system\":\"creator\"}},{\"id\":\"subtasks\",\"key\":\"subtasks\",\"name\":\"Sub-tasks\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"subtasks\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"subtasks\"}},{\"id\":\"customfield_10040\",\"key\":\"customfield_10040\",\"name\":\"DefectDojo
+        Custom DatePicker\",\"untranslatedName\":\"DefectDojo Custom DatePicker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10040]\",\"DefectDojo
+        Custom DatePicker\",\"DefectDojo Custom DatePicker[Date]\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":10040}},{\"id\":\"customfield_10041\",\"key\":\"customfield_10041\",\"name\":\"DefectDojo
+        Customer Date Time Picker\",\"untranslatedName\":\"DefectDojo Customer Date
+        Time Picker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10041]\",\"DefectDojo
+        Customer Date Time Picker\",\"DefectDojo Customer Date Time Picker[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10041}},{\"id\":\"customfield_10042\",\"key\":\"customfield_10042\",\"name\":\"DefectDojo
+        Custom Labels\",\"untranslatedName\":\"DefectDojo Custom Labels\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10042]\",\"DefectDojo
+        Custom Labels\",\"DefectDojo Custom Labels[Labels]\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":10042}},{\"id\":\"reporter\",\"key\":\"reporter\",\"name\":\"Reporter\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"reporter\"],\"schema\":{\"type\":\"user\",\"system\":\"reporter\"}},{\"id\":\"customfield_10043\",\"key\":\"customfield_10043\",\"name\":\"DefectDojo
+        Custom Number Field\",\"untranslatedName\":\"DefectDojo Custom Number Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10043]\",\"DefectDojo
+        Custom Number Field\",\"DefectDojo Custom Number Field[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10043}},{\"id\":\"aggregateprogress\",\"key\":\"aggregateprogress\",\"name\":\"\u03A3
+        Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"progress\",\"system\":\"aggregateprogress\"}},{\"id\":\"customfield_10044\",\"key\":\"customfield_10044\",\"name\":\"DefectDojo
+        Customer Paragraph Field\",\"untranslatedName\":\"DefectDojo Customer Paragraph
+        Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10044]\",\"DefectDojo
+        Customer Paragraph Field\",\"DefectDojo Customer Paragraph Field[Paragraph]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":10044}},{\"id\":\"customfield_10045\",\"key\":\"customfield_10045\",\"name\":\"DefectDojo
+        Custom Radio Buttons Field\",\"untranslatedName\":\"DefectDojo Custom Radio
+        Buttons Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10045]\",\"DefectDojo
+        Custom Radio Buttons Field\",\"DefectDojo Custom Radio Buttons Field[Radio
+        Buttons]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":10045}},{\"id\":\"customfield_10046\",\"key\":\"customfield_10046\",\"name\":\"DefectDojo
+        Custom Select List (Cascading) Field\",\"untranslatedName\":\"DefectDojo Custom
+        Select List (Cascading) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10046]\",\"DefectDojo
+        Custom Select List (Cascading) Field\",\"DefectDojo Custom Select List (Cascading)
+        Field[Select List (cascading)]\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":10046}},{\"id\":\"customfield_10047\",\"key\":\"customfield_10047\",\"name\":\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"untranslatedName\":\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10047]\",\"DefectDojo
+        Custom Select List (MultiChoice) Field\",\"DefectDojo Custom Select List (MultiChoice)
+        Field[Select List (multiple choices)]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":10047}},{\"id\":\"customfield_10048\",\"key\":\"customfield_10048\",\"name\":\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"untranslatedName\":\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10048]\",\"DefectDojo
+        Custom Select List (SingleChoice) Field\",\"DefectDojo Custom Select List
+        (SingleChoice) Field[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10048}},{\"id\":\"customfield_10038\",\"key\":\"com.atlassian.atlas.jira__project-status\",\"name\":\"Project
+        overview status\",\"untranslatedName\":\"Project overview status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10038]\",\"Project
+        overview status\"],\"schema\":{\"type\":\"string\",\"custom\":\"read-only-string-issue-field\",\"customId\":10038}},{\"id\":\"customfield_10039\",\"key\":\"customfield_10039\",\"name\":\"DefectDojo
+        Custom CheckBoxes\",\"untranslatedName\":\"DefectDojo Custom CheckBoxes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10039]\",\"DefectDojo
+        Custom CheckBoxes\",\"DefectDojo Custom CheckBoxes[Checkboxes]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":10039}},{\"id\":\"progress\",\"key\":\"progress\",\"name\":\"Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"progress\"],\"schema\":{\"type\":\"progress\",\"system\":\"progress\"}},{\"id\":\"votes\",\"key\":\"votes\",\"name\":\"Votes\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"votes\"],\"schema\":{\"type\":\"votes\",\"system\":\"votes\"}},{\"id\":\"worklog\",\"key\":\"worklog\",\"name\":\"Log
+        Work\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"array\",\"items\":\"worklog\",\"system\":\"worklog\"}},{\"id\":\"issuetype\",\"key\":\"issuetype\",\"name\":\"Issue
+        Type\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issuetype\",\"type\"],\"schema\":{\"type\":\"issuetype\",\"system\":\"issuetype\"}},{\"id\":\"timespent\",\"key\":\"timespent\",\"name\":\"Time
+        Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"timespent\"],\"schema\":{\"type\":\"number\",\"system\":\"timespent\"}},{\"id\":\"customfield_10030\",\"key\":\"customfield_10030\",\"name\":\"Submitted
+        forms\",\"untranslatedName\":\"Submitted forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10030]\",\"Submitted
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-submitted-field-cftype\",\"customId\":10030}},{\"id\":\"project\",\"key\":\"project\",\"name\":\"Project\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"project\"],\"schema\":{\"type\":\"project\",\"system\":\"project\"}},{\"id\":\"customfield_10031\",\"key\":\"customfield_10031\",\"name\":\"Locked
+        forms\",\"untranslatedName\":\"Locked forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10031]\",\"Locked
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-locked-field-cftype\",\"customId\":10031}},{\"id\":\"customfield_10032\",\"key\":\"customfield_10032\",\"name\":\"Total
+        forms\",\"untranslatedName\":\"Total forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10032]\",\"Total
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-total-field-cftype\",\"customId\":10032}},{\"id\":\"customfield_10033\",\"key\":\"customfield_10033\",\"name\":\"Category\",\"untranslatedName\":\"Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Category[Category]\",\"cf[10033]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:jwm-category\",\"customId\":10033}},{\"id\":\"aggregatetimespent\",\"key\":\"aggregatetimespent\",\"name\":\"\u03A3
+        Time Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimespent\"}},{\"id\":\"customfield_10035\",\"key\":\"customfield_10035\",\"name\":\"Version\",\"untranslatedName\":\"Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10035]\",\"Version\",\"Version[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10035}},{\"id\":\"customfield_10036\",\"key\":\"customfield_10036\",\"name\":\"Defect
+        Type\",\"untranslatedName\":\"Defect Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10036]\",\"Defect
+        Type\",\"Defect Type[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10036}},{\"id\":\"customfield_10037\",\"key\":\"com.atlassian.atlas.jira__project-key\",\"name\":\"Project
+        overview key\",\"untranslatedName\":\"Project overview key\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10037]\",\"Project
+        overview key\"],\"schema\":{\"type\":\"string\",\"custom\":\"read-only-string-issue-field\",\"customId\":10037}},{\"id\":\"customfield_10027\",\"key\":\"customfield_10027\",\"name\":\"Target
+        start\",\"untranslatedName\":\"Target start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10027]\",\"Target
+        start\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-start\",\"customId\":10027}},{\"id\":\"customfield_10028\",\"key\":\"customfield_10028\",\"name\":\"Target
+        end\",\"untranslatedName\":\"Target end\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10028]\",\"Target
+        end\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-end\",\"customId\":10028}},{\"id\":\"customfield_10029\",\"key\":\"customfield_10029\",\"name\":\"Open
+        forms\",\"untranslatedName\":\"Open forms\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10029]\",\"Open
+        forms\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugins.proforma-managed-fields:forms-open-field-cftype\",\"customId\":10029}},{\"id\":\"resolutiondate\",\"key\":\"resolutiondate\",\"name\":\"Resolved\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolutiondate\",\"resolved\"],\"schema\":{\"type\":\"datetime\",\"system\":\"resolutiondate\"}},{\"id\":\"workratio\",\"key\":\"workratio\",\"name\":\"Work
+        Ratio\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"workratio\"],\"schema\":{\"type\":\"number\",\"system\":\"workratio\"}},{\"id\":\"watches\",\"key\":\"watches\",\"name\":\"Watchers\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"watchers\"],\"schema\":{\"type\":\"watches\",\"system\":\"watches\"}},{\"id\":\"issuerestriction\",\"key\":\"issuerestriction\",\"name\":\"Restrict
+        to\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"issuerestriction\",\"system\":\"issuerestriction\"}},{\"id\":\"thumbnail\",\"key\":\"thumbnail\",\"name\":\"Images\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[]},{\"id\":\"created\",\"key\":\"created\",\"name\":\"Created\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"created\",\"createdDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"created\"}},{\"id\":\"customfield_10020\",\"key\":\"customfield_10020\",\"name\":\"Sprint\",\"untranslatedName\":\"Sprint\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10020]\",\"Sprint\"],\"schema\":{\"type\":\"array\",\"items\":\"json\",\"custom\":\"com.pyxis.greenhopper.jira:gh-sprint\",\"customId\":10020}},{\"id\":\"customfield_10021\",\"key\":\"customfield_10021\",\"name\":\"Flagged\",\"untranslatedName\":\"Flagged\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10021]\",\"Flagged\",\"Flagged[Checkboxes]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":10021}},{\"id\":\"customfield_10022\",\"key\":\"customfield_10022\",\"name\":\"[CHART]
+        Date of First Response\",\"untranslatedName\":\"[CHART] Date of First Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[CHART]
+        Date of First Response\",\"[CHART] Date of First Response[Date of first response]\",\"cf[10022]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.ext.charting:firstresponsedate\",\"customId\":10022}},{\"id\":\"customfield_10023\",\"key\":\"customfield_10023\",\"name\":\"[CHART]
+        Time in Status\",\"untranslatedName\":\"[CHART] Time in Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[CHART]
+        Time in Status\",\"[CHART] Time in Status[Time in Status]\",\"cf[10023]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.ext.charting:timeinstatus\",\"customId\":10023}},{\"id\":\"customfield_10026\",\"key\":\"customfield_10026\",\"name\":\"Story
+        Points\",\"untranslatedName\":\"Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10026]\",\"Story
+        Points\",\"Story Points[Number]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":10026}},{\"id\":\"customfield_10016\",\"key\":\"customfield_10016\",\"name\":\"Story
+        point estimate\",\"untranslatedName\":\"Story point estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10016]\",\"Story
+        point estimate\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.pyxis.greenhopper.jira:jsw-story-points\",\"customId\":10016}},{\"id\":\"customfield_10017\",\"key\":\"customfield_10017\",\"name\":\"Issue
+        color\",\"untranslatedName\":\"Issue color\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10017]\",\"Issue
+        color\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:jsw-issue-color\",\"customId\":10017}},{\"id\":\"customfield_10018\",\"key\":\"customfield_10018\",\"name\":\"Parent
+        Link\",\"untranslatedName\":\"Parent Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10018]\",\"Parent
+        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-parent\",\"customId\":10018}},{\"id\":\"customfield_10019\",\"key\":\"customfield_10019\",\"name\":\"Rank\",\"untranslatedName\":\"Rank\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10019]\",\"Rank\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-lexo-rank\",\"customId\":10019}},{\"id\":\"updated\",\"key\":\"updated\",\"name\":\"Updated\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"updated\",\"updatedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"updated\"}},{\"id\":\"timeoriginalestimate\",\"key\":\"timeoriginalestimate\",\"name\":\"Original
+        estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"originalEstimate\",\"timeoriginalestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeoriginalestimate\"}},{\"id\":\"description\",\"key\":\"description\",\"name\":\"Description\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"description\"],\"schema\":{\"type\":\"string\",\"system\":\"description\"}},{\"id\":\"customfield_10010\",\"key\":\"customfield_10010\",\"name\":\"Request
+        Type\",\"untranslatedName\":\"Request Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10010]\",\"Request
+        Type\"],\"schema\":{\"type\":\"sd-customerrequesttype\",\"custom\":\"com.atlassian.servicedesk:vp-origin\",\"customId\":10010}},{\"id\":\"customfield_10011\",\"key\":\"customfield_10011\",\"name\":\"Epic
+        Name\",\"untranslatedName\":\"Epic Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10011]\",\"Epic
+        Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-label\",\"customId\":10011}},{\"id\":\"customfield_10012\",\"key\":\"customfield_10012\",\"name\":\"Epic
+        Status\",\"untranslatedName\":\"Epic Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10012]\",\"Epic
+        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-status\",\"customId\":10012}},{\"id\":\"customfield_10013\",\"key\":\"customfield_10013\",\"name\":\"Epic
+        Color\",\"untranslatedName\":\"Epic Color\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10013]\",\"Epic
+        Color\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-color\",\"customId\":10013}},{\"id\":\"customfield_10014\",\"key\":\"customfield_10014\",\"name\":\"Epic
+        Link\",\"untranslatedName\":\"Epic Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10014]\",\"Epic
+        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-link\",\"customId\":10014}},{\"id\":\"timetracking\",\"key\":\"timetracking\",\"name\":\"Time
+        tracking\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"timetracking\",\"system\":\"timetracking\"}},{\"id\":\"customfield_10015\",\"key\":\"customfield_10015\",\"name\":\"Start
+        date\",\"untranslatedName\":\"Start date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10015]\",\"Start
+        date\",\"Start date[Date]\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":10015}},{\"id\":\"customfield_10005\",\"key\":\"customfield_10005\",\"name\":\"Change
+        type\",\"untranslatedName\":\"Change type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10005]\",\"Change
+        type\",\"Change type[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10005}},{\"id\":\"customfield_10006\",\"key\":\"customfield_10006\",\"name\":\"Change
+        risk\",\"untranslatedName\":\"Change risk\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10006]\",\"Change
+        risk\",\"Change risk[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10006}},{\"id\":\"security\",\"key\":\"security\",\"name\":\"Security
+        Level\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"level\"],\"schema\":{\"type\":\"securitylevel\",\"system\":\"security\"}},{\"id\":\"customfield_10007\",\"key\":\"customfield_10007\",\"name\":\"Change
+        reason\",\"untranslatedName\":\"Change reason\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10007]\",\"Change
+        reason\",\"Change reason[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10007}},{\"id\":\"customfield_10008\",\"key\":\"customfield_10008\",\"name\":\"Change
+        start date\",\"untranslatedName\":\"Change start date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10008]\",\"Change
+        start date\",\"Change start date[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10008}},{\"id\":\"attachment\",\"key\":\"attachment\",\"name\":\"Attachment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"attachments\"],\"schema\":{\"type\":\"array\",\"items\":\"attachment\",\"system\":\"attachment\"}},{\"id\":\"customfield_10009\",\"key\":\"customfield_10009\",\"name\":\"Change
+        completion date\",\"untranslatedName\":\"Change completion date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10009]\",\"Change
+        completion date\",\"Change completion date[Time stamp]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":10009}},{\"id\":\"summary\",\"key\":\"summary\",\"name\":\"Summary\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"summary\"],\"schema\":{\"type\":\"string\",\"system\":\"summary\"}},{\"id\":\"customfield_10000\",\"key\":\"customfield_10000\",\"name\":\"Development\",\"untranslatedName\":\"development\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10000]\",\"development\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:devsummarycf\",\"customId\":10000}},{\"id\":\"customfield_10001\",\"key\":\"customfield_10001\",\"name\":\"Team\",\"untranslatedName\":\"Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10001]\",\"Team\",\"Team[Team]\"],\"schema\":{\"type\":\"team\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team\",\"customId\":10001,\"configuration\":{\"com.atlassian.jira.plugin.system.customfieldtypes:atlassian-team\":true}}},{\"id\":\"customfield_10002\",\"key\":\"customfield_10002\",\"name\":\"Organizations\",\"untranslatedName\":\"Organizations\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10002]\",\"Organizations\"],\"schema\":{\"type\":\"array\",\"items\":\"sd-customerorganization\",\"custom\":\"com.atlassian.servicedesk:sd-customer-organizations\",\"customId\":10002}},{\"id\":\"customfield_10003\",\"key\":\"customfield_10003\",\"name\":\"Approvers\",\"untranslatedName\":\"Approvers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approvers\",\"Approvers[User
+        Picker (multiple users)]\",\"cf[10003]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":10003}},{\"id\":\"customfield_10004\",\"key\":\"customfield_10004\",\"name\":\"Impact\",\"untranslatedName\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10004]\",\"Impact\",\"Impact[Dropdown]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":10004}},{\"id\":\"environment\",\"key\":\"environment\",\"name\":\"Environment\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"environment\"],\"schema\":{\"type\":\"string\",\"system\":\"environment\"}},{\"id\":\"duedate\",\"key\":\"duedate\",\"name\":\"Due
+        date\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"due\",\"duedate\"],\"schema\":{\"type\":\"date\",\"system\":\"duedate\"}},{\"id\":\"comment\",\"key\":\"comment\",\"name\":\"Comment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"comment\"],\"schema\":{\"type\":\"comments-page\",\"system\":\"comment\"}}]"
     headers:
       Atl-Request-Id:
-      - 4cbe6f06-b345-4717-a6f3-706fe035666e
+      - 404dc26c-d5e5-40a9-b448-ec1033619f0d
       Atl-Traceid:
-      - 4cbe6f06b3454717a6f3706fe035666e
+      - 404dc26cd5e540a9b448ec1033619f0d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:48 GMT
+      - Wed, 30 Apr 2025 16:24:38 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1194,7 +1326,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=223,atl-edge-internal;dur=17,atl-edge-upstream;dur=206,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="tSaisnRT0x2cp1unUmEhlHybhprZ7GHBDoLePmZclDUVtyUkXNZvrg==",cdn-downstream-fbl;dur=328,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=325,atl-edge;dur=236,atl-edge-internal;dur=16,atl-edge-upstream;dur=220,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1203,10 +1335,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 87441111f0e4d414e651812e90f76e78.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - tSaisnRT0x2cp1unUmEhlHybhprZ7GHBDoLePmZclDUVtyUkXNZvrg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 93037601a985cf62b55c00d290d99fb7
+      - 20ba89f6c7e9e0145d49c916c5d37874
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1230,61 +1370,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1602
+    uri: https://defectdojo.atlassian.net/rest/api/latest/issue/NTEST-1842
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+bZltvVhxHQHD0MXu1i3LgsRJgGZFwEhnmTVFaiQV20vz33ek
-        JLtx4hbusCJAIpL3fg8fXh48WJZUZF7iKRAZKMjeMOCZ7ghagO7odAYF7cgSFDVMCt2BjJkCDO2k
-        Mypy4DLv3IPSeAbZOZQKNAjTyKaVNrKYWoO3YRCEQU/B3xVoM1mVcKZoalgKXsdj1n84CIYDXGjg
-        U1zOjCl14vsZTCE1mfwge9RwqjWjoifA+OjJ+LRkPqfGfjKtK/BbK3NYoZHTyfhi0sW9CLdcHNpL
-        HjyNAVY6Rb1cqlWdSIYr1IiC6LAbhN0wmERBEh4mcdzrD+IfMPjARmqdGIzemdk30qgO0ur7aM9F
-        VefeLDLQqWKlrR7uvia6oJx3SMa0YSI1pGSQApFTspBq3rPaqRSXiu8ZRSWY7Rnlt/SeGqr8ewYL
-        34W1CbA5CoN+OPxJs3/gxwJ7XxXo1WIDXU6ontuGVXfGfiVTyjV0vFrxLebldDvejCF6VDpbncA9
-        YKzBY8czDOFVIlS8RFSYo7eFlX7QHpRKfsCMvrLgjbYrt2tgW267+AQkm6wuBTMWUNpb+7Zw/d3J
-        ajk1C6osaDUrSs4w4Gwrc+yHQ1k8XMbDPcP9TGfaTNZ9iYNXGEYUL6P4//VSd99hER2Gg2U4+BYO
-        l63HfrTsR9/CYwPwx8fncAx34TRqD6ZseVUTIXb/5v1zyX4rSfNcQY5888VLcNgeYGaSVzUvvCw6
-        2HXwasdBtPNguOvg6Hk4NW3Wu5aU3DPhJd0Ql9Tg61ET7v4Xt6bzDYH7tTllr6X7PJaVLVxoSfna
-        bjCRe4lRFTw2PG2tKZbWVXt4tmcjQ1E9kxXPRkyXnK6aq4zbGJa5QszY691UQwEma/njpUciOOq3
-        j8R22dZUtn2wC1TRGlSlYlIxs/rKIrbqfrzfW8EKmoP2rYZujTDc4HLR0/f5hixP5KIl1dh7fm2i
-        NeY5vQNLiy9cDMsmL5Yh3IXQcGjrMaN6XLL0hIn5G3sygtKOMCJtu+h6u3Bn6x0hxRgnGHrH4Ryo
-        rpGhmi/v7OTyl7entydvj8enF+Pb8fn5n+eYH95SjQVBgckMyBnyvzDE+iVMEyn4iiCXMG6NEiPJ
-        b0xRcqagQDIhlUbM9l7ilBCvkxd8ZEFQSpF49ZuIvcPib+7UE67ANuRMUL4t1AxgTXkdzjlG16xt
-        X3MBa+mqtJd2F47Dw1ctjusx6SuhVyuv392nk81+aNzA7WeaznHibCHXGq99HTfz3H8KuB0K/XY2
-        i9oxQYCFeiq5VKd1NHe8gm6ukDU2I5EkI1k3WxbYVgTKy6A/XJPC5xq7rbQmjKfl/Etsfg4mzHA4
-        SMjNO1qGCTmWcs6AXDODPGfIBaSVAvKG0/yjrQ4Wh8uU8pnUJhkGw8CfMpEhlfpRHL93BkeueJjX
-        B0ksrJID8kVN8h3++t6pX+DQZzkI1ZAtmiBHFZARJoqbf9AVCYMOsWBcJ3F8PcajG/zTHYSxi9T2
-        MV1Ar2BGQU+q3EcYU9tahhObhb+Por2ZKbiLu7ZzZe1cirmQi0+LdKZkVuEMMBY5XuwC2+RPsPjW
-        p6sQxkt+lYuukTuqVDYGovfEJzcLgDmyAKyt7dDaCPh9p/ju9Rm5SKnYIe/+sTmq+/D05+BipQ0U
-        GjPISskQZgeJ23e9sbUqKBOaGeghErFUenYnqcp2STyzP2oR9i8AAAD//+xZbUvcQBD+K4sgKJiY
-        u8v17gpiD7HQD9KiUEGEY7PZeKF3m5AXo1j/e5/Z3dvG9GKLFPGD4IeY3Z2dmcw888xcpkjynAkT
-        SEBdFkmpWCkr1tioqgCLpYmsBJF1wJplKpZsLbkqscjNDisB5l6rSDIuBHBVxuw25axGqojiPgcw
-        YZ9S0pRov6XRGb7yje4sSaHLpVQUWYw7uRkaT1gETcgs8D+WqiQr1voMywpCa47VksASQP1DqgNS
-        DMLTihkewPiq4fdkIsu51q4uEdOMK9ZSEB2jkiufnaqSbHYWGh9cK3IC3UY+ggZWw3KjIgksazho
-        q6Ytm1vWnyMLUXfgMrLehkvTNH7W8DLX+YD0k3d+vsx1LOOSBWQu7N0LXoH4RDVCarH39XJ+8c27
-        OPNQonWWukvyrKhkQXmwx+N1qvbZ3v5PBMqqyj4iDP9kN2NX4rvlrY/2DMI29FUFMF1TNyJj3a2O
-        AHcWgr6F0HHU7gnHMvRH0pxq+8Y+1hH08eLA3fmkWnfBHB+AiyUlv6kIZb1ecypXO39DavI6kc+s
-        eGFtIxJyjHwjyvwlPhrHo+lkGg0mgRyJWSBm42EyGyQ0N3GbcMMz2ySFxDyOcQfqG4pdfP+ppQgA
-        hWQ92w6bXPFRP/U2DVO2JQslKB6PB2H4YSKmk/FoFoloEuD6hMtkKo7jIy1ldzTfHX7Gnznnrbmy
-        8Op55lXp16XXwBHe0CfI9vM6WqWCPOXlnJfkKJzXFQQEEY8nSAo/V+Tzbmv99jXu9uZvX+Nub//W
-        NQZGxaZVtCTwBKEPDpMktRCpTiDCc9OIGoS7Ag3ExtO6yHJ5eAXsEcvfmUazJay61KUb7ERtO3MM
-        +3A17GsnQ9dOFhbf32Hk1QLmHUZeQ+N3GNkCI10Y6GNqoSNkjr/AnBuTlA80BLfPATTJKm5H+F0p
-        fZQs6MOlYLgd4PrmQUGvAb2UzVnWPdHH5Ua9C47kSXWbFpkyRM68imv7+5H591+8d5tV/282aoQ5
-        obgJbdr3TE95NgNNpIBR+WHzaOvLixXQv7UdbuQe7Kz53bks6xUJbhmr5zNFNa+M4TQlphkOme7e
-        Pz08fHLaHtDaPj4+/gIAAP//AwCBSMMdsxwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18179","self":"https://defectdojo.atlassian.net/rest/api/latest/issue/18179","key":"NTEST-1842","fields":{"statuscategorychangedate":"2025-04-30T18:24:33.499+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1842/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:33.171+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00szr:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:33.267+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/244]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/244 (244)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [weekly engagement|http://localhost:8080/engagement/3] / [ZAP Scan|http://localhost:8080/test/94]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1842/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18179/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - e95cda92-4ad7-4aa8-850f-3d2e7c7da391
+      - 2b797552-0a5a-46bc-b6da-cdb4b5affbb2
       Atl-Traceid:
-      - e95cda924ad74aa8850f3d2e7c7da391
+      - 2b7975520a5a46bcb6dacdb4b5affbb2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:48 GMT
+      - Wed, 30 Apr 2025 16:24:39 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1294,7 +1417,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=305,atl-edge-internal;dur=14,atl-edge-upstream;dur=292,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="MA7wPKKTWI-Q3263uTozxBwpaDbasMaB11OSJxcOCA3kUh180tcB2Q==",cdn-downstream-fbl;dur=351,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=348,atl-edge;dur=260,atl-edge-internal;dur=18,atl-edge-upstream;dur=243,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1303,10 +1426,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 04a2159f61dab28d4b7610df116a191a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MA7wPKKTWI-Q3263uTozxBwpaDbasMaB11OSJxcOCA3kUh180tcB2Q==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 242cb8a7357799a199cc499e1c6e3b3f
+      - 1bc171a043cc4108421648db8a25b5a7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_groups_create_edit_update_finding.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_groups_create_edit_update_finding.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"844\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:49764\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:33148\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -76,7 +76,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:15:48 GMT
+      - Wed, 30 Apr 2025 16:24:39 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -94,25 +94,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       95, "url_ui": "http://localhost:8080/test/95", "url_api": "http://localhost:8080/api/v2/tests/95/"},
       "finding_count": 5, "findings": {"new": [{"id": 246, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/246", "url_api": "http://localhost:8080/api/v2/findings/246/"},
-      {"id": 247, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/247",
-      "url_api": "http://localhost:8080/api/v2/findings/247/"}, {"id": 248, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/248", "url_api": "http://localhost:8080/api/v2/findings/248/"},
-      {"id": 249, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/249", "url_api":
-      "http://localhost:8080/api/v2/findings/249/"}, {"id": 250, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/250", "url_api": "http://localhost:8080/api/v2/findings/250/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/246",
+      "url_api": "http://localhost:8080/api/v2/findings/246/"}, {"id": 247, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/247", "url_api": "http://localhost:8080/api/v2/findings/247/"},
+      {"id": 248, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/248",
+      "url_api": "http://localhost:8080/api/v2/findings/248/"}, {"id": 249, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/249", "url_api": "http://localhost:8080/api/v2/findings/249/"},
+      {"id": 250, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/250",
+      "url_api": "http://localhost:8080/api/v2/findings/250/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -123,11 +121,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2502'
+      - '2367'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -139,11 +137,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2502\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2367\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:49780\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:33160\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -158,63 +156,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 95, \\\"url_ui\\\": \\\"http://localhost:8080/test/95\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/95/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 246, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/246\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/246/\\\"}, {\\\"id\\\": 247, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/247\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/247/\\\"}, {\\\"id\\\":
-        248, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/248\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/248/\\\"}, {\\\"id\\\":
-        249, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/249\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/249/\\\"}, {\\\"id\\\":
-        250, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/250\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/250/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        248, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/248\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/248/\\\"}, {\\\"id\\\": 249, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/249\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/249/\\\"}, {\\\"id\\\": 250, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/250\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/250/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 246,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/246/\",\n          \"url_ui\": \"http://localhost:8080/finding/246\"\n
         \       },\n        {\n          \"id\": 247,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/247/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/247/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/247\"\n        },\n
         \       {\n          \"id\": 248,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/248/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/248\"\n        },\n        {\n          \"id\":
-        249,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/249/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/249\"\n        },\n
-        \       {\n          \"id\": 250,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/250/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/250\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 95,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/95/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/248/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/248\"\n        },\n
+        \       {\n          \"id\": 249,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/249/\",\n          \"url_ui\": \"http://localhost:8080/finding/249\"\n
+        \       },\n        {\n          \"id\": 250,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/250/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/250\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        95,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/95/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/95\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/95/\",\n
@@ -227,7 +223,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:15:49 GMT
+      - Wed, 30 Apr 2025 16:24:39 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -252,26 +248,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtLlm5d3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Whe1Tfjrvf
-        /37HHUglPW57QwR5C6HzYjqtUaMKtXt3qQxGet9Im1oMZELqxndG7v/BF9jvGoU1+o81mm6FNmD/
-        1yUrZ7UZ0Cr8XXKHvW+cjTAFoCmkkBSby8di/VD+TDdDW8WKiOcRmsAEXqITO+P2bbyy3HejbWXc
-        UMdQNTSm/ooQEQNssTg1r2QYQQYsS4AmsCwZE3wmeBQDXECEY97HP2BfNu05S6FkIGgm+DLlef7N
-        qvbGahdBTue5koAZakVnC5Rca65BabacZXml5xzZXAM7EwQzGm6bXo4vRC0HE+6ckmP7QMypImhf
-        twU5nh/25Ow4ub4vyfETAAD//wMAbg0QfCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:39.932+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 18fcf5de-4f3e-4256-a031-db0570c66df0
+      - cc820c2e-9ca2-4519-9698-37dcfbf0c5d2
       Atl-Traceid:
-      - 18fcf5de4f3e4256a031db0570c66df0
+      - cc820c2e9ca24519969837dcfbf0c5d2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:49 GMT
+      - Wed, 30 Apr 2025 16:24:39 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -281,7 +273,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=149,atl-edge-internal;dur=17,atl-edge-upstream;dur=134,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=190,atl-edge;dur=157,atl-edge-internal;dur=13,atl-edge-upstream;dur=144,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="-ThbNIAM1F3mtoALGTKiG0ufm1hyzAsQwZ0ogbxYiw8w-yDaIafv5Q==",cdn-downstream-fbl;dur=194
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -290,10 +282,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e665d09233240df4d3172e59222e0ba2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -ThbNIAM1F3mtoALGTKiG0ufm1hyzAsQwZ0ogbxYiw8w-yDaIafv5Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d0090de8550adf0f350af3974a99b75a
+      - 330e3d7578e61dd9efbf9c1936dcb048
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -320,41 +320,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 80d1ed5f-e682-487a-9fc5-daaf8f806fda
+      - 661547e1-34da-4a05-880a-137bd382a4fc
       Atl-Traceid:
-      - 80d1ed5fe682487a9fc5daaf8f806fda
+      - 661547e134da4a05880a137bd382a4fc
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:49 GMT
+      - Wed, 30 Apr 2025 16:24:40 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -364,7 +351,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=14,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="2pf4NSJC1OK4MhtPZfTNSjhlL5X98A4zmJyr7HccSASlkpSv_4Efiw==",cdn-downstream-fbl;dur=377,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=374,atl-edge;dur=285,atl-edge-internal;dur=22,atl-edge-upstream;dur=269,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -373,13 +360,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f266ac47d4aee3a84c8fc38a6ef92022.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 2pf4NSJC1OK4MhtPZfTNSjhlL5X98A4zmJyr7HccSASlkpSv_4Efiw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 912490b594d70a1d156e4512ca7fc1d5
+      - 2ee683b4b6a21ed4b1fb72c0a0845c3a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -391,7 +386,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/91]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -400,28 +395,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/247]\n*Defect Dojo link:* http://localhost:8080/finding/247
-      (247)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (247)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
       Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -435,7 +430,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3357'
+      - '3332'
       Content-Type:
       - application/json
       User-Agent:
@@ -444,18 +439,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16088","key":"NTEST-1604","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16088"}'
+      string: '{"id":"18183","key":"NTEST-1844","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183"}'
     headers:
       Atl-Request-Id:
-      - 9115a7e8-9e42-4c71-a947-c09eeeee8d1c
+      - 0b28c080-a4e2-4744-9127-8dd372c0b1dd
       Atl-Traceid:
-      - 9115a7e89e424c71a947c09eeeee8d1c
+      - 0b28c080a4e2474491278dd372c0b1dd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:50 GMT
+      - Wed, 30 Apr 2025 16:24:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -465,7 +462,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=682,atl-edge-internal;dur=16,atl-edge-upstream;dur=665,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=662,atl-edge;dur=629,atl-edge-internal;dur=17,atl-edge-upstream;dur=612,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="j-16L-TyBEWy2wSJ0ZKHkm73ZwAtBHvlEGF-6oY58UkcC3Ms86p7zA==",cdn-downstream-fbl;dur=667
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -474,10 +471,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ae39d1ac6bb931d0ff3d636fc3e249de.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - j-16L-TyBEWy2wSJ0ZKHkm73ZwAtBHvlEGF-6oY58UkcC3Ms86p7zA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 52411413cc06ef5b840d1b62c745f599
+      - ae2b023fe67188756758f207ec258aed
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -501,66 +506,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1604
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX6VPbRhT/V3b0sbV12RCjmU6HgpPQUkqNk3wgDLNIz9IGaVfdXfloyP/e93Q5
-        HM4UOg180F7v/r3Dnx1Yl1wmTuRokAloSF4LyBMzkLwAMzBxBgUfqBI0t0JJM4BE2AIsH8QZlynk
-        Kh0sQRu8g2QGpQYD0rZv48pYVSyI4XXg+4HvavirAmPnmxLONY+tiMEZOILkB/v+ZIIbA/kCt5m1
-        pYk8L4EFxDZRn5TLbc6NEVy6EqyHkqzHS+GFnjCmAq9jcAsbpD+bTy/mQzwb41GtgnGiz45B3SoT
-        cwup0pvGhgR3SBH64d7QD4aBPw/9KNiL9nx3f/zqR9TbJyVJiEXFazYvVJLoPeTnh73Z7SYBE2tR
-        kuPw9JCZguf5gCXCWCFjy0oBMTC1YCulb12ijpV8p/NnalFJQeHi+TVfcsu1txSw8mq1tgq2V4E/
-        CiY/G/E3/FRg2KsCpRIsUOScm1uKVXVjaRUteG5g4DSEJ2hXTTtwMoHA0XG2OYUloK7+l4FjBSKr
-        RJQ4kazQRucBTEZ+d1Fq9QkteqHDW+ra3XUAO3fT5iuQbK16J4W1yMA4vWxC6m/1W6MWdsU14dWI
-        oswFKpw8sBzjUaNsPFmPJ89U9xuR6Szp4zL2X6Ea4Xgdjv9fKU30ayyiwGB/Hex/D4HrTuIoXI/C
-        7yGxBfiXL4/hGOzCadhdLMT6fVMDMfqXV49fjrqXPE01pFhvHiUBGqDyqkn/p8Xt7brY33XxasdF
-        uPNisuvi4LGeTdlsTqko1R3CiYZBWyspJFrEjUmfH51RoqC3TaaqPDkWpsz5pk0nPF5xi62nKdnP
-        T/2mIWxbgNew05TY9fJIVeT6WtUPdCBk6kRWVyQbmdr3iBlK79YbGtBYqh9PNYlReNA1iYdu60vZ
-        w4tdoAp7UJVaKC3s5oUu6Mi9utP8+14hCp6C8YjCdEwEHmQizVyzTLfV8i2edGU1dB4nTtijPuc3
-        QIXxidSgevKkI4JdGA0m5JGMm2kp4lMhb1/TzTGUNL/IuMNQjaxVfdefSCWnOL7wmxxmwE2DS92u
-        nPPTd29Ozq5PT46mZxfT6+ls9scM7cM8NegSfDDPgJ1jB5CWkVwmDFMy3zCsJiInpswq9qvQnJ1r
-        KLCcsMog5tynqkqACeX4d8L3y3IUOU1XxOih+7dZda9aYCBSIXn+8FE7fbXurZGfo3btniKbSuhf
-        VyWl7S4kj0O/Q3IzKL0QfA1x33nvzzbPw+MWb7/w+BbHzQ5yHfNG1lE70f0nhbuxsMkZFBJ2g4KE
-        FWW3ypU+a7S5ySsYphpr1nYoUuxYNcFWRYkDsbRPg36vLwvfCuxDor5k3HfnR/n1/yFLtapKGhRf
-        C5lgWTMMc4XdAEhWViaDpEbpyeyQvjfAhFySZIJZwvCnAMNuBklEzLLQZW+I3Uf5Q/39IWKXPVsh
-        IybRX1Zwq3Tku3vu6I6cjj7PVczzTBkbTfyJ7y0amutaN+8guEJidnkBcUUlir1Vq6FVO2ixZycV
-        9uzwinnsMjCW/VlxbUGzqUwxMQt08w5S6B94QU19dv47O6ywBLCLmMsdVDQBegd7V41D7+7YBc6u
-        tZ64Pno/rT8fmk8XZ9q0IwAt58JiNSDSGle4QkaMCia7Y5fIYxhiBcDUG4VBrQXhVC4TV+K476Zq
-        6S2rXCJyLVYW7/77K2Ix8v2eLl6BWwirwVU69TC9OUFe4CxLZcHDp25mi5zotuHCTR0wYhbi3wzS
-        Kufo0zX9hKvtOAYpeE5IuoB/AAAA///sWW1v2jAQ/ivWpFWASBoghJeq6lBZpUqjmjZtH7ovGMeB
-        TECivFBN2o/fc44TXkqgo2rVSRMIiO2zz+e753wP0QqVGjNY5a6Yoc7O5snFJaZxTKtaYkt98OdN
-        u0PrD5D5V7JOplLXZ7bPLg722W71nmwXPV7ZxX66XeyjdnlxmzhlNkG85U7Xryn7UBurDVPJhghU
-        NN7Iicl6dUYwzrYxIH/NGmYBAuq5Zb7aYWMHQ4W7gMSfAaOMBKWPyrEKPqr7tn9o86yGeETzD3wZ
-        J4UGVoQ3qSmeF5zbJ1D7GqQRbHnjzyWwU2b2PpsmF1wIGSbq59r5NgSHa4yvAYsLNQKAv4ZN0w/O
-        ubvyYyQQScm2A/j3yOZwovxWQCc6Xq8wZri/MNIfdbm+sUTaG7R25A1u4Q2x9gaeJEi/cZ09zHwx
-        Y7jET6eA4BTwx0KOtZZTxhkqGgFB3IlExD3SYzxQGzU+8eU0BRiP2UxyF5IrjgRqZrtl39cKjYD2
-        c7mZWbb780Krv+mRGPJZ3fDdvB/d07y7sT0DRs4gjkb4uAr2/vGDIcTv0wf5Fx5pWzFmCdPJ3Bf6
-        0Ea+yqP6zL6pqxZZWB9GpgwDyMzREenNQ+52EXKRkMxdwHz1wJD2Vr4r3S13+oKQwv0TS/+NU2jR
-        MKCsST5e4e7CX1ZZpfp7AR9Ogn7ht3sx48XxwjkRLxzCC+d5eHFSyniEF6cmrc3jfW28cP7jxSvg
-        hf1v4YVTiB7Bi8dsR7so+HeL3TIapGFvFkJJBJdRRAwRQ7tDy+gvq6zDLjirXYmCc8itUDawjIOw
-        yngyq1hTBcCMag9diG/W8rulXpwuFpyK13cHqysyOTFRQXRimUt8xBU8ltivW/ey7ba6ne6k0bFk
-        S/Qs0Ws3vV7Dc7BOMQgrHBgmyR8GrkvRgJEicH992FAEdTDNdZAbV2cgTZTSahjJ5PysLa1Gl7sN
-        23Y6otsBXk7EpGNheY9Lryuu3Es1y/vW4H3zBu9Mzljwpa77DCNris00Nh5gCKNpUkFpZnFIljJC
-        zmMyFOQV0vN5jJ/XI8MywyXRDbs8+9vXeJeof/sa7xL9b11jAJSbcdaaD7qG67MR97xUCF8FEJV1
-        Gaecwdt9sKSBH9MoCOX5PYBHEH+qI43+aEJvEbq0gv57bT+JZJeBql3GLdsFtxxpcH8yjPwBAAD/
-        /xotRihNMIOzGAEAAAD//8Lv4tFihNYupksxgl4M4GqmmcBbY/DGCtA76ZBMWQ2aEYeyDYAuyS9J
-        hM7no5uCqz1mgKtcMjDCXsDhmhoywOkBnO01uM/QdeBqyBnjlIC38FLzyjKL8vMgTTyIUEopdDEJ
-        hEtM6JXll1BvmhNiGNxQoE0ZicVh+eAJH9jMKjALQJxcDWNC6xeyHQBeeKMPM1dHKTexIii1uDQH
-        ZDCSZ8FTNUUljiUQj4OmjEHTOSCvw8VRNRuh6IZqALu2trYWAAAA//8DANajgNq7JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:41.238+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:41.043+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/247]\n*Defect Dojo link:* http://localhost:8080/finding/247
+        (247)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d19aed50-e3c3-4604-8f0d-e7e66943c7f5
+      - d9cdd71e-7802-4f03-a158-d82cb8dbebf5
       Atl-Traceid:
-      - d19aed50e3c346048f0de7e66943c7f5
+      - d9cdd71e78024f03a158d82cb8dbebf5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:51 GMT
+      - Wed, 30 Apr 2025 16:24:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -570,7 +576,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=306,atl-edge-internal;dur=24,atl-edge-upstream;dur=281,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=19,cdn-upstream-fbl;dur=336,atl-edge;dur=259,atl-edge-internal;dur=16,atl-edge-upstream;dur=243,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="S-lxvv--6xrtBktp1icf70y0qVj89k6AbnV-kHhjqvYSly_hFygzkw==",cdn-downstream-fbl;dur=340
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -579,10 +585,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 452324c4cfd54555e3a2d8c074edaf78.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - S-lxvv--6xrtBktp1icf70y0qVj89k6AbnV-kHhjqvYSly_hFygzkw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 0477cf5092ac1d6821b517271c469c11
+      - 8479611c4e8c58900f053d66e3f1efd5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -606,67 +620,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf6mNp6syFGM50OBSehpZQaJ/lAGOaQ1tIF6U69O/mlgf/eXcmS
-        g8FpodPAB93bvtzus8+tvziwLLlMnMjRIBPQkLwRkCemJ3kBpmfiDAreUyVoboWSpgeJsAVY3osz
-        LlPIVdqbgza4B8kESg0GpF2fjStjVTEjhdeB7we+q+HPCoydrko41zy2Igan5wiyH+z7oxFODOQz
-        nGbWlibyvARmENtEfVYutzk3RnDpSrAeWrIeL4UXesKYCrxWwS2sUP5sOr6Y9nFtiEu1C8aJvjgG
-        fatMzC2kSq+aOyQ4Q4nQD/f6ftAP/GnoR8FetOe7+8PXP6DfPjlJRiw6Xqt5oZMk76E+P+yuvZ4k
-        YGItSgocrh4yU/A877FEGCtkbFkpIAamZmyh9K1L0rGS73X+TC8qKShdPL/mc2659uYCFl7t1sbB
-        9VbgD4LRT0b8BT8WmPaqQKsECzQ55eaWclXdWBpFM54b6DmN4Aneq5btOZlA4Og4W53CHNBX/77n
-        WIHIKhElTiQrvKOzBZOB326UWn3GG70w4GvpOtx1Attw0+QrkGxu9V4Ka1GBcTrbhNRf67NGzeyC
-        a8KrEUWZC3Q42bo55qNG2XC0HI6e6e43MtPepMvL0H+NboTDZTj8f6002a+xiAaD/WWw/z0MLluL
-        g3A5CL+HxTXA7+8fwzHYhdNw18ag3ZiJ5YeGHBEWl1cIkzTVkCLf/GMR7LUbeDOVVw0vPH10f9fG
-        6x0b4c6N0a6Ng8fuNLTZrBIp1S+EE/UDnHKLD0dDuM8v3IbONwTuNeo0lWU9PFIVBS4gUv5IC0Km
-        TmR1BfdrniZtWsRN1L48WiPP8KjJVJUnx8KUOV+tSxmX0S37ATFD5b2Ohga8LPHHU4/EIDxoH4nt
-        sHVUtr2xC1RhB6pSC6WFXb0wiK24V780//6tEAVPwXgkYVolAhcykWaumacbtnyHKy2ths7jwgm7
-        Msj5DRAxUgVs9wS7wBvswmgwoohk3IxLEZ8KefuGdo6hpP5Fxm0e6+wu6r1uRSo5xvaF3+QwAW4a
-        bOj1yDk/ff/25Oz69ORofHYxvh5PJr9P8H5YpwZDggemGbBzfAGkZWSXCcOUzFcM2UTkpJRZxX4R
-        mrNzDQXSCasMotZ9ilUCLCjHvxO+X5aDyGleRcwehn9TVQ/YAhORCsnz7UPr7msd3hrpOXrXEg5m
-        NpXQna5KKttdSB6GfovkplF6Ifga4e7lfdjbPA+PG7z9zONbbDdbyLXKG1tH647uPznctoVNzaCR
-        sG0UJCyoulWu9FnjzU1eQT/VyBubpkixY9UkWxUlNsTSPg36vY4WvpXYbaGOMh6G85P8+v+QpVpV
-        JTWKb4RMkBgNw1phNwCSlZXJIKlRejI5pO8NMCHnZJlgljD8KcDw0YIkImVZ6LK3pO6TfFV/X0Xs
-        slMrZMQkxssKbpWOfHfPHdxR0DHmuYp5niljo5E/8r1ZI3Nd++YdBFcozC4vIK6Iotg7tehbtUMW
-        3+ykwjc7vGIeuwyMZX9UXFvQbCxTLMwCw7xDFLoDXlBLn53/xg4rpAB2EXO5Q4o6QO9g76oJ6N0d
-        u8DetfYTx0cfxvXnY/Np80yT9UtPw6mwyAYkWuMKR6iIEWGyO3aJOvohMgCW3iAMai8Ip3KeuBLb
-        fTdVc29e5RKRa5FZvIfnr0jFwPc7uXgBbiGsBlfp1MPy5gR5gb0s0YKHR93MFjnJbdKFkzphpCzE
-        vwmkVc4xpkv6CVff4xik4Dkh6QL+BgAA///sWW1v2jAQ/ivWpFWASBoghJeq6lBZpUqjmjZtH7ov
-        GMeBTECihFBN2o/fc44TICXQUbXqpKkVENtnn893z/meRGtUasxglbt8hjo7m68uLjGNY1rVElvq
-        gz9v2h1af4Dsu5Z1MpW6PrN9dnGwz3ar92S76PHKLvbT7WIftcuL28QpswniLXO6fk3Zh9pYbZhI
-        NkSgovFGTkzWqzOCcbaLAdnfrGHmIKCeW+arHTZ2MFS4C0j8GTDKSFD6qByr4KO6b/uHNs9qiEc0
-        /8CXcVJoYEV4k5riecG5ewK1r0ESwZY3/lwCO2Vq77Pp6oILIcOV+rlxvi3B4Qbja8DiXI0A4K9h
-        0/SDc+6u/RgJRFKy7QD+PbI5nCi7FdCJjjcrjBnuL4z0R12ubyyR9gatHXmDm3tDrL2Br1ZIv3Gd
-        Pcx8MWO4SE+ngOAE8MdCjrWWU8YZKhoBQdyJRMQ90mM8UBs1PvHlNAEYj9lMcheSa44Eaqa7Zd83
-        Co2A9nO5nVl2+7N6qr/tkRjyWdUIbtaP7mnW3didASNnEEcjfFwFe//4wRDi9+mD/AuPtK0Ys4TJ
-        ZO4LfWgjX+VRfWbf1FWLLKwPI1WGAWTm6Ij05iF3uwi5WJHMXcB89cCQ9ta+K90dd/qCkML9E0v/
-        jVNo0TCgrEk+XuHuwl9WWaX6ewEfXgX93G/3YsaL44VzIl44hBfO8/DipJTxCC9OTVrbx/vaeOH8
-        x4tXwAv738ILJxc9gheP2Y52XvAXi90yGqRhl3Xk9BdVSKsIvqQ4HmJtCkPtnJoqdFj5HMWOMs7B
-        yjmHzDxlA8t4MitXZqd2L5Z2KjpmVJik9WGcLBacitd3B6srMjkxUUF0YplLfMQVPJb4s1v3su22
-        up3upNGxZEv0LNFrN71ew3OwTj4IKxwYJskfBq5L0YCRInB/fdhSBHUwzXWQG1emliZKaTWMZDJ+
-        1pZWo8vdhm07HdHtAC8nYtKxsLzHpdcVV+6lmuV9a/C+eYP/VM5Y8KWu+wwjbYrNJDYeYAijaVJB
-        aaZxSJYyQs5jMhTkFdLzeYyf1yPDMsMl0Q1Fnv3ta1wk6t++xkWi/61rDBxyU95Y80HXcH024p6X
-        COGrAKKyLmWlUxS7D5Y08GMSBaE8vwe+COJPdaTRiyb05qFLK+jXa/tJJLsMVO0ybtkue2Fh58Ad
-        adQv4ssfAAAA//8aLV9olpIGtHwBAAAA//8i08Wj5QutXUyX8gW9GIC3xuCNF6Cr0yF5rxo0Iw5l
-        GwAtzC9JhM7no5uCs9mFs1zC2R4zwl7y4ZoaMsDVAAUVCFglDHA1QI1x6TCGt/BS88oyi/LzIK04
-        iFBKKXQxCYRLVOjl50JMqIYxocU9GcUv0joYfZi5Okq5iRVBqcWlOSCDkewGz5wUlTiWQNxRll9C
-        vQlbiGFwQ4F2ZSQWh+WDJ55gs6ygKWPQdA7ISrhDUF1rhOJcqAZw8NTW1gIAAAD//wMA++w8a7sk
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:41.238+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:41.043+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/247]\n*Defect Dojo link:* http://localhost:8080/finding/247
+        (247)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - dc469fb6-c9d1-42e4-afa4-a43147382d06
+      - 508efe33-4842-4101-9c71-8e3ce27a33a3
       Atl-Traceid:
-      - dc469fb6c9d142e4afa4a43147382d06
+      - 508efe33484241019c718e3ce27a33a3
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:51 GMT
+      - Wed, 30 Apr 2025 16:24:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -676,7 +690,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=257,atl-edge-internal;dur=15,atl-edge-upstream;dur=243,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="bdFC2axV3JhpBaC6FW6fFcTSQc6lyj7XyxrlW4vCqiMDz8sixvSI1g==",cdn-downstream-fbl;dur=346,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=344,atl-edge;dur=268,atl-edge-internal;dur=17,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -685,10 +699,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 48f2e5da4dd7651bfa3bfd0054610cf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - bdFC2axV3JhpBaC6FW6fFcTSQc6lyj7XyxrlW4vCqiMDz8sixvSI1g==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 159a29f7c95205a815e5cd610c3641ea
+      - ab9a5da15b302f25460dc1ef59eff39d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -715,26 +737,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2TtvvIDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8em0QYXSN/bdpsJr4VwrTGrQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgKaQQlJuLh/L9UP1M92MXR0qwp8jNIEJvAQn9truu3Blte+jbaXt
-        2IRQPba6+YoQHgJsPj81r4SPIANWJEATWFaM8TzjeRADXECAQ96FP+BQtd05S6FiwGnBC5ouIPtm
-        ZXdjlA1gTmcLKQALVJJmcxS5UrkCqdgyKxa1muXIZgrYmcDraLhtBxFfiEqM2t9ZKWL7QPSpImhe
-        tyU5nh/2ZE2cXN9X5PgJAAD//wMAOdIPZiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:42.704+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 1d78dfa9-8942-44cc-84da-265b4d4d2de2
+      - 96ba6139-3377-4186-a494-1a5e267a0da5
       Atl-Traceid:
-      - 1d78dfa9894244cc84da265b4d4d2de2
+      - 96ba613933774186a4941a5e267a0da5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:51 GMT
+      - Wed, 30 Apr 2025 16:24:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -744,7 +762,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=160,atl-edge-internal;dur=12,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="A8DRKzPPjzGiHotIKUxZQfdm_oFBzx5DYrxzW2_T5-8Q6QHqiEWYFw==",cdn-downstream-fbl;dur=283,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=280,atl-edge;dur=192,atl-edge-internal;dur=14,atl-edge-upstream;dur=177,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -753,10 +771,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 452324c4cfd54555e3a2d8c074edaf78.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - A8DRKzPPjzGiHotIKUxZQfdm_oFBzx5DYrxzW2_T5-8Q6QHqiEWYFw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 454cd4b6a5e37ac1c646561ab6df4dad
+      - 51329fa92fc9ddeba00d0ef0f8b79597
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -780,66 +806,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbMmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxvnv3eUh
-        xYfS2p3GfiCuPbD77YfVZwdWJZeJEzkaZAIaktcC8sT0JC/A9EycQcF7qgTNrVDS9CARtgDLe3HG
-        ZQq5SnsL0Ab3IJlCqcGAtO3ZuDJWFXNSeB34fuC7Gv6swNjZuoRzzWMrYnB6jiD7wZ4/HuPEQD7H
-        aWZtaSLPS2AOsU3UJ+Vym3NjBJeuBOuhJevxUnihJ4ypwOsU3MIa5c9mk4tZH9eGuFS7YJzos2PQ
-        t8rE3EKq9Lq5Q4IzlAj9cNT3g37gz0I/CkbRyHf3hvs/oN8+OUlGLDpeq3mhkyTvoT4/3Fy7nSRg
-        Yi1KChyuHjJT8DzvsUQYK2RsWSkgBqbmbKn0rUvSsZLvdP5MLyopKF08v+YLbrn2FgKWXu3W1sF2
-        K/AHwfgnI/6CHwtMe1WgVYIFmpxxc0u5qm4sjaI5zw30nEbwBO9Vy/acTCBwdJytT2EB6Kv/pedY
-        gcgqESVOJCu8o/MAJgO/2yi1+oQ3emHAW+k63HUCu3DT5CuQbG/1TgprUYFxNrYJqb/WZ42a2yXX
-        hFcjijIX6HDy4OaYjxplw/FqOH6mu9/ITHeTTV6G/j66EQ5X4fD/tdJkv8YiGgz2VsHe9zC46iwO
-        wtUg/B4WW4B/+fIYjsEunIbdxlys3jcciNm/vHp8ctCd5GmqIUW++cciGHUbeDOVVw0vPH10b9fG
-        /o6NcOfGeNfGwWN3GtpsVomU6hfCifpBy5WUEi3ixvPPj9aoUDDaJlNVnhwLU+Z83ZYTLi+5xaen
-        oeznl37zIGyfAK9Rp6mw6+GRqij0tasfaEHI1Imsrsg2KrXvETNU3m00NOBliT+eeiQG4UH3SDwM
-        24bKHm7sAlW4AVWphdLCrl8Ygk7cq1+af/9WiIKnYDySMJ0SgQuZSDPXLNItW77FlY5WQ+dx4YQb
-        1Of8BogYnygN4pMnAxHswmgwpohk3ExKEZ8Kefuado6hpP5Fxh2GamQt673NilRygu0Lv8lhCtw0
-        uNTtyDk/fffm5Oz69ORocnYxuZ5Mp79P8X5YpwZDggdmGbBzfAGkZWSXCcOUzNcM2UTkpJRZxX4R
-        mrNzDQXSCasMYs59ilUCLCjHvxO+X5aDyGleRcwehn9bVffYAhORCsnzh4fa7qsNb438HL1r55TZ
-        VMLmdFVS2e5C8jD0OyQ3jdILwdcIb17e+73N8/C4xdvPPL7FdrODXKe8sXXUdnT/yeGuLWxqBo2E
-        XaMgYUnVrXKlzxpvbvIK+qlGzto2RYodqybZqiixIZb2adCPdtHCaEML38r4/XB+lF//H7JUq6qk
-        RvG1kAnSmmFYK+wGQLKyMhkkNUpPpof0vQEm5IIMEMwShj8FGL5mkESkLAtd9obUfZSv6u+riF1u
-        1AoZMYnxsoJbpSPfHbmDOwo6xjxXMc8zZWw09se+N29krmvfvIPgCoXZ5QXEFVEUe6uWfat2yOKb
-        nVT4ZodXzGOXgbHsj4prC5pNZIqFWWCYd4jC5oAX1NJn57+xwwopgF3EXO6Qog7QOxhdNQG9u2MX
-        2LvWfuL46P2k/nxoPl2eadK2ADScCYtsQKI1rnCEihgRJrtjl6ijHyIDYOkNwqD2gnAqF4krsd13
-        U7XwFlUuEbkWmcW7f/6KVAx8fyMXL8EthNXgKp16WN6cIC+wlyVa8PCom9kiJ7ltunBSJ4yUhfg3
-        hbTKOcZ0RT/h6nscgxQ8JyRdwN8AAAD//+xZbW/aMBD+K9akVYBIGiCEl6rqUFmlSqOaNm0fui8Y
-        x4FMQFBeqCbtx+85xwmQEuioWnXSBAJi++zz+e4530O4RqXGDFa5y2eos7N5fHGJaRzTqpbYUh/8
-        edPu0PoDZP61rJOp1PWZ7bOLg322W70n20WPV3axn24X+6hdXtwmTplNEG+Z0/Vryj7UxmrDRLIh
-        AhWNN3Jisl6dEYyzXQzIXrOGmYOAem6Zr3bY2MFQ4S4g8WfAKCNB6aNyrIKP6r7tH9o8qyEe0fwD
-        X8ZJoYEV4U1qiucF5+4J1L4GSQhb3vhzCeyUqb3PpvEFF0KuYvVz43xbgsMNxteAxbkaAcBfw6bp
-        B+fcXfsR8oSkZNsB/HtkczhRdiugEx1vVhgz3F8Y6Y+6XN9YQu0NWjvyBjf3hkh7A49jpN+ozh5m
-        vpgxXOKnU0BwAvhjK461llPGGSoaAUHciUTIPdJjPFAbNT7x5TQBGI/ZTHIXkmuOBGqmu2XfNwqN
-        gPZzuZ1ZdvuzQqu/7ZEY8lnd8N2sH93TrLuxOwNGziCORvi4Cvb+8YMhxO/TB/kXHmlbEWZZJZO5
-        L/ShjXyVR/WZfVNXLbKwPoxUGQaQmaMj1JuH3O1ixUVMMncB89UDQ9pb+650d9zpC0IK908s/TdO
-        oUVXAWVN8vEKdxf+ssoq1d8L+HAc9HO/3YsZL44Xzol44RBeOM/Di5NSxiO8ODVpbR/va+OF8x8v
-        XgEv7H8LL5xc9AhePGY72nnBXyx2y+qdhr1d78QhXEYRMUQMFYfmhFihw86pqUKHVSZh5ZxDZoWy
-        gWUchFXGk1m5MioAZlR76EJ8u5YvVnRRslhwKl7fHayuyOTERAXhiWUu8RFX8Fhiv27dy7bb6na6
-        k0bHki3Rs0Sv3fR6Dc/BOvkgrHBgmCR/GLguRQNGisD99WFLEdTBNNdBblydgTRRSqthJJPxs7a0
-        Gl3uNmzb6YhuB3g5EZOOheU9Lr2uuHIv1SzvW4P3zRu8UzljwZe67jOMtCkyk8h4gCGMpkkFpZnG
-        IVnKWHEekaEgr5CezyP8vB4ZlrlaEt1Q5NnfvsZFov7ta1wk+t+6xgAoN+WsNR90DddnI+55iRC+
-        CiAq61JOOYW3+2BJAz8mYbCS5/cAHkH8qY40+qMJvXno0gr677X9JJJdBqp2Gbds59xyqMH9yTDy
-        BwAA//8aLUYoTTCDsxgBAAAA///C7+LRYoTWLqZLMYJeDOBqppnAW2PwxgrQO+mQTFkNmhGHsg2A
-        LskvSYTO56ObgrPZhbNcwjUHZGCEveTD2SzD6TOc7TW4l9EkjHHpMIa38FLzyjKL8vMgTTyIUEop
-        dDEJhEtM6JXll1BvmhNiGNxQoE0ZicVh+eAJH9jMKjALQJxcDWNC6xeyHQBeeKMPM1dHKTexIii1
-        uDQHZDCSZ8FTNUUljiUQj4OmjEHTOSCvw8VRNRuh6IZqALu2trYWAAAA//8DAIH9S+u7JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:41.238+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:41.043+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/247]\n*Defect Dojo link:* http://localhost:8080/finding/247
+        (247)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - cad7873f-9983-46ec-85f3-13dee96d3eb1
+      - 5cef418a-e96b-4e9c-8b30-5531187706b4
       Atl-Traceid:
-      - cad7873f998346ec85f313dee96d3eb1
+      - 5cef418ae96b4e9c8b305531187706b4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:52 GMT
+      - Wed, 30 Apr 2025 16:24:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -849,7 +876,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=271,atl-edge-internal;dur=12,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=326,atl-edge;dur=293,atl-edge-internal;dur=36,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="cSdedlHRt5uagp4FwzTdk9BTfjKDvUGOo3JiTrjIApfz7SqCQB5iNw==",cdn-downstream-fbl;dur=329
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -858,10 +885,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 cbe94ab27088fc4bb73abf8e3179b3d2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - cSdedlHRt5uagp4FwzTdk9BTfjKDvUGOo3JiTrjIApfz7SqCQB5iNw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - b451ebdbfd9252797047fb55832ee887
+      - b7a40742e489abec83e6493549fc59fd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -888,41 +923,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - dd4e7f8d-05e8-4168-877a-4e865421b0bd
+      - 9bcbcd72-4b32-437e-a4ed-eb5aa1426898
       Atl-Traceid:
-      - dd4e7f8d05e84168877a4e865421b0bd
+      - 9bcbcd724b32437ea4edeb5aa1426898
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:52 GMT
+      - Wed, 30 Apr 2025 16:24:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -932,7 +954,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=301,atl-edge-internal;dur=13,atl-edge-upstream;dur=288,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=361,atl-edge;dur=329,atl-edge-internal;dur=16,atl-edge-upstream;dur=313,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="j5OGcuC7mGyPY88q0me62SSb3X7uCFprlfuleKEhUBxvLMT12thxxw==",cdn-downstream-fbl;dur=366
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -941,13 +963,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ad310b4d7c581c35032fa3fce068e53c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - j5OGcuC7mGyPY88q0me62SSb3X7uCFprlfuleKEhUBxvLMT12thxxw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c58a6acc8ffa9ae36a6a98eb75074ac7
+      - 0fb440f38ed07e7ee8a5ca42f706d5d5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -959,7 +989,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/91]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -968,28 +998,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/247]\n*Defect Dojo link:* http://localhost:8080/finding/247
-      (247)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (247)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
       Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -1003,27 +1033,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3341'
+      - '3316'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - f511626d-62f0-4f8e-9b3d-a68a5324dab1
+      - cd3b7fdc-d0f0-453b-8fd1-9ce636ebaf86
       Atl-Traceid:
-      - f511626d62f04f8e9b3da68a5324dab1
+      - cd3b7fdcd0f0453b8fd19ce636ebaf86
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:52 GMT
+      - Wed, 30 Apr 2025 16:24:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1033,17 +1065,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=269,atl-edge-internal;dur=14,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=305,atl-edge;dur=286,atl-edge-internal;dur=15,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="O66w4ISug0EogE22uL-nTvxzTSVxodTGFGnz562bxUSuiZdf9Yulfw==",cdn-downstream-fbl;dur=311
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a4888bfa57444daa340ca8dc53629170.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - O66w4ISug0EogE22uL-nTvxzTSVxodTGFGnz562bxUSuiZdf9Yulfw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - a1c1374785a1baf4e9e41381d4ef2904
+      - 9d6cdec35985ddc80935bdfb0dcb8750
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1067,66 +1107,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbMmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxvnv3eUh
-        xYfS2p3GfiCuPbD77YfVZwdWJZeJEzkaZAIaktcC8sT0JC/A9EycQcF7qgTNrVDS9CARtgDLe3HG
-        ZQq5SnsL0Ab3IJlCqcGAtO3ZuDJWFXNSeB34fuC7Gv6swNjZuoRzzWMrYnB6jiD7wZ4/HuPEQD7H
-        aWZtaSLPS2AOsU3UJ+Vym3NjBJeuBOuhJevxUnihJ4ypwOsU3MIa5c9mk4tZH9eGuFS7YJzos2PQ
-        t8rE3EKq9Lq5Q4IzlAj9cNT3g37gz0I/CkbRyHf3hvs/oN8+OUlGLDpeq3mhkyTvoT4/3Fy7nSRg
-        Yi1KChyuHjJT8DzvsUQYK2RsWSkgBqbmbKn0rUvSsZLvdP5MLyopKF08v+YLbrn2FgKWXu3W1sF2
-        K/AHwfgnI/6CHwtMe1WgVYIFmpxxc0u5qm4sjaI5zw30nEbwBO9Vy/acTCBwdJytT2EB6Kv/pedY
-        gcgqESVOJCu8o/MAJgN/10bQbZRafcKrvjATrXSdhzqzXR5o8hV6ttd9J4W1qMA4G9sE4V/rs0bN
-        7ZJrArIRRZkLdDh5EBJMVA2/4Xg1HD/T3W+krLvJJmFDfx/dCIercPj/WmlgUYMUDQZ7q2Dvexhc
-        dRYH4WoQfg+LLfK/fHkMx7CD41ys3jcciEm+vHp8ctCd5GmqIUW++cciGHUbeAGVVw0vPH10b9fG
-        /o6NcOfGeNfGwWN3GtpsVomU6hfCifpBy5UUeS3ixvPPj9aoHjCoJlNVnhwLU+Z83VYNLmMK7XtM
-        D1VSa4JbfIwaEn9+zTdPxPZR8Bp1miq6Hh6pipJRO/+BFoRMncjqiryJNeBliSaeeiQG4UH3SDwM
-        2y4qCzdU9nBjA6pSC6WFXb/wwp24V780//6tEAVPwXgkYTolAhcykWauWaRbUnyLKx17hs7j+gg3
-        qM/5DRD/PVEaRBtPBiLYhdFgTBHJuJmUIj4V8vY17RxDSf2LjDsM1cha1nubFankBNsXfpPDFLhp
-        cKnbkXN++u7Nydn16cnR5Oxicj2ZTn+f4v2wTg2GBA/MMmDnSPTSMrLLhGFK5muGpCFyUsqsYr8I
-        zdm5hgJZg1UGEeY+RR4BFpTj3wnfL8tB5DSvImYPw7+tqntsgYlIheT5w0Nt99WGt8Z5jt61c8ps
-        KmFzuiqpbHcheRj6HZKbRumF4GuENw/s/d7meXjc4u1nHt9iu9lBrlPe2DpqO7r/5HDXFjY1g0bC
-        rh+QsKTqVrnSZ403N3kF/VQjZ22bIsWOVZNsVZTYEEv7NOhHu2hhtKGFb2X8fjg/yq//D1mqVVVS
-        o/hayARJzDCsFXYDIFlZmQySGqUn00P63gATckEGCGYJw58CDF8zSCJSloUue0PqPspX9fdVxC43
-        aoWMmMR4WcGt0pHvjtzBHQUdY56rmOeZMjYa+2Pfmzcy17Vv3kFwhcLs8gLiiiiKvVXLvlU7ZPFp
-        Tip8msMr5rHLwFj2R8W1Bc0mMsXCLDDMO0Rhc8ALaumz89/YYYUUwC5iLndIUaPnHYyumoDe3bEL
-        7F1rP3F89H5Sfz40ny7PNGlbABrOhEU2INEaVzhCRYwIk92xS9TRD5EBsPQGYVB7QTiVi8SV2O67
-        qVp4iyqXiFyLzOLdP39FKga+v5GLl+AWwmpwlU49LG9OkBfYshIteHjUzWyRk9w2XTipE0bKQvyb
-        QlrlHGO6op9w9T2OQQqeE5Iu4G8AAAD//+xZbW/aMBD+K9akVYBIGiCEl6rqUFmlSqOaNm0fui8Y
-        x4FMQFBeqCbtx+85xwmQEuioWnXSBAJi++zz+e4530O4RqXGDFa5y2eos7N5fHGJaRzTqpbYUh/8
-        edPu0PoDZP61rJOp1C2Z7bOLg322W70n20WPV3axn24X+6hdXtwmTplNEG+Z0/Vryj7UxmrDRLIh
-        AhWNN3Jisl6dEYyzXQzIXrOGmYOAem6Zr3bY2MFQ4S4g8WfAKCNB6aNyrIKP6r7tH9o8qyEe0fwD
-        X8ZJoYEV4U1qiucF5+4J1L4GSQhb3vhzCeyUqb3PpvEFF0KuYvVz43xbgsMNxteAxbkaAcBfw6bp
-        B+fcXfsR8oSkZNsB/HtkczhRdiugEx1vVhgz3F8Y6Y+6XN9YQu0NWjvyBjf3hkh7A49jpN+ozh5m
-        vpgxXOKnU0BwAvhjK461llPGGSoaAUHciUTIPdJjPFAbNT7x5TQBGI/ZTHIXkmuOBGqmu2XfNwqN
-        gPZzuZ1ZdvuzQqu/7ZEY8lnd592sH93TrLuxOwNGziCORvi4Cvb+8YMhxO/TB/kXHmlbEWZZJZO5
-        L/ShjXyVR/WZfVNXLbKwPoxUGQaQmaMj1JuH3O1ixUVMMncB89UDQ9pb+650d9zpC0IK908s/TdO
-        oUVXAWVN8vEKdxf+ssoq1d8L+HAc9HO/3YsZL44Xzol44RBeOM/Di5NSxiO8ODVpbR/va+OF8x8v
-        XgEv7H8LL5xc9AhePGY72nnBXyx2y+qdhr1d78QhXEbRLkQMFYfmhFihw86pqUKHVSZh5ZxDZoWy
-        gWUchFXGk1m5MioAZlR76EJ8u5YvVnRRslhwKl7fHayuyOTERAXhiWUu8RFX8Fjium7dy7bb6na6
-        k0bHki3Rs0Sv3fR6Dc/BOvkgrHBgmCR/GLguRQNGisD99WFLEdTBNNdBClydgTRRSqthJJPRsLa0
-        Gl3uNmzb6YhuB3g5EZOOheU9Lr2uuHIv1SzvW4P3zRu8UzljwZe67jOMtCkyk8h4gCGMpkkFpZnG
-        IVnKWHEekaEgr5CezyP8vB4ZlrlaEt1QpNPfvsZFPv7ta1zk89+6xgAoN+WsNR90DddnI+55iRC+
-        CiAq61IGOYW3+2BJAz8mYbCS5/cAHkH8qY40+j8JvXno0gr677X9JJJdBqp2Gbds59xyqMH9yTDy
-        BwAA//8aLUYoTTCDsxgBAAAA///C7+LRYoTWLqZLMYJeDOBqppnAW2PwxgrQO+mQTFkNmviGsg2A
-        LskvSYTO56ObgrPZhbNcwjUHZGCEveTD2SzD6TOc7TW4l9EkjHHpMIa38FLzyjKL8vMgTTyIUEop
-        dDEJhEtM6JXll1BvUhNiGNxQoE0ZicVh+eAJH9jMKjALQJxcDWNC6xeyHQBeeKMPM1dHKTexIii1
-        uDQHZDCSZ8FTNUUljiUQj4OmjEHTOSCvw8VRNRuh6IZqALu2trYWAAAA//8DAH1Ai/67JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:41.238+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:41.043+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/247]\n*Defect Dojo link:* http://localhost:8080/finding/247
+        (247)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a66fbf5a-46cc-4e84-a828-bdf26787a157
+      - 20a808c2-75ad-4832-a255-140273d98d8d
       Atl-Traceid:
-      - a66fbf5a46cc4e84a828bdf26787a157
+      - 20a808c275ad4832a255140273d98d8d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:53 GMT
+      - Wed, 30 Apr 2025 16:24:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1136,7 +1177,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=248,atl-edge-internal;dur=12,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="S2hQ4_Xd531z0mdwCiTxsRBfciWRkDimt537H8Fn4k7quF0rfRbKUg==",cdn-downstream-fbl;dur=363,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=360,atl-edge;dur=271,atl-edge-internal;dur=18,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1145,10 +1186,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 bd02c4a72f88f2bbd693051675941962.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - S2hQ4_Xd531z0mdwCiTxsRBfciWRkDimt537H8Fn4k7quF0rfRbKUg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 095a47f53ceacd6c30762feaf7e60d2e
+      - 45c5465fcb61989f672202e53fd11301
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1175,26 +1224,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bprmq5b3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDZrUKEMjXt3iQhGeK+FTSwGMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCKcAaQIJTMvN5WO5fqh+ppuhrWNF+PMITWACL9GJnXH7Nl5Z7bvRtjJu
-        aGKoHrRpviKExwAtilPzSoQRpEDzKaRTWFaUcpZxFsUAFxDhmPfxD9hXuj1nU6go8DTneZbkBftm
-        ZXtjlYsgS+cLKQBzVDLNChRMKaZAKrrM8kWt5gzpXAE9EwQzGm51L8YXohKDCXdOirF9IOZUEbSv
-        25Iczw97cnacXN9X5PgJAAD//wMAc/4yYyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:45.033+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 3ef9f86c-e872-481a-b68c-6b05518d11b7
+      - c6ad5c6e-b8c5-4c32-967e-b686bb81c2e0
       Atl-Traceid:
-      - 3ef9f86ce872481ab68c6b05518d11b7
+      - c6ad5c6eb8c54c32967eb686bb81c2e0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:53 GMT
+      - Wed, 30 Apr 2025 16:24:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1204,7 +1249,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=184,atl-edge-internal;dur=11,atl-edge-upstream;dur=173,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=177,atl-edge;dur=144,atl-edge-internal;dur=14,atl-edge-upstream;dur=130,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="5NzVu8PPPSi3aCVKosTVr3_BOZW8qSjSxTL5SrR5Y_Gj_4gnNUPQ6Q==",cdn-downstream-fbl;dur=181
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1213,10 +1258,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 22067fb5d7eb764108747a104222f50a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 5NzVu8PPPSi3aCVKosTVr3_BOZW8qSjSxTL5SrR5Y_Gj_4gnNUPQ6Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 8c2d499f0543b636a3da1456c76bd35b
+      - 7c3fb04417a8deba707ddccdb7233c1c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1240,67 +1293,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+tjIvSY7MmU7HtZXEreu6spI8OB4PTK5IxCDAAqCOxvnv3SVF
-        KT6Uqd1p7Afi2gO7335YffZgWXGVeYlnQGVgIHstQGa2p3gJtmfTAkre0xUY7oRWtgeZcCU43ksL
-        rnKQOu/NwVjcg2wClQELyq3PprV1upyRwusoDKPQN/BXDdZNVxWcG546kYLX8wTZj/bD0QgnFuQM
-        p4VzlU2CIIMZpC7Tn7TPneTWCq58BS5ASy7glQjiQFhbQ9ApuIUVyp9NxxfTPVwb4FLjgvWSz55F
-        32qbcge5Nqv2DhnOUCIO4+FeGO1F4TQOk2iYDEN/f/DqR/Q7JCfJiEPHGzUvdJLkA9QXxptrrycZ
-        2NSIigKHq4fMllzKHsuEdUKljlUCUmB6xhba3PoknWr1zshnelErQeni8prPueMmmAtYBI1bWwfX
-        W1HYj0Y/W/E3/FRi2usSrRIs0OSU21vKVX3jaJTMuLTQ81rBE7xXI9vzCoHAMWmxOoU5oK/hl57n
-        BCKrQpR4iarxjt4DmPTDbqMy+hPe6IUBX0s34W4S2IWbJl+BZHurd0o4hwqst7FNSP2tOWv1zC24
-        IbxaUVZSoMPZg5tjPhqUDUbLweiZ7n4jM91NNnkZhK/QjXiwjAf/r5U2+w0W0WC0v4z2v4fBZWex
-        Hy/78fewuAb4ly+P4RjtwmncbczE8n3LgZj9y6vHJ/vdSZ7nBnLkm0dFgBfQsm7L/2lzw10b+7s2
-        Xu3YiHdujHZtHDz2s6XNdpVIqXkhvGQvwil3+HC0hPv8wm3pfEvgQavOUFk2wyNdU+AiIuUPtCBU
-        7iXO1IDpQ6XuPWacirN1rtFH+o1I2wB/frRGvqKwLXQts2NhK8lX6+ImSBjAyxJ/PPVI9OOD7pF4
-        GLYNlT3c2AWqeAOqyghthFu9MIideNC8NP/+rRAlz8EGJGE7JQIXCpEXvp3nW7Z8iysdrcbe48KJ
-        N6iX/AaIGJ8oDeKTJwMR7cJoNKKIFNyOK5GeCnX7mnaOoaL+RaVd1ppcLpq9zYrSaoztC7+RMAFu
-        WySY9cg7P3335uTs+vTkaHx2Mb4eTyZ/TPB+WKcWQ4IHpgWwc3wBlGNklwnLtJIrhmwiJCllTrNf
-        heHs3ECJdMJqi6j1n2KVCAvKC+9EGFZVP/HaVxGzh+HfVtU9tsBE5EJx+fDQuvtah7fBtUTv1nPK
-        bK5gc7quqGx3IXkQhx2S20bpheBrhTcv7/3e5nl43OLtF57eYrvZQa5T3to6Wnd0/8nhri1sawaN
-        xF2joGBB1a2lNmetNzeyhr3cIEtsmyLNjnWbbF1W2BAr9zToh7toYbihhW9l/H44P6qv/w9ZbnRd
-        UaP4WqgMidEyrBV2A6BYVdsCsgalJ5ND+t4AE2pOBghmGcOfAgxfM8gSUlbEPntD6j6qH5rvDwm7
-        3KgVKmEK4+UEd9okoT/0+3cUdIy51CmXhbYuGYWjMJi1MteNb8FBdIXC7PIC0pooir3Viz2nd8ji
-        m53V+GbHVyxgl5F17M+aGweGjVWOhVlimHeIwuZAEDXSZ+e/s8MaKYBdpFztkKIOMDgYXrUBvbtj
-        F9i7Nn7i+Oj9uPl8aD9dnmmybgFoOBUO2YBEG1zhCBUxIkx2xy5Rx16MDICl14+jxgvCqZpnvsJ2
-        38/1PJjXUiFyHTJLcP/8Fanoh+FGLl2AXwpnwNcmD7C8OUFeYC9LtBDgUb9wpSS5bbpw0iSMlMX4
-        N4G8lhxjuqSfcM09jkEJLglJF/APAAAA///sWW1v2jAQ/ivWpFWASBoghJeq6lBZpUqjmjZtH7ov
-        GMeBTECihFBN2o/fc44TICXQUbXqpAkExPbZ5/Pdc76HaI1KjRmscpfPUGdn89XFJaZxTKtaYkt9
-        8OdNu0PrD5Br17JOplLXZ7bPLg722W71nmwXPV7ZxX66XeyjdnlxmzhlNkG8ZU7Xryn7UBurDRPJ
-        hghUNN7Iicl6dUYwznYxIHvNGmYOAuq5Zb7aYWMHQ4W7gMSfAaOMBKWPyrEKPqr7tn9o86yGeETz
-        D3wZJ4UGVoQ3qSmeF5y7J1D7GiQRbHnjzyWwU6b2PpuuLrgQMlypnxvn2xIcbjC+BizO1QgA/ho2
-        TT845+7aj5EnJCXbDuDfI5vDibJbAZ3oeLPCmOH+wkh/1OX6xhJpb9DakTe4uTfE2hv4aoX0G9fZ
-        w8wXM4Zr83QKCE4AfyzkWGs5ZZyhohEQxJ1IRNwjPcYDtVHjE19OE4DxmM0kdyG55kigZrpb9n2j
-        0AhoP5fbmWW3Pyu0+tseiSGfVY3gZv3onmbdjd0ZMHIGcTTCx1Ww948fDCF+nz7Iv/BI24oxS5hM
-        5r7QhzbyVR7VZ/ZNXbXIwvowUmUYQGaOjkhvHnK3i5CLFcncBcxXDwxpb+270t1xpy8IKdw/sfTf
-        OIUWDQPKmuTjFe4u/GWVVaq/F/DhVdDP/XYvZrw4Xjgn4oVDeOE8Dy9OShmP8OLUpLV9vK+NF85/
-        vHgFvLD/LbxwctEjePGY7WjnBX+x2C2rdxp2WUdOdlEhtIrgS4rjIY6mMNTOqalCh1VGmFllnIOV
-        cw6ZecoGlvFkVq7MTu1erOBUdMyoMEnrwzhZLDgVr+8OVldkcmKigujEMpf4iCt4LPFnt+5l2211
-        O91Jo2PJluhZotduer2G52CdfBBWODBMkj8MXJeiASNF4P76sKUI6mCa6yA3rkwtTZTSahjJZPys
-        La1Gl7sN23Y6otsBXk7EpGNheY9Lryuu3Es1y/vW4H3zBu9Uzljwpa77DCNtis0kNh5gCKNpUkFp
-        pnFIljJCzmMyFOQV0vN5jJ/XI8MywyXRDUWe/e1rXCTq377GRaL/rWsMHHJTlljzQddwfTbinpcI
-        4asAorIuZaVTFLsPljTwYxIFoTy/B74I4k91pNEfTejNQ5dW0H+v7SeR7DJQtcu4ZTvnlosdOXBH
-        GvWL+PIHAAD//xotX2iWkga0fAEAAAD//yLTxaPlC61dTJfyBb0YgLfG4I0XoKvTIXmvGjQjDmUb
-        AC3ML0mEzuejm4Kz2YWzXMLZHjPCXvLhmhoywNUABRUIWCUMcDVAjXHpMIa38FLzyjKL8vMgrTiI
-        UEopdDEJhEtU6OXnQkyohjGhxT0ZxS/SOhh9mLk6SrmJFUGpxaU5IIOR7AbPnBSVOJZA3FGWX0K9
-        CVuIYXBDgXZlJBaH5YMnnmBzqqApY9B0DshKuENQXWuE4lyoBnDw1NbWAgAAAP//AwBIBrJHuyQA
-        AA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:41.238+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:41.043+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/247]\n*Defect Dojo link:* http://localhost:8080/finding/247
+        (247)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 1dd81143-c2d8-47d9-b989-d2492fd6b9a6
+      - 7a6e1479-eecd-48ff-a61a-68bfbf8af5b7
       Atl-Traceid:
-      - 1dd81143c2d847d9b989d2492fd6b9a6
+      - 7a6e1479eecd48ffa61a68bfbf8af5b7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:53 GMT
+      - Wed, 30 Apr 2025 16:24:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1310,7 +1363,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=285,atl-edge-internal;dur=16,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=275,atl-edge;dur=242,atl-edge-internal;dur=15,atl-edge-upstream;dur=227,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="am9CT4itSeBWt-Du7fSSi--a8pv2ialgQg964s6gAQVw-dehmubTeQ==",cdn-downstream-fbl;dur=278
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1319,10 +1372,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ae39d1ac6bb931d0ff3d636fc3e249de.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - am9CT4itSeBWt-Du7fSSi--a8pv2ialgQg964s6gAQVw-dehmubTeQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 6a2404927510d8bf39024323d9ac5cbb
+      - 0b86839564fd1f893305bf7f5baa1cd8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1349,26 +1410,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2bpvvIDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8em0QYXSN/bdpsJr4VwrTGrQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAZQJZCCkm5uXws1w/Vz3QzdnWoCH+O0AQm8BKc2Gu778KV1b6PtpW2
-        YxNC9djq5itCeAjQ+fzUvBI+ghRokUCWwLKilLOcsyAGuIAAh7wLf8ChartzNoOKAs8KXrA0Z4tv
-        VnY3RtkAsmy2kAKwQCWzfI6CKcUUSEWXebGo1YwhnSmgZwKvo+G2HUR8ISoxan9npYjtA9GniqB5
-        3ZbkeH7YkzVxcn1fkeMnAAAA//8DAEHC09YgAgAA
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:45.756+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 263c6f23-dd20-48c6-8ecc-0cfcf167423b
+      - 10660dbc-8707-4be5-b9b6-3e17bcae2751
       Atl-Traceid:
-      - 263c6f23dd2048c68ecc0cfcf167423b
+      - 10660dbc87074be5b9b63e17bcae2751
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:54 GMT
+      - Wed, 30 Apr 2025 16:24:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1378,7 +1435,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=192,atl-edge-internal;dur=51,atl-edge-upstream;dur=142,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=192,atl-edge;dur=159,atl-edge-internal;dur=15,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="RWf1FUW3ktQroQeRObCIm0TnU-JEdgPwV3tSJVE9HTRxR8z-_7oNwA==",cdn-downstream-fbl;dur=196
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1387,10 +1444,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - RWf1FUW3ktQroQeRObCIm0TnU-JEdgPwV3tSJVE9HTRxR8z-_7oNwA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f38caf7b3b3e8b3d1b8b31a3298c1aee
+      - c74e31c9c4a6648b9fcd531e9be110d7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1414,66 +1479,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX23LbNhD9FQwfU4k3SbbMmU7HtZXEreu6spI8OB4PTK5IxCTAAKAujfPv3SVF
-        Kb4wU7vT2A8kAewFu2fPrr44sCq5TJzI0SAT0JC8FpAnpid5AaZn4gwK3lMlaG6FkqYHibAFWN6L
-        My5TyFXaW4A2uAfJFEoNBqTdnI0rY1UxJ4XXge8HvqvhcwXGztYlnGseWxGD03ME2Q/2/PEYPwzk
-        c/zMrC1N5HkJzCG2ifqkXG5zbozg0pVgPbRkPV4KL/SEMRV4rYJbWKP82WxyMevj2hCXaheME31x
-        DPpWmZhbSJVeN3dI8AslQj8c9f2gH/iz0I+CUTTy3b3h/k/ot09OkhGLjtdqXugkyXuozw+31958
-        JGBiLUoKHK4eMlPwPO+xRBgrZGxZKSAGpuZsqfStS9Kxku90/kwvKikoXTy/5gtuufYWApZe7dbO
-        wc1W4A+C8S9G/A0/F5j2qkCrBAs0OePmlnJV3Vh6i+Y8N9BzGsETvFct23MygcDRcbY+hQWgr/7X
-        nmMFIqtElDiRrPCOzgOYDPx2o9TqE97ohQHfSNfhrhPYhps+vgHJ7lbvpLAWFRhna5uQ+nt91qi5
-        XXJNeDWiKHOBDicPbo75qFE2HK+G42e6+53MtDfZ5mXo76Mb4XAVDv9fK032ayyiwWBvFez9CIOr
-        1uIgXA3CH2FxA/CvXx/DMejCadi1MWg35mL1viFHhMXlFcIkTTWkyDePigAvoPKqKf+ntY66Nva6
-        NvY7NsLOjXHXxsFjPxvabFaJlOoO4UT9YMOVlBIt4uZKXx6tUaFgtE2mqjw5FqbM+XpTTri85BZb
-        T0PZzy/9piHsWoDXqNNU2PXrkaoo9LWrH2hByNSJrK7INiq17xEzVN6baGjAyxJ/PNUkBuFB2yQe
-        hm1LZQ83ukAVbkFVaqG0sOsXhqAV9+pO8+97hSh4CsYjCdMqEbiQiTRzzSLdseVbXGlpNXQeF064
-        LYOc3wARI1XAw5mgC7xBF0aDMUUk42ZSivhUyNvXtHMMJc0vMm4xVCNrWe9tV6SSExxf+E0OU+Cm
-        waXevDnnp+/enJxdn54cTc4uJteT6fTPKd4P69RgSPDALAN2jh1AWkZ2mTBMyXzNkE1ETkqZVew3
-        oTk711AgnbDKIObcp1glwIJy/Dvh+2U5iJymK2L2MPy7qrrHFpiIVEiePzy0mb424a2Rn6N3LeFg
-        ZlMJ29NVSWXbheRh6LdIbgalF4KvEd523vuzzfPwuMPbrzy+xXGzhVyrvLF1tJno/pPD7VjY1Awa
-        CdtBQcKSqlvlSp813tzkFfRTjZy1G4oUO1ZNslVR4kAs7dOgH3XRwmhLC9/L+P1wfpTf/h+yVKuq
-        pEHxtZAJ0pphWCvsBkCysjIZJDVKT6aH9LwBJuSCDBDMEoY/BRg2LUgiUpaFLntD6j7KV/XzVcQu
-        t2qFjJjEeFnBrdKR747cwR0FHWOeq5jnmTI2Gvtj35s3Mte1b95BcIXC7PIC4oooir1Vy75VHbLY
-        s5MKe3Z4xTx2GRjL/qq4tqDZRKZYmAWGuUMUtge8oJY+O/+DHVZIAewi5rJDiiZA72B01QT07o5d
-        4Oxa+4nvR+8n9eND82jzTB+bTk+vM2GRDUi0xhW+oSJGhMnu2CXq6IfIAFh6gzCovSCcykXiShz3
-        3VQtvEWVS0SuRWbx7p+/IhUD39/KxUtwC2E1uEqnHpY3J8gLnGWJFjw86ma2yEluly78qBNGykL8
-        m0Ja5RxjuqKfcPU9jkEKnhOSLuAfAAAA///sWW1v2jAQ/ivWpFWASBoghJeq6lBZpUqjmjZtH7ov
-        GMeBTEBQXqgm7cfvOccJkBLoqFp10tQKiO2zz+e753xPwjUqNWawyl0+Q52dzeOLS0zjmFa1xJb6
-        4M+bdofWHyDzr2WdTKWuz2yfXRzss93qPdkueryyi/10u9hH7fLiNnHKbIJ4y5yuX1P2oTZWGyaS
-        DRGoaLyRE5P16oxgnO1iQPY3a5g5CKjnlvlqh40dDBXuAhJ/BowyEpQ+Kscq+Kju2/6hzbMa4hHN
-        P/BlnBQaWBHepKZ4XnDunkDta5CEsOWNP5fATpna+2waX3Ah5CpWPzfOtyU43GB8DVicqxEA/DVs
-        mn5wzt21HyFPSEq2HcC/RzaHE2W3AjrR8WaFMcP9hZH+qMv1jSXU3qC1I29wc2+ItDfwOEb6jers
-        YeaLGcMlfjoFBCeAP7biWGs5ZZyhohEQxJ1IhNwjPcYDtVHjE19OE4DxmM0kdyG55kigZrpb9n2j
-        0AhoP5fbmWW3P6un+tseiSGf1Q3fzfrRPc26G7szYOQM4miEj6tg7x8/GEL8Pn2Qf+GRthVhllUy
-        mftCH9rIV3lUn9k3ddUiC+vDSJVhAJk5OkK9ecjdLlZcxCRzFzBfPTCkvbXvSnfHnb4gpHD/xNJ/
-        4xRadBVQ1iQfr3B34S+rrFL9vYAPx0E/99u9mPHieOGciBcO4YXzPLw4KWU8wotTk9b28b42Xjj/
-        8eIV8ML+t/DCyUWP4MVjtqOdF/zFYres3mnYZR052UWFUBzClxRDQ4xRYaidU1OFDquMMLPKOAcr
-        5xwy85QNLOPJrFwZFQAzqj32MH/Fii5KFgtOxeu7g9UVmZyYqCA8scwlPuIKHkvs16172XZb3U53
-        0uhYsiV6lui1m16v4TlYJx+EFQ4Mk+QPA9elaMBIEbi/PmwpgjqY5jrIjStTSxOltBpGMhk/a0ur
-        0eVuw7adjuh2gJcTMelYWN7j0uuKK/dSzfK+NXjfvMF/Kmcs+FLXfYaRNkVmEhkPMITRNKmgNNM4
-        JEsZK84jMhTkFdLzeYSf1yPDMldLohuKPPvb17hI1L99jYtE/1vXGDjkppy15oOu4fpsxD0vEcJX
-        AURlXcoppyh2Hyxp4MckDFby/B74Iog/1ZFGL5rQm4curaBfr+0nkewyULXLuGW77IWFnQN3qFG/
-        iC9/AAAA//8aLV9olpIGtHwBAAAA//8i08Wj5QutXUyX8gW9GIC3xuCNFaCr0yF5rxo0Iw5lGwAt
-        zC9JhM7no5uCs9mFs1zC2R4zwl7y4ZoaMsDVAAUVCFglDHA1QI1x6TCGt/BS88oyi/LzIE08iFBK
-        KXQxCYRLVOjl50JMqIYxocU9GcUv0joYfZi5Okq5iRVBqcWlOSCDkewGz5wUlTiWQNxRll9CvelW
-        iGFwQ4F2ZSQWh+WDJ57gM7z5ReDpHJCVcIegutYIxblQDeDgqa2tBQAAAP//AwDACH3guyQAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:41.238+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:41.043+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/247]\n*Defect Dojo link:* http://localhost:8080/finding/247
+        (247)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 754ab924-93d4-45d4-9f2e-44f85d4437fd
+      - 41b6045c-7109-4c42-b41a-8bd7b614431f
       Atl-Traceid:
-      - 754ab92493d445d49f2e44f85d4437fd
+      - 41b6045c71094c42b41a8bd7b614431f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:54 GMT
+      - Wed, 30 Apr 2025 16:24:46 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1483,7 +1549,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=303,atl-edge-internal;dur=13,atl-edge-upstream;dur=286,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=309,atl-edge;dur=276,atl-edge-internal;dur=16,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="mVUgFI8oa3QM5GN_kmuQYDWI8Y9kmKpRbpi5UL5JpEgwLU8Hgk__PQ==",cdn-downstream-fbl;dur=314
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1492,10 +1558,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e665d09233240df4d3172e59222e0ba2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - mVUgFI8oa3QM5GN_kmuQYDWI8Y9kmKpRbpi5UL5JpEgwLU8Hgk__PQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3ee818d71d064e04d591922ed739fb69
+      - 781efac02171d1de5f00727243d45774
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1522,41 +1596,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 36522ad2-171d-403e-b56d-9a9eec9c927d
+      - 2e664f7b-d503-496e-8ac1-2c06ef745855
       Atl-Traceid:
-      - 36522ad2171d403eb56d9a9eec9c927d
+      - 2e664f7bd503496e8ac12c06ef745855
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:55 GMT
+      - Wed, 30 Apr 2025 16:24:46 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1566,7 +1627,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=277,atl-edge-internal;dur=14,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=314,atl-edge;dur=282,atl-edge-internal;dur=14,atl-edge-upstream;dur=269,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="zWXktIMPT2Gs8SEzzQg8-0TVtGGPErHgft4w8KN3lOedRZGIvScgbg==",cdn-downstream-fbl;dur=319
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1575,13 +1636,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 895116b5366f3f5264f7b6361d3fd564.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - zWXktIMPT2Gs8SEzzQg8-0TVtGGPErHgft4w8KN3lOedRZGIvScgbg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 77d07a9ae5db02d180b9456007ad0db8
+      - e744bc44570b25b4f2a3e9e3bf3de3a5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1593,7 +1662,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/91]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -1602,29 +1671,29 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
-      | Inactive, Verified, Mitigated |\n\n*Severity:* High\n\n *Due Date:* Feb. 9,
+      | Inactive, Verified, Mitigated |\n\n*Severity:* High\n\n *Due Date:* May 30,
       2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression Denial
       of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]\n*Defect
       Dojo link:* http://localhost:8080/finding/247 (247)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
       Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -1638,27 +1707,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3354'
+      - '3329'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 0b22fb58-6b25-45f8-8a35-789d1b345086
+      - 7fff255f-d5ab-4119-a3c7-a16e1d8630f1
       Atl-Traceid:
-      - 0b22fb586b2545f88a35789d1b345086
+      - 7fff255fd5ab4119a3c7a16e1d8630f1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:55 GMT
+      - Wed, 30 Apr 2025 16:24:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1668,17 +1739,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=515,atl-edge-internal;dur=12,atl-edge-upstream;dur=503,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=636,atl-edge;dur=508,atl-edge-internal;dur=15,atl-edge-upstream;dur=494,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="3ZZkL2hfFxNygSQsneCCLU6EkfFwZa9QbaC9EHCyuwqLvw5x7KCpmQ==",cdn-downstream-fbl;dur=641
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 3ZZkL2hfFxNygSQsneCCLU6EkfFwZa9QbaC9EHCyuwqLvw5x7KCpmQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 2be6159c81e0d57e342dc3495045dd6f
+      - de278d2ba9408e986db9e11a3df2d688
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1702,67 +1781,68 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSY7MmU7HtZXEreu6spI8OB4PTK5IxBTAAqCOxv7v3eWl
-        +FBau9PYD8S1B3a//bD64sC64DJxIkeDTEBD8kZAnpie5AswPRNnsOA9VYDmVihpepAIuwDLe3HG
-        ZQq5SntL0Ab3IJlCocGAtM3ZuDRWLeak8Crw/cB3NfxZgrGzTQFnmsdWxOD0HEH2gz1/PMaJgXyO
-        08zawkSel8AcYpuoz8rlNufGCC5dCdZDS9bjhfBCTxhTgtcquIENyp/OJuezPq4NcalywTjRF8eg
-        b6WJuYVU6U19hwRnKBH64ajvB/3An4V+FIyike/uDV//gH775CQZseh4peaFTpK8h/r8sLt2M0nA
-        xFoUFDhcPWBmwfO8xxJhrJCxZYWAGJias5XSNy5Jx0q+1/kzvSiloHTx/IovueXaWwpYeZVbWweb
-        rcAfBOOfjPgLflxg2ssFWiVYoMkZNzeUq/La0iia89xAz6kFj/FelWzPyQQCR8fZ5gSWgL76dz3H
-        CkRWgShxIlniHZ0HMBn4uzaCdqPQ6jNe9YWZaKSrPFSZbfNAk6/Qs73ueymsRQXG6WwThH+tzho1
-        tyuuCchGLIpcoMPJg5Bgoir4Dcfr4fiZ7n4jZe1NuoQN/dfoRjhch8P/10oNiwqkaDDYWwd738Pg
-        urU4CNeD8HtYbJB/d/cYjmELx7lYf6g5EJN8cfn45KA9ydNUQ4p8849FMGo38AIqL2teePro3q6N
-        1zs2wp0b410b+4/dqWmzXiVSql4IJ+oHOOUWH46acJ9fnzWdbwncq9Vpqr5qeKhKClxApPyRFoRM
-        ncjqEu4aniZtWsR11L48WiPP8KjJVJknR8IUOd80FYvL6Jb9gNCgKm6ioQEvSzTx1CMxCPfbR+Jh
-        2HZRWdhR2cONDlSFFkoLu3lhEFtxr3pp/v1bIRY8BeORhGmVCFzIRJq5ZpluSfEdrrTsGTqP6yPs
-        UJ/zayD+e6I0iDaeDESwC6PBmCKScTMpRHwi5M0b2jmCgvoXGbd5rLK7qva6FankBNsXfp3DFLip
-        saGbkXN28v7t8enVyfHh5PR8cjWZTn+f4v2wTg2GBA/MMmBnSPTSMrLLhGFK5huGpCFyUsqsYr8I
-        zdmZhgWyBisNotZ9ijwCLCjHvxW+XxSDyKlfRcwehn9bVffYAhORCsnzh4ea7qsJb4X0HL1r5pTZ
-        VEJ3uiyobJ9G8sgdhqMWyXWj9ELw1cLdA3u/t3keHrd4+5nHN9hutpBrlde2DpuO7j853LaFdc2g
-        kbDtBySsqLpVrvRp7c11XkI/1cgb26ZIsSNVJ1stCmyIpX0a9KOOFr6V2IdCHWXcD+cn+fX/AUu1
-        KgtqFN8ImSAxGoa1wq4BJCtKk0FSofR4ekDfa2BCLskywSxh+FOA4WsGSUTKstBlb0ndJ/mq+r6K
-        2EWnVsiISYyXFdwqHfnuyB3cUtAx5rmKeZ4pY6OxP/a9eS1zVfnm7QeXKMwuziEuiaLYO7XqW7VD
-        Fp/mpMSnObxkHrsIjGV/lFxb0GwiUyzMBYZ5hyh0B7ygkj49+40dlEgB7DzmcocUNXre/uiyDujt
-        LTvH3rXyE8eHHybV52P9afNMk6YFoOFMWGQDEq1whSNUxIgw2S27QB39EBkAS28QBpUXhFO5TFyJ
-        7b6bqqW3LHOJyLXILN7985ekYuD7nVy8AnchrAZX6dTD8uYEeYEtK9GCh0fdzC5yktumCydVwkhZ
-        iH9TSMucY0zX9BOuuscRSMFzQtI5/A0AAP//7Fltb9owEP4r1qRWgEgaIISXqupQu0qVRjVt2j50
-        XzCOA5mARAmhmtQfv+ccJ0BKoKNq1UlTK17iO599vnvO9xCt0Kkxg1Xu8hnq7HS2PL/ANI5pVUt8
-        qQ/+rGl3yP4A1Xcl6+QqdUtmu/ziYJ/tVu/ZftHyyi/28/1iH/TLq/vEIdu3C+qDN71SZ0M/S8hH
-        isFaFoH9mnIWPWO160Syawjh4Y0cm6xXZ4TpbBsQsr9pw8wRQX1vmW928tjBtQJh4OOvgFF5wqIP
-        6rEKXqq7tr9v86yG5MTjn3gzjsoTWERoqSlelqnbJ1D7FiQRfHnjzySAVKb+Pp0sz7kQMlyqj+tI
-        3FC8XgN+DcCcLyNAJdAYavrBGXdXfoxqIqnydlALPPI5gii7ItCJjtYWRgyXGUbrR5Oury+Rjga9
-        OooGN4+GWEcDXy5Ri+M6e5j6Yspwq55MgMcJsJCFHLYWE8YZ2hsBRVyQRMQ9WsdooDZqfOaLSQJk
-        HrGp5C40VxzV1Ex3y36sFzQE9M/kZpnZHs+6rv5mRELki2oY3Gwcw5NsuLE9AySnUMdDxLjK/P7h
-        gyH479MLxRe+0rZizBIm45kv9KHpHNZn9l3du8jD+jDSxTAgzgwDkd489G7nIQCBdO4C5qsvDDVw
-        5bvS3Qqnr0gpXEZh+m+CQquGAZVQivEKd+f+osoq1cc5YngZ9PO43YkZr44XzpF44RBeOC/Di6Pq
-        xxO8OLaCbR7vW+OF8x8v3gAv7H8LL5xc9QBePKU+2nn3X+x8yziRhr3ZFS0jhIzidYipKYrm7Fhh
-        wCobsHMCq6iRExCZF8oEywgJq4w0s3KbW418sc9T2TGlLiVtFuNkPufUyX7Y22qRy4mWCqIje14i
-        Jy4RsUSm3boXbbfV7XTHjY4lW6JniV676fUangM7uRAs7BGTFA8D16VsgKQI3N8fNxaCppjm2suH
-        qzOQJvpqJUY6GSdrS6vR5W7Dtp2O6HaAl2Mx7lgw73HpdcWle6FmOWkNTpo3+E/1jDlf6CbQMNJH
-        sZnExgMcYTRN6i7NNA/JU0bIeUyOgr5Cej6L8fFqaFhmuCDuocitv/8VF8n597/iIrn/3lcMgHJT
-        ElmTQ1cIfTbknpcI4asEog4vpahTeLsPFiT4KYmCUJ7dA3gEkak60+jHJYzmqUsW9G9tuxkluwxU
-        7TKi2c6J5kiD+z4Y+QMAAP//Gi1GqJpgBk0xAgAAAP//IsHFo8UIrV1Ml2IEvRjA1UwzgbfG4I0X
-        oHfSIZmyGjQLDmUbAF2SX5IIndxHNwVXe8wAV7lkYIS9gMM1T2SA0wM422twn6HrwNWQM8YpAW/h
-        peaVZRbl50FacRChlFLoyhIIl5jQK8svod6sKcQwuKFAmzISi8PywbM/sKlOYBaAOLkaxoTWL2Q7
-        ALwKRx9mro5SbmJFUGpxaQ7IYCTPgudtikocSyAeB80fg+Z2QF6Hi6NqNkLRDdUAdm1tbS0AAAD/
-        /wMAzk/3ssgkAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:41.238+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:47.147+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Inactive, Verified, Mitigated |\n\n*Severity:* High\n\n *Due Date:* May
+        30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression
+        Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]\n*Defect
+        Dojo link:* http://localhost:8080/finding/247 (247)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a4e0bf4e-248f-4b68-9759-af50f07b40e2
+      - f86051e2-8c7f-44fd-9305-0e164a86caf7
       Atl-Traceid:
-      - a4e0bf4e248f4b689759af50f07b40e2
+      - f86051e28c7f44fd93050e164a86caf7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:56 GMT
+      - Wed, 30 Apr 2025 16:24:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1772,7 +1852,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=287,atl-edge-internal;dur=17,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=322,atl-edge;dur=289,atl-edge-internal;dur=17,atl-edge-upstream;dur=272,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="vC9DEyLasRCj3G1l9Vve2VEGIopyOKXerBgb87Wg7aEnxdGjQ0mf6w==",cdn-downstream-fbl;dur=327
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1781,10 +1861,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5538280951642fc71308aa997730220e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - vC9DEyLasRCj3G1l9Vve2VEGIopyOKXerBgb87Wg7aEnxdGjQ0mf6w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c79464a7f78e44d842d398bec0059ae4
+      - 824216d2ca97521a70451930f137f2c6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1811,26 +1899,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtLlnZb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Whe1Tfjrvf
-        /37HHUglPW57QwR5C6HzYjqtUaMKtXt3qQxGet9Im1oMZELqxndG7v/BF9jvGoU1+o81mm6FNmD/
-        1yUrZ7UZ0Cr8XXKHvW+cjTAFoCmkkBSby8di/VD+TDdDW8WKiOcRmsAEXqITO+P2bbyy3HejbWXc
-        UMdQNTSm/ooQEQNsPj81r2QYQQYsS4AmsCwZE3wmeBQDXECEY97HP2BfNu05S6FkIGgmsjzlfPnN
-        qvbGahdBTvOFkoAZakVnc5Rca65BabacZYtK5xxZroGdCYIZDbdNL8cXopaDCXdOybF9IOZUEbSv
-        24Iczw97cnacXN+X5PgJAAD//wMARv7ziyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:48.405+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - accb6094-0439-4c2e-96e4-3568bb5f2c91
+      - 3a7b886e-34b5-4ef7-a32e-bb5916d0c521
       Atl-Traceid:
-      - accb609404394c2e96e43568bb5f2c91
+      - 3a7b886e34b54ef7a32ebb5916d0c521
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:56 GMT
+      - Wed, 30 Apr 2025 16:24:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1840,7 +1924,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=145,atl-edge-internal;dur=12,atl-edge-upstream;dur=133,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="EtD6JosM0cj_EwJfojGykIxJWdpz7RMhFMOo0gZQqsabBLFRkEOaPQ==",cdn-downstream-fbl;dur=255,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=253,atl-edge;dur=169,atl-edge-internal;dur=14,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1849,10 +1933,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 087e16218fcf1ccb7472a2c9f6a4cbe2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - EtD6JosM0cj_EwJfojGykIxJWdpz7RMhFMOo0gZQqsabBLFRkEOaPQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - c759a57c5cdc72cbc78bf758b60c5413
+      - 4f1e1ac462c2cde2a351ca3893f2abe4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1876,67 +1968,68 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbMmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxvnv3SVF
-        Kj6U1u409gNx7YHdbz+sPjuwKrlMnMjRIBPQkLwWkCemJ3kBpmfiDAreUyVoboWSpgeJsAVY3osz
-        LlPIVdpbgDa4B8kUSg0GpN2cjStjVTEnhdeB7we+q+HPCoydrUs41zy2Igan5wiyH+z54zFODORz
-        nGbWlibyvATmENtEfVIutzk3RnDpSrAeWrIeL4UXesKYCrxWwS2sUf5sNrmY9XFtiEu1C8aJPjsG
-        fatMzC2kSq+bOyQ4Q4nQD0d9P+gH/iz0o2AUjXx3b7j/A/rtk5NkxKLjtZoXOknyHurzw+7am0kC
-        JtaipMDh6iEzBc/zHkuEsULGlpUCYmBqzpZK37okHSv5TufP9KKSgtLF82u+4JZrbyFg6dVubR3c
-        bAX+IBj/ZMRf8GOBaa8KtEqwQJMzbm4pV9WNpVE057mBntMInuC9atmekwkEjo6z9SksAH31v/Qc
-        KxBZJaLEiWSFd3QewGTgtxulVp/wRi8M+Ea6DnedwDbcNPkKJNtbvZPCWlRgnM42IfXX+qxRc7vk
-        mvBqRFHmAh1OHtwc81GjbDheDcfPdPcbmWlv0uVl6O+jG+FwFQ7/XytN9mssosFgbxXsfQ+Dq9bi
-        IFwNwu9hcQPwL18ewzHYhdNw18ag3ZiL1fuGHBEWl1cIkzTVkCLf/GMRjNoNvJnKq4YXnj66t2tj
-        f8dGuHNjvGvj4LE7DW02q0RK9QvhRP0Ap9ziw9EQ7vMLt6HzLYF7jTpNZVkPj1RFgQuIlD/QgpCp
-        E1ldAaYPldr3mHEqzsa5Wh/p1yJu4vj50Rr5isImU1WeHAtT5ny9KW6ChAa8LPHHU4/EIDxoH4mH
-        Yeuo7OHGLlCFHahKLZQWdv3CILbiXv3S/Pu3QhQ8BeORhGmVCFzIRJq5ZpFu2fItrrS0GjqPCyfs
-        yiDnN0DESBXwsCfYBd5gF0aDMUUk42ZSivhUyNvXtHMMJfUvMm6zVudyWe91K1LJCbYv/CaHKXDT
-        IEFvRs756bs3J2fXpydHk7OLyfVkOv19ivfDOjUYEjwwy4Cd4wsgLSO7TBimZL5myCYiJ6XMKvaL
-        0JydayiQTlhlELXuU6wSYEE5/p3w/bIcRE7zKmL2MPzbqrrHFpiIVEiePzy06b424a1xnaN3LeFg
-        ZlMJ3emqpLJ9GskjdxiOWiQ3jdILwdcIdy/v/d7meXjc4u1nHt9iu9lCrlXe2DradHT/yeG2LWxq
-        Bo2EbaMgYUnVrXKlzxpvbvIK+qlGltg2RYodqybZqiixIZb2adCPdtHCqKOFb2X8fjg/yq//D1mq
-        VVVSo/hayASJ0TCsFXYDIFlZmQySGqUn00P63gATckEGCGYJw58CDB8tSCJSloUue0PqPspX9fdV
-        xC47tUJGTGK8rOBW6ch3R+7gjoKOMc9VzPNMGRuN/bHvzRuZ69o37yC4QmF2eQFxRRTF3qpl36od
-        svhmJxW+2eEV89hlYCz7o+LagmYTmWJhFhjmHaLQHfCCWvrs/Dd2WCEFsIuYyx1S1AF6B6OrJqB3
-        d+wCe9faTxwfvZ/Unw/Np80zTTYvPQ1nwiIbkGiNKxyhIkaEye7YJeroh8gAWHqDMKi9IJzKReJK
-        bPfdVC28RZVLRK5FZvHun78iFQPf7+TiJbiFsBpcpVMPy5sT5AX2skQLHh51M1vkJLdNF07qhJGy
-        EP+mkFY5x5iu6CdcfY9jkILnhKQL+BsAAP//7Fltb9owEP4r1qRWgEgaIISXqupQu0qVRjVt2j50
-        XzCxA5mARAmhmtQfv+ccJ0BKoKNq1UlTKyC2zz6f757zPYlWqNSYwSp3+Qx1djpbnl9gGse0qiW2
-        1Ad/1rQ7tP4AuXYl62QqdX1mu+ziYJ/tVu/ZdtHjlV3s59vFPmiXV7eJQ2vfLqgO3rRKnQ39LCAf
-        yQdrmQf2a8pY1MZq14lk1xiExhs5NlmvzgjT2TYgZH/ThpkjgnpumW928tjBtQJh4OOvgFF6gtIH
-        5VgFH9Vd29+3eVZDcKL5J76Mo+IEK8K11BQvi9TtE6h9C5IItrzxZxJAKlN7n06W59x1ZbhUP9ee
-        uCF4vQb8GoA5VyNAJtAYavrBGRcrP0bSkJR5O8gFHtkcTpRdEehER+sVRgyXGUb6o0jX15dIe4PW
-        jrxB5N4Qa2/gyyVycVxnD1PfnTLcoScT4HECLGQhx1qLCeMM5Y0LQVyQ3Ih7pMdooDZqfOaLSQJk
-        HrGp5AKSK45saqa7ZT/WCg0B/TO5mWa2+7Piqr/pkRjyRRUMIutH9yTrbmzPgJFTiKMRPq4iv3/4
-        YAj++/RB/oVH2laMWcJkPPNdfWg6hvWZfVf3LrKwPoxUGQbEmaEj0puH3O08BCCQzF3AfPXAkANX
-        vpBiy52+IqRwGcXSf+MUWjQMKIWSj1e4mPuLKqtUH+fw4WXQz/12J2a8Ol44R+KFQ3jhvAwvjsof
-        T/Di2Ay2ebxvjRfOf7x4A7yw/y28cHLRA3jxlPpo59V/sfItK34adllHzoVRVbSM4EuK8CHCpjDU
-        znmqQoeVz1HsKCMgrJyAyMxTNrCMNLNyZbYK+WI5p6JjSlVKWizGyXzOqZL9sLfUIpMTLRVER9a8
-        RE5cwmOJTLsVF23R6na640bHki23Z7m9dtPrNTwH6+SDsMKeYZL8YSAERQNGuoH4/XFDERTFNNde
-        olyZWpqoq9UwksnIWltajS4XDdt2Om63A7wcu+OOheU9Lr2ueyku1CwnrcFJ8wb/qZwx5wtdBBpG
-        2hSbSWw8wBBG06Tq0kzjkCxlhJzHZCjIK6Tnsxg/r4aGZYYL4h6KpPv717jI2r9/jYus/3vXGDgk
-        UspYk0NXcH025J6XuK6vAogqvJSiTlHsPljQwE9JFITy7B744hKZqiON3jqhNw9dWkG/a9vNKNll
-        oGqXEc122dsLOwfuSKM+AvUPAAAA//8aLV/ok5LoXb4AAAAA//+ihotHyxdau5gu5Qt6MQBvjcEb
-        L0BXp0PyXjVoehzKNgBamF+SCJ3cRzcFZ7MLZ7mEsz1mhL3kwzVPZICrAQoqELBKGOBqgBrj0mEM
-        b+Gl5pVlFuXnQVpxEKGUUujKEgiXqNDLz4WYUA1jQot7MopfpEUx+jBzdZRyEyuCUotLc0AGI9kN
-        nkYpKnEsgbijLL+EerO3EMPghgLtykgsDssHz0LBJlhB88eguR2QlXCHoLrWCMW5UA3g4KmtrQUA
-        AAD//wMAqvLwKsgkAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:41.238+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:47.147+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Inactive, Verified, Mitigated |\n\n*Severity:* High\n\n *Due Date:* May
+        30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression
+        Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]\n*Defect
+        Dojo link:* http://localhost:8080/finding/247 (247)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 19225c7d-ff21-4b3b-a300-46c331497da0
+      - 523ac437-bdb5-4f74-b4f5-2fd28eb04431
       Atl-Traceid:
-      - 19225c7dff214b3ba30046c331497da0
+      - 523ac437bdb54f74b4f52fd28eb04431
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:56 GMT
+      - Wed, 30 Apr 2025 16:24:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1946,7 +2039,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=301,atl-edge-internal;dur=15,atl-edge-upstream;dur=287,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=379,atl-edge;dur=292,atl-edge-internal;dur=17,atl-edge-upstream;dur=276,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="-aKP18RTcKwdDzwVQ2dWQsuIpHUBBcsENckhmdy9nCy8e31yHAUiag==",cdn-downstream-fbl;dur=384
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1955,10 +2048,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 04a2159f61dab28d4b7610df116a191a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -aKP18RTcKwdDzwVQ2dWQsuIpHUBBcsENckhmdy9nCy8e31yHAUiag==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 939975615c3658d07ddff3c140712b8e
+      - 9fe29e1c5e5ab9e374c4e531751e410a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1985,41 +2086,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 4a95adc9-f3cb-4d2e-9c7e-6af4a92489ad
+      - b5cd6315-c1a3-4850-8a59-a8f5419c1253
       Atl-Traceid:
-      - 4a95adc9f3cb4d2e9c7e6af4a92489ad
+      - b5cd6315c1a348508a59a8f5419c1253
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:57 GMT
+      - Wed, 30 Apr 2025 16:24:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2029,7 +2117,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=252,atl-edge-internal;dur=15,atl-edge-upstream;dur=238,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=302,atl-edge;dur=270,atl-edge-internal;dur=15,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="JB3VsWE-Mb3jqkH6awq6keZvx3H3sftS9lL_jdiwPLVCc-SfrEYcZQ==",cdn-downstream-fbl;dur=306
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2038,13 +2126,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 edb5724c2fa0963fde9c6c5089b747ce.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JB3VsWE-Mb3jqkH6awq6keZvx3H3sftS9lL_jdiwPLVCc-SfrEYcZQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c1e266a121bf785a801068345f01de74
+      - ed1b17676ac801afa921ba6ca01fbddd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2056,7 +2152,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/91]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -2065,29 +2161,29 @@ interactions:
       | Inactive, Verified, Mitigated |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
-      | Inactive, Verified, Mitigated |\n\n*Severity:* High\n\n *Due Date:* Feb. 9,
+      | Inactive, Verified, Mitigated |\n\n*Severity:* High\n\n *Due Date:* May 30,
       2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression Denial
       of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]\n*Defect
       Dojo link:* http://localhost:8080/finding/247 (247)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
       Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -2101,27 +2197,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3367'
+      - '3342'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 150cba74-77c7-4742-9715-205be8b7f2fe
+      - 576ee94c-f837-4fef-ab6d-1c400b37a693
       Atl-Traceid:
-      - 150cba7477c747429715205be8b7f2fe
+      - 576ee94cf8374fefab6d1c400b37a693
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:57 GMT
+      - Wed, 30 Apr 2025 16:24:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2131,17 +2229,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=545,atl-edge-internal;dur=17,atl-edge-upstream;dur=527,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=22,cdn-upstream-fbl;dur=605,atl-edge;dur=515,atl-edge-internal;dur=19,atl-edge-upstream;dur=496,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="WcIkGW1Bdf4hyBvP9VYinUY2JCUvTnuw7zbLUM7G5JTg55ZV6Jk1ZQ==",cdn-downstream-fbl;dur=611
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c8780798b589dc6b55523ca0a9bc3c02.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - WcIkGW1Bdf4hyBvP9VYinUY2JCUvTnuw7zbLUM7G5JTg55ZV6Jk1ZQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - e497418e8364ae41e1152b591ca74495
+      - c48dc49c9c2cf15f11e90114a9865454
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2165,67 +2271,68 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbMmU7HtZXEreu6spI8OB4PTK5IxBTAAqCOxvnv3eWl
-        +FBau9PYD8S1B3a//bD67MC64DJxIkeDTEBD8lpAnpie5AswPRNnsOA9VYDmVihpepAIuwDLe3HG
-        ZQq5SntL0Ab3IJlCocGAtM3ZuDRWLeak8Drw/cB3NfxZgrGzTQHnmsdWxOD0HEH2gz1/PMaJgXyO
-        08zawkSel8AcYpuoT8rlNufGCC5dCdZDS9bjhfBCTxhTgtcquIUNyp/NJhezPq4NcalywTjRZ8eg
-        b6WJuYVU6U19hwRnKBH64ajvB/3An4V+FIyike/uDfd/QL99cpKMWHS8UvNCJ0neQ31+2F27mSRg
-        Yi0KChyuHjKz4HneY4kwVsjYskJADEzN2UrpW5ekYyXf6fyZXpRSULp4fs2X3HLtLQWsvMqtrYPN
-        VuAPgvFPRvwFPy4w7eUCrRIs0OSMm1vKVXljaRTNeW6g59SCJ3ivSrbnZAKBo+NscwpLQF/9Lz3H
-        CkRWgShxIlniHZ0HMBn4uzaCdqPQ6hNe9YWZaKSrPFSZbfNAk6/Qs73uOymsRQXG6WwThH+tzho1
-        tyuuCchGLIpcoMPJg5Bgoir4Dcfr4fiZ7n4jZe1NuoQN/X10Ixyuw+H/a6WGRQVSNBjsrYO972Fw
-        3VochOtB+D0sNsj/8uUxHMMWjnOxfl9zICb58urxyUF7kqephhT55h+LYNRu4AVUXta88PTRvV0b
-        +zs2wp0b410bB4/dqWmzXiVSql4IJ+oHDVdS5LWIa88/P1qjesCgmkyVeXIsTJHzTVM1uIwptO8x
-        PVRJjQlu8TGqSfz5NV8/EdtHwavVaaroanikSkpG5fwHWhAydSKrS/Im1oCXJZp46pEYhAftI/Ew
-        bLuoLOyo7OFGB6pCC6WF3bzwwq24V700//6tEAuegvFIwrRKBC5kIs1cs0y3pPgWV1r2DJ3H9RF2
-        qM/5DRD/PVEaRBtPBiLYhdFgTBHJuJkUIj4V8vY17RxDQf2LjFsMVchaVXvdilRygu0Lv8lhCtzU
-        uNTNyDk/fffm5Oz69ORocnYxuZ5Mp79P8X5YpwZDggdmGbBzJHppGdllwjAl8w1D0hA5KWVWsV+E
-        5uxcwwJZg5UGEeY+RR4BFpTj3wnfL4pB5NSvImYPw7+tqntsgYlIheT5w0NN99WEt8J5jt41c8ps
-        KqE7XRZUtk8jed8dBV27UzdKLwRfLdw9sPd7m+fhcYu3n3l8i+1mC7lWeW3rqOno/pPDbVtY1wwa
-        Cdt+QMKKqlvlSp/V3tzkJfRTjZy1bYoUO1Z1stWiwIZY2qdBP9pFC6OOFr6V8fvh/Ci//j9kqVZl
-        QY3iayETJDHDsFbYDYBkRWkySCqUnkwP6XsDTMglGSCYJQx/CjB8zSCJSFkWuuwNqfsoX1XfVxG7
-        7NQKGTGJ8bKCW6Uj3x25gzsKOsY8VzHPM2VsNPbHvjevZa4r37yD4AqF2eUFxCVRFHurVn2rdsji
-        05yU+DSHV8xjl4Gx7I+SawuaTWSKhbnAMO8Qhe6AF1TSZ+e/scMSKYBdxFzukKJGzzsYXdUBvbtj
-        F9i7Vn7i+Oj9pPp8qD9tnmnStAA0nAmLbECiFa5whIoYESa7Y5eoox8iA2DpDcKg8oJwKpeJK7Hd
-        d1O19JZlLhG5FpnFu3/+ilQMfL+Ti1fgLoTV4CqdeljenCAvsGUlWvDwqJvZRU5y23ThpEoYKQvx
-        bwppmXOM6Zp+wlX3OAYpeE5IuoC/AQAA///sWW1v2jAQ/ivWpFaASBoghJeq6qqySpVGNW3aPnRf
-        MLEDmYBECaGqtB+/5xwnQEqgo2rVSVMrXuI7+3y+e873EK3QqTGDVe7yGersdLY8v8A0jmlVS3yp
-        D/6saXdo/dsF9XwrWSdnqXtynQ39LPh2OcnBptut3rOdpOWVk+znO8k+6KRXd5DzLAchE7Nw7NeU
-        s+gZqw0SyQYQwsMbOTZZr84I4Nk2OmR/04aZw4P63jLfLAywg4FCZIDlr4BRrYLRB/VYBS/VXdvf
-        t3lWQ6bi8U+8GUclDVZEaKkpXpa22ydQ+xYkEXx5488kUFWm/j6dLM+568pwqT6uI3FDcbBG/xpQ
-        OjcjQFnQgGr6wRkXKz9GBZFUhjsoDB75HEGU3RfoREfrFUYMNxtG9qNj13eZSEeDto6iQeTREOto
-        4MslCnNcZw9T350yXO8nE4BzAmBkIcdaiwnjDL2OC0XcltyIe2TH6Ept1PjMF5MEMD1iU8kFNFcc
-        pdVMd8t+rA0aog7M5GbN2R7PWrD+ZkRC5Iu66YtsHMOTbLixPQMkp1DHQ8S4yvz+4YOhWtCnF4ov
-        fKVtxZglTMYz39WHpnNYn9l3dQkjD+vDSI1hQJwZBiK9eejdzkMAAuncBcxXXxgK4soXUmyF01ek
-        FG6mWPpvgkKrhgHVU4rxChdzf1FllervOWJ4GfTzuN2JGa+OF86ReOEQXjgvw4uj6scTvDi2gm0e
-        71vjhfMfL94AL+x/Cy+cXPUAXjzlQdo5FVBsg8s6oYa92QktI4SMImSIMiqK5lRZYcDOSavCgFWm
-        YeVsROaFMsEydsIqY9Cs3BiVAFPqSnSLvtnlF3u9OJnPObW1H/b2XeRy4qiC6MgGmJiKS0QssWC3
-        4qItWt1Od9zoWLLl9iy31256vYbnYJ1cCCvsEZMUD1dCUDZA0g3E48cNQ9Ah01x7yXF1BtJEk63E
-        SCcjaG1pNbpcNGzb6bjdDvBy7I47Fpb3uPS67qW4ULOctK5Omjf4T/WMOV/ojtAw0kexmcTGAxxh
-        NE1qNc00D8lTRsh5TI6CvkJ6Povx8XpoWGa4ICKiSLS/f4uLTP37t7jI9L93iwFQImWzNVN0jdBn
-        Q+55iev6KoGow0u55RTe7oMFCX5KoiCUZ/cAHpeYVZ1p9EsTRvPUpRX0D2+76SW7DFTtMtbZzlnn
-        SIN7AUb+AAAA//8aLUZol2AGshgBAAAA//8i18WjxQitXUyXYgS9GMDVTDOBt8bgjRWgd9IhmbIa
-        NCUOZRsAXZJfkgid6Uc3BWezC2e5hGt2yMAIe8mHs1mG02c422twL6NJGOPSYQxv4aXmlWUW5edB
-        mngQoZRS6DITCJeY0CvLL6HedCfEMLihQJsyEovD8sFTQbA5V2AWgDi5GsaE1i9kOwC8JEcfZq6O
-        Um5iRVBqcWkOyGAkz4IncYpKHEsgHgdNJoMmekBeh4ujajZC0Q3VAHZtbW0tAAAA//8DACytC9DV
-        JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:41.238+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:49.941+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Inactive, Verified, Mitigated |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Inactive, Verified, Mitigated |\n\n*Severity:* High\n\n *Due Date:* May
+        30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression
+        Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]\n*Defect
+        Dojo link:* http://localhost:8080/finding/247 (247)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 7c626915-1707-4e8e-9de2-3fc45d267393
+      - 8b83a659-b98d-45c0-87bd-95589a224773
       Atl-Traceid:
-      - 7c62691517074e8e9de23fc45d267393
+      - 8b83a659b98d45c087bd95589a224773
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:58 GMT
+      - Wed, 30 Apr 2025 16:24:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2235,7 +2342,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=270,atl-edge-internal;dur=13,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="amR0-KhFG7VnEwSloGqiSZiAsf2Ef8GWJ3BHql4Q711k06h_X9vFnA==",cdn-downstream-fbl;dur=363,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=360,atl-edge;dur=287,atl-edge-internal;dur=17,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2244,10 +2351,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 81e839ce31651517fdd5c593655bd0d6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - amR0-KhFG7VnEwSloGqiSZiAsf2Ef8GWJ3BHql4Q711k06h_X9vFnA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 719e6310ff0786b39d63fdd286b32652
+      - 1f07a3278a427557561f25ba4b18059f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2273,21 +2388,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1604/transitions
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/transitions
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 58c39e05-0d9a-4673-bfc9-925a81024f76
+      - 7c06d8c3-3393-4259-acba-f51aabe518e4
       Atl-Traceid:
-      - 58c39e050d9a4673bfc9925a81024f76
+      - 7c06d8c333934259acbaf51aabe518e4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:58 GMT
+      - Wed, 30 Apr 2025 16:24:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2297,17 +2414,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=517,atl-edge-internal;dur=13,atl-edge-upstream;dur=505,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=609,atl-edge;dur=576,atl-edge-internal;dur=14,atl-edge-upstream;dur=562,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Sft5Vk0_5RNjByKeQBGvfJU27byUpieNjNTySPtqeJA2azDZbIEtUA==",cdn-downstream-fbl;dur=612
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Sft5Vk0_5RNjByKeQBGvfJU27byUpieNjNTySPtqeJA2azDZbIEtUA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 6ee3330ba8f6402175ae8a05d1da3217
+      - 67fbe80f9c3d7bcc78ffe4cc79c9d0ae
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2334,26 +2459,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1nZr3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwG2WJyaV8JHkAHLpkCnUFSM8XTO0yAGuIAAh7wLf8ChartzlkLFgNOMZ0UCefHN
-        yu7GKBvAlOZLKQAzVJLOFyhSpVIFUrFini1rlafIcgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMA6IelNCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:51.870+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - d76309cb-d143-4bb0-8a1d-ab3b7a669021
+      - 2a539786-3748-450f-97ba-ed67e8032e71
       Atl-Traceid:
-      - d76309cbd1434bb08a1dab3b7a669021
+      - 2a5397863748450f97baed67e8032e71
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:59 GMT
+      - Wed, 30 Apr 2025 16:24:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2363,7 +2484,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=168,atl-edge-internal;dur=13,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=179,atl-edge;dur=146,atl-edge-internal;dur=14,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="L5Kn60NLjyG_5ozmHWtY3wxLqp9jHq58VYgM_iSkoaWeVeQNNV8Gig==",cdn-downstream-fbl;dur=182
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2372,10 +2493,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 60b2b330807c6611e06e3923c8e315cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - L5Kn60NLjyG_5ozmHWtY3wxLqp9jHq58VYgM_iSkoaWeVeQNNV8Gig==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 5a961e011649acfe810fd3290ad50df7
+      - 55ae8762aee6c55e45093a5fc9bd128c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2399,68 +2528,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16088
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18183
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbU/jRhD+Kyt/pCF+ScIFS1WFIHdHSykNAT5wKFrsib2Hs+vuriHpwX/vjN9y
-        hAQVqp6Q8L7NzuzMM89MvjmwyLmMndDRIGPQEH8UkMWmI/kcTMdEKcx5R+WguRVKmg7Ews7B8k6U
-        cplAppLOPWiDexCPIddgQNr6bFQYq+YzunDqe57vdTX8VYCxk2UOZ5pHVkTgdBxB+v09bzjEiYFs
-        htPU2tyErhvDDCIbq6+qy23GjRFcdiVYFzVZl+fCDVxhTAFuc8EdLFH+dDI6n+ziWh+XShOME35z
-        DNpWmIhbSJReVm+IcYYSgRcMdj1/1/cmgRf6g3Aw7PZ7wU9ot0dGkhKLhpfXvNNIknfxPi9on11P
-        YjCRFjk5DlcPmJnzLOuwWBgrZGRZLiACpmbsQem7LklHSl7o7I1WFFJQuHg25ffccu3eC3hwS7NW
-        BtZbvtfzh78Y8Tf8PMewF3PUSrBAlRNu7ihWxa2lUTjjmYGOUwke47tK2Y6TCgSOjtLlCdwD2uo9
-        dRwrEFk5osQJZYFvdNZg0vOajVyrr/iidzq8li7dXQawcTdNvgPJ6lUXUliLFxin1U1I/a08a9TM
-        PnBNeDVinmcCDY7XXo7xKFHWHy76wzea+0pkmpe0cel7H9CMoL8I+v+vlir6JRZRob+38Pd+hMJF
-        o7EXLHrBj9BYA/zp6SUc/W04DZqNmVhcVhyI0b++eXmy15zkSaIhQb55kQT4AJUVVfq/C+6rCzYj
-        /jnBXCGLsJQbdgsgWaQQ0GAhZkoymwrDSjIgmqlT4wj53dngnME25+xt2/iwZSPYujHctrH/0nmv
-        cbnfcjlxaFnQnHDXr6mdXKlF1ERgfY3yGt9vUlVk8ZEwecaXdfbjMsbEXiLMiBEqkx64xdpZ1Zy3
-        B7OqaKsa5lbXaWKmcnioCsJOafwVLQiZOKHVBVkTaUA3UPBf+sHr9oL9xg/rDm2Zd31jWw4EbQ7k
-        Wigt7PKdD27E3bIw/vvSJuY8AeOShGkuEbiQiiTtmvtkheDPuNLkRLABykGvSZbpTrgz9cv/Q98L
-        pjuPO3SARu0GeS/jt0B8vyHjiSY3OszfhnJ/SJ7DjBzlIjoR8u4j7RxBTm2ZjBqslQh8KPfaFank
-        CLsyfpvBGLip8KvrkXN2cvHp+HR6cnw4Oj0fTUfj8R9jNB7px6Dr8MAkBXaGhU1aRnox9ZEFsiVD
-        khQZXcqsYr8KzdmZhjmyJCsMIrG7iSx9TEnHexSel+e90KmKPUYZw0R5uYEEMWCJkDxbP1Q3lbV7
-        y3zI0Lp6TghIJLSni5wSfzPiqYvzG8RX/d87QVoJt/3bc0Z9G27XmHWtGawUHdZd6n+ytml13V6t
-        pNc0P3GlOFKZ0qeVLRgXkGumlVHG+oBjaTejfdDyxmsRXRdqOeW5H7/I7/8OWKJVkVPj+1HIGFnO
-        rMpWXpgUaxbB83h8QN9bYELek2bCV8zwpw3D6gxxSJelQZd9ouu+yJ3yuxOy6/ZaIUMm0VdWcKt0
-        6HUH3d4jORz9namIZ6kyNhx6Q8+dVTLT0jZ3379BYXZ9DlFBHMY+q4ddq7bIYg8SF9iDBDfMZde+
-        sezPgmsLmo1kghk5RzdvEYX2gOuX0qdnv7ODAnOfnUdcbpGijtbdH9xUDn18ZOfYi5d24vjwclR+
-        rqpPE2ea1C0NDSf/AAAA///sWftL40AQ/leWA6UtTZq0afoQ8eSKIJxyKHe/yEG32W0aLo+Slx74
-        x9832yR9aFuvonhwKrVJZnZnZ7/5ZmfipaABUlWYwjcMxIhR2SO7wxhaG6GPmOu0TWUFYTTMhR6i
-        fNHdKG/lmR8CtSkopbUu/5OG6BhGpefcSz3w0ljqUey2ENec4O7hbE580IKoPksDn/SW24ULtWE0
-        WBs/N9LNfA6fPlBJqtYxkqHHfULSrYxzVJ5MY7XraoQmO/bTk1MMY+tGfYsvi41vta0ezX8ZUg2b
-        yyY5SxUETXblleB7zkk2Ft3tDF7spEJeOcl6uZOsvU56cwfZL3IQIrGE47ChnEX3WGOUSTaCEG5e
-        yInOBk1GzM7W2aH8nZl6RQ/quqO/GwywgpFiYzYCHTNKUjB6rx6r4aP+3PJ3LZ41EKm4fYd/2kFB
-        gxkBLTXE68J2fQcat1EWw5cXni/BqnLh72M3PeGOI+ep+rpE4oriaMn+DbB0ZUaEtFAQqu5FLS5y
-        L0FqkZR/e0gMU/I5QFQeFGhHx8sZxgxHGkb2y7g8xMQFGgrrCA2iQkNSoIGnKXd+JU12P/OcGcP5
-        33VBzhmIkc055gpdxhlqNweKOCY5MZ+SHeNztVDtKw/dDDQ9ZjPJBTRz7qOUWqyW/VgadIU84MvV
-        nLP+vCwph6uIhMg3VQqI8jkeu+Vjc30ESM6gjpvAuIr84f6NoVwwpA/CFy5pWQlGmWcT33OKTSti
-        uNiz7+r0RR4uNmNhDAPj+HgQF4uH3mUwByGQznXEPHXBkBBzT0ixBqcbhBSOpJj6b0BRqM4jyqeE
-        8RoXgRfWWa3+GADDaTSscPssZ7w5X9gH8oVNfGG/ji8Oyh9P+OLQDLa6ve/NF/Z/vngHvrD+Lb6w
-        K9U9fPG0UdKtGnqb9e+2DopprZZIaQzIqI4N9ZQ2Rbf11IxtD6yqEbapUbUhSi9sE9zWljC2Nd+M
-        ak4VADOqSorafLW83ywCkywIOJW0n3bWXeRyamJF8YHFL7UozoBYapNditOu6PR7/YnZM2THGRjO
-        oNueDsypjXkqIcywQ0wSHs6FoGiApBOJ359XDEGFTGPtfAug9kDqbrwQI52yE21Jw+xzYVqW3XP6
-        PfDlxJn0DEw/5XLad87EqRrlqHN+1L7A30JPC3hYVISatriV6Fmi3cMRWlunUlNfxCF5SptznpCj
-        oK+YnvsJvn650gx9HlKrbPONwse3ePOVxMe3ePOVxke3GAQlvD8AAAD//wIPd0MHiZyBSV/BNzEt
-        rTQ5OROcgUA9PMjgM6R4iwKNG1kpuZYW5Rek6kcBC55k0NArNKeBptSAsvCsC7IBOpGIfXjJBFeh
-        aoJrWNoEPixdBC3cR4sRrAkGAAAA//+iRYIZLUbo4eLRYgRLMYJeDOBqppnAW2PwxgrQO+mQTFkN
-        mvuHsg2ALskvSYSuXEA3BVd7zABXuWRghL2AwzVbZIDTAzjba3CfoevA1ZAzxikBb+Gl5pVlFuXn
-        QZp4EKGUUuiyGQiXmNAryy+h3nwoxDC4oUCbMhKLw/LBc0CwSVlgFoA4uRrGhNYvZDsAvMRIH2au
-        jlJuYkVQanFpDshgJM+CJ3CKShxLIB4HzTbn5IMa+0jiqJqNUHRDNYBdW1tbCwAAAP//AwAQVIR7
-        pSUAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18183","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183","key":"NTEST-1844","fields":{"statuscategorychangedate":"2025-04-30T18:24:51.193+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:24:51.165+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:40.963+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_10230_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t07:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:51.193+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/1]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]
+        | Inactive, Verified, Mitigated |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]
+        | Inactive, Verified, Mitigated |\n\n*Severity:* High\n\n *Due Date:* May
+        30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression
+        Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/247]\n*Defect
+        Dojo link:* http://localhost:8080/finding/247 (247)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/246]\n*Defect
+        Dojo link:* http://localhost:8080/finding/246 (246)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1844/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18183/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3e24a8ee-cfeb-4506-9afd-f592fd1f28cd
+      - 2ca60ae6-a264-4209-b8f6-7a59a511fb7e
       Atl-Traceid:
-      - 3e24a8eecfeb45069afdf592fd1f28cd
+      - 2ca60ae6a2644209b8f67a59a511fb7e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:59 GMT
+      - Wed, 30 Apr 2025 16:24:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2470,7 +2598,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=275,atl-edge-internal;dur=15,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=304,atl-edge;dur=270,atl-edge-internal;dur=15,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="T0C96mxIVgLy7cYEfV1TnupkhKYo-_T5YB9obsiMJXHuYIPTn9mUJQ==",cdn-downstream-fbl;dur=307
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2479,10 +2607,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - T0C96mxIVgLy7cYEfV1TnupkhKYo-_T5YB9obsiMJXHuYIPTn9mUJQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e5121fcb72018ed71f520d5b1021a300
+      - 24a68735bda289dbdb775a536b6be206
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2509,26 +2645,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrlm5r3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCGcAWQopJOXm8rFcP1Q/083Q1rEi/HmEJjCBl+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0XxHCY4AuFqfmlQgjSIHmCWQJFBWlnM04i2KAC4hwzPv4B+wr3Z6zGVQUeJbzvEiXBftm
-        ZXtjlYsgy+ZLKQBzVDKbLVAwpZgCqWgxy5e1mjOkcwX0TBDMaLjVvRhfiEoMJtw5Kcb2gZhTRdC+
-        bktyPD/sydlxcn1fkeMnAAAA//8DAA6VDDsgAgAA
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:52.784+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - c714753d-765f-4d01-b08b-11cce9244006
+      - 201b8c0e-0a31-4b4a-8016-d81c54e5e7cc
       Atl-Traceid:
-      - c714753d765f4d01b08b11cce9244006
+      - 201b8c0e0a314b4a8016d81c54e5e7cc
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:15:59 GMT
+      - Wed, 30 Apr 2025 16:24:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2538,7 +2670,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=145,atl-edge-internal;dur=21,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=199,atl-edge;dur=166,atl-edge-internal;dur=13,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="cOzkr4QWPvD-rVW765xQZEyKi5E4b_lv7UUjWXMZM2EfyYn_vi15qQ==",cdn-downstream-fbl;dur=202
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2547,10 +2679,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 de5b26aba33b480d2b740b96a34fe916.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - cOzkr4QWPvD-rVW765xQZEyKi5E4b_lv7UUjWXMZM2EfyYn_vi15qQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 2f3471a6a95734181efda3e795e49f0d
+      - 1fbf3d84db95dbf141aba7dfcf743671
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2577,41 +2717,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 1d88df26-0f82-4a31-a6ff-bbda59bce48a
+      - 1aaed495-2b13-4eb8-b598-0e3db093e452
       Atl-Traceid:
-      - 1d88df260f824a31a6ffbbda59bce48a
+      - 1aaed4952b134eb8b5980e3db093e452
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:00 GMT
+      - Wed, 30 Apr 2025 16:24:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2621,7 +2748,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=314,atl-edge-internal;dur=16,atl-edge-upstream;dur=298,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=19,cdn-upstream-fbl;dur=379,atl-edge;dur=298,atl-edge-internal;dur=16,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="fnQZqIVWdU7qg3xNKUD-jTvQKaSc-Jxyb9dCYjo6rv-TsImPWgdlQA==",cdn-downstream-fbl;dur=384
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2630,13 +2757,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 124fcc45b0cac625cd0077abe70a7c60.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - fnQZqIVWdU7qg3xNKUD-jTvQKaSc-Jxyb9dCYjo6rv-TsImPWgdlQA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - d9cc3f07d8d611e9f8ca9b771924883c
+      - 756cfde325f1164aa5053c72a7525af0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2648,15 +2783,15 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Jira Api Test 2", "description": "\n\n\n\n\n\n*Title*: [Jira Api
       Test 2|http://localhost:8080/finding/252]\n\n*Defect Dojo link:* http://localhost:8080/finding/252
-      (252)\n\n*Severity:* High\n\n\n*Due Date:* Feb. 9, 2025\n\n\n\n*CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]\n\n\n\n*CVE:*
+      (252)\n\n*Severity:* High\n\n\n*Due Date:* May 30, 2025\n\n\n\n*CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]\n\n\n\n*CVE:*
       [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n*Product/Engagement/Test:*
       [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n\n\n\n\n\n\n\n\n*Vulnerable
       Component*: negotiator - 0.5.3\n\n\n\n\n*Source File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -2670,7 +2805,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1442'
+      - '1430'
       Content-Type:
       - application/json
       User-Agent:
@@ -2679,18 +2814,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16089","key":"NTEST-1605","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16089"}'
+      string: '{"id":"18185","key":"NTEST-1845","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18185"}'
     headers:
       Atl-Request-Id:
-      - e0615ede-08c6-4734-8af5-642e17552ffa
+      - a73eadd5-3c3f-45d2-95c7-9106635809b8
       Atl-Traceid:
-      - e0615ede08c647348af5642e17552ffa
+      - a73eadd53c3f45d295c79106635809b8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:01 GMT
+      - Wed, 30 Apr 2025 16:24:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2700,7 +2837,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=667,atl-edge-internal;dur=18,atl-edge-upstream;dur=649,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=719,atl-edge;dur=687,atl-edge-internal;dur=14,atl-edge-upstream;dur=672,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="6l2QpOGEgDcz-z7ljd7NEVc2ZDZg3ijLleYN7KNFmYFc551DeTbhRw==",cdn-downstream-fbl;dur=723
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2709,10 +2846,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 6l2QpOGEgDcz-z7ljd7NEVc2ZDZg3ijLleYN7KNFmYFc551DeTbhRw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 257b2e7c09c35f3c439a0c0fa6144377
+      - 055a52b183bf3fd6a2615d4aef0ef8c1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2736,62 +2881,46 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1605
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1845
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWWW/jNhD+K4Se2tTW5dhrCyiKbeJ006apm3izD2kQMNJY5oYiVZLy0d389w51
-        OZe2TYouDCTiMfc3H+eTA5ucisSJHAUiAQXJEQOe6J6gGeiejpeQ0Z7MQVHDpNA9SJjJwNBevKQi
-        BS7T3gqUxjNIziBXoEGY+m5caCOzhVV4Hfh+4LsK/ixAm/k2h5misWExOD2HWfvByB9PcKGBL3C5
-        NCbXkeclsIDYJPKjdKnhVGtGhSvAeGjJeDRnXugxrQvwGgW3sEX50/n0fN7HvSFulS5oJ/rkaPSt
-        0DE1kEq1rWJIcIUSoR8O+37QD/x56EfBKPJ9dzKefId++9ZJa8Sg46WaVzpp5T3U54dt2PUiAR0r
-        ltvE4e5bojPKeY8kTBsmYkNyBjEQuSBrqW5dKx1L8V7xF3pRCGbLRfk1XVFDlbdisPZKt3YO1keB
-        PwjGP2j2F3yfYdmLDK1aWKDJOdW3tlbFjbFf0YJyDT2nEjzGuErZnrNkCBwVL7cnsAL01b/rOYYh
-        snJEiROJAmN0HsFk4DcHuZIfMaJXJryWLtNdFrBJt13cA8kuqveCGYMKtNPatkj9pbyr5cKsqbJ4
-        1SzLOUOHk0eRYz1KlO2PN/vjF7r7hco0kbR12fffoBvh/ibc/3+tVNUvsYgGg9EmGH0Ng5vG4iDc
-        DMKvYbEG+N3dUzgGXTgNm4MF21xUHIjVv7x6enPQ3KRpqiBFvnnSBBiA5EXV/s+bG3YdjLoO3nQc
-        hJ0H466DyVM/K9qsdi0plS+EE/UDXFKDD0dFuC9v3IrOdwTuVeqUbcvy80AWNnGBJeUPdoOJ1ImM
-        KuCu5mmrTbG4SuenJ3vWM7yql7LgySHTOafbupVxG90yF4gZ2951NhRgsJY/nnskRuNB80g8TltL
-        ZY8PukAVtqDKFZOKme0rk9iIe+VL8+/fCpbRFLRnJXSjhOHGkqVLV6/SHVu+w52GVkPnaeOELeo5
-        vQFLjM+0huWTZxMRdGE0GNuMLKme5iw+YeL2yJ4cQm7nFxE3dSyruy7P2h0hxRTHF3rD4QyorrCh
-        6i9ndvL+p+PT65Pjg+np+fR6enb22xnGh32qMSV4Yb4EMsMXQBhi7RKmiRR8S5BNGLdKiZHkZ6Yo
-        mSnIkE5IoRG17nOsEmBDOf5n5vt5fhM51auI1cP077rqAVtgIVImKH98qZ6+6vSWSOfoXb22lU0F
-        tLeL3LZtF5LfDEcNkqtB6ZXgq4Tbl/fhbPMyPO7w9iONb3HcbCDXKK9sHdQT3X9yuBkLq55BI2Ez
-        KAhY2+6WXKrTypsbXkA/Vcgbu6FIkkNZFVtmOQ7EwjwP+mEXLQxbWvhSxR+m8w+x++3NmeGwF5HL
-        EoZvc0bmKE3CzzYZmAsuY8qXUpto7I99b8FEgtzphcPwqpQ/LHOFYXyUxKIo2iP/KEm+wT/fluLn
-        OOVZ0kExyw61U4cFkEP0H3eP4MYlkx6x4GudPvgwxaNL/Nff9/3SVVu3eA1uxowCV6rUQ9hSW0qG
-        M5qFu4dX3aXJeOl4peei0nMx7YdILIjs4WDSqhOrxBU4TbupXHmrggvUZrBxvYf3W3WocKZkUuC4
-        MBUpMkCG9fRsOq2Rc4gLGyl5J9d9Izvym9cKwivikcsAK/F7QZUBRXYqO0RhZzMopU9nv5K3BdIX
-        OY+p6JCy06s3Gd4L4v5v7wLDxoHcUtVBA1FEi0DUG0aNVKRPfHfoDu7JnMtCxX8DAAD//+xZbWvb
-        MBD+K6LQ0o7adRI3aVNKF7oVCssYhe1D6YcolpwY4hf8km50/e97TpKVxIu7rYzSD4UQbEsnnU93
-        zz13luwqUo6FchFhU+zNyjMeBDIr1eVqgTXBDys3fTe8S+w5pPBfYz03So+4WEYFXF0SXvTvklFI
-        LigFq4GNip7JaocJAwQzOkDzJgBdoGS14HmtHaQYckHEFyQLDF6izmS8LIEgxSG7n0fBnIELzGY4
-        iQpmYBnHXsmMcQZSFkAQsB7kPCQ9JiP1os4n1IoVzmTC5pKjVGZLDgxw9duyNdOOcegLuW7WzfGa
-        Kw7Z3qI8O4fF+66HKV8UzRH1OIZn9XBncwXMnEMcD+sDG/75YBjFGf1RlOGWXqvAKlk1XUSBObQx
-        omumync6s68qW5CFzWFoZRgcZYGB3Lw85K7jDOU8yXxOWaRuGLx/GQkpVj6BiTdAGKRQbP0vTmFE
-        s5SCh+Jvn4s4Sg7Y/sHPGEFcpkP4/O8E7NhykGb+bYPgjt82YPk3YXOZw5cU7SQi2ZjqW7bcGPDa
-        OLzXRoM8S4Nq87RNbKPunlVmg040k4qKjjnhjU5ZRRXHnPLpTiOVkJGJDqf5M3MtkaIL+CiR+Gtx
-        fix6J4OTaWfgyV5w6gWnx93wtBP2sY+dhB2emCbJA0ZCkP9jZpCKH+/XFEEyprWeLNCVcaWLfK6m
-        kUxdJPoSlJOLju/3B8HJACliGkwHHrYPuQxPggtxrlbZ7Y12u1f4aTkn5okBcMfRjwq3Kpx7GMLp
-        upQZXB15ZCkn47wgQ0FeZTgQVlxejh3PzRLiPM1i//Vr3OwWvH6Nm92G164xkEfo4tWQ0ku4Phvz
-        MKyCIFIBVEZLqUtjjVu3yPmY+LHK00we3QJRAiriTKRRtwujNnRpB9Pj285k/TYY9dsKXN8WuM0B
-        C9W5wfk3fHkxT3rDl5fQ+A1ftuBLEwYs/7J0BVrPdOw9UFveXHvYMC25+ajQXKWVaLXiUisD625H
-        vrb+lNdGOQkQtg54bZSz1ybRs5xOJssoTxPN2/QjUZkvWvr2r6yXxnqFh/rSwP0z4HftY9xRve7h
-        Tsy/38iiWtDCa3ur9k1ejkqtxzIt/1/XWC9mF8Vec158S1X3q271Ut+aekq0pVVkU9vuhrpGQJnn
-        8fHxFwAAAP//AwAVPC4jQB0AAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18185","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18185","key":"NTEST-1845","fields":{"statuscategorychangedate":"2025-04-30T18:24:54.033+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1845/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:53.734+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t0f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:53.806+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 2|http://localhost:8080/finding/252]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/252 (252)\n\n*Severity:* High\n\n\n*Due Date:*
+        May 30, 2025\n\n\n\n*CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]\n\n\n\n*CVE:*
+        [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n*Product/Engagement/Test:*
+        [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n\n\n\n\n\n\n\n\n*Vulnerable
+        Component*: negotiator - 0.5.3\n\n\n\n\n*Source File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 2","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1845/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18185/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 46d5f013-73d3-41b7-99f4-29251de0190a
+      - 7683e9c4-c66f-4110-b672-71dbbca8b332
       Atl-Traceid:
-      - 46d5f01373d341b799f429251de0190a
+      - 7683e9c4c66f4110b67271dbbca8b332
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:01 GMT
+      - Wed, 30 Apr 2025 16:24:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2801,7 +2930,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=291,atl-edge-internal;dur=21,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=272,atl-edge;dur=239,atl-edge-internal;dur=14,atl-edge-upstream;dur=226,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="8UCwqRXrBSVxbMjyMtVdbI9vUWteG4tDyHmSGHCf-bx3UbXTB1i1og==",cdn-downstream-fbl;dur=275
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2810,10 +2939,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 8UCwqRXrBSVxbMjyMtVdbI9vUWteG4tDyHmSGHCf-bx3UbXTB1i1og==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d97c7d41eb08b3ebe566f814686e2d4c
+      - 0fac3749ff3f3b59e2889f3b205fe4ba
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2837,62 +2974,46 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16089
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18185
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWWVMjNxD+K6p5Sog9l7GxpyqVImCyJIQQMOwDoSgx0x4LNNKspPERlv+e1lzm
-        8m4glS1Xwejo++tPfe/AMqcicSJHgUhAQXLAgCe6I2gGuqPjGWS0I3NQ1DApdAcSZjIwtBPPqEiB
-        y7QzB6XxDJJTyBVoEKa+GxfayGxqFV4Hvh/4roJPBWgzWeVwomhsWAxOx2HWfjDwhyNcaOBTXM6M
-        yXXkeQlMITaJvJUuNZxqzahwBRgPLRmP5swLPaZ1AV6j4A5WKH88GZ9NurjXx63SBe1E945G3wod
-        UwOpVKsqhgRXKBH6Yb/rB93An4R+FAwi33dHw9EP6LdvnbRGDDpeqnmnk1beQ31+2IZdLxLQsWK5
-        TRzu7hKdUc47JGHaMBEbkjOIgcgpWUh151rpWIpzxd/oRSGYLRfl13RODVXenMHCK91aO1gfBX4v
-        GP6k2d/wY4ZlLzK0amGBJidU39laFTfGfkVTyjV0nErwEOMqZTvOjCFwVDxbHcEc0Ff/oeMYhsjK
-        ESVOJAqM0XkGk57fHORK3mJE70x4LV2muyxgk267eASSdVTnghmDCrTT2rZI/a28q+XULKiyeNUs
-        yzlDh5NnkWM9SpRtD5fbwze6+4XKNJG0ddn2d9CNcHsZbv+/Vqrql1hEg8FgGQy+hcFlY7EXLnvh
-        t7BYA/zh4SUcg004DZuDKVteVByI1b+8enmz19ykaaogRb75ahP0mwOMTPKi4oXXrw42HexsOAg3
-        Hgw3HYxeulPRZrVrSal8IZyoG9RcaUuiWFx5fv9izzYKZlvPZMGTfaZzTld1O+H2ghp8eirKfnvr
-        Vw/C+gnwKnXKNnb5uScLm/rS1Y92g4nUiYwqrG1Uai4QM7a962wowGAtf7z2SAyGveaReJ62lsqe
-        H2wCVdiCKldMKmZW70xBI+6VL82/fytYRlPQnpXQjRKGGzOWzlw9T9ds+QF3GloNnZeNE7ao5/QG
-        LDG+0hqWT15NRLAJo8HQZmRG9Thn8RETdwf2ZB9yO7+IuMFQiaxFedbuCCnGOL7QGw6nQHWFS1V/
-        OSdH578cHl8fHe6Nj8/G1+PT0z9OMT7sU40pwQuTGZATfAGEIdYuYZpIwVcE2YRxq5QYSX5lipIT
-        BRnSCSk0Ys59jVUCbCjH/8x8P89vIqd6FbF6mP51Vz1hCyxEygTlzy/V01ed3hL5HL2r17ayqYD2
-        dpHbtt2E5J3+oEFyNSi9E3yVcPvyPp1t3obHNd5+pvEdjpsN5Brlla29eqL7Tw43Y2HVM2gkbAYF
-        AQvb3ZJLdVx5c8ML6KYKOWs9FEmyL6tiyyzHgViY10Hf30QL/ZYWvlTxp+n8S6x/WxNmOGxF5LKE
-        4W7OyASlSfjZJgNzwWVM+UxqEw39oe9NmUiQ+bywH16V8vtlrjCMW0ksiqIt8lVJ8h3++b4UP8Mp
-        z5IOill2qJ3aL4Dso/+4ewA3Lhl1iAVf6/TexzEeXeK/7rbvl67ausULcDNmFLhSpR7CltpSMpzR
-        LNw9vOrOTMZLxys9F5Wei3E3RGJBZPd7o1admCeuwGnaTeXcmxdcoDaDjes9vd+qQ4UnSiYFjgtj
-        kSIDZFhPz6bTGjmDuLCRkg9y0TVyQ37zWkF4RTxyGWAl/iyoMqDIWuUGUVjbDErp45PfyW6B9EXO
-        Yio2SNnp1Rv1HwXx+Ld1gWHjQG6paq+BKKJFIOoNo0Yq0iW+23d7j2TOZKHifwAAAP//7FltT9sw
-        EP4rFhIIJhLSNrSlCLGKDQlpnSak7QPiQ13HaSO1SZSXsonx3/ec47hphtmGJsQHJISS2Gefz3fP
-        PXeV7DJSjoVyEWGT782LUy6ETAv1uFmgIfhh46bvRrexuYcE/qut50bJEQ/WUQ5Xl4QX/dt4HJIL
-        yoDVwEZFz3Szw5QBghldoD4JQBcoWS55VmsHKYZcEPElyQKD16gzGS8KIEh+yO4WkVgw8JD5HDdR
-        wgws5dgrnjPOQMoEBAHrIuMh6TEdq4M6n1ArlriTKVtIjlKZrTkwwK1OyxqmneDSl7Jp1u3xmiuO
-        2N6yOD2DxfuuhylfFEkJ6nEMz+vhzvYKmLmAOD7WFzb688UwijP6R1GGVzpWjlXScraMhL60CaJr
-        rsp3urOvKluQhfVlVMowOMoSA5k+POSuVinKeZL5nLBIvTB4/zoKZLDxCUy8BsIghWLrf3EKLZom
-        FDwUf/s8WEXxAds/+LlCEBfJCD7/OwE7NhyknX9tENzxmxBcZHAZxQ2Jq7anGo7eGvANW24NeDYJ
-        z9Cg2gq2iTZa5Nmou2eUUQGwIEjR3KBJL9pJJi9XK075dKeVSsjIRIeT7Jm5lkjROXyUKPhVcHYc
-        9IaD4awz8GRPnHji5LgbnnTCPvYxk7DDE9MkecA4CMj/MVMkwY/3DUWQjGmtJwt0ZXXpIp+raSRT
-        F4m+BOXkQcf3+wMxHCBFzMRs4GH7kMtwKM6DM7XKbm+8273EXyXnrHisAdxxqk+5W+bOHQzhdF3K
-        DG4VeWQpJ+U8J0NBXmU4EFY8Xkwcz01j4jztYv/1a9zuFrx+jdvdhteuMSApqApnTUov4PpswsOw
-        FCJSAVREa1kVthWg3SDnY+LHMktSeXQDqBFUxOlIo24XRk3o0g66x/c4k/VtMOrbClzfFLiZhvM3
-        GHkxh3mDkZfQ+A1GHoGRNgzYiJlv+JehJzjOvArKe2rL62cPmiQF1z8qtFexEi0rLtkaUV73ceSz
-        EjHryawMzRy5NdCzSfQMp5PxOsqSuCJ11aeg1L9oVa9/Y711Uvy/Xmu1mFkUOy14/i1RXae6vYsQ
-        qFS+rx91fnm2AurXv6N63cOdFf9+LfNySQs3Dqv6RVkxLqqDU9+aekp0dPN9W7i7Ja0FlLYPDw+/
-        AAAA//8DAMY/uONAHQAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18185","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18185","key":"NTEST-1845","fields":{"statuscategorychangedate":"2025-04-30T18:24:54.033+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1845/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:53.734+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t0f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:53.806+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 2|http://localhost:8080/finding/252]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/252 (252)\n\n*Severity:* High\n\n\n*Due Date:*
+        May 30, 2025\n\n\n\n*CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]\n\n\n\n*CVE:*
+        [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n*Product/Engagement/Test:*
+        [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n\n\n\n\n\n\n\n\n*Vulnerable
+        Component*: negotiator - 0.5.3\n\n\n\n\n*Source File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 2","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1845/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18185/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 373b4f45-ae4b-483e-9f50-412023c3d47a
+      - 72c6abfb-be01-4da1-bce8-ab50d8104588
       Atl-Traceid:
-      - 373b4f45ae4b483e9f50412023c3d47a
+      - 72c6abfbbe014da1bce8ab50d8104588
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:01 GMT
+      - Wed, 30 Apr 2025 16:24:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2902,7 +3023,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=255,atl-edge-internal;dur=13,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=322,atl-edge;dur=287,atl-edge-internal;dur=16,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="AENb14gqANqO5k2wA22TUlZZUMADudbdroP6ps8FxL7YQOYWhFHRJg==",cdn-downstream-fbl;dur=326
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2911,10 +3032,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ad310b4d7c581c35032fa3fce068e53c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - AENb14gqANqO5k2wA22TUlZZUMADudbdroP6ps8FxL7YQOYWhFHRJg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 9b5a9a93e546cedbcf814c223ddb5f71
+      - 7ad1b875f74a01da9cd801ea3ac11f0e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2941,26 +3070,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1nVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLD5/NS8EiGBDNhsDHQMy4oxnk95HsUAFxDhmPfxD9hXuj1nKVQMOC04sIwC/WZl
-        e2OVi2BOi4UUgDNUkk7nKHKlcgVSseV0tqhVkSMrFLAzQTDJcKt7kV6ISgwm3DkpUvtAzKkiaF+3
-        JTmeH/bkbJpc31fk+AkAAP//AwADmawWIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:55.619+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - ee09e616-730a-4f5d-ab4c-dbc8e76b1d71
+      - 92cb6b14-10f3-45b7-a3e2-aab9903db14c
       Atl-Traceid:
-      - ee09e616730a4f5dab4cdbc8e76b1d71
+      - 92cb6b1410f345b7a3e2aab9903db14c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:02 GMT
+      - Wed, 30 Apr 2025 16:24:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2970,7 +3095,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=16,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="ffSeDSWck2ZZMucvKLgHMQ4kpHd3wmOqEZsHeC1uQxdlEIMucjRoEA==",cdn-downstream-fbl;dur=386,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=383,atl-edge;dur=299,atl-edge-internal;dur=18,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2979,10 +3104,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 05df0d22c8cc3d4b946b6f2dc43d6b9c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ffSeDSWck2ZZMucvKLgHMQ4kpHd3wmOqEZsHeC1uQxdlEIMucjRoEA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - ba52c2f8d1e4fdb2e6211c490a5b5a06
+      - 23f144fada6925e1e607e085e0691ad8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3006,62 +3139,46 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16089
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18185
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWWVMjNxD+K6p5Sog9l7GxpyqVImCyJIQ4YNgHQlFipj3WopEmksZHWP57WnOZ
-        y5tAKluugtHR99ef+t6BVU5F4kSOApGAguSIAU90R9AMdEfHc8hoR+agqGFS6A4kzGRgaCeeU5EC
-        l2lnAUrjGSRnkCvQIEx9Ny60kdnMKrwJfD/wXQV/FqDNdJ3DRNHYsBicjsOs/WDgD0e40MBnuJwb
-        k+vI8xKYQWwS+Um61HCqNaPCFWA8tGQ8mjMv9JjWBXiNgjtYo/zpdHw+7eJeH7dKF7QT3TsafSt0
-        TA2kUq2rGBJcoUToh/2uH3QDfxr6UTCIfN8dDUffod++ddIaMeh4qeadTlp5D/X5YRt2vUhAx4rl
-        NnG4u090RjnvkIRpw0RsSM4gBiJnZCnVnWulYykuFH+jF4VgtlyU39AFNVR5CwZLr3Rr42B9FPi9
-        YPiDZn/B9xmWvcjQqoUFmpxSfWdrVdwa+xXNKNfQcSrBY4yrlO04c4bAUfF8fQILQF/9h45jGCIr
-        R5Q4kSgwRucZTHp+c5Ar+QkjemfCa+ky3WUBm3TbxSOQbKK6EMwYVKCd1rZF6i/lXS1nZkmVxatm
-        Wc4ZOpw8ixzrUaJsd7jaHb7R3S9Upomkrcuuv4duhLurcPf/tVJVv8QiGgwGq2DwNQyuGou9cNUL
-        v4bFGuAPDy/hGGzDadgczNjqsuJArP7V9cubveYmTVMFKfLNiybAACQvqvZ/3Vx/28Fg28HeloNw
-        68Fw28HopZ8VbVa7lpTKF8KJukHNlbYkisVVSPcv9myjYLb1XBY8OWQ653RdtxNuL6nBp6ei7Le3
-        fvUgbJ4Ar1KnbGOXnweysKkvXf1oN5hInciowtpGpeYSMWPbu86GAgzW8sdrj8Rg2Gseiedpa6ns
-        +cE2UIUtqHLFpGJm/c4UNOJe+dL8+7eCZTQF7VkJ3ShhuDFn6dzVi3TDlh9wp6HV0HnZOGGLek5v
-        wRLjK61h+eTVRATbMBoMbUbmVI9zFp8wcXdkTw4ht/OLiBsMlchalmftjpBijOMLveVwBlRXuFT1
-        lzM5ufjp+PTm5PhgfHo+vhmfnf12hvFhn2pMCV6YzoFM8AUQhli7hGkiBV8TZBPGrVJiJPmZKUom
-        CjKkE1JoxJz7GqsE2FCO/5n5fp7fRk71KmL1MP2brnrCFliIlAnKn1+qp686vSXyOXpXr21lUwHt
-        7SK3bbsNyXv9QYPkalB6J/gq4fblfTrbvA2PG7z9SOM7HDcbyDXKK1sH9UT3nxxuxsKqZ9BI2AwK
-        Apa2uyWX6rTy5pYX0E0VctZmKJLkUFbFllmOA7Ewr4O+39LClwr7XKiljKfp/ENsfjtTZjjsROSq
-        hOF+zsgU1ZLws00G5oLLmPK51CYa+kPfmzGRIPN5YT+8LuUPy1xhGJ8ksSiKdsg/SpJv8M+3pfg5
-        TnmWdFDMskPt1GEB5BADw90juHXJqEMs+FqnDz6O8egK/3V3fb901dYtXoKbMaPAlSr1ELbUlpLh
-        jGbh7uFVd24yXjpe6bms9FyOuyESCyK73xu16sQicQVO024qF96i4AK1GWxc7+n9Vh0qnCiZFDgu
-        jEWKDJBhPT2bTmvkHOLCRko+yGXXyC35zWsF4TXxyFWAlfi9oMqAIhuVW0RhYzMopU8nv5L9AumL
-        nMdUbJGy06s36j8K4vFv5xLDxoHcUtVBA1FEi0DUG0aNVKRLfLfv9h7JnMtCxX8DAAD//+xZbU/b
-        MBD+KxYSCCYS0ja0pQixig0JaZ0mpO0D4kNd22kjtUmUNzYx/vuec5y0zTDb0IT4gIRQEvvs8/nu
-        ueeuil2G2rFQLiJssr15fsqFUEmuH9cLbAh+WLvpu9Ft1NxDDP811nPD+IjLMswQA4rwon8bjQNy
-        QSVZDWxU9EzXO0wZIJjRBZqTAHSBksWSp7V2kGLIBSFfkiwwuESdyXieA0GyQ3a3CMWCgYfM57iJ
-        AmZgCcde0ZxxBlImIAhYFykPSI/pWB/U+YRascCdTNlCcZTKrOTAALc6Ldsw7QSXvlSbZt0er7ni
-        iO0t89MzWLzvepjyRZMUWY9jeF4Pd7ZXwMwFxPGxvrDRny+GUZzRP4oyvNKxMqySFLNlKMylTRBd
-        c12+05191dmCLGwuo1KGwVGWGEjN4SF3tUpQzpPM55iF+oXB+8tQKrn2CUy8BsIghWLrf3EKI5rE
-        FDwUf/tcrsLogO0f/FwhiPN4BJ//nYAdNxyknX9tzKzjb2JznsJlNDckrtqeamPknm3Ab2h0W6Kh
-        QbUVbBNttMizUXev2VMHwIIgxXCDTXrRzj5ZsVpxyqc7rVRCRiY6HKfPzLVEis7ho0TBr+TZsewN
-        B8NZZ+CpnjjxxMlxNzjpBH3s00zCDk9MU+QBYynJ/zFTxPLH+w1FkIxprScLdG115SKf62kkUxeJ
-        vgLl5LLj+/2BGA6QImZiNvCwfcBVMBTn8kyvstsb73Yv8VfJOSseGQB3nOpT5haZcwdDOF2XMoNb
-        RR5Zykk4z8hQkNcZDoQVjxcTx3OTiDhPu9h//Rq3uwWvX+N2t+G1awxIklXhbEjpBVyfTXgQFEKE
-        OoDysFRVYVsB2g1yPiZ+LNI4UUc3gBpBRZyJNOp2YbQJXdrB9PgeZ7K+DUZ9W4HrNwVuauD8DUZe
-        zGHeYOQlNH6DkUdgpA0DNmLmN/yroSc4zrwKyntqy5tnD5rEOTc/KrRXsTEwz4ZLXvdxgLP1pzzr
-        AawMrTlZW8JG3XrWgYbTqagM0ziqSF31SRbmF63q9W+sV8b5/+u1Vos1i2KnBc++xbrrVLd3EQKV
-        yvf1o8kvz1ZA//p3VK97uLPi369VVixp4Y3D6n5Rmo/z6uDUt6aeEh29+b4t3N2SNgJa24eHh18A
-        AAD//wMA3xrgD0AdAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18185","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18185","key":"NTEST-1845","fields":{"statuscategorychangedate":"2025-04-30T18:24:54.033+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1845/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:53.734+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t0f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:53.806+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 2|http://localhost:8080/finding/252]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/252 (252)\n\n*Severity:* High\n\n\n*Due Date:*
+        May 30, 2025\n\n\n\n*CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]\n\n\n\n*CVE:*
+        [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n*Product/Engagement/Test:*
+        [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n\n\n\n\n\n\n\n\n*Vulnerable
+        Component*: negotiator - 0.5.3\n\n\n\n\n*Source File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 2","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1845/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18185/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 90790aa0-370d-4a8e-86ab-aa15248c503d
+      - 60eb77f8-91d5-4f5d-b705-da2aef1e0ef3
       Atl-Traceid:
-      - 90790aa0370d4a8e86abaa15248c503d
+      - 60eb77f891d54f5db705da2aef1e0ef3
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:02 GMT
+      - Wed, 30 Apr 2025 16:24:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3071,7 +3188,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=276,atl-edge-internal;dur=16,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="OA7ittQ2kJt5j5vQU3Bz0dZI31o9W6F1RUxeX-fJMPRCYIesrN1Z2g==",cdn-downstream-fbl;dur=345,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=342,atl-edge;dur=254,atl-edge-internal;dur=18,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3080,10 +3197,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e61f6cd3dfbf1a805c935627b416490e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - OA7ittQ2kJt5j5vQU3Bz0dZI31o9W6F1RUxeX-fJMPRCYIesrN1Z2g==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 0653119c2b2a04b91214f895e24cf603
+      - 4814ec973eb63c00f12049257fa21001
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3110,41 +3235,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - d05530bf-095f-49a8-ad45-d3004947f9cf
+      - 836c9fd3-c2a1-45a9-8b7a-6aa82407fbe4
       Atl-Traceid:
-      - d05530bf095f49a8ad45d3004947f9cf
+      - 836c9fd3c2a145a98b7a6aa82407fbe4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:02 GMT
+      - Wed, 30 Apr 2025 16:24:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3154,7 +3266,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=273,atl-edge-internal;dur=14,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="fX76ZBW0L0J-WbuLo9lh3ckJe6M-GC1xzXzkPTdhSj4SgMat1Ypy3w==",cdn-downstream-fbl;dur=370,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=368,atl-edge;dur=281,atl-edge-internal;dur=16,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3163,13 +3275,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c973663b623c0e82cd366d5ae7837bf4.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - fX76ZBW0L0J-WbuLo9lh3ckJe6M-GC1xzXzkPTdhSj4SgMat1Ypy3w==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - b6f84884262d5006336b258e05885382
+      - 45721428a93acfa5454ed7caea4ca965
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3181,15 +3301,15 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Jira Api Test 2", "description": "\n\n\n\n\n\n*Title*: [Jira Api
       Test 2|http://localhost:8080/finding/252]\n\n*Defect Dojo link:* http://localhost:8080/finding/252
-      (252)\n\n*Severity:* High\n\n\n*Due Date:* Feb. 9, 2025\n\n\n\n*CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]\n\n\n\n*CVE:*
+      (252)\n\n*Severity:* High\n\n\n*Due Date:* May 30, 2025\n\n\n\n*CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]\n\n\n\n*CVE:*
       [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n*Product/Engagement/Test:*
       [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n\n\n\n\n\n\n\n\n*Vulnerable
       Component*: negotiator - 0.5.3\n\n\n\n\n*Source File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -3203,27 +3323,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1426'
+      - '1414'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16089
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18185
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - acf98565-c33e-434e-bd87-46ed408322a5
+      - 3ad6b3ac-84b0-450b-b229-2ed96991c13e
       Atl-Traceid:
-      - acf98565c33e434ebd8746ed408322a5
+      - 3ad6b3ac84b0450bb2292ed96991c13e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:03 GMT
+      - Wed, 30 Apr 2025 16:24:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3233,17 +3355,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=254,atl-edge-internal;dur=13,atl-edge-upstream;dur=241,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=284,atl-edge;dur=251,atl-edge-internal;dur=15,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="nUZuHf2RwgBpV0gtalL4AKv73PFKyz5LKQCxPx-j2D1394tk4CFRkw==",cdn-downstream-fbl;dur=288
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ad310b4d7c581c35032fa3fce068e53c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - nUZuHf2RwgBpV0gtalL4AKv73PFKyz5LKQCxPx-j2D1394tk4CFRkw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e3a172c108dc98facf450744bf3e4968
+      - 643e59d8e5baa5c30dadc6ae90556aa6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3267,62 +3397,46 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16089
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18185
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWWVMjNxD+K6p5Sog9l7GxpyqVImCyJIQ4YNgHQlFipj3WopEmksZHWP57WnOZ
-        y5tAKluugtHR99ef+t6BVU5F4kSOApGAguSIAU90R9AMdEfHc8hoR+agqGFS6A4kzGRgaCeeU5EC
-        l2lnAUrjGSRnkCvQIEx9Ny60kdnMKrwJfD/wXQV/FqDNdJ3DRNHYsBicjsOs/WDgD0e40MBnuJwb
-        k+vI8xKYQWwS+Um61HCqNaPCFWA8tGQ8mjMv9JjWBXiNgjtYo/zpdHw+7eJeH7dKF7QT3TsafSt0
-        TA2kUq2rGBJcoUToh/2uH3QDfxr6UTCIfN8dDUffod++ddIaMeh4qeadTlp5D/X5YRt2vUhAx4rl
-        NnG4u090RjnvkIRpw0RsSM4gBiJnZCnVnWulYykuFH+jF4VgtlyU39AFNVR5CwZLr3Rr42B9FPi9
-        YPiDZn/B9xmWvcjQqoUFmpxSfWdrVdwa+xXNKNfQcSrBY4yrlO04c4bAUfF8fQILQF/9h45jGCIr
-        R5Q4kSgwRucZTHp+c5Ar+QkjemfCa+ky3WUBm3TbxSOQbKK6EMwYVKCd1rZF6i/lXS1nZkmVxatm
-        Wc4ZOpw8ixzrUaJsd7jaHb7R3S9Upomkrcuuv4duhLurcPf/tVJVv8QiGgwGq2DwNQyuGou9cNUL
-        v4bFGuAPDy/hGGzDadgczNjqsuJArP7V9cubveYmTVMFKfLNiybAACQvqvZ/3Vx/28Fg28HeloNw
-        68Fw28HopZ8VbVa7lpTKF8KJukHNlbYkisVVSPcv9myjYLb1XBY8OWQ653RdtxNuL6nBp6ei7Le3
-        fvUgbJ4Ar1KnbGOXnweysKkvXf1oN5hInciowtpGpeYSMWPbu86GAgzW8sdrj8Rg2Gseiedpa6ns
-        +cE2UIUtqHLFpGJm/c4UNOJe+dL8+7eCZTQF7VkJ3ShhuDFn6dzVi3TDlh9wp6HV0HnZOGGLek5v
-        wRLjK61h+eTVRATbMBoMbUbmVI9zFp8wcXdkTw4ht/OLiBsMlchalmftjpBijOMLveVwBlRXuFT1
-        lzM5ufjp+PTm5PhgfHo+vhmfnf12hvFhn2pMCV6YzoFM8AUQhli7hGkiBV8TZBPGrVJiJPmZKUom
-        CjKkE1JoxJz7GqsE2FCO/5n5fp7fRk71KmL1MP2brnrCFliIlAnKn1+qp686vSXyOXpXr21lUwHt
-        7SK3bbsNyXv9QYPkalB6J/gq4fblfTrbvA2PG7z9SOM7HDcbyDXKK1sH9UT3nxxuxsKqZ9BI2AwK
-        Apa2uyWX6rTy5pYX0E0VctZmKJLkUFbFllmOA7Ewr4O+39LClwr7XKiljKfp/ENsfjtTZjjsROSq
-        hOF+zsgU1ZLws00G5oLLmPK51CYa+kPfmzGRIPN5YT+8LuUPy1xhGJ8ksSiKdsg/SpJv8M+3pfg5
-        TnmWdFDMskPt1GEB5BADw90juHXJqEMs+FqnDz6O8egK/3V3fb901dYtXoKbMaPAlSr1ELbUlpLh
-        jGbh7uFVd24yXjpe6bms9FyOuyESCyK73xu16sQicQVO024qF96i4AK1GWxc7+n9Vh0qnCiZFDgu
-        jEWKDJBhPT2bTmvkHOLCRko+yGXXyC35zWsF4TXxyFWAlfi9oMqAIhuVW0RhYzMopU8nv5L9AumL
-        nMdUbJGy06s36j8K4vFv5xLDxoHcUtVBA1FEi0DUG0aNVKRLfLfv9h7JnMtCxX8DAAD//+xZbU/b
-        MBD+KxYSCCYS0ja0pQixig0JaZ0mpO0D4kNd22kjtUmUNzYx/vuec5y0zTDb0IT4gIRQEvvs8/nu
-        ueeuil2G2rFQLiJssr15fsqFUEmuH9cLbAh+WLvpu9Ft1NxDDP811nPD+IjLMswQA4rwon8bjQNy
-        QSVZDWxU9EzXO0wZIJjRBZqTAHSBksWSp7V2kGLIBSFfkiwwuESdyXieA0GyQ3a3CMWCgYfM57iJ
-        AmZgCcde0ZxxBlImIAhYFykPSI/pWB/U+YRascCdTNlCcZTKrOTAALc6Ldsw7QSXvlSbZt0er7ni
-        iO0t89MzWLzvepjyRZMUWY9jeF4Pd7ZXwMwFxPGxvrDRny+GUZzRP4oyvNKxMqySFLNlKMylTRBd
-        c12+05191dmCLGwuo1KGwVGWGEjN4SF3tUpQzpPM55iF+oXB+8tQKrn2CUy8BsIghWLrf3EKI5rE
-        FDwUf/tcrsLogO0f/FwhiPN4BJ//nYAdNxyknX9tzKzjb2JznsJlNDckrtqeamPknm3Ab2h0W6Kh
-        QbUVbBNttMizUXev2VMHwIIgxXCDTXrRzj5ZsVpxyqc7rVRCRiY6HKfPzLVEis7ho0TBr+TZsewN
-        B8NZZ+CpnjjxxMlxNzjpBH3s00zCDk9MU+QBYynJ/zFTxPLH+w1FkIxprScLdG115SKf62kkUxeJ
-        vgLl5LLj+/2BGA6QImZiNvCwfcBVMBTn8kyvstsb73Yv8VfJOSseGQB3nOpT5haZcwdDOF2XMoNb
-        RR5Zykk4z8hQkNcZDoQVjxcTx3OTiDhPu9h//Rq3uwWvX+N2t+G1awxIklXhbEjpBVyfTXgQFEKE
-        OoDysFRVYVsB2g1yPiZ+LNI4UUc3gBpBRZyJNOp2YbQJXdrB9PgeZ7K+DUZ9W4HrNwVuauD8DUZe
-        zGHeYOQlNH6DkUdgpA0DNmLmN/yroSc4zrwKyntqy5tnD5rEOTc/KrRXsTEwz4ZLXvdxgLP1pzzr
-        AawMrTlZW8JG3XrWgYbTqagM0ziqSF31SRbmF63q9W+sV8b5/+u1Vos1i2KnBc++xbrrVLd3EQKV
-        yvf1o8kvz1ZA//p3VK97uLPi369VVixp4Y3D6n5Rmo/z6uDUt6aeEh29+b4t3N2SNgJa24eHh18A
-        AAD//wMA3xrgD0AdAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18185","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18185","key":"NTEST-1845","fields":{"statuscategorychangedate":"2025-04-30T18:24:54.033+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1845/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:53.734+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t0f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:53.806+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Jira Api Test 2|http://localhost:8080/finding/252]\n\n*Defect Dojo link:*
+        http://localhost:8080/finding/252 (252)\n\n*Severity:* High\n\n\n*Due Date:*
+        May 30, 2025\n\n\n\n*CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]\n\n\n\n*CVE:*
+        [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n*Product/Engagement/Test:*
+        [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n\n\n\n\n\n\n\n\n*Vulnerable
+        Component*: negotiator - 0.5.3\n\n\n\n\n*Source File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Jira
+        Api Test 2","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1845/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18185/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 428a5d71-3204-455a-8271-de8426994627
+      - 625794a8-209f-46a9-9459-74fa1621ca3e
       Atl-Traceid:
-      - 428a5d713204455a8271de8426994627
+      - 625794a8209f46a9945974fa1621ca3e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:03 GMT
+      - Wed, 30 Apr 2025 16:24:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3332,7 +3446,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=236,atl-edge-internal;dur=12,atl-edge-upstream;dur=224,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=282,atl-edge;dur=250,atl-edge-internal;dur=15,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="QeR11A_67tziANPnsYWzT_aoBNhfJy8zTyqDqJiQvb2Nzt9VnmuOsg==",cdn-downstream-fbl;dur=286
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3341,10 +3455,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 edb5724c2fa0963fde9c6c5089b747ce.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QeR11A_67tziANPnsYWzT_aoBNhfJy8zTyqDqJiQvb2Nzt9VnmuOsg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - b41c7db4062bdc923c8e58d5b5b3a908
+      - 6adb17b378a7a3d4162093c7af336280
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3371,26 +3493,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL2nVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8HB9qi+HXe/
-        //2OO5BaONwOmnDy4X3v+HTaoELpG/tpU+G1cK4VJjXoyYQ0reu12P+DL3HYtRIbdF9r1P0Kjcfh
-        r0tW1ig9opH4u+QOB9daE2AKQFNIISk318/l+qk6TzdjV4eK8NcITWACb8GJvbb7LlxZ7ftoW2k7
-        NiFUj61ufiKEhwCbz0/NG+EjyIDNEqAJLCvGeJ7xPIgBriDAIe/CH3Co2u6SpVAx4LTgkKXL7MzK
-        7s4oG8CcFgspAGeoJM3mKHKlcgVSsWU2W9SqyJEVCtiFwOtouG8HEV+ISozaP1gpYvtA9KkiaN63
-        JTleHvZiTZzcPlbk+A0AAP//AwBB9zhWIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:24:57.926+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - f9f9f9b8-4461-472d-a447-dde9b06fa23b
+      - 1f1938bd-62d2-44f5-b276-1b855d2bf6e5
       Atl-Traceid:
-      - f9f9f9b84461472da447dde9b06fa23b
+      - 1f1938bd62d244f5b2761b855d2bf6e5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:03 GMT
+      - Wed, 30 Apr 2025 16:24:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3400,7 +3518,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=166,atl-edge-internal;dur=19,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="y-1t_KaqNBwwkRls6xLn9kF9zjdoYLEFPwoKRQlPe7fFGOp5ksIkRg==",cdn-downstream-fbl;dur=284,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=282,atl-edge;dur=197,atl-edge-internal;dur=18,atl-edge-upstream;dur=180,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3409,10 +3527,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9832e15ad117dafc81b031983cbde91e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - y-1t_KaqNBwwkRls6xLn9kF9zjdoYLEFPwoKRQlPe7fFGOp5ksIkRg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 64e617dbdceb66bcd3ff68b57bc3376e
+      - 7b98bd31c0b27c28a015da69714d96b4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3439,41 +3565,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 4f852feb-719f-4240-81b6-7b625a51c809
+      - 1ddf06e1-7e99-41bd-abd7-5543d563dc3c
       Atl-Traceid:
-      - 4f852feb719f424081b67b625a51c809
+      - 1ddf06e17e9941bdabd75543d563dc3c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:04 GMT
+      - Wed, 30 Apr 2025 16:24:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3483,7 +3596,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=307,atl-edge-internal;dur=13,atl-edge-upstream;dur=294,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=321,atl-edge;dur=289,atl-edge-internal;dur=16,atl-edge-upstream;dur=272,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="IZDbnpLzNnrhiuFGATqFlLqNEQbOZ1NEHHaY81taDEayw1MCE_xINQ==",cdn-downstream-fbl;dur=325
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3492,13 +3605,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9fe7d47ea2a815113a41181f1d63f69e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - IZDbnpLzNnrhiuFGATqFlLqNEQbOZ1NEHHaY81taDEayw1MCE_xINQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 84e923d2aacfaab5928b6cdc39cd1d44
+      - c1f09741bd095dfde2c1d48b29c8a537
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3510,16 +3631,15 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/92] in [Security
-      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
-      / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
-      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
-      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
-      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
-      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
-      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
-      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/250] | Active,
-      Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/2] in [Security How-to|http://localhost:8080/product/2]
+      / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n||
+      Severity || CVE || CWE || Component || Version || Title || Status ||\n| High
+      | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
+      | pg | 5.1.0 | [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/250]
+      | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | pg | 0.5.3 | [Jira
       Api Test 3|http://localhost:8080/finding/253] | Active, Verified |\n| High |
       [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
@@ -3527,13 +3647,13 @@ interactions:
       4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0
       &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt;
       6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/248]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/250]\n*Defect
       Dojo link:* http://localhost:8080/finding/250 (250)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -3542,34 +3662,32 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Jira Api Test 3|http://localhost:8080/finding/253]\n*Defect
       Dojo link:* http://localhost:8080/finding/253 (253)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
@@ -3577,7 +3695,7 @@ interactions:
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/248]\n*Defect Dojo link:* http://localhost:8080/finding/248
-      (248)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (248)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -3586,25 +3704,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
     headers:
       Accept:
@@ -3616,7 +3732,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '8381'
+      - '8032'
       Content-Type:
       - application/json
       User-Agent:
@@ -3625,18 +3741,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16090","key":"NTEST-1606","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16090"}'
+      string: '{"id":"18187","key":"NTEST-1846","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18187"}'
     headers:
       Atl-Request-Id:
-      - ca536502-8125-4211-a15b-3503b51e07ed
+      - 14ddf4a0-650c-4111-aa87-e5aac8c22e61
       Atl-Traceid:
-      - ca53650281254211a15b3503b51e07ed
+      - 14ddf4a0650c4111aa87e5aac8c22e61
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:05 GMT
+      - Wed, 30 Apr 2025 16:24:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3646,7 +3764,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=725,atl-edge-internal;dur=24,atl-edge-upstream;dur=701,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=764,atl-edge;dur=728,atl-edge-internal;dur=18,atl-edge-upstream;dur=711,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Bn4QWLmky1JQ0oG7dVKFMkQPR_MOaE4Co8pa5MuNwMjnulaLm6Wi8w==",cdn-downstream-fbl;dur=771
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3655,10 +3773,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 de5b26aba33b480d2b740b96a34fe916.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Bn4QWLmky1JQ0oG7dVKFMkQPR_MOaE4Co8pa5MuNwMjnulaLm6Wi8w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f2e9a24c0f163aef0b4195983681dae6
+      - 6cd7b0e4a12d466475b84ccf8f979981
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3682,83 +3808,126 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1606
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1846
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61PbRhD/V270IdNJbb1swCiT6VDiJLSUUuMkHwjDHNJauiDdKXcnPxryv3dX
-        D7s8nBY6Dcwg6e72cbu//e3yxYFlyWXiRI4GmYCG5LWAPDE9yQswPRNnUPCeKkFzK5Q0PUiELcDy
-        XpxxmUKu0t4ctME9SCZQajAgbXs2roxVxYwUXga+H/iuhs8VGDtdlXCqeWxFDE7PEWQ/2PX3ffww
-        kM/wM7O2NJHnJTCD2Cbqk3K5zbkxgktXgvXQkvV4KbzQE8ZU4HUKrmGF8ifT8dm0j2u7uFS7YJzo
-        i2PQt8rE3EKq9Kq5Q4JfKBH64U7fD/qBPw39KNiN/B03GIx+RL9JbW3EouO1mic6SfIe6vPD9bXb
-        jwRMrEVJgcPVA2YKnuc9lghjhYwtKwXEwNSMLZS+dkk6VvKdzh/pRSUFpYvnl3zOLdfeXMDCq93a
-        ONhuBf4gGP1kxJ/wssC0VwVaJVigySk315Sr6srSWzTjuYGe0wge4b1q2Z6TCQSOjrPVMcwBffW/
-        9hwrEFklosSJZIV3dO7AZOB3G6VWn/BGTwx4K12Hu05gF+47INnc6p0U1qIC46xtE1J/rc8aNbML
-        rgmvRhRlLtDh5M7NMR81yoaj5XD0SHe/kZnuJuu8DP09dCMcLsPh/2ulyX6NRTQY7C6D3e9hcNlZ
-        HITLQfg9LLYA//r1PhyDbTgNu42ZWL5vOBCzf35x/+SgO8nTVEOKfPOPRbDTbeDNVF41vPDw0d1t
-        G3tbNsKtG6NtG/v33Wlos1klUqo7hBP1g5YrKSVaxI3nX+6tUaFgtE2mqjx5JUyZ81VbTri84BZb
-        T0PZjy/9piFsWoDXqNNU2PXroaoo9LWrH2hByNSJrK7INiq17xEzVN5tNDTgZYk/7jeJobs3GnZN
-        4m7Y1lR2d2MbqMI1qEotlBZ29cQQdOJe3Wn+fa8QBU/BeCRhOiUCFzKRZq6Zpxu2fIsrHa2Gzv3C
-        Cdeoz/kVEDE+UBrEJw8GItiG0WBEEcm4GZciPhby+jXtvIKS5hcZdxiqkbWo99YrUskxji/8KocJ
-        cNPgUrdvzunxuzdHJ5fHR4fjk7Px5Xgy+X2C98M6NRgSPDDNgJ1iB5CWkV0mDFMyXzFkE5GTUmYV
-        +0Vozk41FEgnrDKIOfchVgmwoBz/Rvh+WX6KnKYrYvYw/JuqusUWmIhUSJ7fPdROX214a+Tn6F37
-        TZlNJaxPVyWV7TYkj0Z7HZKbQemJ4GuE15339mzzODxu8PYzj69x3Owg1ylvbB22E91/crgbC5ua
-        QSNhNyhIWFB1q1zpk8abq7yCfqqRszZDkWKvVJNsVZQ4EEv7MOh3ttHCzpoWvpXx2+H8KP/+e8BS
-        raqSBsXXQiZIa4ZhrbArAMnKymSQ1Cg9mhzQ8wqYkHMyQDBLGP4rwLCbQRKRsix02RtS91E+r5/P
-        I3a+VitkxMo0wiHZ9W8o2BjrXMU8z5Sx0cgf+d6sOXtZ++TthxcoxM7PIK6ImthbtehbtUUWe3VS
-        Ya9GIY+dB8ayPyquLWg2likWZIHh3SIK6wNeUEufnP7GDiosfXYWc7lFiiY/b3/nognkzQ07w5m1
-        9hPfD9+P68eH5tHllz7a1k+vU2GRBUi0xhO+oSJGRMlu2Dnq6IdY+dSSRmHtBeFTzhNX4pjvpmru
-        zatcImItMop3+/wFqdgfrsXiBbiFsBpcpVMPq5oT0gWOsMQG3v7QzWyRk1SZ4p86TaQixJ8JFMoC
-        XiMBNl5iOkiG9dkPp2mPPcvtCxa6QeCGjD1L7YuXbPAXAAAA///sWG1v2zYQ/isHBChkzaYTyy+r
-        i3wIkg4YsBbD0u3LPMCKzNRqZUkRpTRD1/++50iKkmKrzUs/Ngkc+Y5HHp87Hp+TOIaxVgRiLqZU
-        K6aNYipmYlHLZ418JjBXLZ83cn6cNXL2zspPxLyRTxr5pD0+aOSBCBr5tJFPmw0smnX5sSV36/Lj
-        ZNCTGzaRx5PZMSN6BgZzK4ccet0G0KE4z1FaZ8HLB8fZjtdxnh6bI/WAQGNoN9KAFYBgEn0VneUx
-        vUNmU/DNrQUP3trikSlsx3+vFP6Rvk9N3+nPfTFGia/r3dLX8WYZ+ReVpAvcDRD+Iq8EvRwSMwfq
-        Xjv17/ZEuHtHfw/Ej4rzvJCh4iA2F5rEgF98yIjpHcLxTTvy8DE4FNivhZV8XHIQ/41/oyccVqyH
-        U68neN59180s/zKrikgiuxLpM/EYgSDsYiUZ1vx9a+BFQ4980Bi3LFJPWeYh4mwcbm5jBYqF3mY2
-        mYA5XTPCOAw1oWYOtc7frwlkFf6lFFJhsjjiLJYui3kPsgiv4oTJQrkNS8oiLKTo0xasq0TbYA0Z
-        tatQScoKukE3/C+pXEZ8BhVmj4rwmh0Azax2KTGrFPqcofEoJKHzoPJTVptEpCKZhujQmIphqTja
-        EhgOupIk/ijRl1xjlRBu53kSR/qVrKV8tcOJBD44sdzYtEeZrcGnKlXhNQoF9zEjVfEQ+KduEruc
-        RUbRLoRxnIHytJxXYpVO9meHUQqkFTsD99CIF2DBmNehwyzU+RBapApZVkWK1MaTqpKS0W35gHEH
-        nRAM4NERWrIM8cTfeZZGMi9X6Xq9XqXc5pb0mc6xM9C5L3RK/I46LqT34uhuskBqmf+DemxkRp4S
-        egJr5rFSPwm7OZbUBgzXKa0vX//2+vwdndDZJb24qbLy1Qo/ZvKxbyQ4hIfU/niFc/kTb1VliRTo
-        gjxkf4TOVMj0dvAPe4PWACbpeGys19oB45QG0IMfQ/JkUQwZwQGd8smhz5jZ7glzbdjxLwMLDv3l
-        EoXegI0jX4iPWltev/hadqo4KHBPHYemr5I7o71a7jR71byluVfPW5p7Fb2luVfTW5p7Vd1p9up6
-        S9Ot7MDpd/3aaVODtLQjLUgWFczXgosxspjwQm24GCMLilXVcDFGDpSWpr7xalQ6KgbJodLRMEgO
-        lY6GQXKodDQMkkOlpTEgOVQ6GgNSK5mA1xaZxCk5MnRvuV/ouQlb8gduJ3w7i/gcIDGrKxx/ewe8
-        iXVHa68A3/VoE3En7pb0p34LwgXIFvs6JKiYCTSFaBsFfUYmWgdtpn02JowHbWZ9NibAB23mfTYm
-        Is6GPHrLN5C+ndwNp5NgaCI+1GXXhJivmjBRGeUmgQUxjXCLLvoW1SH9+qI2IXBL7S1gY/frLg+j
-        kuP2NqNYfyGkwG28kZvmmsfAP8CJColqrh5zz1vTPON3CUxTvHCzi9MBeYP/dqAhZbZ01OMgnX18
-        W/U0/hYwfwuex9+e1EfuMbj56H8AAAD//5yZXw7CIAzGr7IDaOJefPMGHoIvW1OJhBFWFo9vu7kM
-        o3vQNxIo5U/p92v4r5Ktb+uD4Ohhn8WjvWp0pshzMxIP4iFDrgx/J7r2dN4jus2Dm+N8gyGL5Exc
-        AvK6OgvYnqJHMFuloMnrDiCC7j4eXgQi2TNTbkrS0QnqSyEFC6chKIitYOcsVyU5XhG5gMk1N0Kv
-        lhNCWUjlu+jWp7Ivvhct/TXj7+uOdbdvMzwBAAD//+yaTQ7CIBBG7+IJoKUpNTHq0mNoaaOLxqTq
-        wtvLkBYHCK3iz2rWHVJC4es88tzENTcHy/kP80xgvWlei+AwK8xkcKgN4353/M2mGIamH38iWfT/
-        xv3OLMkKmZaEQuokFPKzJPwGyaZee+FtG+Rg2ODYwvdzr8h4LPeIZIlkiWSJZB0yc3LdITOc7PGO
-        gkh2XC8iWSLZf5Ist0NnWtnQSiqsmONLKTEvgQvsJVx7TT8nEKZA4PJLrbjmPRBWIfMesNgIZt2g
-        cRVihTFXiMV8NmYnY1juCK7AIMxg58Y3Ly63rtuDZLIYscCxIGCpwRQ794kaCnQnaw1dYKft1KpQ
-        uSzlgZesyeuK1VWRtRVvwWi2RfoNE2UN7IOtUgB0ulK3e/cNmkh9Bqd3wl19AAAA///smz1vwjAQ
-        hv9KVYkNh5BYTZaqQhXdWDp0YDNOQhlIonzQVij/vXc+x1LcWKoYUIZIDMbJ2XcW93KB58Bvdfap
-        d6zoNrTp+Ume+utYJGvOnyIZR/DIf5CHyIftM5FmsXxJntUqi3CzCN7gRXbsLHLNZzBGU7XX1uwL
-        DoIFHoIfHmkgnhQrhajxoMBe1eiQbTB83THfK3PEgWwOdvoe2yDt9D22QdypewzClBBTqnkteF7/
-        ediJLGulPKkEwv/AifkkWdsXOd64bauiTFd7EByJfKPONATB4apJXdxB4+/jkBd3iSl3sZ/csJ+V
-        FvVZRu72gZll5B4ezzIyIiO2DLjKM26qMFOkQDhHSsordqzosQ+eFI3Q/Tb2Ks5yy6lLLkbbD8aV
-        z1mOOSNz1mkmZOtC6LIITWWX5pdTVeRU2tFU0upmL3r7n9O7QNl/Kwb9pw2BFjOLwk6fov4oFJDd
-        dz5ACpDL136ov19udkA1xq36dZePZ/H9Tj88DYJVKHXVbBoKHFs6ELfG0M380DgYWGsD5W3Xdb8A
-        AAD//wMAGxbEGVs4AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18187","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18187","key":"NTEST-1846","fields":{"statuscategorychangedate":"2025-04-30T18:24:59.164+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1846/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:58.851+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t0n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:58.961+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/2]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/250] | Active,
+        Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | pg | 0.5.3 | [Jira
+        Api Test 3|http://localhost:8080/finding/253] | Active, Verified |\n| High
+        | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
+        | pg | 5.1.0 | [Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+        3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+        6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+        &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/248]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/250]\n*Defect
+        Dojo link:* http://localhost:8080/finding/250 (250)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Jira Api Test 3|http://localhost:8080/finding/253]\n*Defect
+        Dojo link:* http://localhost:8080/finding/253 (253)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/248]\n*Defect Dojo link:*
+        http://localhost:8080/finding/248 (248)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1846/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18187/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f06f195b-284e-487a-aaf0-d11dbcde345c
+      - 00ceb5a6-31f6-438b-8e8d-376f07511345
       Atl-Traceid:
-      - f06f195b284e487aaaf0d11dbcde345c
+      - 00ceb5a631f6438b8e8d376f07511345
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:05 GMT
+      - Wed, 30 Apr 2025 16:24:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3768,7 +3937,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=325,atl-edge-internal;dur=14,atl-edge-upstream;dur=311,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="dgYrXD5MscdMhwx92WOEpXkzpj36b1cknwHqspbFnU0zB9pzNqPjxA==",cdn-downstream-fbl;dur=338,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=336,atl-edge;dur=258,atl-edge-internal;dur=15,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3777,10 +3946,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - dgYrXD5MscdMhwx92WOEpXkzpj36b1cknwHqspbFnU0zB9pzNqPjxA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - c0591fe34d357d4235bf46fc28c52907
+      - 35e16871de5a0d0caa75caf7eb3092c5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3804,83 +3981,126 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16090
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18187
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61PbRhD/V270IdNJbb1swCiT6VDiJLSUUuMkHwjDHNJauiDdqXcnPxryv3dX
-        suxiokyh08AMkm5v37998NmBZcll4kSOBpmAhuS1gDwxPckLMD0TZ1DwnipBcyuUND1IhC3A8l6c
-        cZlCrtLeHLRBGiQTKDUYkHZ9N66MVcWMBF4Hvh/4roY/KzB2uirhXPPYihicniNIf7DvH/r4YSCf
-        4WdmbWkiz0tgBrFN1CflcptzYwSXrgTroSbr8VJ4oSeMqcBrBdzCCvnPpuOLaR/P9vGoNsE40WfH
-        oG2VibmFVOlV40OCX8gR+uFe3w/6gT8N/SjYj/w9NxiMfkS7SWytxKLhtZgnGkn8Hsrzw43b648E
-        TKxFSYHD0yNmCp7nPZYIY4WMLSsFxMDUjC2UvnWJO1bync4faUUlBaWL59d8zi3X3lzAwqvN2hq4
-        JgX+IBj9ZMRf8LLAtFcFaiVYoMopN7eUq+rG0ls047mBntMwnqBfNW/PyQQCR8fZ6hTmgLb6X3qO
-        FYisElHiRLJCH50dmAz8llBq9Qk9emLA19x1uOsEtuHeAcnWq3dSWIsCjLPRTUj9tb5r1MwuuCa8
-        GlGUuUCDkx3PMR81yoaj5XD0SHO/kZnWk01ehv4BmhEOl+Hw/9XSZL/GIioM9pfB/vdQuGw1DsLl
-        IPweGtcA//LlIRyDLpyGXYRBS5iJ5fumOSIsLq8QJmmqIcV+86AI0AGVV035f13qXhdhv4tw0EEI
-        OwmjLsLhQzubttmcUlOqJ4QT9YOeg5mx7zHqVCDNhbq5UJK0iBsnPz84o9LB+JtMVXnySpgy56t1
-        geHxglscRk0Tf3wzaEbEdih4jThNpV6/HquKkhGQqR/oQMjUiayuSHesAZ2l/vFwSAzdg9GwHRK7
-        Ydu0sl1CF6jCDahKLZQWdvVEh1t2r540/35WiIKnYDziMK0QgQeZSDPXzNNtt3yLJ21bDZ2HhRNu
-        yiDnN0CNkSpgdyfoAm/QhdFgRBHJuBmXIj4V8vY1UV5BSfuLjFvE1Dha1LTNiVRyjOsLv8lhAtw0
-        KNTrN+f89N2bk7Pr05Pj8dnF+Ho8mfw+Qf+wTg2GBC9MM2DnOAGkZaSXCcOUzFcMu4nISSiziv0i
-        NGfnGgpsJ6wyiDD3a10lwIJy/Dvh+2X5KXKaqYjZw/Bvq+pet8BEpELyfPfSevtah7fGeY7WtQ0H
-        M5tK2NyuSirbLiSPRgctkptF6Ynga5g3k/f+bvM4PG7x9jOPb3HdbCHXCm90Ha83uv9kcLsWNjWD
-        SsJ2UZCwoOpWudJnjTU3eQX9VGOH2i5Fir1STbJVUeJCLO3XQb/X1Rb2Nm3hWxm/H86P8p+/RyzV
-        qippUXwtZIJNzDCsFXYDIFlZmQySGqUnkyN63gATck4KCGYJw38FGA4tSCISloUue0PiPsrn9fN5
-        xC43YoWMWJlGuCS7/h0FG2Odq5jnmTI2Gvkj35s1d69rm7zD8AqZ2OUFxBW1JvZWLfpWdfDirE4q
-        nNXI5LHLwFj2R8W1Bc3GMsWCLDC8HaywueAFNffZ+W/sqMLSZxcxlx1ctPl5h3tXTSDv7tgF7qy1
-        nfh+/H5cPz40jza/9LGe8PQ6FRa7ALHWeMI3FMSoUbI7doky+iFWPg2gUVhbQfiU88SVuOa7qZp7
-        8yqXiFiLHcW7f/+KRBwON2zxAtxCWA2u0qmHVc0J6QJXWOoG3uHQzWyRE1eZ4p86TSQixJ8JFMoC
-        upEAGy8xHcTD+uyH87THnuX2BQvdIHBDxp6l9sVLNvgbAAD//+xYbW/bNhD+KwcEKGTNphPLL6uL
-        fAiSDhiwFsPS7cs8wIrM1GplSRGlNEPX/77nSIqSYqvNSz82CRz5jkcenzsen5M4hrFWBGIuplQr
-        po1iKmZiUctnjXwmMFctnzdyfpw1cvbOyk/EvJFPGvmkPT5o5IEIGvm0kU+bDSyadfmxJXfr8uNk
-        0JMbNpHHk9kxI3oGvnIrhxx63QbQoTjPUVpnwcsHx9mO13GeHpsj9YBAY2g30oAVgGASfRWd5TG9
-        Q2ZT8M2tBQ/e2uKRKWzHf68U/pG+T03f6c99MUaJr+vd0tfxZhn5F5WkC9wNEP4irwS9HBIzB+pe
-        O/Xv9kS4e0d/D8SPivO8kKHiIDYXmsSAX3zIiOkdwvFNO/LwMTgU2K+FlXxcchD/jX+jJxxWrIdT
-        ryd43n3XzSz/MquKSCK7Eukz8RiBIOxiJRnW/H1r4EVDj3zQGLcsUk9Z5iHibBxubmMFioXeZjaZ
-        gDldM8I4DDWhZg61zt+vCWQV/qUUUmGyOOIsli6LeQ+yCK/ihMlCuQ1LyiIspOjTFqyrRNtgDRm1
-        q1BJygq6Qe/7L6lcRnwGFWaPivCaHQDNrHYpMasU+pyh8SgkofOg8lNWm0SkIpmG6NCYimGpONoS
-        GA66kiT+KNGXXGOVEG7neRJH+pWspXy1w4kEPjix3Ni0R5mtwacqVeE1CgX3MSNV8RD4p24Su5xF
-        RtEuhHGcgfK0nFdilU72Z4dRCqQVOwP30HYXYMGY16HDLNT5EFqkCllWRYrUxpOqkpLRbfmAcQed
-        EAzg0RFasgzxxN95lkYyL1fper1epdzmlvSZzrEz0LkvdEr8jjoupPfi6G6yQGqZ/4N6bGRGnhJ6
-        AmvmsVI/Cbs5ltQGDNcprS9f//b6/B2d0NklvbipsvLVCj9m8rFvJDiEh9T+eIVz+RNvVWWJFOiC
-        PGR/hM5UyPR28A97g9YAJul4bKzX2gHjlAbQgx9D8mRRDBnBAZ3yyaHPmNnuCXNt2PEvAwsO/eUS
-        hd6AjSNfiI9aW16/31p2qjgocE8dh6avkjujvVruNHvVvKW5V89bmnsVvaW5V9NbmntV3Wn26npL
-        063swOl3/ZJpU4O0tCMtSBYVzNeCizGymPBCbbgYIwuKVdVwMUYOlJamvvFqVDoqBsmh0tEwSA6V
-        joZBcqh0NAySQ6WlMSA5VDoaA1IrmYDXFpnEKTkydG+5X+i5CVvyB24nfDuL+BwgMasrHH97B7yJ
-        dUdrrwDf9WgTcSfulvSnfgvCBcgW+zokqJgJNIVoGwV9RiZaB22mfTYmjAdtZn02JsAHbeZ9NiYi
-        zoY8ess3kL6d3A2nk2BoIj7UZdeEmK+aMFEZ5SaBBTGNcIsu+hbVIf36ojYhcEvtLWBj9+suD6OS
-        4/Y2o1h/IaTAbbyRm+aax8A/wIkKiWquHnPPW9M843cJTFO8cLOL0wF5g/92oCFltnTU4yCdfXxb
-        9TT+FjB/C57H357UR+4xuPnofwAAAP//nJlfDsIgDMavsgNo4l588wYegi9bU4mEEVYWj2+7uQyj
-        e9A3EijlT+n3a/ivkq1v64Pg6GGfxaO9anSmyHMzEg/iIUOuDH8nuvZ03iO6zYOb43yDIYvkTFwC
-        8ro6C9ieokcwW6WgyesOIILuPh5eBCLZM1NuStLRCepLIQULpyEoiK1g5yxXJTleEbmAyTU3Qq+W
-        E0JZSOW76Nansi++Fy39NePv6451t28zPAEAAP//7JpLDoIwEIbv4glaaEMxMerSYyiF6IKQoC68
-        vZ0Gah8OaH2sumYamtL+zNd8buLqm4Pl/Id5JLDaNK9FcJgVejJ2qA3jfnf89aYYhsYf/0Sy1v/b
-        7ndmSZaJuCRkQiUhE58l4TdINvbay962QQ6GDY4pfD/3eEax3Eskm0g2kWwiWYfMnFx3yMxOdryj
-        SCQ7rlci2USy/yRZaobOtLKhlcSNmONLKZiXQBn2wEhpICxceoVFJ/CmwOPySplRyLwHBBPbCOYG
-        EeMGjcuDFWI+GzGT0Sx3BFfgiaHnmxfna9vuQTJZjFjgWBCw1GCKdX2khgLdyVpBF7hoO7niMheF
-        ONCC1HlVkqrkWVPSBoxmU6TeMFFWwz7YSglApypVu3fbWBOpOnB6J9zVOwAAAP//7Js9a8MwEIb/
-        SilkqxzFFnWWUkJptywdOmRT/JFksGX8kbYE//fe6WRRuxaUDMGDIYNiW3fHkXs5Oc9B3DrFiXco
-        6THc0/GTIuGrtYxXQjyG0TqEI/8+2occ3KcySdfRc/ykrSyCzcJ/gw/tY5nMDZ/BGF2qvKZin5AI
-        5nsIfnikgZgpVkhZYaJgv+7Rodpg+bJl3CtyxIGGHOz0Ix6CtNOPeAjiTj1i0J+YCFLDa8F5/ftu
-        K9O0iaKTLiD8D5wIT1KvncrxwdemVEWy3IGuRMg3mkpDEBzu2tJFDwZ/H4e8hEtMhYv9FC6gWFjB
-        Lo3az/pys1/SrC+3iHjWlxF9GcqA7cJskwJRH6j2LjixYtYcHKpamnmboRVnu+XUJWcf5o8rnwvd
-        5q7GEwVh9AZ3NZ6Ba0dgO7skP59KlVNrR5fixgx70dd/ZU9lZOHSLY3cXyG/v+bUlp3dh/tMfr3T
-        e6Ceb002l/WmpjjOcPy4Fsf+M/xAxqxR8HWU1YfSYLidt1Clxq3RpQ2kH63fC9ds0Olp2/YHAAD/
-        /wMA97GqLls4AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18187","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18187","key":"NTEST-1846","fields":{"statuscategorychangedate":"2025-04-30T18:24:59.164+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1846/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:24:58.851+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t0n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:24:58.961+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/2]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/95]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/250] | Active,
+        Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | pg | 0.5.3 | [Jira
+        Api Test 3|http://localhost:8080/finding/253] | Active, Verified |\n| High
+        | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
+        | pg | 5.1.0 | [Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+        3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+        6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+        &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/248]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/250]\n*Defect
+        Dojo link:* http://localhost:8080/finding/250 (250)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Jira Api Test 3|http://localhost:8080/finding/253]\n*Defect
+        Dojo link:* http://localhost:8080/finding/253 (253)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/248]\n*Defect Dojo link:*
+        http://localhost:8080/finding/248 (248)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1846/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18187/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 75e6c435-a7fb-4743-a24c-137ea51f9404
+      - 65be480c-d3aa-4b55-9a8f-a3209d78c39f
       Atl-Traceid:
-      - 75e6c435a7fb4743a24c137ea51f9404
+      - 65be480cd3aa4b559a8fa3209d78c39f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:05 GMT
+      - Wed, 30 Apr 2025 16:25:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3890,7 +4110,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=284,atl-edge-internal;dur=12,atl-edge-upstream;dur=272,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=324,atl-edge;dur=302,atl-edge-internal;dur=17,atl-edge-upstream;dur=286,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="u6Q3Kt6RjgQCiYLDyYJ0KYaDGhI_LTbJoIhh8DgOgxXBTfs5JexPEg==",cdn-downstream-fbl;dur=328
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3899,10 +4119,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 3cab2977109e9e185607e6a3005951e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - u6Q3Kt6RjgQCiYLDyYJ0KYaDGhI_LTbJoIhh8DgOgxXBTfs5JexPEg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 7df86b79f08ccfb03ac17383a7b693ef
+      - 80de8f951872e4ca022cc4bcdfec0650
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_add_comments_then_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_add_comments_then_push_to_jira.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"838\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:35452\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:53970\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,111 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:16:06 GMT
+      - Wed, 30 Apr 2025 16:25:00 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/96", "url_api": "http://localhost:8080/api/v2/tests/96/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      96, "url_ui": "http://localhost:8080/test/96", "url_api": "http://localhost:8080/api/v2/tests/96/"},
+      "finding_count": 2, "findings": {"new": [{"id": 254, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/254",
+      "url_api": "http://localhost:8080/api/v2/findings/254/"}, {"id": 255, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/255",
+      "url_api": "http://localhost:8080/api/v2/findings/255/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1310\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:53978\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/96\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/96/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 96, \\\"url_ui\\\": \\\"http://localhost:8080/test/96\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/96/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 254, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/254\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/254/\\\"},
+        {\\\"id\\\": 255, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/255\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/255/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 254,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/254/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/254\"\n        },\n
+        \       {\n          \"id\": 255,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/255/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/255\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        96,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/96/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/96\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/96/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/96\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:25:00 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -101,26 +205,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1rVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmDzBGgCy4oxns14FsQAFxDgkHfhDzhUbXfOUqgYcJpzyNO8oN+s
-        7G6MsgHMaL6QAnCOStJZgSJTKlMgFVvO5ota5RmyXAE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMA3JxYYCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:00.833+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - f580d00e-e2b9-4c02-8f9b-1c09a0f09c44
+      - 2c3a869a-f689-4701-b2fa-2b31fc3c2e71
       Atl-Traceid:
-      - f580d00ee2b94c028f9b1c09a0f09c44
+      - 2c3a869af6894701b2fa2b31fc3c2e71
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:06 GMT
+      - Wed, 30 Apr 2025 16:25:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +230,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=188,atl-edge-internal;dur=13,atl-edge-upstream;dur=175,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="6bYRlkIqY3toKoYHe0V9CN5bToJG0b4EkrDt6LB0wwO8Y-J85KPE-w==",cdn-downstream-fbl;dur=293,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=97,cdn-upstream-fbl;dur=291,atl-edge;dur=161,atl-edge-internal;dur=14,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,10 +239,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 995d6494814d695ff2add6899f970080.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 6bYRlkIqY3toKoYHe0V9CN5bToJG0b4EkrDt6LB0wwO8Y-J85KPE-w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 675a5063d33422a4e32d9a7d5bc50faf
+      - aa03a8cc42d7129b28bd62933f7c1b87
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -169,41 +277,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - c3d2cf61-1c43-4ed1-a5d9-df9bf11d90f1
+      - 0d4a36a5-de0a-4a30-8952-5da9a948f4c0
       Atl-Traceid:
-      - c3d2cf611c434ed1a5d9df9bf11d90f1
+      - 0d4a36a5de0a4a3089525da9a948f4c0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:07 GMT
+      - Wed, 30 Apr 2025 16:25:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -213,7 +308,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=304,atl-edge-internal;dur=14,atl-edge-upstream;dur=290,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=312,atl-edge;dur=280,atl-edge-internal;dur=15,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="N9Pl1mC9kfQwefwCzj1zpT3S43xF5jPq7JVCmpsIt2jZlrAHsFAPuQ==",cdn-downstream-fbl;dur=317
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -222,13 +317,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 7d27498ef63e76e5a81975299a76fae4.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - N9Pl1mC9kfQwefwCzj1zpT3S43xF5jPq7JVCmpsIt2jZlrAHsFAPuQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 8baabec38d85295e681e4be068491737
+      - fca7cfa1ee1d43a398ec367d1f20d0e1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -241,7 +344,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/254]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/254 (254)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/96]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -249,7 +352,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -261,7 +364,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1302'
+      - '1322'
       Content-Type:
       - application/json
       User-Agent:
@@ -270,18 +373,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16091","key":"NTEST-1607","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16091"}'
+      string: '{"id":"18189","key":"NTEST-1847","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189"}'
     headers:
       Atl-Request-Id:
-      - 08d7d818-97e1-4838-b082-986389de8beb
+      - 2073face-9730-40e1-b4cb-c8b1527d674e
       Atl-Traceid:
-      - 08d7d81897e14838b082986389de8beb
+      - 2073face973040e1b4cbc8b1527d674e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:07 GMT
+      - Wed, 30 Apr 2025 16:25:02 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -291,7 +396,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=624,atl-edge-internal;dur=18,atl-edge-upstream;dur=605,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=754,atl-edge;dur=722,atl-edge-internal;dur=15,atl-edge-upstream;dur=707,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="VV0-lOJmAm4Nq-T0XAzlkl7dOnr5fjGgWir4rAj-G_7auqw730kr-w==",cdn-downstream-fbl;dur=758
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -300,10 +405,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - VV0-lOJmAm4Nq-T0XAzlkl7dOnr5fjGgWir4rAj-G_7auqw730kr-w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 921aa67344b7b3b03bbd4002f9f0d3e0
+      - e42a7f498549b441887f9ec885dea37c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -327,61 +440,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1607
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1847
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeeRBGKmqtiS0bCmlEEBaipCZuZmYeOyp7SFJWf57r+eR
-        QGB2BVVXSGHs6/s+Pr4PDiwzKmIndBSIGBTEBwx4rFuCpqBbOppBSlsyA0UNk0K3IGYmBUNb0YyK
-        BLhMWvegNMogPoVMgQZhqrNRro1Mp9bgje95vtdR8HcO2kxWGZwoGhkWgdNymPXvD7w9Hxca+BSX
-        M2MyHbpuDFOITCzvZIcaTrVmVHQEGBc9GZdmzA1cpnUObm1gDivUP56MzyZt3NvFrSIE7YQPjsbY
-        ch1RA4lUqzKHGFeoEXhBv+35bd+bBF7oD0Jvt7Pr937AuD0bpHViMPDCzDuDtPou2vOCddrVIgYd
-        KZbZwuHuB6JTynmLxEwbJiJDMgYREDklC6nmHasdSXGu+BujyAWz7aL8ht5TQ5V7z2DhFmFtAqxE
-        vtf1hz9p9g/8mGLb8xS9WligywnVc9ur/NbYr3BKuYaWUyoeYl6FbsuZMQSOimarI7gHjNV7bDmG
-        IbIyRIkTihxzdLZg0vVqQabkHWb0zoJX2kW5iwbW5baLJyDZZHUumDFoQDtr3xapvxVntZyaBVUW
-        r5qlGWcYcLyVOfajQFlvuOwN3xjuFzpTZ7LuS69AddBbBr3/10vZ/QKL6NAfLP3Bt3C4rD12g2U3
-        +BYeK4A/Pr6Eo9+E06BJ0K0FU7a8KMkRYXF1jTBJEgUJ8s1XL0G/FmBmkuclL7x+dNAk2G0QBI2C
-        YZNg72U4JW2Wu5aUihfCCds+LqnBh6Mk3Ldf3JLONwTuluaUvZbF577MbeF8S8qXdoOJxAmNyuGx
-        4mlrTbGorNrDiz0bGR7VM5nzeMR0xumqusq4jWGZC8SMvd5VNRRgspY/XnskekG3fiS2y7amsm1B
-        E6iCNagyxaRiZvXOItbqbu9tbwVLaQLatRq6NsJwg8tFR98nG7I8kouaVHvOy2sTrC8Bp7dgadHi
-        f3siaIKu34RQf2jrMaN6nLHoiIn5gZWMILPTi4jqLha9XRSy9Y6QYozDC73lcApUl8hQ1ZdzcnT+
-        y+HxzdHh/vj4bHwzPj394xTzw1uqsSB4YDIDcoL8LwyxfgnTRAq+IsgljFujxEjykSlKThSkSCYk
-        14jZzmuc4uN1crzPzPOyTIVO+SZi77D4mzv1jCuwDQkTlG8fqmavqrwFzjlGV9MN9jURsD6dZ/bS
-        NuJ4r1/juByT3gm9Unn97j6fbN6Gxg3cfqbRHIfNGnK18dLXfjXP/aeA66HQrWezoB4TBFioR5JL
-        dVxGc8tzaCcKWWMzEkkykmWzZZrhOCzM66DvN5FCf00KX+r483L+JTZ/OxNmOOyE5OoTzfyQ7Es5
-        Z0AumUGeM+QMolwBOeA0+Wyrg8XhMqJ8JrUJh97Qc6dMxEilbtDvXRcGR0XxMK87SSyswh3yVU3y
-        Hf58X6if4dBnOQjVkC2qIEc5kBHmg5u/0xXxvRaxYFwnsX85RtEV/msP/F4Rqe1jtIBOyoyCjlSJ
-        izCmtrUMJzYLfxePdmYm5UXcpZ0La+dczIVcPC3SiZJxjjPAWCR4sVNskzvBGlufRYUwXvKrXLSN
-        bKhSVhkIrolLrnxtyJ85VQYU2ZhsUIWNT7/Q/vThhJxFVDSct8OouzdYJ/UkjbOVNpBqTCPOJEOs
-        7YTFftEgW7CUMqGZgQ7CEeulZ7eSqrjpxAv7ow3M0PK/AAAA///sWW1r2zAQ/iuiUGihdp3EaZJB
-        6ULZYB/KRgsrlEKQZbkxi2Xjl7ql63/fc5KipV7cjTJKPxTywYmku9P57rnnLmrOhIkmQC+LpFSs
-        kjVrbWjVwMbKhFeC8Dpg7TIVS5ZJrioscrPDSsB1r1UkGRcC4Cpjdpty1iBfRHlfAJ2wTylp6rS/
-        YdEZXvWN7izJoMulVBRejDu5ORpP3AiW0LVAAlmqkrzM9BmWlwTZHKsVISbQ+odUB2QYhKc1M2SA
-        8VXL7+mKrODauqZCYDOu2IaBaBuVXPl44RXd2d3Q+OBakRNIG/kIFlgLq7WJJLBq4KCtlm7ceeP2
-        50hFFB+4jG5vw6VtWz9veVXopEAOyju/WBY6oKFkAZkLq3vBa7CfqEFILfa+Xs4vvnkXZx7qtE5V
-        p6TIKZIpGfZ4nKVqn+3t/0SgrOr8A8LwT4ozdnW+W+P6YG4Q9i04zkv4V5dAfE3siKp1toaOj3YW
-        Aieju9BHNQJHNfTb04xr+8Y+chw4Y56U7C5w4wVwsaTkN2WharKMU83a+Rtck9eJgeblCwscMZET
-        5Bvx5i/x8TgeTSfTaDAJ5EjMAjEbD5PZIDmCHrcJGp7ZJikk5nEMHShyqHjx/ccNQwAoJOvZntjk
-        io8iqrdpmLJ9WSjB83g8CMOjiZhOxqNZJKJJAPUJl8lUnMTHWsruaL47/IyPOedlXFl49TzzU+U3
-        ldfCEd7QJ9z2iyZapYI85RWcV+QonNdlBCwRj6dICr9Q5PNuf/32Le426G/f4m6D/9YtBhTFpl+0
-        TPAUoQ8ikySNEKlOIMJz040aILsCF8TGT02ZF/LwChAjlr8zjQZMWHWpSxrsWG07fQz7cDXs6ynD
-        vkFF6LC7tMD/ji+vFknv+PIaFr/jyxZ86cKAI2SOv8DqG5N7DzQJt88BFOY1t3P8rpRe5tWLS72U
-        bLgd+fqGQkEfByVA2LoQ9HHQUd+JkSN5Ut2mZa4MkTM/xY39E8l8/Sfv5ZmR8LB+tHD/Avjd+P/r
-        cC33YCfjd+eyalYkeEO3npmU9bw2dtzm9f8b1BphTih0oV38nuuR03q6SqNiGuSQSmfIU2uHT8y1
-        B7R7Hh8ffwEAAP//AwD3PKTpsxwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18189","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189","key":"NTEST-1847","fields":{"statuscategorychangedate":"2025-04-30T18:25:02.089+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1847/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:01.748+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t0v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:01.830+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/254]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/254 (254)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/96]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1847/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 54a3c432-3432-43a1-a03a-d66d3c39f576
+      - 07963d39-5ad7-495e-8475-f80beb9f9047
       Atl-Traceid:
-      - 54a3c432343243a1a03ad66d3c39f576
+      - 07963d395ad7495e8475f80beb9f9047
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:08 GMT
+      - Wed, 30 Apr 2025 16:25:02 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -391,7 +487,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=315,atl-edge-internal;dur=21,atl-edge-upstream;dur=294,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="4Fs3W8pq5VzYLZUgCo1z2iuc3kreStNdCLFrSH_wyP-aiM7tGlC6Yw==",cdn-downstream-fbl;dur=363,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=360,atl-edge;dur=277,atl-edge-internal;dur=24,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -400,10 +496,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c973663b623c0e82cd366d5ae7837bf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 4Fs3W8pq5VzYLZUgCo1z2iuc3kreStNdCLFrSH_wyP-aiM7tGlC6Yw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 15ae628e4930fb04203a0d0404b05806
+      - 2ce0a36067c429ad081a3df9bdafd421
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -427,61 +531,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16091
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18189
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxtXmhLiTRNd7Rs3DHGoIB0GUImOU1NHTuzHdqOy3/fsdO0
-        vOVewbQrpBL7+Lw/fnzuPVgUVKRe7CkQKShI9xnwVLcEzUG3dDKFnLZkAYoaJoVuQcpMDoa2kikV
-        GXCZte5AaZRBegKFAg3CrM4mpTYyn1iD12EQhEFHwd8laDNeFnCsaGJYAl7LY9Z/2A92Q1xo4BNc
-        To0pdOz7KUwgMam8lR1qONWaUdERYHz0ZHxaMD/ymdYl+LWBGSxR/2g8Oh23cW8Ht1wI2ovvPY2x
-        lTqhBjKpllUOKa5QIwqiXjsI22EwjoI47MfBTmcn7P6AcQc2SOvEYODOzDuDtPo+2guiddqrRQo6
-        UaywhcPdD0TnlPMWSZk2TCSGFAwSIHJC5lLNOlY7keJM8TdGUQpm20X5Nb2jhir/jsHcd2FtAlyJ
-        wmA7HPyk2T/wY45tL3P0amGBLsdUz2yvyhtjv+IJ5RpaXqV4gHk53ZY3ZQgclUyXh3AHGGvw0PIM
-        Q2QViBIvFiXm6D2DyXbQJAhrQaHkLab6zk6stF0fXGfrPtjFI/Rs0j0TzBg0oL21bwvh39xZLSdm
-        TpUFsmZ5wRkGnD4rCTbKwa87WHQHbwz3Cy2rM1k3rOvgHnUXUff/9VLBwoEUHYb9Rdj/Fg4Xtcft
-        aLEdfQuPK+Q/PLyEY9SE0+1aMGGL84ocsfuXV4iGLFOQId989RL0agEmIHlZ8cLrR/tNgp0GQdQo
-        GDQJdl+GU9FmtWtJyb0QXtwOcUkNPhwV4b79flZ0viFwvzKn7O1zn3uytIULLSlf2A0mMi82qgTs
-        Eho159hYewer4Jw9a1+xpKrj/Ys9Gysq66kseTpkuuB0ubrDtvMKMFlLE689Et1ou34knpeticqi
-        NZU9F6xBVSgmFTPLdxaxVve7b3srWE4z0L7V0LURhhtczjv6Lttw4qGc19zZ9V7ejmh9CTi9Act+
-        Fv/PJ4Im6IZNCA0Hth5TqkcFSw6ZmO1byRAKO72IpO6Z6+TcydY7QooRDi/0hsMJUF3hQK2+vOPD
-        s18Ojq4PD/ZGR6ej69HJyR8nmB/eUo0FwQPjKZBjpHlhiPVLmCZS8CVBymDcGiVGko9MUXKsIEfO
-        IKVGzHZeo44Qr5MXfGZBUBQq9qo3EXuHxd/cqSdcgW3ImKD8+aHV7LUqr0M1x+hqusG+ZgLWp8vC
-        XtpGHO/2ahxXY9I7oVcpr5/Xp5PN29C4gdvPNJnhsFlDrjZe+dpbzXP/KeB6KPTr2SyqpwEBFuqJ
-        5FIdVdHc8BLamUKO2IxEkgxl1WyZFzgOC/M66HtNpNBbk8KXOv60nH+Jzd/WmBkOWzG5/ESLMCZ7
-        Us4YkAtmkNUMOYWkVED2Oc0+2+pgcbhMKJ9KbeJBMAj8CRMpUqkf9bpXzuDQFQ/zupXEwireIl/V
-        JN/hz/dO/RSHPstBqIZssQpyWAIZYj64+TtdkjBoEQvGdRJ7FyMUXeK/dj/sukhtH5M5dHJmFHSk
-        ynyEMbWtZTiYWfj7eLQzNTl3cVd2zq2dMzETcv64SMdKpiU+9SOR4cXOsU3+GGtsfboKYbzkVzlv
-        G9lQpWJlILoiPrkMtSF/llQZUGRjskEVNj5Dp/3pwzE5TahoOG9nTn+3v07qURqnS20g15hGWkiG
-        WNuK3b5rkC1YTpnQzEAH4Yj10tMbSVXadOKF/eEGZmj5XwAAAP//7Flta9swEP4rolBooXadxGmS
-        QelC2WAfykYLK5RCUGS5MYtl45e6pet/33OSorle3I0ySj8U8sGJpLvT+e655y5qzoSJJkAvW0qp
-        WCkr1tjQqoCNpQmvGOF1wJpVIlYslVyVWORmh5WA616rpWRcCICrjNhtwlmNfBHFfQ50wj6lpKnK
-        fsuiM7zqG91ZkkGXK6kovBh3cjM0nrgRLKFrgeuxRMVZkeozLCsIsjlWS0JMoPUPqQ7IMAhPKmZK
-        P+Prht/TFVnOtXV1icBmXLGWgWgblVz7eOEl3dnd0PjgWpETSBv5CBZYC8uNiSSwrOGgrZa27ty6
-        /TlSEcUHLqPb23BpmsbPGl7mOimQg/LOz1e5DmgoWUDmwupe8ApcZ1kjpBZ7Xy/nF9+8izMPdVqn
-        qlOSZxTJlAx7PEoTtc/29n8iUNZV9gFh+CfFGbs6361xfTA3CNswVxUAds3fiH91tzoW3FkIHR/t
-        LAR9J4I+qhE4qqHfnmZc2zf2kePAGfOkZHeBGy+AixUlvykLZZ2mnGrWzt/gmrxODDQrXljgiImc
-        IN+IN3+JjsfRaDqZLgeTQI7ELBCz8TCeDeIj6HGboOGZbZJCYh5F0IEih4oX3X9sGQJAIVnPtr4m
-        V3wUUb1Nw5Rtv0IJnsejQRgeTcR0Mh7NlmI5CaA+5jKeipPoWEvZHc13h5/xMee8lCsLr55nfir9
-        uvQaOMIb+oTbfl4v14kgT3k55yU5Cud1GQFLxOMpksLPFfm820a/fYu7ffjbt7jbx791i4FRkekO
-        LRM8ReiDyMRxLUSiE4jw3HSjBuGuwAWx8VNdZLk8vALEiNXvTKM5ElZd6pIGO1bbTh/DPlwN+3rK
-        sG9QETrsLizwv+PLq0XSO768hsXv+LIFX7ow4AiZ4y+w+sbk3gMNvO1zAIVZxe0cvyull3n14lIv
-        JRtuR76+oVDQx0EJELYuBO7KnYVR34mRI3lS3SZFpgyRMz9Ftf0TyXz9J+9lqZHwsHm0cP8C+G39
-        /3W4kXuwk/K7c1nWaxLc0q1nJkU1r4wdt1n1/wa1RpgTCl1oF79neuS0maXSqJgGOaTSGfLU2uET
-        c+0B7Z7Hx8dfAAAA//8DAMz+VkOzHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18189","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189","key":"NTEST-1847","fields":{"statuscategorychangedate":"2025-04-30T18:25:02.089+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1847/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:01.748+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t0v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:01.830+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/254]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/254 (254)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/96]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1847/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a012feb4-65d5-4998-8296-10170d65a75e
+      - 011afd23-eded-4c61-b288-88f58217f082
       Atl-Traceid:
-      - a012feb465d54998829610170d65a75e
+      - 011afd23eded4c61b28888f58217f082
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:08 GMT
+      - Wed, 30 Apr 2025 16:25:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -491,7 +578,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=247,atl-edge-internal;dur=15,atl-edge-upstream;dur=232,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="pQTd1Kt0mY4_sRZ0ZcHUXekq5bMk50pqWwTX9kJWd4REb5ZCKFK6Rg==",cdn-downstream-fbl;dur=316,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=314,atl-edge;dur=230,atl-edge-internal;dur=17,atl-edge-upstream;dur=213,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -500,10 +587,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 64d5385c423c2207e3680beec4636de8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - pQTd1Kt0mY4_sRZ0ZcHUXekq5bMk50pqWwTX9kJWd4REb5ZCKFK6Rg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 2b9aa019d0e9a305c1e56256c4cd1abd
+      - b634b497aa536d0df10c65feb24a8008
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -530,26 +625,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bprmrVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDZrUKEMjXt3iQhGeK+FTSwGMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCKcAaQIJTMvN5WO5fqh+ppuhrWNF+PMITWACL9GJnXH7Nl5Z7bvRtjJu
-        aGKoHrRpviKExwAtilPzSoQRpEDnU0insKwo5SzjLIoBLiDCMe/jH7CvdHvOplBR4GnOYZEULPtm
-        ZXtjlYsgS/OFFIBzVDLNChRMKaZAKrrM5ota5QxproCeCYIZDbe6F+MLUYnBhDsnxdg+EHOqCNrX
-        bUmO54c9OTtOru8rcvwEAAD//wMAA93SDyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:03.435+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - df88e8af-6acf-443a-bbf8-e83c07ac4b89
+      - 098695c6-f543-4439-a696-e4151bd25e4e
       Atl-Traceid:
-      - df88e8af6acf443abbf8e83c07ac4b89
+      - 098695c6f5434439a696e4151bd25e4e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:08 GMT
+      - Wed, 30 Apr 2025 16:25:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +650,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=167,atl-edge-internal;dur=35,atl-edge-upstream;dur=131,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=209,atl-edge;dur=176,atl-edge-internal;dur=17,atl-edge-upstream;dur=160,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Fs9dnyDoqfEFiLgDnCO3LHDX0hRR0TK7kEtidJ9MEpjmp2o-iKfEhQ==",cdn-downstream-fbl;dur=212
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,10 +659,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Fs9dnyDoqfEFiLgDnCO3LHDX0hRR0TK7kEtidJ9MEpjmp2o-iKfEhQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f5a9374a1a1131cc5cbdd628f9d0db83
+      - b2669fdf7c8b41ed292ef6c4ae9d4d79
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -597,26 +696,28 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16091/comment
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment
   response:
     body:
-      string: '{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/16091/comment/10703","id":"10703","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+      string: '{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment/11330","id":"11330","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
         Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"body":"((admin)):
         testing note. creating it and pushing it to JIRA","updateAuthor":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
-        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-01-10T20:16:09.004+0100","updated":"2025-01-10T20:16:09.004+0100","jsdPublic":true}'
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-04-30T18:25:03.875+0200","updated":"2025-04-30T18:25:03.875+0200","jsdPublic":true}'
     headers:
       Atl-Request-Id:
-      - e6fe6324-651b-4f84-9cfb-3ef6b0bc2ddc
+      - 71822a85-c906-4c17-8700-6b98bfffedf6
       Atl-Traceid:
-      - e6fe6324651b4f849cfb3ef6b0bc2ddc
+      - 71822a85c9064c1787006b98bfffedf6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:09 GMT
+      - Wed, 30 Apr 2025 16:25:04 GMT
       Location:
-      - https://defectdojo.atlassian.net/rest/api/2/issue/16091/comment/10703
+      - https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment/11330
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -626,7 +727,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=386,atl-edge-internal;dur=17,atl-edge-upstream;dur=370,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="9JABk4IPc5etkRqU18HBUEzwr1Gx05lW_eAPU0LTSit0Qi-ULkrfZg==",cdn-downstream-fbl;dur=540,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=96,cdn-upstream-fbl;dur=538,atl-edge;dur=409,atl-edge-internal;dur=17,atl-edge-upstream;dur=392,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -635,10 +736,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 9JABk4IPc5etkRqU18HBUEzwr1Gx05lW_eAPU0LTSit0Qi-ULkrfZg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 8b27c296f95898ab113f1def16f70958
+      - 01ef8adccc2e1bce4d68ecc461c179dd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -665,26 +774,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1nZb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwCbz0/NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4LTgsExzYN+s
-        7G6MsgHMaLGQAjBHJelsjiJTKlMgFVvO8kWtigxZoYCdCbyOhtt2EPGFqMSo/Z2VIrYPRJ8qguZ1
-        W5Lj+WFP1sTJ9X1Fjp8AAAD//wMAm7/6oCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:04.339+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 4f00ec53-2d01-4721-80a8-fa4bcb2a2fe1
+      - b137bde6-e1e8-4b0b-853d-77a0c0ade435
       Atl-Traceid:
-      - 4f00ec532d01472180a8fa4bcb2a2fe1
+      - b137bde6e1e84b0b853d77a0c0ade435
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:09 GMT
+      - Wed, 30 Apr 2025 16:25:04 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -694,7 +799,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=146,atl-edge-internal;dur=13,atl-edge-upstream;dur=134,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=189,atl-edge;dur=157,atl-edge-internal;dur=14,atl-edge-upstream;dur=144,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="kpaK978aK5fgk3i738rcXTtfeX1W_sqOiIgNYDs2sB8nz9CiVRU7nw==",cdn-downstream-fbl;dur=194
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -703,10 +808,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 d45e064f8c3e1035d136019303749e0e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - kpaK978aK5fgk3i738rcXTtfeX1W_sqOiIgNYDs2sB8nz9CiVRU7nw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 6ba034ffde3311e8cc036d3430d066f0
+      - c7a7c4ab94b6d400ceb88a05e7befa06
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -733,26 +846,28 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16091/comment
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment
   response:
     body:
-      string: '{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/16091/comment/10704","id":"10704","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+      string: '{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment/11331","id":"11331","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
         Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"body":"((admin)):
         testing second note. creating it and pushing it to JIRA","updateAuthor":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
-        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-01-10T20:16:09.744+0100","updated":"2025-01-10T20:16:09.744+0100","jsdPublic":true}'
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-04-30T18:25:04.747+0200","updated":"2025-04-30T18:25:04.747+0200","jsdPublic":true}'
     headers:
       Atl-Request-Id:
-      - e69b87cf-41a9-40e5-b1cb-187d7187ec35
+      - 0ec19603-c8f7-4416-ac90-47154bf05f91
       Atl-Traceid:
-      - e69b87cf41a940e5b1cb187d7187ec35
+      - 0ec19603c8f74416ac9047154bf05f91
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:09 GMT
+      - Wed, 30 Apr 2025 16:25:04 GMT
       Location:
-      - https://defectdojo.atlassian.net/rest/api/2/issue/16091/comment/10704
+      - https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment/11331
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -762,7 +877,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=320,atl-edge-internal;dur=17,atl-edge-upstream;dur=303,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="VMHdJSR9jGl2axGOXHz5m_VO9yGNlUigvW-l_5Dkl0hCrWhdkNUS6Q==",cdn-downstream-fbl;dur=452,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=449,atl-edge;dur=365,atl-edge-internal;dur=15,atl-edge-upstream;dur=350,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -771,10 +886,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b6805b08a4af317938604723e3f3424a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - VMHdJSR9jGl2axGOXHz5m_VO9yGNlUigvW-l_5Dkl0hCrWhdkNUS6Q==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 97ecd5ddfaffb2686ef11bd0a366de60
+      - 9be3f2c428c329b0c16655977128b123
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -801,26 +924,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtr1nZb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8HB9qi+HXe/
-        //2OO5CGO9wOmjDy4X3v2HTaokThW/tpU+41d05xkxr0ZEJa5XrN9//gKxx2SmCL7muNul+h8Tj8
-        dcnKGqlHNAJ/l9zh4JQ1Ac4AshRSSKrN9XO1fqrP083YNaEi7DVCE5jAW3Bir+2+C1fW+z7aVtqO
-        bQg1o9LtT4SwEKDz+al5w30EKdAigSyBZU0py2csD2KAKwhwyLvwBxxq1V2yGdQUWFaGhSktzqzo
-        7oy0AcyzciE4YIFSZLM58lzKXIKQdDkrFo0sc6SlBHoh8Doa7tXA4wtR8lH7Byt4bB+IPlUEzfu2
-        IsfLw16siZPbx5ocvwEAAP//AwAiceYiIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:05.308+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 4302341d-71fa-4edb-acbc-5f277ff5d341
+      - 2933ea28-8b53-4191-ac69-e6f2e15e0c46
       Atl-Traceid:
-      - 4302341d71fa4edbacbc5f277ff5d341
+      - 2933ea288b534191ac69e6f2e15e0c46
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:10 GMT
+      - Wed, 30 Apr 2025 16:25:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -830,7 +949,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=14,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=202,atl-edge;dur=168,atl-edge-internal;dur=14,atl-edge-upstream;dur=154,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="T2tC1imiNzjCVAdyv6C-Qr8hQY5Qu4jLk9QyPT8Jvb-T8luM2NXUtA==",cdn-downstream-fbl;dur=205
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -839,10 +958,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - T2tC1imiNzjCVAdyv6C-Qr8hQY5Qu4jLk9QyPT8Jvb-T8luM2NXUtA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 49efce442b598165ef5e1053fd6a0f88
+      - 8405d96edb0462b6df87a4c3b90663db
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -866,65 +993,50 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16091
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18189
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeRBCGKmqtiS0bCmlEEBaipCZuZmYeOyp7SFJWf57r+cV
-        yGNXUHWFFMa+vu/j4/vkwDyjInZCR4GIQUF8xIDHuiVoCrqlowmktCUzUNQwKXQLYmZSMLQVTahI
-        gMuk9QhKowzic8gUaBCmOhvl2sh0bA3e+Z7nex0Ff+egzWiRwZmikWEROC2HWf9+zzvwcaGBj3E5
-        MSbToevGMIbIxPJBdqjhVGtGRUeAcdGTcWnG3MBlWufg1gamsED909HwYtTGvX3cKkLQTvjkaIwt
-        1xE1kEi1KHOIcYUagRfstT2/7XujwAv9Xujtd/b97g8Yt2eDtE4MBl6YeWeQVt9Fe17QpF0tYtCR
-        YpktHO5+IDqlnLdIzLRhIjIkYxABkWMyk2rasdqRFJeKvzGKXDDbLsrv6CM1VLmPDGZuEdYywErk
-        e7t+/yfN/oEfU2x7nqJXCwt0OaJ6anuV3xv7FY4p19BySsVjzKvQbTkThsBR0WRxAo+AsXrPLccw
-        RFaGKHFCkWOOzgpMdr1tAr8WZEo+YKrv7ESlXfSh6GzdB7t4gZ5lupeCGYMGtNP4thD+rTir5djM
-        qLJA1izNOMOA45WSYKMK+HX7827/jeF+oWV1Jk3DugXcg+486P6/XkpYFCBFh35v7ve+hcN57XE3
-        mO8G38Jjhfzn53U4BjUcx2x+VXIgNvnmdv3kbn2SJomCBPnmq5dgrxZgApLnJS9sPtrbJtjfIgi2
-        CvrbBAfr4ZS0We5aUipeCCds+7ikBh+OknDffj9LOl8SuFuaU/b2FZ+HMreF8y0pX9sNJhInNCqH
-        54qnrTXForJqT2t7NjI8qicy5/GA6YzTRXVjcRvDMlcIDXuLq2oowGQtTWx6JLrBbv1IrJZtG5UF
-        DZWtChpQZYpJxczinUWs1d3u294KltIEtGs1dG2E4QaXs45+TJaceCJnNXd2nfXbETSY5/QeLPtt
-        uBiWNDaWwd+GUL9v6zGhepix6ISJ6ZGVDCCz04uI6i4WvZ0VsmZHSDHE4YXeczgHqktkqOrLOTu5
-        /OX49O7k+HB4ejG8G56f/3GO+eEt1VgQPDCaADlDmheGWL+EaSIFXxCkDMatUWIk+cgUJWcKUuQM
-        kmvEbGcTdfh4nRzvM/O8LFOhU76J2Dss/vJOveIKbEPCBOWrh6rZqypvgXOO0VVr29dEQHM6z+yl
-        3Yzjg85+txl2yjHpndArlZvn9fVk8zY0LuH2M42mOGzWkKuNl74Oq3nuPwVcD4VuPZsF9TQgwEI9
-        klyq0zKae55DO1HIGsuRSJKBLJst0wzHYWE2g36vIYUvNXZVqSGM1+X8Syz/dkbMcNgJyc0nmvkh
-        OZRyyoBcM4M8Z8gFRLkCcsRp8tlWB4vDZUT5RGoT9r2+546ZiJFK3WCve1sYHBTFw7weJLGwCnfI
-        VzXJd/jzfaF+gUOf5SBUQ7aoghzkQAaYKG7+ThfE91rEgrFJ4vB6iKIb/Nfu+d0iUtvHaAadlBkF
-        HakSF2FMbWsZDmYW/i4e7UxMyou4SztX1s6lmAo5e1mkMyXjHJ/6oUjwYqfYJneExbc+iwphvORX
-        OWsbuaVKWWUguCUuufG1IX/mVBlQZGlyiyosffqF9qcPZ+QiomLLeTtzuge9JqkXaVwstIFUYxpx
-        JhlibScs9osG2YKllAnNDHQQjlgvPbmXVMXbTqzZHyxhhpb/BQAA///sWVtr2zAU/itiUGihdp3E
-        aZJB6ULZYA9lY4UVSiHIstyYJbLxpV7pfny/I6la5kXd2KX0IZAHJ5LPTed85zuKmjNhsgnQyxIp
-        FatlwzqbWg2wsTbplSG9Dlm3zMWSrSVXNRa52WElwN1rlUjGhQC4ypTd5py1qBdR3ZVAJ+xTSpo+
-        HW5YdI6jvtGTJRl0uZSK0otxJ7fA4AmPYAm5Ba7HcpUV1Vq/w4qKIJtjtSbEBFp/keqQDIPwvGGG
-        DDC+6vgduchKrq1rayQ244ptGIixUclViAOvyWfnoYnBtaIgkDaKESywFtaPJpLAukWAtlq64fOG
-        959Qimg+CBl5b9Ol67qw6Hhd6qJADcqvYbksdUJDyQIyF1b3gjdgP0mLlFrsf7icX3wMLs4D9Gld
-        qk5JWVAmUzHs83SdqwO2f/ANibJqitdIw58pztj1+X6P83GfQbyJf00FYNf8jRhZf6tjwb2FyLcQ
-        O6Laf8NRDX1Imlht3+ijHpGPHEdO5w8tu4/oOAAullT8pi3U7XrNqWe9+hVcU9SJgRbVHzY4YiKn
-        qDfize/Tk3E6mk6myWASyZGYRWI2HmazQXYMPW4TNDyxTVJKzNMUOtDk0PHSuzcbhgBQSNaTo6+p
-        lRBNVG/TMGXHr1iC5/F0EMfHEzGdjEezRCSTCOozLrOpOE1PtJS90Xxv+A4f816w5srCaxCYn+qw
-        rYMOgQiGIeF2WLbJKhcUqaDkvKZA4X3dRsAS8XiGoghLRTHvj9Ev3+L+HP7yLe7P8S/dYmBUauZF
-        ywTPkPogMlnWCpHrAiI8N9OoQbgrcEFsfNtWRSmProA9Yvm90ugeCauudEmDvVbbTh9jH67Gvpky
-        djNlZfF9ByPPljA7GHkOi3cwsgVG+jDgY2qxI2SOv8CdG1OU93ThbZ8jWFI03N7j96X4KFnkw6Vo
-        uB3gfJdCkdcBL2VznvXf8HG5kXfBkTypbvOqUIbImZ/S1v6JZL7+TvRui+bfXZAaYU4oNGFM+1zo
-        q57HW02UgDH5/vGR+stf6Nf/tx1ZWUeDaILzcbcz5gtvwWV33eb5cOV/dZsHAAAA//+ipYtHaxta
-        uxh3bQMAAAD//6JibZMENBMopgEdN9C0UgCNXoGGOvKABZGeArgHC+Jmligk5qUoFJQWg+ZtQFzQ
-        wLlnkKMSbIDacbTYoG8CGS026OHi0WIDS7GBb2rVUg/YUoNNSeGfu0JSmFWcEgD2I3RKGAAAAP//
-        0iGrGMHVxgFPp8LaOCDOaBuHzslytLCih4tHCysshRXuNg4wePKBjZrRps5gTyejpQc9XDxaemAp
-        PfA3dZBW3+Bv6iApRG/qAAAAAP//iqV0+TSoqQMAAAD//wIFKdDs3MSKoNTi0hzQMJERfOjKCLzk
-        pqjEsQQyjAVa+AdalgMqwODiaJqRBr7gGkBjT7G1tbUAAAAA//8DABDBte6BLgAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18189","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189","key":"NTEST-1847","fields":{"statuscategorychangedate":"2025-04-30T18:25:02.089+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1847/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:01.748+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t0v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:04.747+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/254]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/254 (254)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/96]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1847/votes","votes":0,"hasVoted":false},"comment":{"comments":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment/11330","id":"11330","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"body":"((admin)):
+        testing note. creating it and pushing it to JIRA","updateAuthor":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-04-30T18:25:03.875+0200","updated":"2025-04-30T18:25:03.875+0200","jsdPublic":true},{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment/11331","id":"11331","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"body":"((admin)):
+        testing second note. creating it and pushing it to JIRA","updateAuthor":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-04-30T18:25:04.747+0200","updated":"2025-04-30T18:25:04.747+0200","jsdPublic":true}],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18189/comment","maxResults":2,"total":2,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 2aff8c53-68a6-4451-b363-cab193774550
+      - f8ddbfd2-d8e3-4e30-b93b-79f722f9dd1f
       Atl-Traceid:
-      - 2aff8c5368a64451b363cab193774550
+      - f8ddbfd2d8e34e30b93b79f722f9dd1f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:10 GMT
+      - Wed, 30 Apr 2025 16:25:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -934,7 +1046,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=309,atl-edge-internal;dur=18,atl-edge-upstream;dur=288,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="ucHToMM7VB6MwVWK3Q4_eoaJQwLxH5C9OjOkgsK6Pja_BzrEyy3szA==",cdn-downstream-fbl;dur=335,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=333,atl-edge;dur=259,atl-edge-internal;dur=18,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -943,10 +1055,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 82e46a17c2e4998f87de230e61a57612.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ucHToMM7VB6MwVWK3Q4_eoaJQwLxH5C9OjOkgsK6Pja_BzrEyy3szA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 85f68bb697f71d250e629c31399cdc5c
+      - 04115b78f39d67c3a1c6dc4d5ddbbf67
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_grouped_reopen_expired_sla.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_grouped_reopen_expired_sla.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1rVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmDzBGgCy4oxns14FsQAFxDgkHfhDzhUbXfOUqgYcJpzSlNa5N+s
-        7G6MsgHMaL6QAnCOStJZgSJTKlMgFVvO5ota5RmyXAE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMAmHv8biACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:06.285+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 1517e01b-9ae9-4fe7-9698-a3b08881a7d4
+      - 4e770015-6bee-4551-b898-dc1335a075e0
       Atl-Traceid:
-      - 1517e01b9ae94fe79698a3b08881a7d4
+      - 4e7700156bee4551b898dc1335a075e0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:11 GMT
+      - Wed, 30 Apr 2025 16:25:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=165,atl-edge-internal;dur=13,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="JLqzFwViCXKELXa6jtpZxdlt5dZEo5mPpMX8eGV0cXCWU63Hb2DMCA==",cdn-downstream-fbl;dur=261,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=59,cdn-upstream-fbl;dur=258,atl-edge;dur=180,atl-edge-internal;dur=15,atl-edge-upstream;dur=166,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 41e9e91568ab5e34cd26bd32ceb4035e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JLqzFwViCXKELXa6jtpZxdlt5dZEo5mPpMX8eGV0cXCWU63Hb2DMCA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - db52454f32ba88168e4994052353d8c9
+      - b0fe46b92f0dd60621b3506518034a19
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - acf73c77-857b-40e3-8d58-cd4587764da2
+      - e5937a24-434d-4c54-8135-bded0efed76a
       Atl-Traceid:
-      - acf73c77857b40e38d58cd4587764da2
+      - e5937a24434d4c548135bded0efed76a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:11 GMT
+      - Wed, 30 Apr 2025 16:25:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=291,atl-edge-internal;dur=12,atl-edge-upstream;dur=279,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=339,atl-edge;dur=306,atl-edge-internal;dur=17,atl-edge-upstream;dur=289,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="lv53L0U7T69YwlhcOA19GsI0fUWzzdSVKNTDtgHAcE3hN3S5eamf9g==",cdn-downstream-fbl;dur=343
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a78d8f4a6ccd81221651cd6112d5330a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - lv53L0U7T69YwlhcOA19GsI0fUWzzdSVKNTDtgHAcE3hN3S5eamf9g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c45629be1a4184dc6f3425b65b1f593d
+      - 58a03fe735b0843025dcaec6f99a13f4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -157,7 +156,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/94]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -166,28 +165,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
-      (257)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
       Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -201,7 +200,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3357'
+      - '3332'
       Content-Type:
       - application/json
       User-Agent:
@@ -210,18 +209,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16092","key":"NTEST-1608","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16092"}'
+      string: '{"id":"18191","key":"NTEST-1848","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191"}'
     headers:
       Atl-Request-Id:
-      - 9a0e157f-6a70-48e8-b4a7-8ec719b96c1c
+      - 3c5d260b-9e6f-4727-b59d-4a90d9252c33
       Atl-Traceid:
-      - 9a0e157f6a7048e8b4a78ec719b96c1c
+      - 3c5d260b9e6f4727b59d4a90d9252c33
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:12 GMT
+      - Wed, 30 Apr 2025 16:25:07 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -231,7 +232,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=846,atl-edge-internal;dur=17,atl-edge-upstream;dur=823,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="qKUER7NM5XHYDpqjuNOl8CA7aSI8CSWrweCfJqwqn2stSAgy0b8PVQ==",cdn-downstream-fbl;dur=834,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=831,atl-edge;dur=741,atl-edge-internal;dur=17,atl-edge-upstream;dur=724,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -240,10 +241,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 41e9e91568ab5e34cd26bd32ceb4035e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qKUER7NM5XHYDpqjuNOl8CA7aSI8CSWrweCfJqwqn2stSAgy0b8PVQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - c7a090185a754943877dce0497731160
+      - 47ac7e7ef5748875695e10fe2b9d3fc3
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -267,67 +276,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1608
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf6mNp6swGjmU6HgpPQUkqNIR8IwxzSWrog3al3J78k5L93V7Ls
-        8KJModPAB0l3ty+3++yz6y8OLEsuEydyNMgENCRvBeSJ6UlegOmZOIOC91QJmluhpOlBImwBlvfi
-        jMsUcpX25qAN7kEygVKDAWnXZ+PKWFXMSOFN4PuB72r4uwJjp6sSzjSPrYjB6TmC7Ae7/n6IHwby
-        GX5m1pYm8rwEZhDbRH1SLrc5N0Zw6UqwHlqyHi+FF3rCmAq8VsEdrFD+dDo+n/ZxbYRLtQvGib44
-        Bn2rTMwtpEqvmjsk+IUSoR/u9P2gH/jT0I+C3SgI3eHe/k/ot09OkhGLjtdqXukkyXuozydHm2uv
-        PxIwsRYlBQ5XD5gpeJ73WCKMFTK2rBQQA1MztlD6ziXpWMkLnb/Qi0oKShfPb/icW669uYCFV7u1
-        dXC9FfiDYPSLEZ/h5wLTXhVolWCBJqfc3FGuqltLb9GM5wZ6TiN4jPeqZXtOJhA4Os5WJzAH9NX/
-        2nOsQGSViBInkhXe0XkEk4HfbpRafcIbvTLga+k63HUC23DTxzcg2d7qQgprUYFxNrYJqb/XZ42a
-        2QXXhFcjijIX6HDy6OaYjxplw9FyOHqhu9/JTHuTTV6G/h66EQ6X4fD/tdJkv8YiGgx2l8HujzC4
-        bC0OwuUg/BEW1wD/+vUpHIMunIZdG4N2YyaWlw05IiyurhEmaaohRb55UgR4AZVXTfk/r3Wna2O3
-        a2OvYyPs3Bh1bew/9bOhzWaVSKnuEE7UD3oOZsZeYtSpQJoDNblQkrSIm0t+ebJGpYPxN5mq8uRI
-        mDLnq3WB4fKCW2xGDYm/nAyaFrFtCl6jTlOp16+HqqJkBOTqB1oQMnUiqyuyHWvAyxJ/PNckgiBs
-        m8TjsG2o7PFGF6jCDahKLZQWdvXKC7fiXt1p/n2vEAVPwXgkYVolAhcykWaumadbtnyPKy2ths7T
-        wgk3ZZDzWyBipAp4PBN0gTfowmgwoohk3IxLEZ8IefeWdo6gpPlFxi1iahwt6r3NilRyjOMLv81h
-        Atw0KNTrN+fs5OLd8enNyfHh+PR8fDOeTP6c4P2wTg2GBA9MM2Bn2AGkZWSXCcOUzFcM2UTkpJRZ
-        xX4TmrMzDQXSCasMIsx9jlUCLCjHvxe+X5afI6fpipg9DP+2qh6wBSYiFZLnjw+tp691eGuc5+hd
-        SziY2VTC5nRVUtl2ITn0d1skN4PSK8HXCG8678PZ5mV43OLtVx7f4bjZQq5V3tg6XE90/8nhdixs
-        agaNhO2gIGFB1a1ypU8bb27zCvqpRobaDkWKHakm2aoocSCW9nnQ73TRws6GFr6X8Yfh/Ci//T9g
-        qVZVSYPiWyETJDHDsFbYLYBkZWUySGqUHk8O6HkLTMg5GSCYJQx/CjBsWpBEpCwLXfaO1H2Ub+rn
-        m4hdbdQKGTGJ8bKCW6Uj391xB/cUdIx5rmKeZ8rYaOSPfG/WyNzUvnn7w2sUZlfnEFdEUey9WvSt
-        6pDFnp1U2LPDa+axq8BY9lfFtQXNxjLFwiwwzB2isDngBbX06dkf7KBCCmDnMZcdUjQBevt7101A
-        7+/ZOc6utZ/4fng5rh8fmkebZ/pYd3p6nQqLbECiNa7wDRUxIkx2z65QRz9EBsDSG4RB7QXhVM4T
-        V+K476Zq7s2rXCJyLTKL9/D8NakY+P5GLl6AWwirwVU69bC8OUFe4CxLtODhUTezRU5y23ThR50w
-        Uhbi3wTSKucY0yX9hKvvcQRS8JyQdA7/AAAA///sWW1v2jAQ/ivWpFWASBoghJeq6lBZpUqjmjZt
-        H7ovGMeBTEBQXqgm7cfvOccJkBLoqFp10tQKiO2zz+e753xPwjUqNWawyl0+Q52dzeOLS0zjmFa1
-        xJb64M+b7Q6tP0CeX8s6mUpdn9k+uzjYZ7vVe7Jd9HhlF/vpdrGP2uXFbeKU2QTxljldv6bsQ22s
-        NkwkGyJQ0XgjJybr1RnBONvFgOxv1jBzEFDPLfPVDhs7GCrcBST+DBhlJCh9VI5V8FHdt/1Dm2c1
-        xCOaf+DLOCk0sCK8SU3xvODcPYHa1yAJYcsbfy6BnTK199k0vuBCyFWsfm6cb0twuMH4GrA4VyMA
-        +GvYNP3gnLtrP0KekJRsO4B/j2wOJ8puBXSi480KY4b7CyP9UZfrG0uovUFrR97g5t4QaW/gcYz0
-        G9XZw8wXM4Yr+3QKCE4Af2zFsdZyyjhDRSMgiDuRCLlHeowHaqPGJ76cJgDjMZtJ7kJyzZFAzXS3
-        7PtGoRHQfi63M8tuf1ZP9bc9EkM+q/u8m/Wje5p1N3ZnwMgZxNEIH1fB3j9+MIT4ffog/8IjbSvC
-        LKtkMveFPrSRr/KoPrNv6qpFFtaHkSrDADJzdIR685C7Xay4iEnmLmC+emBIe2vfle6OO31BSOH+
-        iaX/xim06CqgrEk+XuHuwl9WWaX6ewEfjoN+7rd7MePF8cI5ES8cwgvneXhxUsp4hBenJq3t431t
-        vHD+48Ur4IX9b+GFk4sewYvHbEc7L/iLxW5ZvdOwyzpysosKoTiELyk+hvihwlA7p6YKHVYZYWaV
-        cQ5Wzjlk5ikbWMaTWbkyKgBmVHvsYf6KFV2ULBacitd3B6srMjkxUUF4YplLfMQVPJa4rlv3su22
-        up3upNGxZEv0LNFrN71ew3OwTj4IKxwYJskfBq5L0YCRInB/fdhSBHUwzXWQG1emliZKaTWMZDJ+
-        1pZWo8vdhm07HdHtAC8nYtKxsLzHpdcVV+6lmuV9a/C+eYP/VM5Y8KWu+wwjbYrMJDIeYAijaVJB
-        aaZxSJYyVpxHZCjIK6Tn8wg/r0eGZa6WRDcUefa3r3GRqH/7GheJ/reuMXDITRlqzQddw/XZiHte
-        IoSvAojKupRBTlHsPljSwI9JGKzk+T3wRRB/qiONXjShNw9dWkG/XttPItlloGqXcct22QsLOwfu
-        UKN+EV/+AAAA//8aLV9olpIGtHwBAAAA//8i08Wj5QutXUyX8gW9GIC3xuCNFaCr0yF5rxo0Iw5l
-        GwAtzC9JhM7no5uCs9mFs1zC2R4zwl7y4ZoaMsDVAAUVCFglDHA1QI1x6TCGt/BS88oyi/LzIE08
-        iFBKKXQxCYRLVOjl50JMqIYxocU9GcUv0joYfZi5Okq5iRVBqcWlOSCDkewGz5wUlTiWQNxRll9C
-        vclViGFwQ4F2ZSQWh+WDJ57g87n5ReDpHJCVcIegutYIxblQDeDgqa2tBQAAAP//AwBZIRjRuyQA
-        AA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:07.743+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:07.506+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
+        (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d0327749-1444-4135-abfc-79931b51d680
+      - 20f151d3-9f90-461a-9e9e-bd4af4c1b041
       Atl-Traceid:
-      - d032774914444135abfc79931b51d680
+      - 20f151d39f90461a9e9ebd4af4c1b041
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:12 GMT
+      - Wed, 30 Apr 2025 16:25:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -337,7 +346,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=315,atl-edge-internal;dur=13,atl-edge-upstream;dur=302,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=355,atl-edge;dur=323,atl-edge-internal;dur=14,atl-edge-upstream;dur=309,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0CX5eePW_bcOu3LxBDAn62ozTTg3KI3qSDPOQyyemHY_wBlH_sVtng==",cdn-downstream-fbl;dur=359
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -346,10 +355,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0CX5eePW_bcOu3LxBDAn62ozTTg3KI3qSDPOQyyemHY_wBlH_sVtng==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a26668a7cc2bc55ba31f769e00e2d283
+      - ff2115f6a9d1980db03e88a13fdb5a06
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -373,66 +390,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWVMbRxD+K1P76Eh7SYDYqlSKgGyTEEKEwA+Yoobd1u6Y3ZnNzKwOG//3dO8h
-        mUOuQCqGh52rj+n++pvWFweWJZeJEzkaZAIakrcC8sT0JC/A9EycQcF7qgTNrVDS9CARtgDLe3HG
-        ZQq5Sntz0Ab3IJlAqcGAtO3ZuDJWFTNSeBP4fuC7Gv6uwNjpqoQzzWMrYnB6jiD7wa6/H+LEQD7D
-        aWZtaSLPS2AGsU3UJ+Vym3NjBJeuBOuhJevxUnihJ4ypwOsU3MEK5U+n4/NpH9dGuFS7YJzoi2PQ
-        t8rE3EKq9Kq5Q4IzlAj9cKfvB/3An4Z+FOxGQegO9/Z/Qr99cpKMWHS8VvNKJ0neQ30+Odpcu50k
-        YGItSgocrh4wU/A877FEGCtkbFkpIAamZmyh9J1L0rGSFzp/oReVFJQunt/wObdce3MBC692a+Ng
-        uxX4g2D0ixGf4ecC014VaJVggSan3NxRrqpbS6NoxnMDPacRPMZ71bI9JxMIHB1nqxOYA/rqf+05
-        ViCySkSJE8kK7+g8gsnA37YRdBulVp/wqq/MRCtd56HObJcHmnyDns11L6SwFhUYZ22bIPx7fdao
-        mV1wTUA2oihzgQ4nj0KCiarhNxwth6MXuvudlHU3WSds6O+hG+FwGQ7/XysNLGqQosFgdxns/giD
-        y87iIFwOwh9hsUX+169P4Rh2cJyJ5WXDgZjkq+unJwfdSZ6mGlLkmydFgH6qvGrK/3n072zb2N22
-        sbdlI9y6Mdq2sf/Uz4Y2m1UipfqFcKJ+0HIlRV6LuLnSlydrVA8YVJOpKk+OhClzvmqrBpcxhfYS
-        00OV1JrgFh+jhsRfXvPNE7F5FLxGnaaKroeHqqJk1M5/oAUhUyeyuiJvYg14WaKJ5x6JIAi7R+Jx
-        2LZRWbimsscba1CVWigt7OqVF+7Evfql+fdvhSh4CsYjCdMpEbiQiTRzzTzdkOJ7XOnYM3Se1ke4
-        Rn3Ob4H475nSINp4NhDBNowGI4pIxs24FPGJkHdvaecISupfZNxhqEbWot5br0glx9i+8NscJsBN
-        g0vdjpyzk4t3x6c3J8eH49Pz8c14MvlzgvfDOjUYEjwwzYCdIdFLy8guE4Ypma8YkobISSmziv0m
-        NGdnGgpkDVYZRJj7HHkEWFCOfy98vyw/R07zKmL2MPybqnrAFpiIVEiePz7Udl9teGuc5+hdO6fM
-        phLWp6uSynYbkkN/t0Ny0yi9EnyN8PqBfdjbvAyPG7z9yuM7bDc7yHXKG1uHbUf3nxzu2sKmZtBI
-        2PUDEhZU3SpX+rTx5javoJ9q5KxNU6TYkWqSrYoSG2Jpnwf9zpoWvpfYx0JryngYzo/y2/8DlmpV
-        ldQovhUyQRIzDGuF3QJIVlYmg6RG6fHkgL63wISck2WCWcLwpwDD1wySiJRlocvekbqP8k39fROx
-        q7VaISMmMV5WcKt05Ls77uCego4xz1XM80wZG438ke/NGpmb2jdvf3iNwuzqHOKKKIq9V4u+VVtk
-        8WlOKnyaw2vmsavAWPZXxbUFzcYyxcIsMMxbRGF9wAtq6dOzP9hBhRTAzmMut0hRo+ft7103Ab2/
-        Z+fYu9Z+4vjwclx/PjSfLs80aVsAGk6FRTYg0RpXOEJFjAiT3bMr1NEPkQGw9AZhUHtBOJXzxJXY
-        7rupmnvzKpeIXIvM4j08f00qBr6/losX4BbCanCVTj0sb06QF9iyEi14eNTNbJGT3CZdOKkTRspC
-        /JtAWuUcY7qkn3D1PY5ACp4Tks7hHwAAAP//7Fltb9owEP4r1qRVgEgaIISXqupQWaVKo5o2bR+6
-        LxjHgUxAorxQTdqP33OOE15KoKNq1UkTCIjts8/nu+d8D9EKlRozWOWumKHOzubJxSWmcUyrWmJL
-        ffDnzXaH1h8g869knUylbslsn10c7LPd6j3ZLnq8sov9dLvYR+3y4jZxymyCeMudrl9T9qE2Vhum
-        kg0RqGi8kROT9eqMYJxtY0D+mjXMAgTUc8t8tcPGDoYKdwGJPwNGGQlKH5VjFXxU923/0OZZDfGI
-        5h/4Mk4KDawIb1JTPC84t0+g9jVII9jyxp9LYKfM7H02TS64EDJM1M+1820IDtcYXwMWF2oEAH8N
-        m6YfnHN35cdIIJKSbQfw75HN4UT5rYBOdLxeYcxwf2GkP+pyfWOJtDdo7cgb3MIbYu0NPEmQfuM6
-        e5j5YsZwiZ9OAcEp4I+FHGstp4wzVDQCgrgTiYh7pMd4oDZqfOLLaQowHrOZ5C4kVxwJ1Mx2y76v
-        FRoB7edyM7Ns9+eFVn/TIzHks7rPu3k/uqd5d2N7BoycQRyN8HEV7P3jB0OI36cP8i880rZizBKm
-        k7kv9KGNfJVH9Zl9U1ctsrA+jEwZBpCZoyPSm4fc7SLkIiGZu4D56oEh7a18V7pb7vQFIYX7J5b+
-        G6fQomFAWZN8vMLdhb+sskr19wI+nAT9wm/3YsaL44VzIl44hBfO8/DipJTxCC9OTVqbx/vaeOH8
-        x4tXwAv738ILpxA9gheP2Y52UfDvFrtlNEjD3iyEkgguo2gXIoZ2h5bRX1ZZh11wVrsSBeeQW6Fs
-        YBkHYZXxZFaxpgqAGdUeuhDfrOV3S704XSw4Fa/vDlZXZHJiooLoxDKX+IgreCxxXbfuZdttdTvd
-        SaNjyZboWaLXbnq9hudgnWIQVjgwTJI/DFyXogEjReD++rChCOpgmusgBa7OQJoopdUwkslpWFta
-        jS53G7btdES3A7yciEnHwvIel15XXLmXapb3rcH75g3emZyx4Etd9xlG1hSbaWw8wBBG06SC0szi
-        kCxlhJzHZCjIK6Tn8xg/r0eGZYZLoht26fS3r/EuH//2Nd7l89+6xgAoN+OsNR90DddnI+55qRC+
-        CiAq6zIGOYO3+2BJAz+mURDK83sAjyD+VEca/Z+E3iJ0aQX999p+EskuA1W7jFu2C2450uD+ZBj5
-        AwAA//8aLUYoTTCDsxgBAAAA///C7+LRYoTWLqZLMYJeDOBqppnAW2PwxgrQO+mQTFkNmviGsg2A
-        LskvSYTO56Obgqs9ZoCrXDIwwl7A4ZoaMsDpAZztNbjP0HXgasgZ45SAt/BS88oyi/LzIE08iFBK
-        KXQxCYRLTOiV5ZdQb1ITYhjcUKBNGYnFYfngCR/YzCowC0CcXA1jQusXsh0AXnijDzNXRyk3sSIo
-        tbg0B2QwkmfBUzVFJY4lEI+DpoxB0zkgr8PFUTUboeiGagC7tra2FgAAAP//AwCwe6uEuyQAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:07.743+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:07.506+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
+        (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 0a16a10d-b721-44ee-9984-65f932d689a1
+      - eece372d-82eb-47c4-bea7-2139547784a4
       Atl-Traceid:
-      - 0a16a10db72144ee998465f932d689a1
+      - eece372d82eb47c4bea72139547784a4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:13 GMT
+      - Wed, 30 Apr 2025 16:25:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -442,7 +460,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=286,atl-edge-internal;dur=15,atl-edge-upstream;dur=272,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="bpMXImTxCT5acMd84e0CtYQXi2wTRz6O42lmNN1RzsqJKDwOFg2hJg==",cdn-downstream-fbl;dur=362,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=359,atl-edge;dur=280,atl-edge-internal;dur=16,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -451,10 +469,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 bbfdc39b99d2b072cca90c3f38450aea.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - bpMXImTxCT5acMd84e0CtYQXi2wTRz6O42lmNN1RzsqJKDwOFg2hJg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - e73b39cf811c83865db5a28050c2faec
+      - ca8f22b5e5005f4a20300d68bca5b165
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -481,26 +507,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TfmzLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPATYfH5qXgkfQQYsnwKdwrJijGcpz4IY4AICHPIu/AGHqu3OWQoVA04LTtMkz9Nv
-        VnY3RtkAZrRYSAGYo5I0naPIlMoUSMWWab6oVZEhKxSwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAqkjBgiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:09.099+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 74d86fda-821a-43c4-a68d-60fd5ae30559
+      - 96d30bbf-00ba-4a72-8b4d-2e7cc26ce018
       Atl-Traceid:
-      - 74d86fda821a43c4a68d60fd5ae30559
+      - 96d30bbf00ba4a728b4d2e7cc26ce018
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:13 GMT
+      - Wed, 30 Apr 2025 16:25:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -510,7 +532,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=15,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="4X1eaXLPO0KWdY_5fRkhOW8b0X7Dka1v0fzwQx56Ml97fFRw6_d1gQ==",cdn-downstream-fbl;dur=249,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=246,atl-edge;dur=159,atl-edge-internal;dur=13,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -519,10 +541,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 471c951325b4c2c11c6c583a1d28e92a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 4X1eaXLPO0KWdY_5fRkhOW8b0X7Dka1v0fzwQx56Ml97fFRw6_d1gQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - b9615d9fde5a7bc54688c003f3aaeae6
+      - a18fc8a84398461ffbc9d3c22e6822cb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -549,41 +579,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - ccae8c1c-67c4-4ff4-adb8-77663e93abb5
+      - 76bc4e6f-bfce-4c55-a538-08034da8f661
       Atl-Traceid:
-      - ccae8c1c67c44ff4adb877663e93abb5
+      - 76bc4e6fbfce4c55a53808034da8f661
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:13 GMT
+      - Wed, 30 Apr 2025 16:25:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -593,7 +610,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=319,atl-edge-internal;dur=16,atl-edge-upstream;dur=304,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=324,atl-edge;dur=291,atl-edge-internal;dur=20,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="XCS-YIzcdg-z4vuVPe6Hm74LskynSQH073XTFQ2sMQysFMFFFeuMdA==",cdn-downstream-fbl;dur=328
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -602,13 +619,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 aa3674a12327640af71c59263be8ffc6.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - XCS-YIzcdg-z4vuVPe6Hm74LskynSQH073XTFQ2sMQysFMFFFeuMdA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 695841bbff32fbaa80a31dbe754302e0
+      - 6b969086005787be68b94222f4638c03
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -620,28 +645,27 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/95] in [Security
-      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
-      / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
-      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
-      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
-      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
-      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
-      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
-      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Active,
-      Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5] in [Security How-to|http://localhost:8080/product/2]
+      / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n||
+      Severity || CVE || CWE || Component || Version || Title || Status ||\n| High
+      | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
+      | pg | 5.1.0 | [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]
+      | Active, Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
       | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
       Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
       Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -650,31 +674,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:* http://localhost:8080/finding/258
-      (258)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (258)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -683,25 +705,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
     headers:
       Accept:
@@ -713,7 +733,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7139'
+      - '6802'
       Content-Type:
       - application/json
       User-Agent:
@@ -722,18 +742,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16093","key":"NTEST-1609","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16093"}'
+      string: '{"id":"18193","key":"NTEST-1849","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193"}'
     headers:
       Atl-Request-Id:
-      - 5f3691af-5885-49f9-8209-c5dba57a58c2
+      - e4dffc46-4f11-4d6a-b146-0fb8b2ffe71e
       Atl-Traceid:
-      - 5f3691af588549f98209c5dba57a58c2
+      - e4dffc464f114d6ab1460fb8b2ffe71e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:14 GMT
+      - Wed, 30 Apr 2025 16:25:10 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -743,7 +765,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=703,atl-edge-internal;dur=14,atl-edge-upstream;dur=691,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=793,atl-edge;dur=759,atl-edge-internal;dur=21,atl-edge-upstream;dur=739,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="q7LTY_BpL-9HaAc2OsedoZwLRYUEeFh5siJOk9zn7paeZ-8rtRyKqQ==",cdn-downstream-fbl;dur=798
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -752,10 +774,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 cbe94ab27088fc4bb73abf8e3179b3d2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - q7LTY_BpL-9HaAc2OsedoZwLRYUEeFh5siJOk9zn7paeZ-8rtRyKqQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d49052320123cc453667a6ca12fc01ce
+      - ba2194e12848f40a04ebec0be883ca52
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -779,78 +809,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1609
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61PbRhD/V270IdNJbb1swCiT6VDiJLSUUuMkHwjDHNJauiDdKXcnPxryv3dX
-        suzwUKbQaWAGSbe3798++OLAsuQycSJHg0xAQ/JaQJ6YnuQFmJ6JMyh4T5WguRVKmh4kwhZgeS/O
-        uEwhV2lvDtogDZIJlBoMSLu+G1fGqmJGAi8D3w98V8PnCoydrko41Ty2Igan5wjSH+z6+wP8MJDP
-        8DOztjSR5yUwg9gm6pNyuc25MYJLV4L1UJP1eCm80BPGVOC1Aq5hhfwn0/HZtE9neFSbYJzoi2PQ
-        tsrE3EKq9KrxIcEv5Aj9cKfvB/3An4Z+FOxGwdDd84c/o90+GUlKLBpei3mikcTvoTw/3Li9/kjA
-        xFqUFDg8PWCm4HneY4kwVsjYslJADEzN2ELpa5e4YyXf6fyRVlRSULp4fsnn3HLtzQUsvNqsrYFr
-        UuAPgtEvRvwNLwtMe1WgVoIFqpxyc025qq4svUUznhvoOQ3jEfpV8/acTCBwdJytjmEOaKv/tedY
-        gcgqESVOJCv00bkDk4HfEkqtPqFHTwz4mrsOd53ANtz08Q1Itl69k8JaFGCcjW5C6u/1XaNmdsE1
-        4dWIoswFGpzc8RzzUaNsOFoOR4809zuZaT3Z5GXo76EZ4XAZDv9fLU32ayyiwmB3Gez+CIXLVuMg
-        XA7CH6FxDfCvX+/DMejCadhFGLSEmVi+b5ojwuL8AmGSphpS7Df3igAdUHnVlP/DUne6CLtdhL0O
-        QthJGHUR9u/b2bTN5pSaUj0hnKgf9BzMjH2PUacCaS7UzYWSpEXcOPnl3hmVDsbfZKrKk1fClDlf
-        rQsMjxfc4jBqmvjjm0EzIrZDwWvEaSr1+vVQVZSMgEz9QAdCpk5kdUW6Yw3oLPWPh4bEYBS0Q+Ju
-        2Dat7C6hC1ThBlSlFkoLu3qiwy27V0+afz8rRMFTMB5xmFaIwINMpJlr5um2W77Fk7aths79wgk3
-        ZZDzK6DGSBVwdyfoAm/QhdFgRBHJuBmXIj4W8vo1UV5BSfuLjFvE1Dha1LTNiVRyjOsLv8phAtw0
-        KNTrN+f0+N2bo5PL46PD8cnZ+HI8mfw5Qf+wTg2GBC9MM2CnOAGkZaSXCcOUzFcMu4nISSiziv0m
-        NGenGgpsJ6wyiDD3oa4SYEE5/o3w/fLzXuQ0UxGzh+HfVtWtboGJSIXk+d1L6+1rHd4a5zla1zYc
-        zGwqYXO7Kqlsu5A83NttkdwsSk8EX8O8mby3d5vH4XGLt195fI3rZgu5Vnij63C90f0ng9u1sKkZ
-        VBK2i4KEBVW3ypU+aay5yivopxo71HYpUuyVapKtihIXYmkfBv1OV1vY2bSF72X8djg/ym9/D1iq
-        VVXSovhayASbmGFYK+wKQLKyMhkkNUqPJgf0vAIm5JwUEMwShv8KMBxakEQkLAtd9obEfZTP6+fz
-        iJ1vxAoZsTKNdtzA9W8o2BjrXMU8z5Sx0cgf+d6suXtZ2+Tt71wgEzs/g7ii1sTeqkXfqg5enNVJ
-        hbM6vGAeOw+MZX9VXFvQbCxTLMgCw9vBCpsLXlBzn5z+wQ4qLH12FnPZwUWbn7e/d9EE8uaGneHO
-        WtuJ74fvx/XjQ/No80sf6wlPr1NhsQsQa40nfENBjBolu2HnKKMfYuXTABqFtRWETzlPXIlrvpuq
-        uTevcomItdhRvNv3L0jE/nDDFi/ALYTV4CqdeljVnJAucIWlbuDtD93MFjlxlSn+qdNEIkL8mUCh
-        LKAbCbDxEtNBPKzPfjpNe+xZbl+w0A0CN2TsWWpfvGSDfwAAAP//7Fhtb9NIEP4rI1VCjkk31ImT
-        Xk79ULUgIVGErgdfCFJcZ0sMjp36pRRx/Pd7Zne9XjcxiHL3rW2VOjM7u7PPzM48a/EMxkoxFlMx
-        oUYxaRUTEYpZIw9beSgwVyOftnJ+DFs5e2fkR2LayoNWHrjjx618LMatfNLKJ+0GZu26/OjI7br8
-        GAx6csMk8iiYPmNET8FXbuWQQ6+uAbQvzrNfjLMZ/1/F+THGD41xeNwXY9TBpijMfRVvlpF/Xks6
-        RwGF8IW8EvTHkLi9Urc2N7/rI2GLs/o+Fo/H8vdChmOJ2JyrTo8m/Ckn5kAIx0/tyMPHYF9gfxRW
-        8tEJIH6Pf4cPOKxYD6deTfB7TaGbWf5lXhexRHal0ufufIguuklKybBuPzoDz1sO4aPX22WReqVp
-        zyLJR9HqNinBQ3ABCIMA9OKaEcZhaFgnE43l9uOSwOjgX0YRFTqLY85iabOY9yCL6CpJuaNW66ii
-        PMZCJX1Zg5pU4NbGkFG7ikpJeUE3uCB+JVyUYz6DJWaPi+iaHQAXqzcZMfUS6pyBnReSQM+p+pI3
-        JjGVscwiXGOYr2CpJF4TaACoe5p8liDv11glgtvbbZrE6r2l4UWNw6kEPjixzP7dUXpr8KnOyuga
-        hYLJ/mFZ8xD4V96kZjmDTEmbCMZJDl7gOF+KRRbszg6jDEiX7Azcw920AFXEvBYdpmrWh8ggVciq
-        LjKkNp7KOq0YXccHjNvrhGAADw5wb8kRT/yd5Vkst9UiWy6Xi4zvghV9ozPsDJznO50Qv8hNCuk9
-        ObgLZkgt/X/QjI31yBMCcTZmHivVkzCbY0ljwHCd0PLy+avnZ3/TEZ1e0pObOq/+XOBHTz7ytQSH
-        cJ/aHy1wLp/yVss8lQJXBQ/ZH+P6JmR2O/jA3oA/wyQbjbT1UjmgnVIAevBjSJ4siiEjOKATPjn0
-        DTObPWGuFTv+fWDAoXc2UegClBX5QnzUXHnzEmjeqeLgiT11HJq+Sm6Ndmq51exUc0dzr547mnsV
-        3dHcq+mO5l5Vt5qduu5oupUdOL1Rb2JWDUhzM9KAZFDBfA5cjJHBhBdy4WKMDChG1cDFGFlQHE3T
-        8RpUOioGyaLS0TBIFpWOhkGyqHQ0DJJFxdFokCwqHY0GyUkm4LVGJnFKHmq6N98t9HxTmfMHuhO+
-        ncZ8DpCY9RWOv+kBF4m69pkW4NuLTCDuxN2c3qpXBVyATLFvQoKKmUJTCNdo3Geko7XXZtJno8O4
-        1ybss9EB3msz7bPREbE25NFr7kCqO9kOp5JgqCM+VGVXh5hbTZSWOW11AgtiGmEXnfUtqkL640VN
-        QqBL7SxgYvdys43iiuP2OqdEfSGkwG2ykqu2zWPgX+BEhUQ1L3+lzxvTbc4XbqYpXrTaJNmAvME/
-        G9CQKp9b6rGXzj5SWecAuwXvp1QWt48HUdnwGFQ2PP5/qOy/AAAA//8ipSlLbr8XOdnSuilrONqU
-        BasCAAAA///smtFqgzAUhl9lDHoZFzVWvShdGRvsoi/Qu/REtzHUopXRt985xoY2Mx1sN14EeiHN
-        SU84mJ+//J+3st7Keis7oepX1uxK16+s2aWyeyt7npe3st7KzsPKhmbrL1b2Z3afmPjajm5d6V0o
-        XAsG3aBY79hK+BzoAqIdrFJhQAtrgbvwD+5K0LlJ0M/jcRW6qA9uDiOPRwnvlKhNcCx2Ptn1VSUp
-        ir2fzApp1MRTNO0fw1pyJ2sJQMTGq1olKs7SbB+mvIgh55AnUZmH5RL7mCLscKOsoPdgoxT26LAS
-        7d7p8eIg0BD5dpvwGkZcBG+tLqM9Z8pIFDzMpAqFWKaQpUmc72GfcmxfyqLMYK1Ww68s4s0iesGP
-        3scqWY8pJmP6qy7oO/aFg2BRQPFooDWQJsUOUnY0KNw/eHS8bfj4tGU8ONQUmtu02PxPbONm8z+x
-        javN/cSoP0pzViPVgP/XT3dbWZY9wMdwgSgE0xyUVq9dU1Phc982h+Jhh7oCRAGNN41wSVw1V5c6
-        jJDoNAohXGIqXISUcGF3wgh2O6q915f/vknfAAAA//8iOiWNli/0cPFo+YKlfEEvBuCtMHgjBejq
-        dEjeqwat64ayDYAW5pckQlelo5uCs7mFs1zC2Q4zwl7y4VrgaICr4QkqELBKGOBqeBrj0mEMb9ml
-        5pVlFuXnQZp2EKGUUuiWCAiXqNDLz4WYUA1jQot7MopfpN0c+jBzdZRyEyuCIONAKHaD1/8VlTiW
-        QNxRBux+kLtoEWOJMMQwuKFAuzISi8Pywcsn4auS84vAixJBVsIdgupaIxTnQjWAg6e2thYAAAD/
-        /wMAZjWE+oEzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:10.376+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:10.150+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
+        Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - c8888172-a311-4172-8430-5ea0a39ffc0f
+      - 30ba3c06-e0b0-43a9-9216-149fec58aaf7
       Atl-Traceid:
-      - c8888172a311417284305ea0a39ffc0f
+      - 30ba3c06e0b043a99216149fec58aaf7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:15 GMT
+      - Wed, 30 Apr 2025 16:25:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -860,7 +925,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=272,atl-edge-internal;dur=14,atl-edge-upstream;dur=258,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="JYXlXd17_pTAmaGCkZnGncfzPJYb_H7xXXLV08rBcBfF98wCKXKtiQ==",cdn-downstream-fbl;dur=366,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=358,atl-edge;dur=273,atl-edge-internal;dur=15,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -869,10 +934,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 595c26368a4c8eede29e4b5da7206efc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JYXlXd17_pTAmaGCkZnGncfzPJYb_H7xXXLV08rBcBfF98wCKXKtiQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 6d2f1ad7ccfa9bdad97a445f2bf23ae3
+      - 231a7183c9390190e5f025edb1ce70a7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -896,78 +969,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX6VPbRhT/V3b0IdNJbV02YJTJdChxElpKqXGSD4RhFulZ2iDtKrsrHw353/ue
-        DjsczhQ6Dcygvd79ewdfHFiWXCZO5GiQCWhIXgvIE9OTvADTM3EGBe+pEjS3QknTg0TYAizvxRmX
-        KeQq7c1BG7yDZAKlBgPStm/jylhVzIjhZeD7ge9q+FyBsdNVCaeax1bE4PQcQfKDXX9/gBsD+Qy3
-        mbWliTwvgRnENlGflMttzo0RXLoSrIeSrMdL4YWeMKYCr2NwDSukP5mOz6Z9OsOjWgXjRF8cg7pV
-        JuYWUqVXjQ0J7pAi9MOdvh/0A38a+lGwGwVDd88f/ox6+6QkCbGoeM3miUoSvYf8/HBtdrtJwMRa
-        lOQ4PD1gpuB53mOJMFbI2LJSQAxMzdhC6WuXqGMl3+n8kVpUUlC4eH7J59xy7c0FLLxarY2C7VXg
-        D4LRL0b8DS8LDHtVoFSCBYqccnNNsaquLK2iGc8N9JyG8Ajtqml7TiYQODrOVscwB9TV/9pzrEBk
-        lYgSJ5IV2ujcgcnA7y5KrT6hRU90eEtdu7sOYOdu2nwDko1V76SwFhkYZy2bkPp7/daomV1wTXg1
-        oihzgQondyzHeNQoG46Ww9Ej1f1OZDpL1nEZ+nuoRjhchsP/V0oT/RqLKDDYXQa7P0LgspM4CJeD
-        8EdIbAH+9et9OAbbcBp2FzOxfN/UQIz++cX9l4PuJU9TDSnWm3tJgAaovGrS/2FxO9sudrdd7G25
-        CLdejLZd7N/XsymbzSkVpbpDOFE/aGslhUSLuDHpy70zShT0tslUlSevhClzvmrTCY8xtvY9xo1S
-        rBXBLTajpog/vhg0LWLTFLyGnaZUr5eHqqJg1Mp/oAMhUyeyuiJtYg1oLNWPh5rEYBR0TeKu29al
-        7O7FNlCFa1CVWigt7OqJBnfkXt1p/n2vEAVPwXhEYTomAg8ykWaumaebavkWT7qyGjr3Eydcoz7n
-        V0CF8YHUoHryoCOCbRgNRuSRjJtxKeJjIa9f080rKGl+kXGHoRpZi/pufSKVHOP4wq9ymAA3DS51
-        u3JOj9+9OTq5PD46HJ+cjS/Hk8mfE7QP89SgS/DBNAN2ih1AWkZymTBMyXzFsJqInJgyq9hvQnN2
-        qqHAcsIqgwhzH6oqASaU498I3y8/70VO0xUxeuj+TVbdqhYYiFRInt991E5frXtrnOeoXbunyKYS
-        1q+rktJ2G5KHe7sdkptB6Ynga4jXnff2bPM4PG7w9iuPr3Hc7CDXMW9kHbYT3X9SuBsLm5xBIWE3
-        KEhYUHarXOmTRpurvIJ+qrFmbYYixV6pJtiqKHEglvZh0O+sy8L3AnuXaF0ybrvzo/z294ClWlUl
-        DYqvhUywiBmGucKuACQrK5NBUqP0aHJA3ytgQs5JMsEsYfivAMNuBklEzLLQZW+I3Uf5vP4+j9j5
-        mq2QESvTaMcNXP+GnI2+zlXM80wZG438ke/NmreXtU7e/s4FErHzM4grKk3srVr0rdpCi706qbBX
-        hxfMY+eBseyvimsLmo1liglZoHu3kML6gRfU1Cenf7CDClOfncVcbqGiyc/b37toHHlzw85wZq31
-        xPXh+3H9+dB8uvjSpm39tJwKi1WASGs84QoZMSqU7IadI49+iJlPDWgU1loQPuU8cSWO+W6q5t68
-        yiUi1mJF8W6/vyAW+8M1WbwAtxBWg6t06mFWc0K6wBGWqoG3P3QzW+REVab4pw4TsQjxZwKFsoBm
-        JMDGSwwH0bA+++k07bFnuX3BQjcI3JCxZ6l98ZIN/gEAAP//7Fhtb9NIEP4rI1VCjkk31ImTXk79
-        ULUgIVGErgdfCFJcZ0sMjp36pRRx/Pd7Zne9XjcxiHL3rW2VOjM7u7PPzM48a/EMxkoxFlMxoUYx
-        aRUTEYpZIw9beSgwVyOftnJ+DFs5e2fkR2LayoNWHrjjx618LMatfNLKJ+0GZu26/OjI7br8GAx6
-        csMk8iiYPmNET8FgbuWQQ6+uAbQvzrNfjLMZ/1/F+THGD41xeNwXY9TBpijMfRVvlpF/Xks6RwGF
-        8IW8EvTHkLi9Urc2N7/rI2GLs/o+Fo/H8vdChmOJ2JyrTo8m/Ckn5kAIx0/tyMPHYF9gfxRW8tEJ
-        IH6Pf4cPOKxYD6deTfB7TaGbWf5lXhexRHal0ufufIguuklKybBuPzoDz1sO4aPX22WReqVpzyLJ
-        R9HqNilBUHABCIMA9OKaEcZhaFgnE43l9uOSwOjgX0YRFTqLY85iabOY9yCL6CpJuaNW66iiPMZC
-        JX1Zg5pU4NbGkFG7ikpJeUE3uDJ+JVyUYz6DJWaPi+iaHQAXqzcZMfUS6pyBnReSQM+p+pI3JjGV
-        scwiXGOYr2CpJF4TaACoe5p8liDv11glgtvbbZrE6r2l4UWNw6kEPjixzP7dUXpr8KnOyugahYLJ
-        /mFZ8xD4V96kZjmDTEmbCMZJDl7gOF+KRRbszg6jDEiX7Azcw920AB3EvBYdpmrWh8ggVciqLjKk
-        Np7KOq0YXccHjNvrhGAADw5wb8kRT/yd5Vkst9UiWy6Xi4zvghV9ozPsDJznO50Qv8hNCuk9ObgL
-        Zkgt/X/QjI31yBMCcTZmHivVkzCbY0ljwHCd0PLy+avnZ3/TEZ1e0pObOq/+XOBHTz7ytQSHcJ/a
-        Hy1wLp/yVss8lQJXBQ/ZH+P6JmR2O/jA3oA/wyQbjbT1UjmgnVIAevBjSJ4siiEjOKATPjn0DTOb
-        PWGuFTv+fWDAoXc2UegClBX5QnzUXHnzdmjeqeLgiT11HJq+Sm6Ndmq51exUc0dzr547mnsV3dHc
-        q+mO5l5Vt5qduu5oupUdOL1Rb2JWDUhzM9KAZFDBfA5cjJHBhBdy4WKMDChG1cDFGFlQHE3T8RpU
-        OioGyaLS0TBIFpWOhkGyqHQ0DJJFxdFokCwqHY0GyUkm4LVGJnFKHmq6N98t9HxTmfMHuhO+ncZ8
-        DpCY9RWOv+kBF4m69pkW4NuLTCDuxN2c3qpXBVyATLFvQoKKmUJTCNdo3Geko7XXZtJno8O41ybs
-        s9EB3msz7bPREbE25NFr7kCqO9kOp5JgqCM+VGVXh5hbTZSWOW11AgtiGmEXnfUtqkL640VNQqBL
-        7SxgYvdys43iiuP2OqdEfSGkwG2ykqu2zWPgX+BEhUQ1L3+lzxvTbc4XbqYpXrTaJNmAvME/G9CQ
-        Kp9b6rGXzj5SWecAuwXvp1QWt48HUdnwGFQ2PP5/qOy/AAAA//8ipSlLbr8XOdnSuilrONqUBasC
-        AAAA///smtFqgzAUhl9lDHoZF2uselG6MjbYRV+gd+mJbmOoRSujb79zjA2aNR0MBl4EeiH1xBMO
-        5ueX//NW1ltZb2WvqPrEmk10fWLNxsrurexlXt7Keis7DysbmqW/WNmf2X1s4ms7unWF+qFw3TDo
-        BuV9p0bCZ08XEP9glXIX5SEMgWGvMAn6ZQquQleizl3UBzc95ekk4Z0StSFWHifTdnDZdmUpKYq9
-        v5oV0qiJp6ibP4a15E42EoCIjVe1jlWUJukhTHgeQcYhi5dFFhYr7GOKsMONspzeg61S2KPFSrR7
-        58fRRqAm8u024dXPPg/eGl1Gay6Ukch5mEoVCrFKIE3iKDvAIeHYvpB5kcJGrfunLKLtYvmCP72O
-        lbIaUkzG9F9t0LXsCwfBlgHFo4HWQJoUO0rZ0qBwfe/R8bTh5dOO8eBYUWhu02Lz37GNm81/xzau
-        Nvcdo/4oTV4NVAN+r5/vdrIoOoCP/gBRCKY5KK1e+7qiwueuqY/5wx4FB4gCGk4a4ZJ41xxd6jBA
-        otdRCOESU+EipIQhpJpB1L2M/NsL8w0AAP//Qk8wo8UIPVw8WoxgKUbQiwFczTMTeCsM3kgBeicd
-        kimrQeu6oWwDoEvySxKhq9LRTcHVDjPAVS4ZGGEv4HAtcDTA6QGc7TRc7UtQEYJVwhinBLxll5pX
-        llmUnwdp2kGEUkqhWyIgXGJCrwzY7Cd3sSDG0lyIYXBDgTZlJBaH5YOXLcLWBwOzAMTJ1TAmtH4h
-        2wHg7SP6MHN1lHITK4IgA08ongUvOCwqcSyBeBy08Bm0KBHkdbg4qmYjFN1QDWDX1tbWAgAAAP//
-        AwDjtmLMgTMAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:10.376+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:10.150+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
+        Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 7b4ea889-2bf9-4739-98a5-6242adf6ffa1
+      - 48b1180a-f90b-4e52-bdb0-23fa73fa1acd
       Atl-Traceid:
-      - 7b4ea8892bf9473998a56242adf6ffa1
+      - 48b1180af90b4e52bdb023fa73fa1acd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:15 GMT
+      - Wed, 30 Apr 2025 16:25:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -977,7 +1085,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=262,atl-edge-internal;dur=14,atl-edge-upstream;dur=248,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=289,atl-edge;dur=256,atl-edge-internal;dur=16,atl-edge-upstream;dur=241,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="JNZi507_PLCglddjlRMVlPQBXZl1Y2JNeNF_3e-DxjPbqvE2lFQQxg==",cdn-downstream-fbl;dur=294
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -986,10 +1094,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 800cba2437ee092ab9e4755c65d34a72.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JNZi507_PLCglddjlRMVlPQBXZl1Y2JNeNF_3e-DxjPbqvE2lFQQxg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 6a9b2ea887f9c0970b2e184787dc1f4a
+      - d1985f1897e4d6e72fcf5045cd713a03
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1016,26 +1132,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2T9WPLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPARYUZyaV8JHkAHLpkCnsKwY4+mcp0EMcAEBDnkX/oBD1XbnLIWKAac5p1lSZPSb
-        ld2NUTaAKc0XUgBmqCSdFyhSpVIFUrHlPFvUKk+R5QrYmcDraLhtBxFfiEqM2t9ZKWL7QPSpImhe
-        tyU5nh/2ZE2cXN9X5PgJAAD//wMAuMbsISACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:11.745+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 415a5a99-5ecb-44c7-9808-353339a6e2b0
+      - e0a20f83-3d2f-41e2-9492-86a9dcff3fd7
       Atl-Traceid:
-      - 415a5a995ecb44c79808353339a6e2b0
+      - e0a20f833d2f41e2949286a9dcff3fd7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:15 GMT
+      - Wed, 30 Apr 2025 16:25:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1045,7 +1157,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=146,atl-edge-internal;dur=13,atl-edge-upstream;dur=134,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=199,atl-edge;dur=166,atl-edge-internal;dur=13,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="R4oAvb4IvXFK4-SQwETf5-JQ8-FaSEMy9lb77848XB1gJIfCP2yZjg==",cdn-downstream-fbl;dur=204
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1054,10 +1166,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 535c2b5354e6ba6798fd64420ee97a2c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - R4oAvb4IvXFK4-SQwETf5-JQ8-FaSEMy9lb77848XB1gJIfCP2yZjg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 42898dc5ffad985b28ddd011f40110f9
+      - ec6cae3195ccf9fb78e7ffe9325816c0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1084,41 +1204,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 7cb9ffec-b81d-4fce-b2ac-8f9789dfb284
+      - fa4896d6-e80f-4ba4-aadd-82961a0cd619
       Atl-Traceid:
-      - 7cb9ffecb81d4fceb2ac8f9789dfb284
+      - fa4896d6e80f4ba4aadd82961a0cd619
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:16 GMT
+      - Wed, 30 Apr 2025 16:25:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1128,7 +1235,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=242,atl-edge-internal;dur=13,atl-edge-upstream;dur=229,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="2-_97sOcBeob_emLowXbGK6-WljII0z-NCUbki2qU4_hZj7IRZaL2A==",cdn-downstream-fbl;dur=368,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=365,atl-edge;dur=278,atl-edge-internal;dur=17,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1137,13 +1244,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f4931915c262d78fa3e94b48faa4f55a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 2-_97sOcBeob_emLowXbGK6-WljII0z-NCUbki2qU4_hZj7IRZaL2A==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 3c7c3d378992916f1ff925ddf55d540a
+      - 9d0bb0901e4eab565635f3a65e9fe15a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1155,22 +1270,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/96] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/6] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]\n*Defect
       Dojo link:* http://localhost:8080/finding/259 (259)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -1184,7 +1298,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1971'
+      - '1943'
       Content-Type:
       - application/json
       User-Agent:
@@ -1193,18 +1307,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16094","key":"NTEST-1610","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16094"}'
+      string: '{"id":"18195","key":"NTEST-1850","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195"}'
     headers:
       Atl-Request-Id:
-      - 01a91754-cfe7-423d-a88f-9198a998c563
+      - 2fe94f64-0cbb-42bb-b846-1ac1a3fe9723
       Atl-Traceid:
-      - 01a91754cfe7423da88f9198a998c563
+      - 2fe94f640cbb42bbb8461ac1a3fe9723
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:16 GMT
+      - Wed, 30 Apr 2025 16:25:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1214,7 +1330,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=658,atl-edge-internal;dur=15,atl-edge-upstream;dur=643,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=840,atl-edge;dur=807,atl-edge-internal;dur=16,atl-edge-upstream;dur=791,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="fmku7p53dHCtaNnPh_uEMi2Ou0nbdt4ROy5kkW5694CGpyTfB1aOqQ==",cdn-downstream-fbl;dur=845
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1223,10 +1339,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 22067fb5d7eb764108747a104222f50a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - fmku7p53dHCtaNnPh_uEMi2Ou0nbdt4ROy5kkW5694CGpyTfB1aOqQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 0de5ff6857c24b8d4a8cbb0f6b0975e5
+      - bb93cdc32a573e22143f18e9f296821f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1250,64 +1374,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1610
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+DZ2ttziOI2AYssRp02VZ5rjthzQIGOkssZFIlaT8sqb/fXeS
-        ZTcvKpYMKxJAEsl74d1zz52/OLAsuUycyNEgE9CQHAvIE9OTvADTM3EGBe+pEjS3QknTg0TYAizv
-        xRmXKeQq7c1BG9yDZAKlBgPSrs/GlbGqmJHC68D3A9/V8LkCY6erEs41j62Iwek5guwHQ39/gB8G
-        8hl+ZtaWJvK8BGYQ20R9Ui63OTdGcOlKsB5ash4vhRd6wpgKvFbBLaxQ/mw6vpj2g2Hg41LtgnGi
-        L45B3yoTcwup0qvmDgl+oUToh7t9P+gH/jT0o2CI/+7ID35Gv0lHbcSi47WaFzpJ8h7q88PNtdcf
-        CZhYi5ICh6sHzBQ8z3ssEcYKGVtWCoiBqRlbKH3rknSs5DudP9OLSgpKF8+v+Zxbrr25gIVXu7V1
-        cL0V+DvB6Fcj/oZfCkx7VaBVggWanHJzS7mqbiy9RTOeG+g5jeAJ3quW7TmZQODoOFudwhzQV/9r
-        z7ECkVUiSpxIVnhH5wFMdvx2o9TqE97ohQFfS9fhrhPYhps+vgHJ9lbvpLAWFRhnY5uQ+nt91qiZ
-        XXBNeDWiKHOBDicPbo75qFE2GC0Ho2e6+53MtDfZ5GXg76Eb4WAZDv5fK032ayyiwWC4DIY/wuCy
-        tbgTLnfCH2FxDfCvXx/DMejCadi1sdNuzMTyfUOOCIvLK4RJmmpIkW8eFQFeQOVVU/5Pa93t2hh2
-        bex1bISdG6Oujf3Hfja02awSKdUdwon6wZorKSVaxM2Vvjxao0LBaJtMVXlyJEyZ89W6nHB5wS22
-        noayn1/6TUPYtgCvUaepsOvXQ1VR6GtXP9CCkKkTWV2RbVRq3yNmqLzX0dCAlyX+eKpJDEbDtkk8
-        DNuGyh5udIEq3ICq1EJpYVcvDEEr7tWd5t/3ClHwFIxHEqZVInAhE2nmmnm6Zcs3uNLSaug8Lpxw
-        UwY5vwEiRqqAhzNBF3iDLowGI4pIxs24FPGpkLfHtHMEJc0vMm4xVCNrUe9tVqSSYxxf+E0OE+Cm
-        waVevznnp+9en5xdn54cjs8uxtfjyeTPCd4P69RgSPDANAN2jh1AWkZ2mTBMyXzFkE1ETkqZVeyt
-        0JydayiQTlhlEHPuU6wSYEE5/p3w/fLzLHKarojZw/Bvq+oeW2AiUiF5/vDQevpah7dGfo7etYSD
-        mU0lbE5XJZVtF5J39/wWyc2g9ELwNcKbznt/tnkeHrd4+43HtzhutpBrlTe2DtcT3X9yuB0Lm5pB
-        I2E7KEhYUHWrXOmzxpubvIJ+qpGztkORYkeqSbYqShyIpX0a9LtdtLC7oYXvZfx+OD/Kb/8OWKpV
-        VdKgeCxkgrRmGNYKuwGQrKxMBkmN0pPJAT1vgAk5JwMEs4ThTwGGTQuSiJRloctek7qP8lX9fBWx
-        y41aISM2wxhmke/uuP4dxRvDnauY55kyNhr5I9+bNceva7e8/eEVyrHLC4grYif2Ri36VnXIYrtO
-        KmzX4RXz2GVgLPur4tqCZmOZYk0WGOEOUdgc8IJa+uz8D3ZQYfWzi5jLDika/rz9vasmlnd37ALH
-        1tpPfD98P64fH5pHm2L6WDd5ep0Ki0RAojWk8A0VMeJKdscuUUc/RG6jrhTs114QROU8cSVO+m6q
-        5t68yiWC1iKpePfPX5GKgd+EmuTiBbiFsBpcpVMPK5sT2gWOscQIHh51M1vkJFdnCp91rkjPBNIq
-        5xjKJf1oq90/Ail4Tti5AD3H32asz346JsF/AAAA///sWW1P2zAQ/ivWJBCtmpC2KX1BiFUwJD50
-        mjZtH9gXXNuhmdqmSpOiCX78nrNd04aabUxDfEAgaHx+udydn3vu2mD70+IYizthq+YxnvX0Yauj
-        FR0iy69Ug2yjqTK7J5vW1xYd1LVRaIzVz0vFzhGAGLxQ45D1G4zgiW3H9vpn0gxdcOvndvifXwd6
-        n2sUwQX/kTHCV6j623XsAH9qu176qVdmdYQYhr/jX/Asb+NEBI7e4t/ibdvu9S9ZmcOKF+lUAQmU
-        sfT+TXGsg2tj4vkDQtWBJO7YDNBlb36YZodcrtIlUA70otM6AnglZGOEyjqnke+u9ebXDImXkaoo
-        KG2qza3LrSLkculcvrQuv50Q8HHsN79hYNwCcuRskfOETqIMDURalEUIy3972H8E6Jkqi3DbojWl
-        H2xEEWZ80hxTrsWQwjInTryxAWZOsBqDiEh9IQdVYzY2BpZgNh5BvlIB5a5UPJ5opAlfUbbd8BIh
-        2ID+UHDhcSgE9hsgO4ynqbAeHKU6JVgHftWsgWxuPWPeimU5m0KQh87zl7MFFwWt+ZixVD8wwPgq
-        lUpuxdJn3CdQKRz9NxFily4yygIU4AdcztJ5jR3U7mcI4CIbIGgfE/GO46JVHuZLxc3YJ3B1GOXo
-        Igcr0cUDFTOVqbGrmiqCyFfLRT46HDk6vDaPb6KvhIucMrwouJhQbtxRlFbJxrKczTjxqne+xE/W
-        pvooy59JvugOnnIhqCa7lCcd2e51e+NmN1Jt0Y9Ev9NK+s3kCOe4STjhiWmKQmEoJd0TzBSZ/Pl+
-        QxGwM9rryY6NtrIKQfD0NFqz7hrECjUIl804PuqKXrfT7o/FuBvh+ISrpCdO5YneZa893Gtd4Nes
-        C2Z8bilJEJihZVgug1sYImiFxHVCcwXJUsGC8yUZCus1wqOCwcezURCFizmR4Gr35/VrXG0fvX6N
-        q+2n164xIEiaToqtUs4Q+mzEk6QUItUXiEiZ6XQYALsCicXED2WeLdThFaBFUFVvbxq1PyF1V5dO
-        sE3f3aVN7MPT2NfxiH1ttNhhdm4B/w1fXiyS3vDlJTR+w5cd+FKFAUfEHE+B1jfm7t3R9zT2c4QD
-        s4Lbb5mqu3gZlxeXvFSstRv5fA3LyMc9CRB2CiIf92z7VrQduVPzVZpnc8PuzJAs7Vec5vGPrJfN
-        zA535uMvAAAA//+Cj2SRUfwizc7qw8zVUcpNrAhKLS7NARmMZDd4PK+oxLEE4o6y/BLqTQJADIMb
-        CrQrI7E4LB88HAqfd8gvAg8ygqyEOwTVtUYozoVqAAdPbW0tAAAA//8DANcCNEBRHwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18195","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195","key":"NTEST-1850","fields":{"statuscategorychangedate":"2025-04-30T18:25:13.029+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:12.710+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:12.797+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/6]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]\n*Defect
+        Dojo link:* http://localhost:8080/finding/259 (259)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 41665da4-a720-4bec-9647-4eaa060aea5e
+      - 3912e53e-9db0-4e82-8560-8a9352466830
       Atl-Traceid:
-      - 41665da4a7204bec96474eaa060aea5e
+      - 3912e53e9db04e8285608a9352466830
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:17 GMT
+      - Wed, 30 Apr 2025 16:25:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1317,7 +1428,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=283,atl-edge-internal;dur=12,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=277,atl-edge;dur=244,atl-edge-internal;dur=16,atl-edge-upstream;dur=228,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="X941HcQUDQIry_gVVM9iLxjNRN1pvlcLSwnMLnd5VdC4uPmcR7EA0g==",cdn-downstream-fbl;dur=281
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1326,10 +1437,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - X941HcQUDQIry_gVVM9iLxjNRN1pvlcLSwnMLnd5VdC4uPmcR7EA0g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d9f94102d7208e148cf68f47b15e0dde
+      - 82d4c7fa4d2e0d8b944b077a1e5b6978
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1353,64 +1472,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16094
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18195
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+DZ2ttziOI2AYssRps2VZ5rjthzQIGOkssZFIlaT8sqb/fXeS
-        ZTcv6pYMKxJAEsl74d1zz50/O7AsuUycyNEgE9CQHAvIE9OTvADTM3EGBe+pEjS3QknTg0TYAizv
-        xRmXKeQq7c1BG9yDZAKlBgPSrs/GlbGqmJHC68D3A9/V8KkCY6erEs41j62Iwek5guwHQ39/gB8G
-        8hl+ZtaWJvK8BGYQ20R9VC63OTdGcOlKsB5ash4vhRd6wpgKvFbBLaxQ/mw6vpj2g2Hg41LtgnGi
-        z45B3yoTcwup0qvmDgl+oUToh7t9P+gH/jT0o2CI/+7ID35Ev0lHbcSi47WaFzpJ8h7q88PNtdcf
-        CZhYi5ICh6sHzBQ8z3ssEcYKGVtWCoiBqRlbKH3rknSs5FudP9OLSgpKF8+v+Zxbrr25gIVXu7V1
-        cL0V+DvB6Gcj/oKfCkx7VaBVggWanHJzS7mqbiy9RTOeG+g5jeAJ3quW7TmZQODoOFudwhzQV/9L
-        z7ECkVUiSpxIVnhH5wFMdvx2o9TqI97ohQFfS9fhrhPYhps+vgLJ9lZvpbAWFRhnY5uQ+lt91qiZ
-        XXBNeDWiKHOBDicPbo75qFE2GC0Ho2e6+43MtDfZ5GXg76Eb4WAZDv5fK032ayyiwWC4DIbfw+Cy
-        tbgTLnfC72FxDfAvXx7DMejCadi1sdNuzMTyXUOOCIvLK4RJmmpIkW/+sQh22w28mcqrhheePjrs
-        2tjr2Ag7N0ZdG/uP3Wlos1klUqo7hBP1A/zkFhtHQ7jPL9yGzrcE7jXqNJVl/XqoKgpcQKT8nhaE
-        TJ3I6gowfajUvsOMU3E2ztX6SL8WcRPHz4/WyFcUNpmq8uRImDLnq3VxEyQ04GWJP55qEoPRsG0S
-        D8O2obKHG12gCjegKrVQWtjVC4PYint1p/n3vUIUPAXjkYRplQhcyESauWaebtnyDa60tBo6jwsn
-        3JRBzm+AiJEq4OFM0AXeoAujwYgiknEzLkV8KuTtMe0cQUnzi4zbrNW5XNR7mxWp5BjHF36TwwS4
-        aZCg12/O+enb1ydn16cnh+Ozi/H1eDL5Y4L3wzo1GBI8MM2AnWMHkJaRXSYMUzJfMWQTkZNSZhX7
-        VWjOzjUUSCesMoha9ylWCbCgHP9O+H75aRY5TVfE7GH4t1V1jy0wEamQPH94aD19rcNb4zpH71rC
-        wcymEjanq5LKtgvJu3t+i+RmUHoh+BrhTee9P9s8D49bvP3C41scN1vItcobW4frie4/OdyOhU3N
-        oJGwHRQkLKi6Va70WePNTV5BP9XIEtuhSLEj1SRbFSUOxNI+DfrdLlrY3dDCtzJ+P5wf5Nd/ByzV
-        qippUDwWMkFiNAxrhd0ASFZWJoOkRunJ5ICeN8CEnJMBglnC8KcAw6YFSUTKstBlr0ndB/mqfr6K
-        2OVGrZARm2EMs8h3d1z/juKN4c5VzPNMGRuN/JHvzZrj17Vb3v7wCuXY5QXEFbETe6MWfas6ZLFd
-        JxW26/CKeewyMJb9WXFtQbOxTLEmC4xwhyhsDnhBLX12/js7qLD62UXMZYcUDX/e/t5VE8u7O3aB
-        Y2vtJ74fvhvXj/fNo00xfaybPL1OhUUiINEaUviGihhxJbtjl6ijHyK3UV8L9msvCKJynrgSJ303
-        VXNvXuUSQWuRVLz7569IxcBvQk1y8QLcQlgNrtKph5XNCe0Cx1hiBA+PupktcpKrM4XPOlekZwJp
-        lXMM5ZJ+tNXuH4EUPCfsXICe428z1mc/HJPg3wAAAP//7FltT9swEP4r1iQQrZqQtil9QYhVMCQ+
-        dJo2bR/YF1zboZnapkqTogl+/J6zXdOGmm1MQ3xAIGh8frncnZ977tpg+9PiGIs7YavmMZ719GGr
-        oxUdIq+uVINso6kyuyeb1tcWHdS1UWiM1c9Lxc4RgBi8UOOQ9RuM4Iltx/b6Z9IMXXDr53b4n18H
-        ep9rFMEF/5Exwleo+tt17AB/arte+qlXZnWEGIa/41/wLG/jRASO3uLf4m3b7vUvWZnDihfpVAEJ
-        lLH0/k1xrINrY+L5A0LVgSTu2AzQZW9+mGaHXK7SJVAO9KLTOgJ4JWRjhMo6p5HvrvXm1wyJl5Gq
-        KChtqs2ty60i5HLpXL60Lr+dEPBx7De/YWDcAnLkbJHzhE6iDA1EWpRFCMt/e9h/BOiZKotw26I1
-        pR9sRBFmfNIsVa7FkMIyJ068sQFmTrAag4hIfSEHVWM2NgaWYDYeQb5SAeWuVDyeaKQJX1G23fAS
-        IdiA/lBw4XEoBPYbIDuMp6mwHhylOiVYB37VrIFsbj1j3oplOZtCkIfO85ezBRcFrfmYsVQ/MMD4
-        KpVKbsXSZ9wnUCkc/TcRYpcuMsoCFOAHXM7SeY0d1O5nCOAiGyBoHxPxjuOiVR7mS8XN2CdwlRnl
-        6CIHK9HlB5UPlamxq5oqgsjtURX46HDk6PDaPL6JvhIucsps0coqueBFwcWEEqehLstyNuPEq975
-        Ej9Zm+qjLH8m+aI7eMqFoKruUp50ZLvX7Y2b3Ui1RT8S/U4r6TeTI5zjJuGEJ6YpCoWhlHRPMFNk
-        8uf7DUXAzmivJzs22soqBMHT02jNumsQK9QgXDbj+Kgret1Ouz8W426E4xOukp44lSd6l732cK91
-        gV+zLpjxuaUkQWCGlmG5DG5hiKAVEtcJzRUkSwULzpdkKKzXCI8KBh/PRkEULuZEgqvdn9evcbV9
-        9Po1rrafXrvGgCBpehe2SjlD6LMRT5JSiFRfICJlpldiAOwKJBYTP5R5tlCHV4AWQVW9vWnU/oTU
-        XV06wTZ9d5c2sQ9PY1/HI/a10WKH2bkF/Dd8ebFIesOXl9D4DV924EsVBhwRc7wFWt+Yu3dH39PY
-        zxEOzApuv2Wq7uJlXF5c8lKx1m7k8zUsIx/3JEDYKYh83LPtW9F25E7NV2mezQ2BM0OytF9xmsc/
-        sl42MzvcmY+/AAAA//+Cj2SRUfwizc7qw8zVUcpNrAhKLS7NARmMZDd4PK+oxLEE4o6y/BLqTSNA
-        DIMbCrQrI7E4LB88HAob6QdNZIAGGUFWwh2C6lojFOdCNYCDp7a2FgAAAP//AwDQcGo8UR8AAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18195","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195","key":"NTEST-1850","fields":{"statuscategorychangedate":"2025-04-30T18:25:13.029+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:12.710+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:12.797+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/6]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]\n*Defect
+        Dojo link:* http://localhost:8080/finding/259 (259)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 32b970ea-05d3-40b8-9ca2-174880b9f905
+      - bb7913f3-db37-4333-b17c-d7511e8a71a9
       Atl-Traceid:
-      - 32b970ea05d340b89ca2174880b9f905
+      - bb7913f3db374333b17cd7511e8a71a9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:17 GMT
+      - Wed, 30 Apr 2025 16:25:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1420,7 +1526,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=339,atl-edge-internal;dur=36,atl-edge-upstream;dur=295,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=304,atl-edge;dur=272,atl-edge-internal;dur=15,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="_8kh1X9bQK7UECzs4cD0lqaFtZJ4KYmyuayqta3Gpb8d-H58D6ox_w==",cdn-downstream-fbl;dur=308
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1429,10 +1535,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - _8kh1X9bQK7UECzs4cD0lqaFtZJ4KYmyuayqta3Gpb8d-H58D6ox_w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 43ca06bb88482c211c0a51669a7bbd27
+      - 332b06364da28403326ee9154f40c0b0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1465,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1479,9 +1593,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"844\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:59276\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:37872\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -1517,7 +1631,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:16:17 GMT
+      - Wed, 30 Apr 2025 16:25:14 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1535,25 +1649,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       97, "url_ui": "http://localhost:8080/test/97", "url_api": "http://localhost:8080/api/v2/tests/97/"},
       "finding_count": 5, "findings": {"new": [{"id": 256, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/256", "url_api": "http://localhost:8080/api/v2/findings/256/"},
-      {"id": 257, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/257",
-      "url_api": "http://localhost:8080/api/v2/findings/257/"}, {"id": 258, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/258", "url_api": "http://localhost:8080/api/v2/findings/258/"},
-      {"id": 259, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/259", "url_api":
-      "http://localhost:8080/api/v2/findings/259/"}, {"id": 260, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/260", "url_api": "http://localhost:8080/api/v2/findings/260/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/256",
+      "url_api": "http://localhost:8080/api/v2/findings/256/"}, {"id": 257, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/257", "url_api": "http://localhost:8080/api/v2/findings/257/"},
+      {"id": 258, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/258",
+      "url_api": "http://localhost:8080/api/v2/findings/258/"}, {"id": 259, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/259", "url_api": "http://localhost:8080/api/v2/findings/259/"},
+      {"id": 260, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/260",
+      "url_api": "http://localhost:8080/api/v2/findings/260/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -1564,11 +1676,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2502'
+      - '2367'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -1580,11 +1692,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2502\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2367\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:59286\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:37876\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -1599,63 +1711,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 97, \\\"url_ui\\\": \\\"http://localhost:8080/test/97\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/97/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 256, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/256\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/256/\\\"}, {\\\"id\\\": 257, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/257\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/257/\\\"}, {\\\"id\\\":
-        258, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/258\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/258/\\\"}, {\\\"id\\\":
-        259, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/259\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/259/\\\"}, {\\\"id\\\":
-        260, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/260\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/260/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        258, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/258\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/258/\\\"}, {\\\"id\\\": 259, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/259\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/259/\\\"}, {\\\"id\\\": 260, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/260\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/260/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 256,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/256/\",\n          \"url_ui\": \"http://localhost:8080/finding/256\"\n
         \       },\n        {\n          \"id\": 257,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/257/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/257/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/257\"\n        },\n
         \       {\n          \"id\": 258,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/258/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/258\"\n        },\n        {\n          \"id\":
-        259,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/259/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/259\"\n        },\n
-        \       {\n          \"id\": 260,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/260/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/260\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 97,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/97/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/258/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/258\"\n        },\n
+        \       {\n          \"id\": 259,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/259/\",\n          \"url_ui\": \"http://localhost:8080/finding/259\"\n
+        \       },\n        {\n          \"id\": 260,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/260/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/260\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        97,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/97/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/97\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/97/\",\n
@@ -1668,7 +1778,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:16:17 GMT
+      - Wed, 30 Apr 2025 16:25:14 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1693,26 +1803,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1nVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLD5/NS8EiGBDNhsDHQMy4oxnk95HsUAFxDhmPfxD9hXuj1nKVQMOC04XUSWfbOy
-        vbHKRTCnxUIKwBkqSadzFLlSuQKp2HI6W9SqyJEVCtiZIJhkuNW9SC9EJQYT7pwUqX0g5lQRtK/b
-        khzPD3tyNk2u7yty/AQAAP//AwAxx7oMIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:14.452+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - c4736c30-787e-4e58-931b-3a19dd34a5e5
+      - a9bbe70f-85a5-42c2-9bb6-20592407dd6c
       Atl-Traceid:
-      - c4736c30787e4e58931b3a19dd34a5e5
+      - a9bbe70f85a542c29bb620592407dd6c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:18 GMT
+      - Wed, 30 Apr 2025 16:25:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1722,7 +1828,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=139,atl-edge-internal;dur=13,atl-edge-upstream;dur=126,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="r9cKqQi37pSpdWIxBdsmO-bevZY__0HfX1F67B68oKtdfs3qqM4ppw==",cdn-downstream-fbl;dur=242,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=240,atl-edge;dur=167,atl-edge-internal;dur=15,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1731,10 +1837,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 35f3ad5aa26e63a13ffedf420998e698.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - r9cKqQi37pSpdWIxBdsmO-bevZY__0HfX1F67B68oKtdfs3qqM4ppw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - aa75dfdb29ab2e07abf91d9f8e5dc9d7
+      - 21f5943150930d1ebcf0ea23afd9fde8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1758,67 +1872,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61PbRhD/V270MbX1sgGjmU6HgpPQUkqNk3wgDHNIa+mCdKfcnfwI5H/vrmTZ
-        4aG00Gngg+61j9v97e/Wtw4sSy4TJ3I0yAQ0JK8F5InpSV6A6Zk4g4L3VAmaW6Gk6UEibAGW9+KM
-        yxRylfbmoA3uQTKBUoMBaddn48pYVcxI4VXg+4HvavhcgbHTVQlnmsdWxOD0HEH2g11/P8SJgXyG
-        08za0kSel8AMYpuoT8rlNufGCC5dCdZDS9bjpfBCTxhTgdcquIEVyp9Ox+fTPq6NcKl2wTjRrWPQ
-        t8rE3EKq9Kq5Q4IzlAj9cKfvB/3An4Z+FOxGQegO9/Z/Qr99cpKMWHS8VvNCJ0neQ30+Odpcez1J
-        wMRalBQ4XD1gpuB53mOJMFbI2LJSQAxMzdhC6RuXpGMl3+n8mV5UUlC6eH7F59xy7c0FLLzara2D
-        663AHwSjX4z4Aj8XmPaqQKsECzQ55eaGclVdWxpFM54b6DmN4DHeq5btOZlA4Og4W53AHNBX/2vP
-        sQKRVSJKnEhWeEfnAUwGftdG0G6UWn3Cq74wE2vpOg91Zts80OQb9Gyv+04Ka1GBcTa2CcK/12eN
-        mtkF1wRkI4oyF+hw8iAkmKgafsPRcjh6prvfSVl7k03Chv4euhEOl+Hw/7XSwKIGKRoMdpfB7o8w
-        uGwtDsLlIPwRFtfI//r1MRzDLpwO2o2ZWL5vyBGzf3GJaEhTDSnyzT8WwU67gRdQedXwwtNHd7s2
-        9jo2ws6NUdfG/mN3GtpsVomU6hfCifoBTrnFh6Mh3OfXZ0PnWwL3GnWaqq8eHqqKAhcQKX+gBSFT
-        J7K6AswSKrXvMbFUg41ztT7Sr0XcxPH20Rr5isImU1WeHAlT5ny1rmHKvAa8LNHEU49EEITtI/Ew
-        bF1UFm6o7OHGBlSlFkoLu3phEFtxr35p/v1bIQqegvFIwrRKBC5kIs1cM0+3pPgWV1r2DJ3H9RFu
-        yiDn10D8RxXwsCfoAm/QhdFgRBHJuBmXIj4R8uY17RxBSf2LjNus1blc1HubFankGNsXfp3DBLhp
-        kKDXI+fs5N2b49Ork+PD8en5+Go8mfw5wfthnRoMCR6YZsDOkOilZWSXCcOUzFcMSUPkpJRZxX4T
-        mrMzDQWyBqsMotZ9ijwCLCjHvxO+X5ZfIqd5FTF7GP5tVd1jC0xEKiTPHx5ad1/r8Na4ztG7lnAw
-        s6mEzemqpLLtQnLo77ZIbhqlF4KvEd48sPd7m+fhcYu3X3l8g+1mC7lWeWPrcN3R/SeH27awqRk0
-        Erb9gIQFVbfKlT5tvLnOK+inGlli2xQpdqSaZKuixIZY2qdBv9NFCzsbWvhexu+H86P89v+ApVpV
-        JTWKr4VMkBgNw1ph1wCSlZXJIKlRejw5oO81MCHnZIBgljD8KcDw0YIkImVZ6LI3pO6jfFV/X0Xs
-        YqNWyIhJjJcV3Cod+e6OO7ijoGPMcxXzPFPGRiN/5HuzRuaq9s3bH16iMLs4h7giimJv1aJvVYcs
-        Ps1JhU9zeMk8dhEYy/6quLag2VimWJgFhrlDFDYHvKCWPj37gx1USAHsPOayQ4oaPW9/77IJ6N0d
-        O8fetfYTx4fvx/XnQ/Np80yT9UtPw6mwyAYkWuMKR6iIEWGyO3aBOvohMgCW3iAMai8Ip3KeuBLb
-        fTdVc29e5RKRa5FZvPvnL0nFwPc3cvEC3EJYDa7SqYflzQnyAltWogUPj7qZLXKS26YLJ3XCSFmI
-        fxNIq5xjTJf0E66+xxFIwXNC0jn8DQAA///sWW1v2jAQ/ivWpFWASBoghJeq6lBZpUqjmjZtH7ov
-        GMeBTEBQXqgm7cfvOccJkBLoqFp10tQKiO2zz+e753xPwjUqNWawyl0+Q52dzeOLS0zjmFa1xJb6
-        4M+b7Q6tP0CuXcs6mUrdktk+uzjYZ7vVe7Jd9HhlF/vpdrGP2uXFbeKU2QTxljldv6bsQ22sNkwk
-        GyJQ0XgjJybr1RnBONvFgOxv1jBzEFDPLfPVDhs7GCrcBST+DBhlJCh9VI5V8FHdt/1Dm2c1xCOa
-        f+DLOCk0sCK8SU3xvODcPYHa1yAJYcsbfy6BnTK199k0vuBCyFWsfm6cb0twuMH4GrA4VyMA+GvY
-        NP3gnLtrP0KekJRsO4B/j2wOJ8puBXSi480KY4b7CyP9UZfrG0uovUFrR97g5t4QaW/gcYz0G9XZ
-        w8wXM4Zr83QKCE4Af2zFsdZyyjhDRSMgiDuRCLlHeowHaqPGJ76cJgDjMZtJ7kJyzZFAzXS37PtG
-        oRHQfi63M8tuf1ZP9bc9EkM+qxrBzfrRPc26G7szYOQM4miEj6tg7x8/GEL8Pn2Qf+GRthVhllUy
-        mftCH9rIV3lUn9k3ddUiC+vDSJVhAJk5OkK9ecjdLlZcxCRzFzBfPTCkvbXvSnfHnb4gpHD/xNJ/
-        4xRadBVQ1iQfr3B34S+rrFL9vYAPx0E/99u9mPHieOGciBcO4YXzPLw4KWU8wotTk9b28b42Xjj/
-        8eIV8ML+t/DCyUWP4MVjtqOdF/zFYres3mnYZR05/UWFUBzClxTHQxxNYaidU1OFDiufo9hRxjlY
-        OeeQmadsYBlPZuXK7NTuxQpORceMCpO0PoySxYJT8fruYHVFJicmKghPLHOJj7iCxxJ/dutett1W
-        t9OdNDqWbImeJXrtptdreA7WyQdhhQPDJPnDwHUpGjBSBO6vD1uKoA6muQ5S4MrU0kQprYaRTEbD
-        2tJqdLnbsG2nI7od4OVETDoWlve49Lriyr1Us7xvDd43b/CfyhkLvtR1n2GkTZGZRMYDDGE0TSoo
-        zTQOyVLGivOIDAV5hfR8HuHn9ciwzNWS6IYinf72NS7y8W9f4yKf/9Y1Bg65KUus+aBruD4bcc9L
-        hPBVAFFZl7LSKYrdB0sa+DEJg5U8vwe+COJPdaTR+yT05qFLK+jXa/tJJLsMVO0ybtkue2Fh58Ad
-        atQv4ssfAAAA//8aLV9olpIGtHwBAAAA//8i08Wj5QutXUyX8gW9GIC3xuCNF6Cr0yF5rxo08Q1l
-        GwAtzC9JhM7no5uCs9mFs1zC2R4zwl7y4ZoaMsDVAAUVCFglDHA1QI1x6TCGt/BS88oyi/LzIK04
-        iFBKKXQxCYRLVOjl50JMqIYxocU9GcUv0joYfZi5Okq5iRVBqcWlOSCDkewGz5wUlTiWQNxRll9C
-        vQlbiGFwQ4F2ZSQWh+WDJ55gc6qgKWPQdA7ISrhDUF1rhOJcqAZw8NTW1gIAAAD//wMAFuD777sk
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:07.743+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:07.506+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
+        (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 77eae5be-6d49-4622-99d1-510d4a4f951d
+      - e2fcadfb-97de-4a72-936d-31c231fbee13
       Atl-Traceid:
-      - 77eae5be6d49462299d1510d4a4f951d
+      - e2fcadfb97de4a72936d31c231fbee13
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:18 GMT
+      - Wed, 30 Apr 2025 16:25:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1828,7 +1942,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=283,atl-edge-internal;dur=21,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=301,atl-edge;dur=268,atl-edge-internal;dur=16,atl-edge-upstream;dur=250,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="-RNS25MXiLoUTO5DUAZFvC43cikladAM24mi4-ixxqGWIJZ1kLK_EQ==",cdn-downstream-fbl;dur=304
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1837,10 +1951,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -RNS25MXiLoUTO5DUAZFvC43cikladAM24mi4-ixxqGWIJZ1kLK_EQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ea38e62d029b87c11f7fd7b2275c99aa
+      - 79aab7bd8979a37710097aee89efd909
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1867,26 +1989,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1nVd3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwBbLE7NK+EjyIDNE6AJLCvGeDbjWRADXECAQ96FP+BQtd05S6FiwGnOaZEWBf1m
-        ZXdjlA1gRvNCCsA5KklnCxSZUpkCqdhyNi9qlWfIcgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAhfYu/SACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:15.404+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 70b86c57-1715-4a6f-a3f0-744950ce2f20
+      - 4b4e15b7-1980-4e59-9e49-5e930de7d574
       Atl-Traceid:
-      - 70b86c5717154a6fa3f0744950ce2f20
+      - 4b4e15b719804e599e495e930de7d574
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:18 GMT
+      - Wed, 30 Apr 2025 16:25:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1896,7 +2014,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=15,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="uldF8UCP8TNkipEi5MC-S7Dh9I2Tk1JaWNKa7malTuxrMfQYVQlVXw==",cdn-downstream-fbl;dur=248,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=245,atl-edge;dur=161,atl-edge-internal;dur=13,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1905,10 +2023,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8dac9acbf37a4821f35529f7cc336eba.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - uldF8UCP8TNkipEi5MC-S7Dh9I2Tk1JaWNKa7malTuxrMfQYVQlVXw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 84eb3abe15759dd73537d5b90003fd3c
+      - 664de2b4d66e801647c1e0de8cd2be92
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1932,66 +2058,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvybbMmU7HtZXEreu6spI8OB4PTK5IxCTAAKCOxP7v3eUh
-        xYfS2p3GfiCuPbD77YfVVweWJZeJEzkaZAIaktcC8sT0JC/A9EycQcF7qgTNrVDS9CARtgDLe3HG
-        ZQq5Sntz0Ab3IJlAqcGAtO3ZuDJWFTNSeBX4fuC7Gj5XYOx0VcKZ5rEVMTg9R5D9YNffD3FiIJ/h
-        NLO2NJHnJTCD2Cbqk3K5zbkxgktXgvXQkvV4KbzQE8ZU4HUKbmCF8qfT8fm0j2sjXKpdME701THo
-        W2VibiFVetXcIcEZSoR+uNP3g37gT0M/CnajIHSHe/s/od8+OUlGLDpeq3mhkyTvoT6fHG2u3U4S
-        MLEWJQUOVw+YKXie91gijBUytqwUEANTM7ZQ+sYl6VjJdzp/pheVFJQunl/xObdce3MBC692a+Ng
-        uxX4g2D0ixFf4OcC014VaJVggSan3NxQrqprS6NoxnMDPacRPMZ71bI9JxMIHB1nqxOYA/rq3/Uc
-        KxBZJaLEiWSFd3QewGTgb9sIuo1Sq0941RdmopWu81BntssDTb5Bz+a676SwFhUYZ22bIPx7fdao
-        mV1wTUA2oihzgQ4nD0KCiarhNxwth6NnuvudlHU3WSds6O+hG+FwGQ7/XysNLGqQosFgdxns/giD
-        y87iIFwOwh9hsUX+3d1jOIYdHGdi+b7hQEzyxeXjk4PuJE9TDSnyzT8WwU63gRdQedXwwtNHd7dt
-        7G3ZCLdujLZt7D92p6HNZpVIqX4hnKgf4JRbfDgawn1+fTZ0viFwr1Gnqfrq4aGqKHABkfIHWhAy
-        dSKrK7hreZq0aRE3Ufv6aI08w6MmU1WeHAlT5nzVViwuo1v2PUKDqriNhga8LNHEU49EEITdI/Ew
-        bNuoLFxT2cONNahKLZQWdvXCIHbiXv3S/Pu3QhQ8BeORhOmUCFzIRJq5Zp5uSPEtrnTsGTqP6yNc
-        oz7n10D890RpEG08GYhgG0aDEUUk42ZcivhEyJvXtHMEJfUvMu7yWGd3Ue+tV6SSY2xf+HUOE+Cm
-        wYZuR87Zybs3x6dXJ8eH49Pz8dV4MvlzgvfDOjUYEjwwzYCdIdFLy8guE4Ypma8YkobISSmziv0m
-        NGdnGgpkDVYZRK37FHkEWFCOfyt8vyy/RE7zKmL2MPybqrrHFpiIVEiePzzUdl9teGuk5+hdO6fM
-        phLWp6uSynYbkkN/t0Ny0yi9EHyN8PqBvd/bPA+PG7z9yuMbbDc7yHXKG1uHbUf3nxzu2sKmZtBI
-        2PUDEhZU3SpX+rTx5jqvoJ9q5I1NU6TYkWqSrYoSG2Jpnwb9zpoWvpfYh0Jryrgfzo/y2/8DlmpV
-        ldQovhYyQWI0DGuFXQNIVlYmg6RG6fHkgL7XwISck2WCWcLwpwDD1wySiJRlocvekLqP8lX9fRWx
-        i7VaISMmMV5WcKt05Ls77uCWgo4xz1XM80wZG438ke/NGpmr2jdvf3iJwuziHOKKKIq9VYu+VVtk
-        8WlOKnyaw0vmsYvAWPZXxbUFzcYyxcIsMMxbRGF9wAtq6dOzP9hBhRTAzmMut0hRo+ft7102Ab29
-        ZefYu9Z+4vjw/bj+fGg+XZ5p0rYANJwKi2xAojWucISKGBEmu2UXqKMfIgNg6Q3CoPaCcCrniSux
-        3XdTNffmVS4RuRaZxbt//pJUDHx/LRcvwC2E1eAqnXpY3pwgL7BlJVrw8Kib2SInuU26cFInjJSF
-        +DeBtMo5xnRJP+HqexyBFDwnJJ3D3wAAAP//7Fltb9owEP4r1qRVgEgaIISXqupQWaVKo5o2bR+6
-        LxjHgUxAUF6oJu3H7znHCZAS6KhaddIEAmL77PP57jnfQ7hGpcYMVrnLZ6izs3l8cYlpHNOqlthS
-        H/x5s92h9QfIvmtZJ1OpWzLbZxcH+2y3ek+2ix6v7GI/3S72Ubu8uE2cMpsg3jKn69eUfaiN1YaJ
-        ZEMEKhpv5MRkvTojGGe7GJC9Zg0zBwH13DJf7bCxg6HCXUDiz4BRRoLSR+VYBR/Vfds/tHlWQzyi
-        +Qe+jJNCAyvCm9QUzwvO3ROofQ2SELa88ecS2ClTe59N4wsuhFzF6ufG+bYEhxuMrwGLczUCgL+G
-        TdMPzrm79iMkEEnJtgP498jmcKLsVkAnOt6sMGa4vzDSH3W5vrGE2hu0duQNbu4NkfYGHsdIv1Gd
-        Pcx8MWO4SE+ngOAE8MdWHGstp4wzVDQCgrgTiZB7pMd4oDZqfOLLaQIwHrOZ5C4k1xwJ1Ex3y75v
-        FBoB7edyO7Ps9meFVn/bIzHks6oR3Kwf3dOsu7E7A0bOII5G+LgK9v7xgyHE79MH+RceaVsRZlkl
-        k7kv9KGNfJVH9Zl9U1ctsrA+jFQZBpCZoyPUm4fc7WLFRUwydwHz1QND2lv7rnR33OkLQgr3Tyz9
-        N06hRVcBZU3y8Qp3F/6yyirV3wv4cBz0c7/dixkvjhfOiXjhEF44z8OLk1LGI7w4NWltH+9r44Xz
-        Hy9eAS/sfwsvnFz0CF48ZjvaecFfLHbLaJCGvV0IxSFcRlE5RM4Uh+aEWKHDKuuwc86qKJFzDpkV
-        ygaWcRBWGU9m5Wvu1O7F0k5Fx4wKk7Q+jJLFglPx+u5gdUUmJyYqCE8sc4mPuILHEn9261623Va3
-        0500OpZsiZ4leu2m12t4DtbJB2GFA8Mk+cPAdSkaMFIE7q8PW4qgDqa5DlLg6gykiVJaDSOZjIa1
-        pdXocrdh205HdDvAy4mYdCws73HpdcWVe6lmed8avG/e4J3KGQu+1HWfYaRNkZlExgMMYTRNKijN
-        NA7JUsaK84gMBXmF9Hwe4ef1yLDM1ZLohiKd/vY1LvLxb1/jIp//1jUGQLkpb6z5oGu4Phtxz0uE
-        8FUAUVmXstIpvN0HSxr4MQmDlTy/B/AI4k91pNH/SejNQ5dW0H+v7SeR7DJQtcu4ZTvnlkMN7k+G
-        kT8AAAD//xotRihNMIOzGAEAAAD//8Lv4tFihNYupksxgl4M4GqmmcBbY/DGC9A76ZBMWQ2a+Iay
-        DYAuyS9JhM7no5uCqz1mgKtcMjDCXsDhmhoywOkBnO01uM/QdeBqyBnjlIC38FLzyjKL8vMgrTiI
-        UEopdDEJhEtM6JXll1BvohRiGNxQoE0ZicVh+eAJH9jsJjALQJxcDWNC6xeyHQBeeKMPM1dHKTex
-        Iii1uDQHZDCSZ8FTNUUljiUQj4OmjEHTOSCvw8VRNRuh6IZqALu2trYWAAAA//8DAHN/+kK7JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:07.743+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:07.506+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
+        (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - ace2b139-ff5e-4a4b-8397-f0ba740dd5be
+      - 1a845ab5-7182-412a-bf34-64b54c1e448e
       Atl-Traceid:
-      - ace2b139ff5e4a4b8397f0ba740dd5be
+      - 1a845ab57182412abf3464b54c1e448e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:19 GMT
+      - Wed, 30 Apr 2025 16:25:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2001,7 +2128,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=400,atl-edge-internal;dur=13,atl-edge-upstream;dur=387,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="-mWUeBOkl9aymAzsngqL2mJc8w5P-ivgxREMUM6VQ3daRm0TFfM2dA==",cdn-downstream-fbl;dur=381,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=379,atl-edge;dur=292,atl-edge-internal;dur=15,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2010,10 +2137,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 82e46a17c2e4998f87de230e61a57612.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -mWUeBOkl9aymAzsngqL2mJc8w5P-ivgxREMUM6VQ3daRm0TFfM2dA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 0a7bf9d2ad3480e5d9e38def9a798797
+      - 7817a5d0925db3b330a404bb170a1043
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2040,41 +2175,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 5371b30a-d76f-4e0b-ae23-21df7b4f75aa
+      - b7684974-065d-4c06-b08f-e3016241e053
       Atl-Traceid:
-      - 5371b30ad76f4e0bae2321df7b4f75aa
+      - b7684974065d4c06b08fe3016241e053
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:19 GMT
+      - Wed, 30 Apr 2025 16:25:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2084,7 +2206,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=291,atl-edge-internal;dur=14,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="etMx3-2yxOVJjC5W0yqXDS4u1l8-4dL537M5pzmS7ABc9-3lq_iDvw==",cdn-downstream-fbl;dur=355,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=352,atl-edge;dur=276,atl-edge-internal;dur=15,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2093,13 +2215,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2bdfafaaaec33c116889588ecd9de280.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - etMx3-2yxOVJjC5W0yqXDS4u1l8-4dL537M5pzmS7ABc9-3lq_iDvw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 39d5b893459ad323a0b4fae3904d0768
+      - 9460fbd12b517916526f2c6a671420d5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2111,7 +2241,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/94]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -2120,29 +2250,29 @@ interactions:
       | Inactive, Verified, Risk Accepted |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
-      | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Feb.
-      9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression Denial
+      | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* May
+      30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression Denial
       of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]\n*Defect
       Dojo link:* http://localhost:8080/finding/257 (257)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
       Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -2156,27 +2286,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3375'
+      - '3350'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - d3b67f06-8e64-4c31-a7aa-2092d23a1417
+      - b9cb8993-b190-48ef-afd5-b74ba2ecb200
       Atl-Traceid:
-      - d3b67f068e644c31a7aa2092d23a1417
+      - b9cb8993b19048efafd5b74ba2ecb200
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:20 GMT
+      - Wed, 30 Apr 2025 16:25:17 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2186,17 +2318,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=482,atl-edge-internal;dur=13,atl-edge-upstream;dur=470,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="RkfO_tH9843GilePXor0bKgFg4l8zlP0qHDLSbDK5S-S0b7QAfI7FQ==",cdn-downstream-fbl;dur=672,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=95,cdn-upstream-fbl;dur=670,atl-edge;dur=542,atl-edge-internal;dur=17,atl-edge-upstream;dur=525,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1b7fa09f50c08a88d619f90eef5ee94a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - RkfO_tH9843GilePXor0bKgFg4l8zlP0qHDLSbDK5S-S0b7QAfI7FQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a209dcd882deb691798f884d5b27b6a6
+      - 58112f599009482b9c76a0d30f38071b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2220,67 +2360,68 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf6mNp6swGjmU6HgkloKaXGIR8IwxzSWrog3Sl3J78k8N+7K1l2
-        MDgtdBr4oHvbl9t99rn1VwfmJZeJEzkaZAIakmMBeWI6khdgOibOoOAdVYLmVihpOpAIW4DlnTjj
-        MoVcpZ0paIN7kIyg1GBA2uXZuDJWFRNSeBP4fuC7Gj5XYOx4UcK55rEVMTgdR5D9YNffD3FiIJ/g
-        NLO2NJHnJTCB2Cbqk3K5zbkxgktXgvXQkvV4KbzQE8ZU4LUK7mCB8mfj4cW4i2sDXKpdME701THo
-        W2VibiFVetHcIcEZSoR+uNP1g27gj0M/CnajIHT7e/s/od8+OUlGLDpeq3mlkyTvoT6fHG2uvZwk
-        YGItSgocrh4wU/A877BEGCtkbFkpIAamJmym9J1L0rGS73X+Qi8qKShdPL/hU2659qYCZl7t1trB
-        5Vbg94LBL0Z8gZ8LTHtVoFWCBZocc3NHuapuLY2iCc8NdJxG8ATvVct2nEwgcHScLU5hCuir/9Bx
-        rEBklYgSJ5IV3tHZgEnPbzdKrT7hjV4Z8KV0He46gW24afINSNa3ei+FtajAOCvbhNTf67NGTeyM
-        a8KrEUWZC3Q42bg55qNGWX8w7w9e6O53MtPeZJWXvr+HboT9edj/f6002a+xiAaD3Xmw+yMMzluL
-        vXDeC3+ExSXAHx6ewjHYhtNw20av3ZiI+WVDjgiLq2uESZpqSJFv/rEIdtoNvJnKq4YXnj+6u21j
-        b8tGuHVjsG1j/6k7DW02q0RK9QvhRN0Ap9ziw9EQ7ssLt6HzNYF7jTpNZVkPD1VFgQuIlD/QgpCp
-        E1ldwcOSp0mbFnETta9P1sgzPGoyVeXJkTBlzhfLUsZldMteImaovJfR0ICXJf547pEIgrB9JDbD
-        tqKyzY1toApXoCq1UFrYxSuD2Ip79Uvz798KUfAUjEcSplUicCETaeaaabpmy3e40tJq6DwtnHBV
-        Bjm/BSJGqoDNnmAbeINtGA0GFJGMm2Ep4lMh745p5whK6l9k3Oaxzu6s3lutSCWH2L7w2xxGwE2D
-        Db0cOeen79+enN2cnhwOzy6GN8PR6M8R3g/r1GBI8MA4A3aOL4C0jOwyYZiS+YIhm4iclDKr2G9C
-        c3auoUA6YZVB1LrPsUqABeX498L3y/JL5DSvImYPw7+uqkdsgYlIheT55qFl97UMb430HL1rCQcz
-        m0pYna5KKttnkRz6rr+70yK5aZReCb5GePXyPu5tXobHNd5+5fEdtpst5Frlja3DZUf3nxxu28Km
-        ZtBI2DYKEmZU3SpX+qzx5javoJtq5I11U6TYkWqSrYoSG2Jpnwf9zooWvpfYTaEVZTwO50f57f8B
-        S7WqSmoUj4VMkBgNw1phtwCSlZXJIKlRejI6oO8tMCGnZJlgljD8KcDw0YIkImVZ6LK3pO6jfFN/
-        30TsaqVWyIhJjJcV3Cod+e6O27unoGPMcxXzPFPGRgN/4HuTRuam9s3b71+jMLu6gLgiimLv1Kxr
-        1RZZfLOTCt/s8Jp57Cowlv1VcW1Bs6FMsTALDPMWUVgd8IJa+uz8D3ZQIQWwi5jLLVLUAXr7e9dN
-        QO/v2QX2rrWfOD68HNafD82nzTNNli89DcfCIhuQaI0rHKEiRoTJ7tkV6uiGyABYer0wqL0gnMpp
-        4kps991UTb1plUtErkVm8R6fvyYVPd9fycUzcAthNbhKpx6WNyfIC+xliRY8POpmtshJbp0unNQJ
-        I2Uh/o0grXKOMZ3TT7j6HkcgBc8JSRfwNwAAAP//7Fltb9owEP4r1qRVgEgaIISXquqqskqVRjV1
-        2j50XzCxA9mARAmhmrQfv+ccJ0BKoKNq1UlTKyC2zz6f757zPYlWqNSYwSq3+Qx1djJbnp1jGse0
-        qiW21Ad/2mx3aP2bBdV8K1knY6kLdJ3d+fFPdum6MiQH3GUoBxtvt3pPNpQerwxlP91Q9kFDvbiR
-        nCcbCRGZuWW/pgxGbaw2SCQbIJTReC3HJuvVGQE920aJ7G/aMHOYUM8t89XcATsYKGQGaP4IGOUs
-        KH1QjlXwUd21/X2bZzVELJq/48s4KniwItxLTfG88N0+gdqXIIlgy2t/JoGuMrX3yWR5xtVpq59r
-        b9wQHKyzQA1onasRID1oYDX94JSLlR8jxUhKxx0kCI9sDifK7g10oqP1CiOGGw4j/VG56ztNpL1B
-        a0feIHJviLU38OUSCTqus4ep704ZrtqTCUA6AUCykGOtxYRxhprHhSBuTW7EPdJjlLq18YkvJgng
-        esSmkgtIrjhSrJnuln1bKzREPpjJzdyz3Z9VXP1Nj8SQz6qKEFk/uidZd2N7BoycQhyN8HEV/f3D
-        B0M5oU8f5F94pG3FmCVMxjPf1Yc29FWm1Wf2VV3GyML6MFJlGFBnho5Ibx5yN/MQoEAytwHz1QND
-        Ylz5Qootd7pDSOGGiqX/xim0aBhQXiUfr3Ax9xdVVqn+nsOHl0E/99udmPHieOEciRcO4YXzPLw4
-        Koc8wotjs9jm8b42Xjj/8eIV8ML+t/DCyUUP4MVjPqSdUwLFcriMKGnYZR05QUY11DKCLykWiHid
-        wlA7J68KHVY+R7GjjJWwclYiM0/ZwDImzcqV2arui8Wfio4plS5pBRkn8zmn8vbd3vqLTE5cVRAd
-        WQgTY3EBjyWG7Uact0Wr2+mOGx1Lttye5fbaTa/X8Byskw/CCnuGSfKHSyEoGjDSDcSvDxuKoFKm
-        ufay58rU0kSxrYaRTMbg2tJqdLlo2LbTcbsd4OXYHXcsLO9x6XXdC3GuZnnfunzfvMZ/KmfM+UJX
-        hoaRNsVmEhsPMITRNKnkNNM4JEsZIecxGQryCun5LMbPq6FhmeGCCIkiE//2NS5S+W9f4+KrgLeu
-        MXBIpMyyZoyu4PpsyD0vcV1fBRBVeSlvnaLYfbCggR+TKAjl6T3wxSWGVUcavYpCbx66tIJ+Abeb
-        ZrLLQNUuY5/tslcafwAAAP//MoEX3EXQUn+0fKFbSqJh+QIAAAD//6KZi0fLF1q7mC7lC3oxAG+N
-        wRsvQFenQ/JeNWjOHMo2AFqYX5IInfFHNwVnswtnuYSzPWaEveTDNXlkgKsBCioQsEoY4GqAGuPS
-        YQxv4aXmlWUW5edBWnEQoZRS6HITCJeo0MvPhZhQDWNCi3syil+klTL6MHN1lHITK4JSi0tzQAYj
-        2Q2eWykqcSyBuKMsv4R6U7oQw+CGAu3KSCwOywdPTcHmYUGTyqAJH5CVcIegutYIxblQDeDgqa2t
-        BQAAAP//AwDnWSNG3SQAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:07.743+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:16.959+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Inactive, Verified, Risk Accepted |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:*
+        May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression
+        Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]\n*Defect
+        Dojo link:* http://localhost:8080/finding/257 (257)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - ddace946-c62c-4b51-9bc1-781d09ade795
+      - 45205931-a90c-4f6e-a0fc-caf39498c7fd
       Atl-Traceid:
-      - ddace946c62c4b519bc1781d09ade795
+      - 45205931a90c4f6ea0fccaf39498c7fd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:20 GMT
+      - Wed, 30 Apr 2025 16:25:17 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2290,7 +2431,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=263,atl-edge-internal;dur=16,atl-edge-upstream;dur=248,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="gK50Qg11MnrVrDIxEk76lC09utEq9YllzEz520ld9XuzK0jNlKI0IA==",cdn-downstream-fbl;dur=484,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=481,atl-edge;dur=398,atl-edge-internal;dur=16,atl-edge-upstream;dur=381,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2299,10 +2440,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 d4aa84013921cdd269ab20fbd29fbe1e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - gK50Qg11MnrVrDIxEk76lC09utEq9YllzEz520ld9XuzK0jNlKI0IA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - e185ade1ddc6f5ad299da7a65fd56dcf
+      - 4bad563c5d8b8d55418cd30314128fc2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2328,21 +2477,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1608/transitions
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/transitions
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - e6c43697-68bb-4459-8e1e-722cb592194a
+      - 01a55549-2298-4f3a-8ef1-9e5f823bdd3d
       Atl-Traceid:
-      - e6c4369768bb44598e1e722cb592194a
+      - 01a5554922984f3a8ef19e5f823bdd3d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:21 GMT
+      - Wed, 30 Apr 2025 16:25:18 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2352,17 +2503,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=566,atl-edge-internal;dur=16,atl-edge-upstream;dur=551,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=563,atl-edge;dur=526,atl-edge-internal;dur=16,atl-edge-upstream;dur=508,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="baQeUG7kt9cPunLJ_Jk4xNlfetjLVyf94hrXG6dk3CXcx31UBM3ObA==",cdn-downstream-fbl;dur=567
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - baQeUG7kt9cPunLJ_Jk4xNlfetjLVyf94hrXG6dk3CXcx31UBM3ObA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a89a04a6ec18ffbf27aaf152fc88865d
+      - 2172d69a7f7ef86b63881ac119f8f57b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2389,26 +2548,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1rVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmDzBGgCy4oxns14FsQAFxDgkHfhDzhUbXfOUqgYcJpzRtMCsm9W
-        djdG2QBmNF9IAThHJemsQJEplSmQii1n80Wt8gxZroCdCbyOhtt2EPGFqMSo/Z2VIrYPRJ8qguZ1
-        W5Lj+WFP1sTJ9X1Fjp8AAAD//wMAsZ0g5iACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:19.040+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 929dd9b5-1581-4d4e-bea8-a69868538885
+      - ace3fa1d-00bb-460e-8f6b-f59328de3e20
       Atl-Traceid:
-      - 929dd9b515814d4ebea8a69868538885
+      - ace3fa1d00bb460e8f6bf59328de3e20
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:21 GMT
+      - Wed, 30 Apr 2025 16:25:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2418,7 +2573,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=189,atl-edge-internal;dur=16,atl-edge-upstream;dur=174,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="FW7-l1PCZH6VteqDnSqAE2tvM_rqfvNHzSZeST4NTgDYN2r7W8OfEA==",cdn-downstream-fbl;dur=253,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=250,atl-edge;dur=161,atl-edge-internal;dur=19,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2427,10 +2582,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9041bc1ab42f996e0fd971e734eff2e2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - FW7-l1PCZH6VteqDnSqAE2tvM_rqfvNHzSZeST4NTgDYN2r7W8OfEA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - fd8fa29095619861b82dc9ca83c49bb3
+      - 7b9f3c1218b5537800df22edb72203ef
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2454,68 +2617,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbU/jRhD+Kyt/pCF+SQLBUlUhCHe0lFII8IFD0WJP7D2cXXd3HZI7+O+d8UsC
-        IaGFqickvG+zMzvzzDOT7w7Mci5jJ3Q0yBg0xEcCsti0JJ+AaZkohQlvqRw0t0JJ04JY2AlY3opS
-        LhPIVNKagja4B/E55BoMSFufjQpj1WRMF458z/O9toa/CjB2OM/hTPPIigicliNIv7/j7QU4MZCN
-        cZpam5vQdWMYQ2Rj9VW1uc24MYLLtgTroibr8ly4gSuMKcBtLriHOcqfDgcXw21c6+NSaYJxwu+O
-        QdsKE3ELidLz6g0xzlAi8ILetudv+94w8EJ/Jwy89l6v8xPa7ZGRpMSi4eU1HzSS5F28zyNDq2fX
-        kxhMpEVOjsPVfWYmPMtaLBbGChlZlguIgKkxe1D6vk3SkZKXOnunFYUUFC6ejfiUW67dqYAHtzRr
-        aWC95Xsdv/+LEd/g5wmGvZigVoIFqhxyc0+xKu4sjcIxzwy0nErwGN9VyracVCBwdJTOT2AKaKv3
-        1HKsQGTliBInlAW+0VmBScdrNnKtvuKLPujwWrp0dxnAxt00eQaS5asupbAWLzDOQjch9bfyrFFj
-        +8A14dWISZ4JNDheeTnGo0RZtz/r9t9p7huRaV6yiEvX20Uzgu4s6P6/Wqrol1hEhf7OzN/5EQpn
-        jcZOMOsEP0JjDfCnp9dw9DfhNGg2xmJ2VXEgRv/m9vXJTnOSJ4mGBPnmH5Og12zgy1RWVLzwoTxY
-        XrA+FV4yzzXSC0u5YXcAkkUKkQ4WYqYks6kwrGQJ4p86Zw6R+J01XtvZ9LDdDRvBxo3+po291z56
-        i8uDnYbLiUPLguaE235N7eQxLaLG0atrlNf4TJOqIosPhckzPq+zH5cfuMVKWVWY90eoql/LiuVW
-        12nioXJ4oApCSmnqNS0ImTih1QXpxkvtFUKc2Kj2kwZ0A8X4lR/8oO37QeOHVYcumHd1Y1MOBIsc
-        yLVQWtj5B13QiLtlYfz3pU1MeALGJQnTXCJwIRVJ2jbTZAnUz7jSQD9Yg9ig0+TEaCvcGvnl/36/
-        i4PHLTrgBc82yHsZvwPi+zUZTzS51mH+JpT7ffIcJt4gF9GJkPdHtHMIObVlMmqwViLwodxbrEgl
-        B9iV8bsMzoGbCr+6HjlnJ5efjk9HJ8cHg9OLwWhwfv7HORqP9GPQdXhgmAI7w8ImLSO9mOGY7Nmc
-        IUmKjC5lVrFfhebsTMMEWZIVBrHZXkeWPqak4z0Kz8vzb6FTFXuMMoaJ8nINCWLAEiF5tnqobipr
-        95YZkqF19ZwQkEhYnC5ySvy1iH/ZxVX93wdBWgkv+reXxPk+3K4Q6EozWCk6qLvU/2Rt0+q6nVpJ
-        p2l+4kpxpDKlTytbMC4gV0wro4xlAMfSrkd7bxNv9Ba88VaoX/rxi3z+t88SrYqcGt8jIWPkPbOs
-        TnlhUixNBM/j83363gETckoKCF8xw582DKszxCFdlgZt9omu+yK3yu9WyG4W1woZMom+soJbpUOv
-        3Wt3Hsnh6O9MRTxLlbFh3+t77riSGZW2uXvdWxRmNxcQFcRh7LN62LZqgyz2IHGBPUhwy1x24xvL
-        /iy4tqDZQCaYkRN08wZRWBxw/VL69Ox3tl9g7rOLiMsNUtTRunu7t5VDHx/ZBfbipZ04PrgalJ/r
-        6tPEmSZ1S0PD4d8AAAD//+xZ+2vbMBD+V8SgJQmxYyeO8yilKwuFwlpGy/ZLGUSxFcfUj+BXN+gf
-        v+/kRxK3SbqUlg6WhtS2dNLp9N13urObgAZIVGIKVxiIEaOyR3aHMZQuXB8+1+vqUgvCaJDZaoD0
-        RXXCrJOlXgDUJqCUzmb/nzRET9MqOetBqL6bREINI6cDv+YEdxdnc+KDDrqqi8T3SG61XbiRG0aD
-        dfG5EU7qcdj0F6Wkch0TEbjcIyTdiihD5skU1riuRmizYy85OcUwpqo1t9iy2PhOtz+g+S8DymEz
-        0SZjyYSgzW7c+J6dW5ZYEgCfM5SJhfd7oxcbqugvDWW83FDGXkO9uZHMFxsJHlnCctySBqNnrDVJ
-        BZvAlfHwQsxUNmozYni2yRLl30JXK5qQ9z313eCAFUwkK7MJaJlRsILSe+VYAz/N55a/a/GsBY/F
-        4zv8Uw5yHswIeMkhXue+mzvQug3TCLa8cD0BdhW5vY+d5ITL3ZaXKzSuCU5WUaAFtq7UCBEeCmJV
-        3bDD7cyNEUkExeEBAsScbA4QlQcG2tHpaoYpw9GGkf4iKg8zUYGGQjtCg12hIS7QwJOEW/dxmz0s
-        XGvBkAc4Dkg6BUGyJcdcgcM4Qw5nQRDHJSvic9JjmsNa+coDJwVdT9lCcBuSGfeQOeWrZT9WCl0h
-        HnhiPfZstpep5XgdkejyTSYJdtmOZqds1jdHQM8FxPEQGJfeP96/MRQTxvRD+MItLSvGKMt05rlW
-        sWlXroy0xZ59l6cwsnCxGbkyDKzjoSEqFg+5S38JUiCZ65C58oYhMGauLewNON3ApXA0xdR/A4pC
-        dBlSXCWMN7jtu0GTNZqPPjCchOMKt89yxpvzhXkgX5jEF+br+OKgGPKELw6NYuvb+958Yf7ni3fg
-        C+Pf4guzEt3DF08LJv2qsFfPg7dlRLqxnhElESAjazlUW6p3rUqAtQajqnvVGrRtElpVjiitsK3j
-        tvKEtq0Ip1XKSAdYUHZS5OjraX4954tT3+eU2n7amX+RyamYFUYHJsFUqjgDYqmAdmmf9u3ecDCc
-        6QNN9KyRZo363flIn5uYp+qEGXZ0E4SHc9smb0BPK7R/f15TBJkyjbXzbYDcA6E6Ud6NZMqKtCE0
-        fcht3TDMgTUcgC9n1mygYfo5F/OhdWafylGOeudH3Qt8cznF50GRGSpK/ihW01h5gCGUrkopp5r7
-        IVlKWXIek6EgL5meezEuv1wpmroMqGRWf7Pw8TWuv5r4+BrXX218aI3/AAAA//8CuhhYQKVAhr2h
-        g0XOwKSv4JuYllaanJwJzkCgXh5kWBpSvEWBxo+slFxLi/ILUvWjgAVPMmgIFprTQFNrQFl41gXZ
-        AJ1QxD7MZIKrUDXBNTxtAh+eLoIW7qPFCEqCAQAAAP//omWCGS1G6OHi0WIESzGCXgzgaqaZwFtj
-        8MYK0DvpkExZDVoDAGUbAF2SX5IIXcGAbgrOZhfOcgnX9JCBEfaSD2ezDKfPcLbX4F5GkzDGpcMY
-        3sJLzSvLLMrPgzTxIEIppdDlMxAuMaFXll9CvZlSiGFwQ4E2ZSQWh+WD54Jgk7PALABxcjWMCa1f
-        yHYAeKmRPsxcHaXcxIqg1OLSHJDBSJ4FT+QUlTiWQDwOmnXOyQc19pHEUTUboeiGagC7tra2FgAA
-        AP//AwBL/rcvrSUAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:18.266+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:18.244+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_10873_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:18.266+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Inactive, Verified, Risk Accepted |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:*
+        May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression
+        Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]\n*Defect
+        Dojo link:* http://localhost:8080/finding/257 (257)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 9a5d5e11-119d-4345-8184-58969eb32fd5
+      - c3223988-c40d-484b-9459-91d7b1c9809f
       Atl-Traceid:
-      - 9a5d5e11119d4345818458969eb32fd5
+      - c3223988c40d484b945991d7b1c9809f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:22 GMT
+      - Wed, 30 Apr 2025 16:25:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2525,7 +2687,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=257,atl-edge-internal;dur=12,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="hUTE0T2snwQb-Dyb9nunOy40GLANpOmNvR45xiNevAge08mAvC_-fg==",cdn-downstream-fbl;dur=354,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=351,atl-edge;dur=277,atl-edge-internal;dur=18,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2534,10 +2696,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8f3e5b5af450fbcfb7e821f6aa6b3d76.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - hUTE0T2snwQb-Dyb9nunOy40GLANpOmNvR45xiNevAge08mAvC_-fg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - c297861de34c530bca858dc616345c5c
+      - 5663b4af80fd05f01ec6b4b0a68cf6c9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2564,41 +2734,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - c705cffe-a816-4a2a-8903-5fe0673fbdf5
+      - 3b25ec98-6c7d-481a-b728-3cc6a57e62a4
       Atl-Traceid:
-      - c705cffea8164a2a89035fe0673fbdf5
+      - 3b25ec986c7d481ab7283cc6a57e62a4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:22 GMT
+      - Wed, 30 Apr 2025 16:25:20 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2608,7 +2765,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=309,atl-edge-internal;dur=19,atl-edge-upstream;dur=290,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="JSBFO-OUmeXdAcAu4x66q7Dt2GylnVhiduwPIx3LaTTf2MPGxrvD8A==",cdn-downstream-fbl;dur=436,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=433,atl-edge;dur=346,atl-edge-internal;dur=16,atl-edge-upstream;dur=330,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2617,13 +2774,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f31fa40e0863bae8e02d0ba21cedaeb0.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JSBFO-OUmeXdAcAu4x66q7Dt2GylnVhiduwPIx3LaTTf2MPGxrvD8A==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 94e64a73025ff49a5c656bcf0881c33a
+      - 13ec505ad168c4a5f3005a8512b520e0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2635,7 +2800,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/94]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -2644,29 +2809,29 @@ interactions:
       | Inactive, Verified, Risk Accepted |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
-      | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Feb.
-      9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression Denial
+      | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* May
+      30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression Denial
       of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]\n*Defect
       Dojo link:* http://localhost:8080/finding/257 (257)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
       Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -2680,27 +2845,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3375'
+      - '3350'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 46c37827-0264-490e-995e-fc8daca000c1
+      - df922305-c684-4fbc-a72d-8f1050645acf
       Atl-Traceid:
-      - 46c378270264490e995efc8daca000c1
+      - df922305c6844fbca72d8f1050645acf
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:22 GMT
+      - Wed, 30 Apr 2025 16:25:20 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2710,17 +2877,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=306,atl-edge-internal;dur=14,atl-edge-upstream;dur=293,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=319,atl-edge;dur=286,atl-edge-internal;dur=35,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="mR6Gz3eGy5wCbg2nk7Jx86nQZlTQ2AAgSPpjPYH6qLNpryUx7zA5SA==",cdn-downstream-fbl;dur=346
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a78d8f4a6ccd81221651cd6112d5330a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - mR6Gz3eGy5wCbg2nk7Jx86nQZlTQ2AAgSPpjPYH6qLNpryUx7zA5SA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4ac15b9238b22ef9eec31b745f00726a
+      - c7db55fe8b952ebf44f9aba94fb41a1e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2744,68 +2919,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbU/jRhD+Kyt/pCF+SQjBUlUhCHe0lFII8IFD0WJP7D2cXd/uOiR38N8745cE
-        QoIKVU9IeN9mZ3bmmWcmPxyY5VzGTuhokDFoiI8EZLFpST4B0zJRChPeUjloboWSpgWxsBOwvBWl
-        XCaQqaQ1BW1wD+JzyDUYkLY+GxXGqsmYLhz5nud7bQ3fCjB2OM/hTPPIigicliNIv9/z9gKcGMjG
-        OE2tzU3oujGMIbKx+qra3GbcGMFlW4J1UZN1eS7cwBXGFOA2F9zDHOVPh4OL4Tau9XGpNME44Q/H
-        oG2FibiFROl59YYYZygReMHOtudv+94w8EK/FwZee2+n8wva7ZGRpMSi4eU1HzSS5F28zyNDq2fX
-        kxhMpEVOjsPVfWYmPMtaLBbGChlZlguIgKkxe1D6vk3SkZKXOnunFYUUFC6ejfiUW67dqYAHtzRr
-        aWC95Xsdv/+bEd/h1wmGvZigVoIFqhxyc0+xKu4sjcIxzwy0nErwGN9VyracVCBwdJTOT2AKaKv3
-        1HKsQGTliBInlAW+0VmBScdrNnKtvuKLPujwWrp0dxnAxt00eQaS5asupbAWLzDOQjch9Y/yrFFj
-        +8A14dWISZ4JNDheeTnGo0RZtz/r9t9p7huRaV6yiEvX20Uzgu4s6P6/Wqrol1hEhX5v5vd+hsJZ
-        o7ETzDrBz9BYA/zp6TUc/U04DZqNsZhdVRyI0b+5fX2y05zkSaIhQb55lQT4AJUVVfp/CO7LC9Yj
-        /iXBXCOLsJQbdgcgWaQQ0GAhZkoymwrDSjIgmqlT4xD53VnjnJ1Nzult2tjdsBFs3Ohv2th77by3
-        uDzoNVxOHFoWNCfc9mtqJ1dqETURWF2jvMb3m1QVWXwoTJ7xeZ39uPzALVbKqsK8P3RV/VpWLLe6
-        ThMPlcMDVRBSSlOvaUHIxAmtLkg3XmqvEOLERrWfNKAbKPiv/OAHbd8PGj+sOnTBvKsbm3IgWORA
-        roXSws4/6IJG3C0L478vbWLCEzAuSZjmEoELqUjStpkmSwR/xpUmJ4I1UA46TbKMtsKtkV/+7/e7
-        OHjcogNe8GyDvJfxOyC+X5PxRJNrHeZvQrnfJ89hRg5yEZ0IeX9EO4eQU1smowZrJQIfyr3FilRy
-        gF0Zv8vgHLip8KvrkXN2cvnp+HR0cnwwOL0YjAbn53+do/FIPwZdhweGKbAzLGzSMtKLqY8skM0Z
-        kqTI6FJmFftdaM7ONEyQJVlhEJvtdWTpY0o63qPwvDz/HjpVsccoY5goL9eQIAYsEZJnq4fqprJ2
-        b5khGVpXzwkBiYTF6SKnxF+L+JddXNX/fRCklfCif3vJqO/D7QqzrjSDlaKDukv9T9Y2ra7bqZV0
-        muYnrhRHKlP6tLIF4wJyxbQyylgfcCzterTvLHjjrYiuCi045aUfv8jnf/ss0arIqfE9EjJG3jPL
-        spUXJsWaRfA8Pt+n7x0wIaekmfAVM/xpw7A6QxzSZWnQZp/oui9yq/xuhexmca2QIZPoKyu4VTr0
-        2jvtziM5HP2dqYhnqTI27Ht9zx1XMqPSNneve4vC7OYCooI4jH1WD9tWbZDFHiQusAcJbpnLbnxj
-        2d8F1xY0G8gEM3KCbt4gCosDrl9Kn579yfYLzH12EXG5QYo6Wndv97Zy6OMju8BevLQTxwdXg/Jz
-        XX2aONOkbmloOPwHAAD//+xZ+0vjQBD+V5YDpS1NmrRp+hDx5IognHIod7/IQbfJNg3mUfLyDvzj
-        75vNow9N61UUD06lNsnO7uzMN9/sTNwENECiElP4hokYMSp7ZHeYQ+ki9BFzva4utSCMBpmtBihf
-        VCfMOlnqBUBtAkrpbI7/SVP0NK2Ssx6E6rtJJNQwcjqIa05wd3E2Jz7oYKi6SHyP5FbuwoV0GE3W
-        xc+NcFKPw6a/qCSV+5iIwOUeIelWRBkqT6awxnU1Q5sde8nJKaYxVa1ZY8vC8Z1uf0DrXwZUw2ai
-        TcaSBUGb3bjxPTu3LLEkAD5nKBMb7/dGLzZUMV4ayni5oYy9hnpzI5kvNhIisoTluCUNRvdYa5IK
-        NkEo4+aFmKls1GbE8GyTJcrfha5WNCGve+q7wQE7mEhWZhPQMqNkBaX3yrEGPprPbX/X5lkLEYvb
-        d/inHBQ8WBHwklO8Lnw3PdC6DdMItrxwPQF2Fbm9j53khEtvy68rNK4JTlZZoAW2rtQIkR4KYlXd
-        sMPtzI2RYgTl4QESxJxsDhCVBwby6HS1wpThaMNIfxGVh5moQEOhHaHBrtAQF2jgScKt+7jNHhau
-        tWCoAxwHJJ2CINmSY63AYZyhhrMgiOOSFfE56THNYa185YGTgq6nbCG4DcmMeyip8t2yHyuFrpAP
-        PLGeezafl6XleB2RGPJNFgl2+RyPnfKxvjkDRi4gjpvAuIz+8X7HUE4Y0wfhC5e0rRizLNOZ51qF
-        065cmWkLn32XpzCycOGMXBkG1vHwICo2D7lLfwlSIJnrkLnygiExZq4t7A043SCkcDTF0n8DikJ0
-        GVJeJYw3uO27QZM1mo8+MJyE4wq3z3LGm/OFeSBfmMQX5uv44qAc8oQvDs1i6+59b74w//PFO/CF
-        8W/xhVmJ7uGLpw2TftXY266D6zopurFeKiURICN7OdRb2h5a11vT6h4YVUNsW6JqR5RWqBtY157Q
-        6ppwWrWmDIAFVSdFjb5e5m8Xg3Hq+5xK20876y8yOTWzwujAIphaFWdALDXQLu3Tvt0bDoYzfaCJ
-        njXSrFG/Ox/pcxPrVIOwwo5hgvBwbtsUDRhphfbvz2uKoFKmuXa+DZA+EKoT5cNIpuxIG0LTh9zW
-        DcMcWMMB+HJmzQYalp9zMR9aZ/apnOWod37UvcBfLqf4PCgqQ0XJb8VqGisPMITSVankVPM4JEsp
-        S85jMhTkJdNzL8bXL1eKpi4Dapltv1n4+Bpvv5r4+Bpvv9r40Br/AQAA//8CuhhYQKVAhr2hg0XO
-        wKSv4JuYllaanJwJzkCgXh5kWBpSvEWBxo+slFxLi/ILUvWjgAVPMmgIFprTQFNrQFl41gXZAJ1Q
-        xD7MZIKrUDXBNTxtAh+eLoIW7qPFCEqCAQAAAP//omWCGS1G6OHi0WIESzGCXgzgaqaZwFtj8MYK
-        0DvpkExZDVoDAGUbAF2SX5IIXcGAbgqu9pgBrnLJwAh7AYdr1sgApwdwttfgPkPXgashZ4xTAt7C
-        S80ryyzKz4M08SBCKaXQ5TMQLjGhV5ZfQr2ZUohhcEOBNmUkFoflg+eCYJOzwCwAcXI1jAmtX8h2
-        AHipkT7MXB2l3MSKoNTi0hyQwUieBU/kFJU4lkA8Dpp1zskHNfaRxFE1G6HohmoAu7a2thYAAAD/
-        /wMA78X+Zq0lAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:18.266+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:18.244+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_10873_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:18.266+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Inactive, Verified, Risk Accepted |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:*
+        May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression
+        Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]\n*Defect
+        Dojo link:* http://localhost:8080/finding/257 (257)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - fc123f94-b76b-46f8-b8c8-f8ec2a4afc94
+      - 9b568cb5-a686-47c0-93e5-783586466a7f
       Atl-Traceid:
-      - fc123f94b76b46f8b8c8f8ec2a4afc94
+      - 9b568cb5a68647c093e5783586466a7f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:23 GMT
+      - Wed, 30 Apr 2025 16:25:21 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2815,7 +2989,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=295,atl-edge-internal;dur=13,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="t_gRj2qjww-e_CaFaF54yN-2E2QP6D4DyWqIZRhPfMH1i-zXW7gMzA==",cdn-downstream-fbl;dur=348,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=346,atl-edge;dur=260,atl-edge-internal;dur=17,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2824,10 +2998,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 7b64a70fe0edcfd6cd8e281be975ea8a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - t_gRj2qjww-e_CaFaF54yN-2E2QP6D4DyWqIZRhPfMH1i-zXW7gMzA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 8299d2134209fb896da4f0dc0e83e5d5
+      - 5274eded0c07d1a5ed0327983064222c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2854,26 +3036,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TfmzLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPATYfH5qXgkfQQYsnwKdwrJijGcpz4IY4AICHPIu/AGHqu3OWQoVA04LztIkX9Jv
-        VnY3RtkAZrRYSAGYo5I0naPIlMoUSMWWab6oVZEhKxSwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAyQMbbCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:21.563+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 9bb10b7c-cb2e-43fe-becd-b0e5a9b96598
+      - b79d3e98-ef0d-4f11-87b5-4d96c8fe7b46
       Atl-Traceid:
-      - 9bb10b7ccb2e43febecdb0e5a9b96598
+      - b79d3e98ef0d4f1187b54d96c8fe7b46
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:23 GMT
+      - Wed, 30 Apr 2025 16:25:21 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2883,7 +3061,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=160,atl-edge-internal;dur=15,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=194,atl-edge;dur=161,atl-edge-internal;dur=14,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="EvQI9UyrUKMgE74MeV___tsuYdsvfUI92hI7QZmFTIADzjF8_d548w==",cdn-downstream-fbl;dur=198
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2892,10 +3070,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - EvQI9UyrUKMgE74MeV___tsuYdsvfUI92hI7QZmFTIADzjF8_d548w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 545183c1a48ee007ba5b0b7108af58df
+      - dfc2531f06984be110ad623c492c7c9c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2919,78 +3105,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPcNhD+Kxp/yHTSO7/dAYczmQ4ll4SUUnpckg+EYYS9ZyvYkiPJ99LAf++u
-        fT7Ci9NCp4EZbEvaF+0+++zy1YFlyWXiRI4GmYCG5LWAPDE9yQswPRNnUPCeKkFzK5Q0PUiELcDy
-        XpxxmUKu0t4ctME9SCZQajAg7fpsXBmrihkpPA98P/BdDV8qMHa6KuFY89iKGJyeI8h+sO3vDvDD
-        QD7Dz8za0kSel8AMYpuoz8rlNufGCC5dCdZDS9bjpfBCTxhTgdcquIQVyh9NxyfTPq3hUu2CcaKv
-        jkHfKhNzC6nSq+YOCX6hROiHW30/6Af+NPSjYDsKhu6OP/wZ/fbJSTJi0fFazROdJHkP9fnh5trr
-        jwRMrEVJgcPVPWYKnuc9lghjhYwtKwXEwNSMLZS+dEk6VvK9zh/pRSUFpYvn53zOLdfeXMDCq926
-        cXC9FfiDYPSLEX/BywLTXhVolWCBJqfcXFKuqgtLb9GM5wZ6TiN4gPeqZXtOJhA4Os5WhzAH9NW/
-        7jlWILJKRIkTyQrv6NyBycBvN0qtPuONnhjwtXQd7jqBbbjp4xuQ3NzqvRTWogLjbGwTUn+rzxo1
-        swuuCa9GFGUu0OHkzs0xHzXKhqPlcPRId7+TmfYmm7wM/R10Ixwuw+H/a6XJfo1FNBhsL4PtH2Fw
-        2VochMtB+CMsrgF+fX0fjkEXTsOujUG7MRPLDw05IixOzxAmaaohRb75xyLYajfwZiqvGl54+Oh2
-        18ZOx0bYuTHq2ti9705Dm80qkVLdIZyoH+Ant9g4GsJ9fOE2dH5D4F6jTlNZ1q/7qqLABUTKH2lB
-        yNSJrK7ges3TpE2LuIna13tr5BkeNZmq8uSVMGXOV+tSxmV0y35AzFB5r6OhAS9L/PFQkxiMgrZJ
-        3A3bhsrubnSBKtyAqtRCaWFXTwxiK+7Vnebf9wpR8BSMRxKmVSJwIRNp5pp5esOWb3GlpdXQuV84
-        4aYMcn4BRIxUAXdngi7wBl0YDUYUkYybcSniQyEvX9POKyhpfpFxm8c6u4t6b7MilRzj+MIvcpgA
-        Nw029PrNOT58/+bg6PzwYH98dDI+H08mf0zwflinBkOCB6YZsGPsANIyssuEYUrmK4ZsInJSyqxi
-        74Tm7FhDgXTCKoOodR9ilQALyvGvhO+XX3Yip+mKmD0M/01V3WILTEQqJM/vHlpPX+vw1kjP0buW
-        cDCzqYTN6aqksu1C8nBnu0VyMyg9EXyN8Kbz3p5tHofHG7z9yuNLHDdbyLXKG1v764nuPzncjoVN
-        zaCRsB0UJCyoulWu9FHjzUVeQT/VyBs3Q5Fir1STbFWUOBBL+zDot7poYWtDC9/L+O1wfpLf/u6x
-        VKuqpEHxtZAJEqNhWCvsAkCysjIZJDVKDyZ79LwAJuScDBDMEob/CjBsWpBEpCwLXfaG1H2Sz+vn
-        84idbtQKGbEyjbbcwPWvKNgY61zFPM+UsdHIH/nerDl7Xvvk7W6doRA7PYG4Impib9Wib1WHLPbq
-        pMJeHZ4xj50GxrI/K64taDaWKRZkgeHtEIXNAS+opY+Of2d7FZY+O4m57JCiyc/b3TlrAnl1xU5w
-        Zq39xPf9D+P68bF5tPmlj3WHp9epsMgCJFrjCd9QESOiZFfsFHX0Q6x8amqjsPaC8CnniStxzHdT
-        NffmVS4RsRYZxbt9/oxU7A43YvEC3EJYDa7SqYdVzQnpAkdYYgNvd+hmtshJqkzxT50mUhHizwQK
-        ZQGvkQAbLzEdJMP67KfjtMee5fYFC90gcEPGnqX2xUs2+BsAAP//7Fhtb9NIEP4rI1VCjkk31ImT
-        Xk79ULUgIVGErgdfCFJcZ0sMjp36pRRx/Pd7Zne9XjcxiHL3rW2VOjM7u7PPzM48a/EMxkoxFlMx
-        oUYxaRUTEYpZIw9beSgwVyOftnJ+DFs5e2fkR2LayoNWHrjjx618LMatfNLKJ+0GZu26/OjI7br8
-        GAx6csMk8iiYPmNET8EibuWQQ6+uAbQvzrNfjLMZ/1/F+THGD41xeNwXY9TBpijMfRVvlpF/Xks6
-        RwGF8IW8EvTHkLi9Urc2N7/rI2GLs/o+Fo/H8vdChmOJ2JyrTo8m/Ckn5kAIx0/tyMPHYF9gfxRW
-        8tEJIH6Pf4cPOKxYD6deTfB7TaGbWf5lXhexRHal0ufufIguuklKybBuPzoDz1sO4aPX22WReqVp
-        zyLJR9HqNinBQ3ABCIMA9OKaEcZhaFgnE43l9uOSwOjgX0YRFTqLY85iabOY9yCL6CpJuaNW66ii
-        PMZCJX1Zg5pU4NbGkFG7ikpJeUE3uLZ9JVyUYz6DJWaPi+iaHQAXqzcZMfUS6pyBnReSQM+p+pI3
-        JjGVscwiXGOYr2CpJF4TaACoe5p8liDv11glgtvbbZrE6r2l4UWNw6kEPjixzP7dUXpr8KnOyuga
-        hYLJ/mFZ8xD4V96kZjmDTEmbCMZJDl7gOF+KRRbszg6jDEiX7Azcw323AFXEvBYdpmrWh8ggVciq
-        LjKkNp7KOq0YXccHjNvrhGAADw5wb8kRT/yd5Vkst9UiWy6Xi4zvghV9ozPsDJznO50Qv8hNCuk9
-        ObgLZkgt/X/QjI31yBMCcTZmHivVkzCbY0ljwHCd0PLy+avnZ3/TEZ1e0pObOq/+XOBHTz7ytQSH
-        cJ/aHy1wLp/yVss8lQJXBQ/ZH+P6JmR2O/jA3oA/wyQbjbT1UjmgnVIAevBjSJ4siiEjOKATPjn0
-        DTObPWGuFTv+fWDAoXc2UegClBX5QnzUXHnzEmjeqeLgiT11HJq+Sm6Ndmq51exUc0dzr547mnsV
-        3dHcq+mO5l5Vt5qduu5oupUdOL1Rb3dWDUhzM9KAZFDBfA5cjJHBhBdy4WKMDChG1cDFGFlQHE3T
-        8RpUOioGyaLS0TBIFpWOhkGyqHQ0DJJFxdFokCwqHY0GyUkm4LVGJnFKHmq6N98t9HxTmfMHuhO+
-        ncZ8DpCY9RWOv+kBF4m69pkW4NuLTCDuxN2c3qpXBVyATLFvQoKKmUJTCNdo3Geko7XXZtJno8O4
-        1ybss9EB3msz7bPREbE25NFr7kCqO9kOp5JgqCM+VGVXh5hbTZSWOW11AgtiGmEXnfUtqkL640VN
-        QqBL7SxgYvdys43iiuP2OqdEfSGkwG2ykqu2zWPgX+BEhUQ1L3+lzxvTbc4XbqYpXrTaJNmAvME/
-        G9CQKp9b6rGXzj5SWecAuwXvp1QWt48HUdnwGFQ2PP5/qOy/AAAA//8ipSlLbr8XOdnSuilrONqU
-        BasCAAAA///smk1qwzAQha9SClnKlWM5thchDaWFLnKB7JSR3Zbi2PiHktt3xnJErEYptBsvBFmY
-        aJQRg/V44X3eynor663sFVWfWLOJrk+s2aWyeyt7npe3st7KzsPKhmbrL1b2Z3Yfm/jajm5d6V0o
-        LtO7rpHwOYAJhBrYpQbvsBaEAS2sBe7awV0JOjcJ+nk8rkIX9cHNYSZJtJ1Hyq6T8E5xm047274s
-        JUWx91ezQho18RRV88ewltzJRgIQBfKq1rGK0iQ9hAnPI8g4ZPGyyMJihX1MEXa4UZbTe7BVCnu0
-        WIl27/R4cRCoiHy7TXgNI86Dt0aX0Z4zZSRyHqZShUKsEkiTOMoOcEg4ti9kXqSwUevhVxbRdrF8
-        wY/ex0p5HFNMxvRXbdC37AsHwZYBxaOB1kCaFKulbGlQuH/w6Hjb8PFpx3hQHyk0t2mx+Z/Yxs3m
-        f2IbV5v7iVGYlKafRqoB/6+f7nayKHqAj+ECUQim2Sota/vqSIXPfVPV+cMedQWIAhpvGuGSuGqu
-        LnUYIdHrKIRwialwEVLChd0JI9jNqPZeX/77Jn0DAAD//yI6JY2WL/Rw8Wj5gqV8QS8G4K0weKMF
-        6Op0SN6rBq3rhrINgBbmlyRCV6Wjm4KzuYWzXMLZDjPCXvLhWuBogKvhCSoQsEoYwL2MJmGMS4cx
-        vGWXmleWWZSfB2m9QYRSSqFbIiBcokIvPxdiQjWMCS3uySh+kXZz6MPM1VHKTawIgowDodgNXv9X
-        VOJYAnFHGbD7Qe6iRYxlxxDD4IYC7cpILA7LBy+fhK0VBi18Bi1KBFkJdwiqa41QnAvVAA6e2tpa
-        AAAAAP//AwBB8b14gTMAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:10.376+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:10.150+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
+        Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 85a42642-7f8b-4b06-bbc7-fda62544fcf4
+      - 56342d89-d37f-48f0-b3f3-c0d5b5173def
       Atl-Traceid:
-      - 85a426427f8b4b06bbc7fda62544fcf4
+      - 56342d89d37f48f0b3f3c0d5b5173def
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:23 GMT
+      - Wed, 30 Apr 2025 16:25:22 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3000,7 +3221,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=17,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="a-aVRGUn9FvdpF5N6i-QYd1gJZq6s9483xQkbBEPGCOJ7eq7_0tqNw==",cdn-downstream-fbl;dur=379,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=376,atl-edge;dur=297,atl-edge-internal;dur=19,atl-edge-upstream;dur=279,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3009,10 +3230,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9a3eef6ee6df44793fb3d5e366a7238.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - a-aVRGUn9FvdpF5N6i-QYd1gJZq6s9483xQkbBEPGCOJ7eq7_0tqNw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - a1ba5c502c392172c5d36ad2a723cf5a
+      - 1ac4cf3755b05e296ce3eb4a9e41eb95
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3039,41 +3268,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 663e105b-3d07-4d8a-854e-fea12a2fcb5d
+      - 19ba46d1-feec-477e-a905-b752dc2a2692
       Atl-Traceid:
-      - 663e105b3d074d8a854efea12a2fcb5d
+      - 19ba46d1feec477ea905b752dc2a2692
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:24 GMT
+      - Wed, 30 Apr 2025 16:25:22 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3083,7 +3299,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=260,atl-edge-internal;dur=13,atl-edge-upstream;dur=247,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=328,atl-edge;dur=296,atl-edge-internal;dur=15,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="paDd0IR-qx7-mbGLFf1JBZOauscpbeIGtf411LkVBN4iKOAAl8HpRg==",cdn-downstream-fbl;dur=332
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3092,13 +3308,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ad310b4d7c581c35032fa3fce068e53c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - paDd0IR-qx7-mbGLFf1JBZOauscpbeIGtf411LkVBN4iKOAAl8HpRg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - caa2b1da7f9e5f12790e54dddc6ecdbf
+      - c21421b32dbc7c3e94e28dfff75a3bb0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3110,28 +3334,27 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/95] in [Security
-      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
-      / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
-      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
-      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
-      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
-      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
-      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
-      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Inactive,
-      Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5] in [Security How-to|http://localhost:8080/product/2]
+      / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n||
+      Severity || CVE || CWE || Component || Version || Title || Status ||\n| High
+      | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
+      | pg | 5.1.0 | [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]
+      | Inactive, Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
       | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
       Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Inactive,
-      Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
       Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -3140,31 +3363,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:* http://localhost:8080/finding/258
-      (258)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (258)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -3173,25 +3394,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -3203,27 +3422,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7157'
+      - '6820'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 6cb6e1c5-473b-48f8-b5e4-969cb49a1b31
+      - cce5292b-4555-42d7-ad7e-1dcf67eb1a03
       Atl-Traceid:
-      - 6cb6e1c5473b48f8b5e4969cb49a1b31
+      - cce5292b455542d7ad7e1dcf67eb1a03
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:24 GMT
+      - Wed, 30 Apr 2025 16:25:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3233,17 +3454,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=471,atl-edge-internal;dur=16,atl-edge-upstream;dur=457,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=541,atl-edge;dur=506,atl-edge-internal;dur=16,atl-edge-upstream;dur=491,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="LsxXLaBzvX-GRotRe-BPK-x8jr0lZ32CqAwsH5zT9phBpQQ0eiw-HQ==",cdn-downstream-fbl;dur=546
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 848ee9f48eafd6caa6bf5371a2f79f28.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - LsxXLaBzvX-GRotRe-BPK-x8jr0lZ32CqAwsH5zT9phBpQQ0eiw-HQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 723193d2f615e96ef3d6c71175bb1a11
+      - dbce342de831af5441d9d40559fbd165
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3267,78 +3496,114 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61PbRhD/V270IdNJbb1swFYm06HESUgppcZJPhCGOaS1fEG6U+5OfjTwv3dX
-        DxPATgudBmbQvfZxu7/93fLVgWXBZeJEjgaZgIbktYAsMR3JczAdE88g5x1VgOZWKGk6kAibg+Wd
-        eMZlCplKO3PQBvcgGUOhwYC0zdm4NFblU1J4Efh+4LsavpRg7GRVwInmsRUxOB1HkP1g1x/2cGIg
-        m+J0Zm1hIs9LYAqxTdRn5XKbcWMEl64E66El6/FCeKEnjCnBaxVcwQrljyej00mX1nCpcsE40VfH
-        oG+libmFVOlVfYcEZygR+uFO1w+6gT8J/SjYjYK+u+f3f0a/fXKSjFh0vFLzRCdJ3kN9fri+djNJ
-        wMRaFBQ4XN1nJudZ1mGJMFbI2LJCQAxMTdlC6SuXpGMl3+vskV6UUlC6eHbB59xy7c0FLLzKrVsH
-        m63A7wWDX4z4C17mmPYyR6sECzQ54eaKclVeWhpFU54Z6Di14CHeq5LtODOBwNHxbHUEc0Bf/ZuO
-        YwUiq0CUOJEs8Y7OPZj0/G0bQbtRaPUZr/rETDTSVR6qzLZ5oMk36Lm97nsprEUFxlnbJgj/Vp01
-        amoXXBOQjciLTKDDyb2QYKIq+PUHy/7gke5+J2XtTdYJ6/t76EbYX4b9/9dKDYsKpGgw2F0Guz/C
-        4LK12AuXvfBHWGyQf3PzEI5hC8epWH6oORCTfHb+8GSvPcnTVEOKfPOPRbDTbuAFVFbWvLD56O62
-        jb0tG+HWjcG2jeFDd2rarFeJlKoXwom6AU65xYejJtzH12dN57cE7tXqNFVfNTxQJQUuIFL+SAtC
-        pk5kdQk3DU+TNi3iOmpfH6yRZ3jUzFSZJa+EKTK+aioWl9Et+wGhQVXcREMDXpZoYtMj0RsE7SNx
-        P2zbqCxcU9n9jTWoCi2UFnb1xCC24l710vz7t0LkPAXjkYRplQhcmIl05pp5ekuKb3GlZc/QeVgf
-        4Rr1Gb8E4r8NpUG0sTEQwTaMBgOKyIybUSHiIyGvXtPOKyiof5Fxm8cqu4tqb70ilRxh+8IvMxgD
-        NzU2dDNyTo7evzk8vjg6PBgdn44uRuPxH2O8H9apwZDggckM2AkSvbSM7DJhmJLZiiFpiIyUMqvY
-        O6E5O9GQI2uw0iBq3U3kEWBBOf618P3iy17k1K8iZg/Df1tVd9gCE5EKybP7h5ruqwlvhfQMvWvm
-        lNlUwvp0WVDZbkRy2Hd3w2GL5LpReiL4auH1A3u3t3kcHm/x9iuPr7DdbCHXKq9tHTQd3X9yuG0L
-        65pBI2HbD0hYUHWrTOnj2pvLrIRuqpE3bpsixV6pOtkqL7AhlnYz6HfWtPC9xN4XWlPG3XB+kt/+
-        7rNUq7KgRvG1kAkSo2FYK+wSQLKiNDNIKpQejvfpewlMyDlZJpglDP8VYPiaQRKRslnosjek7pN8
-        Xn2fR+xsrVbIiBVptOMGrn9NwcZYZyrm2UwZGw38ge9N67MXlU/ecOcchdjZKcQlURN7qxZdq7bI
-        4pOclPgkh+fMY2eBsezPkmsLmo1kigWZY3i3iML6gBdU0scnv7P9EkufncZcbpGiBs8b7p3Xgby+
-        ZqfYs1Z+4vjgw6j6fKw/bX5p0jz9NJwIiyxAohWecISKGBElu2ZnqKMbYuXTozYIKy8In3KeuBLb
-        fDdVc29eZhIRa5FRvLvnz0nFsL8Wixfg5sJqcJVOPaxqTkgX2KkSG3jDvjuzeUZSRYp/qjSRihB/
-        xpArC3iNBNhoiekgGdZlP52kHfYssy9Y6AaBGzL2LLUvXrLe3wAAAP//7Fhtb9s2EP4rBwQoZM2h
-        G9uyUw/5UCQdUGAtimbbl3mAFZmptcqSIkppirb/fc+RFEXFdl/SfUwSOPIdTzw9d7x7TuIpjLVi
-        ImZiSq1i2immIhLzVh518kjgXq181sn5Murk7J2Vn4hZJx938rG/ftLJJ2LSyaedfNo9wLzbly89
-        uduXL8eDA7lhE3k0nj1lRF/mPLveyiEHX/P9Ib1N1Xt6niSy5IO0L/DzHwy8Xf9/Bf4x6A8NenT6
-        3UFHpWzLxiLUCcAyCi8aSRcosRD+Jq8EPRsSN2DqV+/2d3MiXPnW3yfi8eD+XAxxcBGbC80F0Kb/
-        LYhZEsLxTTsK8DHYF9ivhZVC9AqI/8a/4wecXuyHMqBv8HNto59Z4WXRVIlEdmUy5P59jD67TZVk
-        WMt33sKLjmWEYANuW6Sesg1cpMUoXt+mChQGI0I0HoOAXDPCOAwtL2UqsirfrQicD/7lFFNlsjjh
-        LJYui/kZZBVfpRn33HoT11Qk2EjRhw3ISw32bQ0ZtatYSSoqusFg95EwSid8JBXunlTxNTsAttZs
-        c2JyJvQ5A3+vJIHAU/2haE0SUonMYww6zGiwVZpsCEQB5D5L30vQ+2vsEsPtsszSRL/ZtMypdTiT
-        wAcnlucDf5V5NPjU5Cq+Rt3gceBYNbwE/qmbzG5nkVG0jWGcFmAOnvNKLPPx7t1hlANpxc7APUzE
-        FQgj7uvQYTLnfIgtUpWsmypHauNKNVnN6Ho+YN1eJwQDeHSEyaZAPPF3XuRc9Zb5arVa5jwt1vSJ
-        zvFkYEVf6Iz4VW9ayeDJ0d14jtQy/wft2sSsPCNQa2sWsFJfCftwLGkNGK4zWl2++P3F+R90Qs8v
-        6clNU9S/LvFjbj4KjQSHcJ86HC1xLn/hR1VFJgWGiQDZn2DAEzK/HfzD3oBhwyQfjYz1SjtgnNIA
-        BvBjSIGsqiEjOKAzPjn0CXe2z4R7rdnxLwMLDv3lEoVegdQiX4iPmi9v3x8telUcTPJAHYfmUCV3
-        Rju13Gl2qrmnuVfPPc29iu5p7tV0T3OvqjvNTl33NP3KDpze6Pc/6xakhV1pQbKo4H4eXIyRxYQ3
-        8uFijCwoVtXCxRg5UDxN2/FaVHoqBsmh0tMwSA6VnoZBcqj0NAySQ8XTGJAcKj2NAclLJuC1QSZx
-        Sh4b/rfYLfQ8yyz4A90J35jEKBiVzRWOv+0Br1I9GNoWELpRZyzuxN2C/tQvE7gA2WLfhgQVM4Om
-        Er7R5JCRidZem+khGxPGvTbRIRsT4L02s0M2JiLOhgJ6zR1IdyfX4XQSDE3Eh7rsmhBzq4kzVVBp
-        ElgQ0wi36fzQpjqkX9/UJgS61M4GNnYvtyX4KsftdUGp/kJIgdt0Ldddm8fCt+BElUQ1Vz/S561p
-        WfBIzjQliNfbNB9QMPi8BQ2pi4WjHnvp7COV9Q6wX/C+SWUxjjyIykanoLLR6UOo7H8AAAD//6Ju
-        U5bcjjBysqV1U9ZwRDRlAQAAAP//7JrRasIwFIZfZQy8TJfa1LYX4mRssAtfwLt40m5j1EprGb79
-        zmlqMJlx4FUvAl4Uc+IJh+bnl/8LVjZY2WBlbWtmabplzSxVt6yZpeuWNbtU9mBlz/MKVjZY2WlY
-        2dhs/cfK/k33UxNwu+GuL/aPxWXwd2wlfA/oAsEIbqkBQJwF7lsQhtFwd5iM/TwFX6Evc+c+LoSb
-        nlZW7UaZ8niU8EmBnM5Du76uJYW1j1fTRBo1ERdNe2ecS+5kJQGIE3lXy1QleZbv4oyXCRQcinRe
-        FXG1wD6mCDvcKCvpPVgrhT06rES7d3q+OAg0xMbdRr2G2ZfRR6vLaM8ZNxIlj3OpYiEWGeRZmhQ7
-        2GUc21eyrHJYqeXwK7NkPZu/4UfvY7XcjzknY/qrLuo79oODYPOIAtRIayBNih2k7GhQuH/w6Hjb
-        8PFlw3h02FOs7mJj0z+xy51N/8Qutzb1E6MwKc1HjdwD/l8/PWxkVfUAX8MFokxM01da1rbNngpf
-        +7Y5lE9bFBwgTmi8acRN4qq5utRhxEivwxLCJ6bCx1AJw1C1o6gHGbnzhfkFAAD//yI9wYwWI/Rw
-        8WgxgqUYQS8GcDXPTOCtMHijBeiddEimrAYt8IayDYAuyS9JhK5bRzcFVzvMAFe5ZGCEvYDDtQTS
-        AKcHcLbT4D5D14GrAWeMUwLeskvNK8ssys+DtN4gQiml0E0TEC4xoVcGbPaTu5wQY0EwxDC4oUCb
-        MhKLw/LBCxthq3iBWQDi5GoYE1q/kO0A8AYTfZi5Okq5iRVBkIEnFM+ClyQWlTiWQDwOWhoNWrYI
-        8jpcHFWzEYpuqAawa2trawEAAAD//wMAo/UQUKMzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:10.376+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:22.907+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Inactive,
+        Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Inactive,
+        Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025
+        \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect Dojo link:*
+        http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a38aeabf-aa75-4130-b204-51a1faf08c85
+      - c8235c6c-7dc8-404b-a4e1-7d3582c36b19
       Atl-Traceid:
-      - a38aeabfaa754130b20451a1faf08c85
+      - c8235c6c7dc8404ba4e17d3582c36b19
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:25 GMT
+      - Wed, 30 Apr 2025 16:25:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3348,7 +3613,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=256,atl-edge-internal;dur=16,atl-edge-upstream;dur=241,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="oWtmsaAvI6kxyX9vao4tIkozDh17LveDAZ-FcI19JBOR5iQFVsg8xw==",cdn-downstream-fbl;dur=350,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=60,cdn-upstream-fbl;dur=347,atl-edge;dur=265,atl-edge-internal;dur=18,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3357,10 +3622,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 3699bc5ea5aacbe1d32ebe3e874f0c68.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - oWtmsaAvI6kxyX9vao4tIkozDh17LveDAZ-FcI19JBOR5iQFVsg8xw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 1eecbec3998a4867d62250228fa6b0f8
+      - 4940320b2dcc6a526be822a2edb3e0c0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3386,21 +3659,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1609/transitions
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/transitions
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 8d4a3644-daf1-4e55-869f-f9da83efd905
+      - f8a3ad81-cffc-4c9e-a302-83ce519d2dce
       Atl-Traceid:
-      - 8d4a3644daf14e55869ff9da83efd905
+      - f8a3ad81cffc4c9ea30283ce519d2dce
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:25 GMT
+      - Wed, 30 Apr 2025 16:25:24 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3410,17 +3685,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=536,atl-edge-internal;dur=13,atl-edge-upstream;dur=524,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="rVvT5kawyxmJhyn5WeGBkOnD-1gKHL2lyqZdgIq1kk10piefEFqRDQ==",cdn-downstream-fbl;dur=735,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=71,cdn-upstream-fbl;dur=732,atl-edge;dur=635,atl-edge-internal;dur=22,atl-edge-upstream;dur=614,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f82a4020c8fc9b14a403737c65661074.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - rVvT5kawyxmJhyn5WeGBkOnD-1gKHL2lyqZdgIq1kk10piefEFqRDQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 82bad49624d4a19558835f4137be3060
+      - 13b2d9233fb8714075a7ed2becf5e33d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3447,26 +3730,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1nVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLD5/NS8EiGBDNhsDHQMy4oxnk95HsUAFxDhmPfxD9hXuj1nKVQMOC04KzIGxTcr
-        2xurXARzWiykAJyhknQ6R5ErlSuQii2ns0WtihxZoYCdCYJJhlvdi/RCVGIw4c5JkdoHYk4VQfu6
-        Lcnx/LAnZ9Pk+r4ix08AAAD//wMAOj8sHiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:24.855+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 8f30af82-9be6-4ed3-9be6-2fe480e1f0a3
+      - d02e2df8-f828-42db-8f23-260e84b54085
       Atl-Traceid:
-      - 8f30af829be64ed39be62fe480e1f0a3
+      - d02e2df8f82842db8f23260e84b54085
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:26 GMT
+      - Wed, 30 Apr 2025 16:25:24 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3476,7 +3755,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=179,atl-edge-internal;dur=15,atl-edge-upstream;dur=165,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=195,atl-edge;dur=163,atl-edge-internal;dur=17,atl-edge-upstream;dur=144,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="zQaNXmVrYbXa9EKfNLGCQy5iji02sFPVEcBN-SUZ4VlvFFdDZvFOxQ==",cdn-downstream-fbl;dur=199
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3485,10 +3764,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - zQaNXmVrYbXa9EKfNLGCQy5iji02sFPVEcBN-SUZ4VlvFFdDZvFOxQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3e79fec96a1e4e5c083705bd30d14da7
+      - ac4913a810c01bd34bd75b0554eaeccb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3512,64 +3799,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16094
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18195
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX62/bNhD/Vwh9GjpbrziOI2AYssRps2VZ5rjthzQIGOkssZFIlaT8WNP/fXd6
-        2M3D3ZJhRQJIInkP3v3ud+fPDixLLhMncjTIBDQkxwLyxPQkL8D0TJxBwXuqBM2tUNL0IBG2AMt7
-        ccZlCrlKe3PQBvcgmUCpwYC07dm4MlYVM1J4Hfh+4LsaPlVg7HRVwrnmsRUxOD1HkP1g6O8P8MNA
-        PsPPzNrSRJ6XwAxim6iPyuU258YILl0J1kNL1uOl8EJPGFOB1ym4hRXKn03HF9N+MAx8XKpdME70
-        2THoW2VibiFVetXcIcEvlAj9cLfvB/3An4Z+FAzx3x35wY/oN+mojVh0vFbzQidJ3kN9fri+dvuR
-        gIm1KClwuHrATMHzvMcSYayQsWWlgBiYmrGF0rcuScdKvtX5M72opKB08fyaz7nl2psLWHi1WxsH
-        263A3wlGPxvxF/xUYNqrAq0SLNDklJtbylV1Y+ktmvHcQM9pBE/wXrVsz8kEAkfH2eoU5oC++l96
-        jhWIrBJR4kSywjs6D2Cy42/bCLqNUquPeNUXZqKVrvNQZ7bLA318hZ7Ndd9KYS0qMM7aNkH4t/qs
-        UTO74JqAbERR5gIdTh6EBBNVw28wWg5Gz3T3GynrbrJO2MDfQzfCwTIc/L9WGljUIEWDwXAZDL+H
-        wWVncSdc7oTfw2KL/C9fHsMx7OA4E8t3DQdiki+vHp/c6U7yNNWQIt/8YxHsdht4AZVXDS88fXS4
-        bWNvy0a4dWO0bWP/sTsNbTarREp1h3CiftByJUVei7jx/POjNaoHDKrJVJUnR8KUOV+1VYPLmEL7
-        DtNDldSa4BabUUPiz6/5pkVsmoLXqNNU0fXroaooGbXz72lByNSJrK7Im1gDXpZo4qkmMRgNuybx
-        MGzbqCxcU9nDjTWoSi2UFnb1wgt34l7daf59rxAFT8F4JGE6JQIXMpFmrpmnG1J8gysde4bO4/oI
-        16jP+Q0Q/z1RGkQbTwYi2IbRYEQRybgZlyI+FfL2mHaOoKT5RcYdhmpkLeq99YpUcozjC7/JYQLc
-        NLjU7Ztzfvr29cnZ9enJ4fjsYnw9nkz+mOD9sE4NhgQPTDNg50j00jKyy4RhSuYrhqQhclLKrGK/
-        Cs3ZuYYCWYNVBhHmPkUeARaU498J3y8/zSKn6YqYPQz/pqrusQUmIhWS5w8PtdNXG94a5zl6135T
-        ZlMJ69NVSWW7Dcm7e36H5GZQeiH4GuF1g70/2zwPjxu8/cLjWxw3O8h1yhtbh+1E958c7sbCpmbQ
-        SNjNAxIWVN0qV/qs8eYmr6CfauSszVCk2JFqkq2KEgdiaZ8G/e42Wthd08K3Mn4/nB/k138HLNWq
-        KmlQPBYyQRIzDGuF3QBIVlYmg6RG6cnkgJ43wISckwGCWcLwpwDDbgZJRMqy0GWvSd0H+ap+vorY
-        5VqtkBGbYQyzyHd3XP+O4o3hzlXM80wZG438ke/NmuPXtVve/vAK5djlBcQVsRN7oxZ9q7bIYldO
-        KuzK4RXz2GVgLPuz4tqCZmOZYk0WGOEtorA+4AW19Nn57+ygwupnFzGXW6RoxvP2966aWN7dsQsc
-        W2s/8f3w3bh+vG8eXYrpo+3+9DoVFomARGtI4RsqYsSV7I5doo5+iNxGPSjYr70giMp54kqc9N1U
-        zb15lUsErUVS8e6fvyIVA78JNcnFC3ALYTW4SqceVjYntAucVokRPDzqZrbISa7OFD7rXJGeCaRV
-        zjGUS/rRVrt/BFLwnLBzAXqOv81Yn/1wTIJ/AwAA///sWW1v2jAQ/ivWpFUFkTRAUl6qqkNllfqB
-        adq0fei+1NhOyQQEhYRqWn/8nnOMG1LcbZ1W9UPVCojPr3fn5567tNjBPD/B4MjvNBzKM5Y+6kR6
-        oyNE+Y1qkW40I2Z3pNPmVqPDplYKtbHmuFBsDAdE44Wa+mzQYgRPbNe3t3+ztm+dWz93/f98HOx7
-        rFEEF/x7yghfsdXfjmOH+GjsO/RjR2ZNuBiav+HLe5K1sSIcR0/xb/62q/fm57TIoMWLZK6ABKrU
-        9MFNfqKdq9JxfI9QTSCJXTYFdJmb7yfpEZebZA2UA72IOscAr5h0DFfZxjSy3bWe/Joh8DLaKhJK
-        E2ozY3KzETK5tCZfG5Pfzgj4OOZb3jAwbgE5YrbIeEwrUYQGIq2K3Ifmv97PPwH0zJVBuF3RlusP
-        K16EHh81o5RbMaTQzKkVVyZAzxlGoxEeqS/ksK7MVqVhDWbjEGQb5VHsSsTDjqU05huKthUrEYIN
-        6YOcC48jITDfENFhOk+EseAk0SHBGPCLZg2kc2OZ8lQszdgcgsy3lr9crLjIacyHlCX6gQHGN4lU
-        cseXPuE+gUph6b/xEDN0lVIUIAc/5HKRLBvssHG3gAPn6RBO+5CIR5aL1nmYKxS3w2oozjOQD50R
-        UM5S72pztZogtFlTTRC4RgSWDm+14OrooseBK4UL7GZ4nnMxo9hoOGKVZtbJxrpYLDjxqjeuwE/a
-        pvwozZ5IvugOnnEhKAO7lKeR7PZ7/Wm7F6iuGARiEHXiQTs+xjq2E1Z4pJsiVxhJSfcEPUUqf7yr
-        bATsjOZ6tDCj1a98EDzdjcZsiwOhQg7CZTsMj3ui34u6g6mY9gIsH3MV98WZPNWzvO2O3nYu8F+O
-        8xZ8aSiJ55VNa79Ye7dQhNfxiev45RUkTXkrztekKIzXCI8MBj/PJ17gr5ZEgutFnpe/43qV6OXv
-        uF5leuk7BjbJspJispRzuD6b8DguhEj0BSJSVtY1SmS7AolFx/dFlq7U0RUwR1BWb24aVTkhtVeX
-        VjBF3/2pTejC09BV8QhtxSMzuP4KI8/mMK8w8hw7foWRPTBShwEXQwstEbM8Bce5KS/lT3odY34H
-        2Emac/OWqT6Lk3E5cclVmQw6+5HPycicJ3NSNXvkmqDrGtG15E4tN0mWLkt2VzbJwrziLB//RHub
-        NN8ptf8CAAD//yKlHMYYaocYBjcUaFNGYnFYPngYEjbeD8wCECdXw5jQ+oVsB4Cng/Vh5uoo5SZW
-        BKUWl+aADEbyLHgAsajEsQTicdBEBmiQEeR1uDiqZiMU3VANYNfW1tYCAAAA//8DAGSVDVZRHwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18195","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195","key":"NTEST-1850","fields":{"statuscategorychangedate":"2025-04-30T18:25:13.029+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:12.710+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:12.797+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/6]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]\n*Defect
+        Dojo link:* http://localhost:8080/finding/259 (259)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d04e7bd6-ab87-493e-a567-c7114c742e15
+      - ddbeb39c-a1aa-48a9-a3fa-2a6893a0fa0b
       Atl-Traceid:
-      - d04e7bd6ab87493ea567c7114c742e15
+      - ddbeb39ca1aa48a9a3fa2a6893a0fa0b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:26 GMT
+      - Wed, 30 Apr 2025 16:25:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3579,7 +3853,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=259,atl-edge-internal;dur=14,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=291,atl-edge;dur=258,atl-edge-internal;dur=16,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="cpewgVnDKjJPZvEfBuATKMNRTgEMDqMDg5pdo0txkWFxdjYmEMnJdQ==",cdn-downstream-fbl;dur=294
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3588,10 +3862,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - cpewgVnDKjJPZvEfBuATKMNRTgEMDqMDg5pdo0txkWFxdjYmEMnJdQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d3689da972db036109d0caedd5f02138
+      - dd685a57c79c6aa4ecc5c3f8c5de69e7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3618,41 +3900,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 1b94e42e-ca4f-43ed-be71-28aea22136a6
+      - 90f41ae9-a47e-4914-8113-0bbe7fc306ea
       Atl-Traceid:
-      - 1b94e42eca4f43edbe7128aea22136a6
+      - 90f41ae9a47e491481130bbe7fc306ea
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:26 GMT
+      - Wed, 30 Apr 2025 16:25:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3662,7 +3931,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=313,atl-edge-internal;dur=15,atl-edge-upstream;dur=298,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=20,cdn-upstream-fbl;dur=386,atl-edge;dur=302,atl-edge-internal;dur=15,atl-edge-upstream;dur=287,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="yTX3ISwEtF3OKOmNB669AzpxcUmkK8zcnZ_ff47YOX-gZO49Wge52w==",cdn-downstream-fbl;dur=390
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3671,13 +3940,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 40867fef594010a8d9ec2cb0a5cb2350.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - yTX3ISwEtF3OKOmNB669AzpxcUmkK8zcnZ_ff47YOX-gZO49Wge52w==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - b2d49a1c16c52175639825378d39547b
+      - 9ee4b5af2e462bfba8d44b9b7688a261
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3689,23 +3966,22 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/96] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/6] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]
-      | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Feb.
-      9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+      | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* May
+      30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
       of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]\n*Defect
       Dojo link:* http://localhost:8080/finding/259 (259)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -3719,27 +3995,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1972'
+      - '1944'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16094
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18195
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - c80b9f44-fe5c-4e50-83ab-6015cffb6569
+      - 6a3c71a2-09e2-465c-939f-fe35635491fd
       Atl-Traceid:
-      - c80b9f44fe5c4e5083ab6015cffb6569
+      - 6a3c71a209e2465c939ffe35635491fd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:27 GMT
+      - Wed, 30 Apr 2025 16:25:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3749,17 +4027,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=473,atl-edge-internal;dur=19,atl-edge-upstream;dur=460,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=505,atl-edge;dur=471,atl-edge-internal;dur=15,atl-edge-upstream;dur=456,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="eWLEW8JD8S3Ek9dAYnggj2uZhGHS0OHYPVhlj5RzRS1C72b_lCAo4w==",cdn-downstream-fbl;dur=511
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 995d6494814d695ff2add6899f970080.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - eWLEW8JD8S3Ek9dAYnggj2uZhGHS0OHYPVhlj5RzRS1C72b_lCAo4w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a11acfd011c1d37359a753d2ef062700
+      - 19e3c18930963f61daabeb8ef135a64e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3783,65 +4069,52 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16094
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18195
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWW/bRhD+Kws+FanEy4osEygK15YTt67rykry4BjGmhyRG5O7zO5SR2P/987w
-        kOJDae2igQ1wrzl25ptvR18cWJZcJk7kaJAJaEiOBOSJ6UlegOmZOIOC91QJmluhpOlBImwBlvfi
-        jMsUcpX25qAN7kEygVKDAWnbs3FlrCpmpPAq8P3AdzV8rsDY6aqEM81jK2Jweo4g+8HQ3xvgxEA+
-        w2lmbWkiz0tgBrFN1CflcptzYwSXrgTroSXr8VJ4oSeMqcDrFNzACuVPp+PzaT8YBj4u1S4YJ/ri
-        GPStMjG3kCq9au6Q4AwlQj983feDfuBPQz8KhvjvjvzgR/SbdNRGLDpeq3mhkyTvoT4/XF+7nSRg
-        Yi1KChyu7jNT8DzvsUQYK2RsWSkgBqZmbKH0jUvSsZLvdP5MLyopKF08v+Jzbrn25gIWXu3WxsF2
-        K/B3gtHPRvwFPxWY9qpAqwQLNDnl5oZyVV1bGkUznhvoOY3gMd6rlu05mUDg6DhbncAc0Ff/rudY
-        gcgqESVOJCu8o/MAJjv+to2g2yi1+oRXfWEmWuk6D3VmuzzQ5Cv0bK77TgprUYFx1rYJwr/VZ42a
-        2QXXBGQjijIX6HDyICSYqBp+g9FyMHqmu99IWXeTdcIG/i66EQ6W4eD/tdLAogYpGgyGy2D4PQwu
-        O4s74XIn/B4WW+Tf3T2GY9jBcSaW7xsOxCRfXD4+udOd5GmqIUW++ccieN1t4AVUXjW88PTR4baN
-        3S0b4daN0baNvcfuNLTZrBIp1S+EE/UDnHKLD0dDuM+vz4bONwTuNeo0VV89PFAVBS4gUv5AC0Km
-        TmR1BXctT5M2LeImal8erZFneNRkqsqTQ2HKnK/aisVldMu+R2hQFbfR0ICXJZp46pEYjIbdI/Ew
-        bNuoLFxT2cONNahKLZQWdvXCIHbiXv3S/Pu3QhQ8BeORhOmUCFzIRJq5Zp5uSPEtrnTsGTqP6yNc
-        oz7n10D890RpEG08GYhgG0aDEUUk42ZcivhEyJsj2jmEkvoXGXd5rLO7qPfWK1LJMbYv/DqHCXDT
-        YEO3I+fs5N2b49Ork+OD8en5+Go8mfwxwfthnRoMCR6YZsDOkOilZWSXCcOUzFcMSUPkpJRZxX4V
-        mrMzDQWyBqsMotZ9ijwCLCjHvxW+X36eRU7zKmL2MPybqrrHFpiIVEiePzzUdl9teGuk5+hdO6fM
-        phLWp6uSyvZJJIe7bhiMOiQ3jdILwdcIrx/Y+73N8/C4wdsvPL7BdrODXKe8sXXQdnT/yeGuLWxq
-        Bo2EXT8gYUHVrXKlTxtvrvMK+qlG3tg0RYodqibZqiixIZb2adC/XtPCtxL7UGhNGffD+VF+/bfP
-        Uq2qkhrFIyETJEbDsFbYNYBkZWUySGqUHk/26XsNTMg5WSaYJQx/CjB8zSCJSFkWuuwNqfsoX9Xf
-        VxG7WKsVMmIzjGEW+e6O699SvDHcuYp5niljo5E/8r1Zc/yqdsvbG16iHLs4h7gidmJv1aJv1RZZ
-        fJWTCl/l8JJ57CIwlv1ZcW1Bs7FMsSYLjPAWUVgf8IJa+vTsd7ZfYfWz85jLLVLU43l7u5dNLG9v
-        2Tm2rbWfOD54P64/H5pPl2KatK8/DafCIhGQaA0pHKEiRlzJbtkF6uiHyG30rgV7tRcEUTlPXImd
-        vpuquTevcomgtUgq3v3zl6Ri4DehJrl4AW4hrAZX6dTDyuaEdoHdKjGCh0fdzBY5ydWZwm+dK9Iz
-        gbTKOYZyST/aavcPQQqeE3bOQc/xtxnrsx+OSPBvAAAA///sWW1P2zAQ/ivWpCFaNSFtU/qCEEN0
-        SHzoNDFtH9gXXNuh2domykvRNH78nnNc04aabUxDfECgtvH55Xx3fvzcpcX25sURBvf8TsNhPOPp
-        g05PK3qxpPxupVpkHc2JW+wyzr+zUyFUSsF2R0Zurk08amorURtrjkvFxohINJ6rqc+GLUZ4xbaD
-        ff03a/s22vVz1//P+4PeYw0rOPHfEkaAC1V/O47t46Oxa9OPbZk1EXNo/oov70nux4qIJD3FvwXg
-        tt2bn5IygxXP47kCNKjK0ns3xZGOto2O43vIagJa7LIJsMxAgR8nB1yu4hx4CL7R6xwCzSKyMUJl
-        fcmR76715NcMNzEjVZFhmrs3My43ipDLpXV5blx+OyMk5JhvecNAwQXkuMRFxiNaia5sQFRaFj4s
-        /+V+/gmwaK4M5G2L1uR/tBFF6PFR01a5FkMKyxxb8cYE6DnDaDQiIvUJHdWN2dpoyEF1HIJspTy6
-        zGLxsGMljfiKrt8NLxGkjeiDgguPdEBzqJOW03ksjAcnsb4jjAM/axpBNjeeqXbFkozNIch86/mL
-        RQocoDEfEhbrBwZcX8VSya1YusR5ArfC0n8TIWZomtC1QAG+z+UiXjbYfuNugQAukhGC9iEz71ly
-        WidmLsreDjcv7SIDG9FpByUS9a42easJApcgtPlVfYTlx2sruDq6+HLgyukCu+YWz6zTEF4UXMzo
-        Jq24TF4uFpyI1hsXEyBrU8KUZE9kY3QGT7gQlOZdyOOe7A76g2m7H6iuGAZi2OtEw3Z0iHVsJ6zw
-        SDdFoXAqJZ0T9BSJ/PFuQxHQNZrr0UqNNr/ywfh0NxqzrhaECkkJl+0wPOyLQb/XHU7FtB9g+Yir
-        aCBO5LGe5W339G3nHP/VOG/Bl4ajeF7VlPtl7t3CEF7HJ/LjV0eQLOWlnOdkKIzXCI+UBj/PJl7g
-        p0tixfWqz8vXuF42evka18tOL11jYJOsyhsmbTlD6LMJj6JSiFgfIOJoVfGkQrYrsFp0fF9mSaoO
-        roA5gtJ8c9Ko7AmpPbq0gqkC7851Qheehq4SSGhLIJnB9VcYebaAeYWR59D4FUZ2wEgdBlwMLbRE
-        zPIWbOemOpQ/6f2M+R1Ak6Tg5rVTfRYXFQtcuBR0dgOcq4IZODfgpGp2Z/URLg7XdQosuVPLVZwl
-        y4rAVU2yNO88q8c/sN4vAAAA//9SKssvod54PsQwuKFAmzISi8PyweOSsEF4YBaAOLkaxoTWL2Q7
-        ADw/rA8zV0cpN7EiKLW4NAdkMJJnwSOKRSWOJRCPg2Y2QKOOIK/DxVE1G6HohmoAu7a2thYAAAD/
-        /wMAc0UvlWIfAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18195","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195","key":"NTEST-1850","fields":{"statuscategorychangedate":"2025-04-30T18:25:13.029+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:12.710+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:26.125+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/6]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]
+        | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:*
+        May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [Regular Expression
+        Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]\n*Defect
+        Dojo link:* http://localhost:8080/finding/259 (259)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 24ed3f8e-d680-4904-9411-b6be02cf0e52
+      - ac6119fe-482b-41d5-99b3-b3e254794063
       Atl-Traceid:
-      - 24ed3f8ed68049049411b6be02cf0e52
+      - ac6119fe482b41d599b3b3e254794063
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:27 GMT
+      - Wed, 30 Apr 2025 16:25:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3851,7 +4124,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=311,atl-edge-internal;dur=17,atl-edge-upstream;dur=294,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=288,atl-edge;dur=255,atl-edge-internal;dur=20,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="FfELzcSNYCi3Ex8dbVIKY22ByuZaKYka9QDF1aY8iwu9_uuKLQqbIQ==",cdn-downstream-fbl;dur=291
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3860,10 +4133,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - FfELzcSNYCi3Ex8dbVIKY22ByuZaKYka9QDF1aY8iwu9_uuKLQqbIQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 906ad0965ea474da5c915efdb4e54741
+      - ff81752237b9afaf80deff108d529d5c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3889,21 +4170,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1610/transitions
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/transitions
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 4cf1d033-2eb0-4020-9d55-674aee5ad574
+      - 8cf62239-4d02-40cf-8545-0115ba2c11d3
       Atl-Traceid:
-      - 4cf1d0332eb040209d55674aee5ad574
+      - 8cf622394d0240cf85450115ba2c11d3
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:28 GMT
+      - Wed, 30 Apr 2025 16:25:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3913,17 +4196,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=504,atl-edge-internal;dur=14,atl-edge-upstream;dur=490,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=522,atl-edge;dur=489,atl-edge-internal;dur=18,atl-edge-upstream;dur=471,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Wa4zTAhgPLmZeNYaiFwHNKj6dfKYEHvyZFcNQPlBi8XMKYd2TJaEUA==",cdn-downstream-fbl;dur=526
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 848ee9f48eafd6caa6bf5371a2f79f28.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Wa4zTAhgPLmZeNYaiFwHNKj6dfKYEHvyZFcNQPlBi8XMKYd2TJaEUA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d11208c947e6becf5ad6c2d33659f56b
+      - b46bc19eb57d8ab8f6a6139282630f9b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3950,26 +4241,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2nVd3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwG2WJyaV8JHkAGbT4FOYVkxxrOUZ0EMcAEBDnkX/oBD1XbnLIWKAac5Z0VSpMU3
-        K7sbo2wAM5oXUgDOUUmaLlBkSmUKpGLLdF7UKs+Q5QrYmcDraLhtBxFfiEqM2t9ZKWL7QPSpImhe
-        tyU5nh/2ZE2cXN9X5PgJAAD//wMASI8A7CACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:27.821+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 084faa0d-fe0e-477c-b704-4ed9ca4a7e14
+      - 3803a85e-1b2b-4d6b-b8fb-9842ac5cda1e
       Atl-Traceid:
-      - 084faa0dfe0e477cb7044ed9ca4a7e14
+      - 3803a85e1b2b4d6bb8fb9842ac5cda1e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:28 GMT
+      - Wed, 30 Apr 2025 16:25:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3979,7 +4266,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=159,atl-edge-internal;dur=25,atl-edge-upstream;dur=134,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="SkK-tKb5KppIX3MftNtM2tp4DulXoEWl_pWn2yWq_KLZQdjS1un7Yw==",cdn-downstream-fbl;dur=225,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=223,atl-edge;dur=149,atl-edge-internal;dur=17,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3988,10 +4275,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c973663b623c0e82cd366d5ae7837bf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - SkK-tKb5KppIX3MftNtM2tp4DulXoEWl_pWn2yWq_KLZQdjS1un7Yw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - f933cf5ed7459089c004f2c7767aad35
+      - 20c84b84bca8d4df20d513618895ccf1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4015,78 +4310,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbU/jRhD+Kyt/pCF+SYBgqaoQhDtajlII8IFD0WJP7D2cXd/uGpJe+O+d8RsQ
-        ElSoeiDhfZud2Zlnnhl+ODDLuYyd0NEgY9AQHwrIYtORfAqmY6IUpryjctDcCiVNB2Jhp2B5J0q5
-        TCBTSecetME9iM8g12BA2vpsVBirphO6cOx7nu91NXwvwNjRPIdTzSMrInA6jiD9/ra328OJgWyC
-        09Ta3ISuG8MEIhurb6rLbcaNEVx2JVgXNVmX58INXGFMAW5zwR3MUf5kNDwfbdIaLpUmGCf84Ri0
-        rTARt5AoPa/eEOMMJQIv2Nr0/E3fGwVe6G+HwVa3v+v/gnZ7ZCQpsWh4ec0HjSR5F+/zgvbZ9SQG
-        E2mRk+NwdY+ZKc+yDouFsUJGluUCImBqwh6UvuuSdKTkhc7eaUUhBYWLZ2N+zy3X7r2AB7c068nA
-        esv3ev7gNyP+hl+nGPZiiloJFqhyxM0dxaq4tTQKJzwz0HEqwSN8VynbcVKBwNFROj+Ge0BbvceO
-        YwUiK0eUOKEs8I3OEkx6XrORa/UNX/RBh9fSpbvLADbupskzkDy96kIKa/EC47S6Cal/lGeNmtgH
-        rgmvRkzzTKDB8dLLMR4lyvqDWX/wTnPfiEzzkjYufW8HzQj6s6D//2qpol9iERX62zN/+2conDUa
-        e8GsF/wMjTXAHx9fw9Ffh9Og2ZiI2WXFgRj965vXJ3vNSZ4kGhLkm1dJgA9QWVGl/4fg/nTBasS/
-        JJgrZBGWcsNuASSLFAIaLMRMSWZTYVhJBkQzdWocIL87K5yztc452+s2dtZsBGs3Bus2dl877y0u
-        3x40XE4cWhY0J9z0a2onV2oRNRFYXqO8xvebVBVZfCBMnvF5nf24/MAtVsqqwrw/dFX9eqpYbnWd
-        Jh4qh/uqIKSUpl7RgpCJE1pdkG681F4ixImNaj9pQDdQ8F/5we93e4O2pi07tGXe5Y11ORC0OZBr
-        obSw8w+6oBF3y8L470ubmPIEjEsSprlE4EIqkrRr7pMnBH/GlSYnghVQDnpNsow3wo2xX/3FH5wv
-        NuiEFzzbIfdl/BaI8FekPPHkSo/562DuD8h1mJLDXETHQt4d0s4B5NSXyagBWwnBh3KvXZFKDrEt
-        47cZnAE3FYB1PXJOjy8+HZ2Mj4/2hyfnw/Hw7OzPMzQe+ceg7/DAKAV2ipVNWkZ6MfeRBrI5Q5YU
-        GV3KrGK/C83ZqYYp0iQrDIKzu4otfcxJx1sIz8u/74ROVe0xzBgnSswVLIgRS4Tk2fKhuqus3Vum
-        SIbW1XOCQCKhPV3klPkrIf+yjasawA+itBJuG7iXlPo+4C5R61I3WCnar9vU/2Rt0+u61BuTkl7T
-        /cSV4khlSp9UtmBcQC6ZVkYZCwSOpV2N9q2WON6K6LJQSyov/fhVPv/dY4lWRU6d76GQMRKfeapb
-        eWFSLFoEz6OzPfreAhPynjQTvmKG/9swLM8Qh3RZGnTZJ7ruq9wovxshu26vFTJkeRJudf2utyBH
-        o58zFfEsVcaGA2/guZPq7Li0yd3dukEhdn0OUUHkxT6rh02r1shi8xEX2HwEN8xl176x7K+Cawua
-        DWWCmThF964RhfaA65fSJ6df2F6BOc/OIy7XSFEr6+7u3FSOXCzYOTbhpZ043r8clp+r6tPElyZ1
-        L0PDkbCY/ovFPwAAAP//7Fhtb9s2EP4rBwQIZM+mavmtceAPRZwBBdaiSLZ9qQtYkRlbqCwpouRk
-        aPvf9xxFUVJsd2u7T0OTwJHveOTxuePdQ9GtziU8YSLiUkqf6T3m6Hs48ty0XnraC87NeL8WMe4t
-        YpPs3X0RxcjWHKXEbY//wFNcjKxZ8CjFLswzKZJs4+I4+5zlITg5lwH3YiS2+S5iq3SDDx0mnsLD
-        z43cJbnENtaSrp8QDrahPjnvNj06j/JL8sRgIDyi801+OaeheAFjrRiKiRhRpRjVipEYi2klH9fy
-        scBclXxSy/lxXMvZOyMfiEkt92q51xw/rOVDMazlo1o+qjcwrdflx4bcrsuPXudEbphEdr3JC0b0
-        dcyX8b3scfD1zaZHN6H6SK+CQKZ8kI4FfvqNgTfj/6vA/wz69wZ9/PJfBx2Vsiobs65OAJZRd1FI
-        WqDEQvirvBN00SPuvNSu3tXvdiBs+dbfh+Lnwf2xGOLgIjYLzQNoASJATI8Qjn+0IwcfnWOB/VpY
-        qYteAfF7/Ot/x+nFeigDeoIfaxvtzOreJkUWSGRXJLvcv/vos7tQSYY13TQGLmqW0QUbsMsi9ZRp
-        4CJMXH+9DxUoDC4RY88DAblnhHEYKkLKVGSVbla4NcfwLyafsjKLA85iabOY9yAz/y6MuOfmWz+n
-        JMBCih63ku/ZsjJk1O58JSnJ6AHXzr9IpTLgI6kwe5D59+wAiFqxi4m5mdDnDMQ9kwTmTvljUpkE
-        pAIZ+7gKMaPBUmGwJRAFsPoo/CjB6++xig+30zQKA/2q1jCnyuFIAh+cWL4YNEeVW4NPRaz8e9QN
-        vgf0VcFD4J96iMxyBhlFOx/GYQLm0HBeiWXsHc4OoxhIK3YG7uHGm4EwYl6LDpM564NvkMpkXmQx
-        UhtPqohyRrfhA8YddUIwgGdnuNIkiCf+rpKYq94yXq1Wy5jvkzl9oivsDKzoC82J312HmXTOz568
-        KVKr/N+pxgblyDnF8tGYOazUT8JsjiWVAcM1p9Xt9W/XV7/TgF7d0vlDkeSXS/yUk7vdUoJDeEzd
-        dZc4l7/wVlUSSRElGwfZH+BmJ2S873xgb8CwYRK7bmm90g6UTmkAHfjRI0dmWY8R7NCcTw59wsxm
-        T5hrzY5/6Rhw6E+bKPQGpBb5QnzUmvLqhdisVcXBJE/UcWhOVXJrdFDLreagmjc0z+p5Q/Osojc0
-        z2p6Q/OsqlvNQV1vaNqVHTi90+931hVIMzPSgGRQwXwNuBgjgwkv1ISLMTKgGFUFF2NkQWloqo5X
-        odJSMUgWlZaGQbKotDQMkkWlpWGQLCoNTQmSRaWlKUFqJBPw2iKTOCX7Jf+bHRZ6vsvM+APdCd+Y
-        xCgYpcUdjr/pAW9CfTE0LaBrrzqeeBJPM/pDv0XgAmSKfRUSVMwImkw0jYanjMpoHbUZnbIpw3jU
-        ZnzKpgzwUZvJKZsyItaGHHrLHUh3J9vhdBL0yoj3dNktQ8ytxo9UQmmZwIKYRthFp6cW1SH9+qIm
-        IdClDhYwsXu9S8FXOW5vEwr1F0IK7MO1XNdtHgNvwIkyiWquvqXPG9M04Ss50xTHX+/CuENO5/MO
-        NCRPZpZ6HKWz/2cq+zcAAAD//0KI06IpC+yOkNWUNbUANmVNLQa+KUtuRxg52dK6KWuIrSkLAAAA
-        ///smlFrgzAQx7/KKPQxLtFYdVC6MjbYQ79A39KLbmPYFq2MfvvdGRskazrYQ+kg4IOYOy8c5vjL
-        /xekbJCyQcoGKRuk7KhfQcoGKft/paywqb9I2Z/+f2o5FdfV9YEBQo6Nv0Oj4LNHEwiVcEN9qAj3
-        LUjLd7gZ1lw/dcEX6DPbuY8p4bamOhwUvJPnNjjOY9PatTbbrq4VGbWTs24itZqYjF3zRyuX1MlC
-        ARAH8qrnqU7yLN+IjJcJFByKNK4KUc2wjg3CChfCSvoOllpjjRYjUe4dH0cbgR3Bfpehtr73ZfTW
-        mDDKOYFVsuQiV1pIOcsgz9Kk2MAm41i+UmWVw0LP+7dMk+U0fsHL5LFabQefkzHzqI26ln1hI1gc
-        kYEamRlInWJ7pVpqFOb3Gh1PG94+rRiP9lsiP1xA7vZ37BJ2t79jl9C79R3jYNKG3hqQB/xfP96t
-        VFV1AB/9ASJPzNBVZqytiYJ4mDx3zW5f3q9x4ACRRMNJI0IUV+3RpQoDF3selpC+YSp9lJW0lFUz
-        DPVrjZFvAAAA//8aLUZGixG6uHi0GMFSjKAXA7iaZybwVhi8kQL0TjokU1aDlrJD2QZAl+SXJEIX
-        4qObgqsdZoCrXDIwwl7A4Vr7aIDTAzjbaXCfoevA1YAzxikBb9ml5pVlFuXnQZp2EKGUUuguEAiX
-        mNArAzb7yV1HiLHgF2IY3FCgTRmJxWH54BWNsDXGwCwAcXI1jAmtX8h2AHjHjD7MXB2l3MSKIMjA
-        E4pnwcsRi0ocSyAeBy2ezskHNfKRxFE1G6HohmoAu7a2thYAAAD//wMAcXfysXQ0AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:24.135+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:24.108+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_14095_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:24.134+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Inactive,
+        Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Inactive,
+        Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025
+        \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect Dojo link:*
+        http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 485a75ae-4725-41c1-a3b9-1eacaca71506
+      - 00672268-5730-4e55-bd0a-214bcdd5f87d
       Atl-Traceid:
-      - 485a75ae472541c1a3b91eacaca71506
+      - 0067226857304e55bd0a214bcdd5f87d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:29 GMT
+      - Wed, 30 Apr 2025 16:25:28 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4096,7 +4426,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=263,atl-edge-internal;dur=13,atl-edge-upstream;dur=250,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=312,atl-edge;dur=279,atl-edge-internal;dur=14,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="p8FSK5hEjolnsUua-7194iiTby0V1DQvypvKwv2oTiHHGjAbnd4Ajw==",cdn-downstream-fbl;dur=315
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4105,10 +4435,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - p8FSK5hEjolnsUua-7194iiTby0V1DQvypvKwv2oTiHHGjAbnd4Ajw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 365ef95d00613092f44dc72aef7704cf
+      - 42a2135ef66e5cbba56be59d9199e34f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4135,41 +4473,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 804dd13d-264c-45cd-bcf0-a68d0355f32f
+      - e4dc9fc2-3fb6-4b5a-aece-dcde8038ceba
       Atl-Traceid:
-      - 804dd13d264c45cdbcf0a68d0355f32f
+      - e4dc9fc23fb64b5aaecedcde8038ceba
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:29 GMT
+      - Wed, 30 Apr 2025 16:25:28 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4179,7 +4504,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=315,atl-edge-internal;dur=14,atl-edge-upstream;dur=301,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=352,atl-edge;dur=319,atl-edge-internal;dur=17,atl-edge-upstream;dur=302,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="2PmuCaVC90Bwf9Xhp7Rms7Cl-I9qvqnul9eYSPi5TD711k0PNx0VoQ==",cdn-downstream-fbl;dur=357
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4188,13 +4513,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 771067dca4682f83a6c9963c412d66cc.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 2PmuCaVC90Bwf9Xhp7Rms7Cl-I9qvqnul9eYSPi5TD711k0PNx0VoQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7087568b0b93d4e9502140f03d46593b
+      - 1997e1b970f0b2be738be99a00737f10
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4206,28 +4539,27 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/95] in [Security
-      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
-      / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
-      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
-      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
-      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
-      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
-      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
-      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Inactive,
-      Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5] in [Security How-to|http://localhost:8080/product/2]
+      / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n||
+      Severity || CVE || CWE || Component || Version || Title || Status ||\n| High
+      | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
+      | pg | 5.1.0 | [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]
+      | Inactive, Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
       | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
       Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Inactive,
-      Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
       Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -4236,31 +4568,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:* http://localhost:8080/finding/258
-      (258)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (258)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -4269,25 +4599,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -4299,27 +4627,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7157'
+      - '6820'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 4fd84ecf-6436-4c69-b7a7-589603d8b0f8
+      - 28ae6d91-bdab-4c22-9944-aa2316551c5e
       Atl-Traceid:
-      - 4fd84ecf64364c69b7a7589603d8b0f8
+      - 28ae6d91bdab4c229944aa2316551c5e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:29 GMT
+      - Wed, 30 Apr 2025 16:25:29 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4329,17 +4659,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=288,atl-edge-internal;dur=13,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=324,atl-edge;dur=290,atl-edge-internal;dur=15,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="A2AML7rcLXHBLWibXck0CGtLvLq_Ff9xzg1CaoKH6t2dIlxrtl4T_w==",cdn-downstream-fbl;dur=329
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - A2AML7rcLXHBLWibXck0CGtLvLq_Ff9xzg1CaoKH6t2dIlxrtl4T_w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 14539d41905be84ee91a520d39d1a6a9
+      - c8b1328e2c10064052e4cee821804fdf
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4363,79 +4701,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/pCF+SQLBM50OA+GOlqMUAnzgmIywN7YOR/JJckh64b931y8B
-        QsIUOj2YwZalfdHus88uPxyY5VzGTuhokDFoiI8EZLFpST4B0zJRChPeUjloboWSpgWxsBOwvBWl
-        XCaQqaQ1BW1wD+JzyDUYkLY+GxXGqsmYFI58z/O9tobvBRg7nOdwpnlkRQROyxFk39/x9jq4MJCN
-        cZlam5vQdWMYQ2Rj9U21uc24MYLLtgTroiXr8ly4gSuMKcBtFNzDHOVPh4OL4TZ9w0+lC8YJfzgG
-        fStMxC0kSs+rO8S4QonAC3rbnr/te8PAC/2dMOi1u3v+L+i3R06SEYuOl2o+6CTJu6jPC5bXrhcx
-        mEiLnAKHX/eZmfAsa7FYGCtkZFkuIAKmxuxB6fs2SUdKXursnV4UUlC6eDbiU265dqcCHtzSrScH
-        6y3f6/j934z4G36dYNqLCVolWKDJITf3lKviztJbOOaZgZZTCR7jvUrZlpMKBI6O0vkJTAF99R5b
-        jhWIrBxR4oSywDs6KzDpeM1GrtU3vNEHA15Ll+EuE9iEmxbPQPJ0q0sprEUFxlnaJqT+UZ41amwf
-        uCa8GjHJM4EOxys3x3yUKOv2Z93+O919IzPNTZZ56Xq76EbQnQXd/9dKlf0Si2jQ35n5Oz/D4Kyx
-        2AlmneBnWKwB/vj4Go7+JpwGzcZYzK4qDsTs39y+PtlpTvIk0ZAg37wqAryAyoqq/D8E9ycF6xH/
-        kmCukUVYyg27A5AsUghosBAzJZlNhWElGRDN1KVxiPzurAlOb1NwdjZt7G7YCDZu9Ddt7L0O3ltc
-        vtNvuJw4tGxoTrjt45Jb7HNVf3h/4Kvu89Rv3EqdJhYpXw9UQXn2qYdc0wchEye0ugAMKCq1VwhQ
-        4pLqMqU+0q9F1OBh9Rv5isImVUUWHwqTZ3xecxElSQOGgZL/Kg5+t93pL3vaakCXzLu6sakGgmUN
-        5FooLez8g0FsxN2yMf771iYmPAHjkoRplAj8kIokbZtp8oTgz/ilqYlgDZSDTlMso61wa+RXf/EH
-        14stOuEFz3YofBm/AyL8NSVPPLk2Yv4mmPt9Ch2W5CAX0YmQ90e0cwg5zWUyatJbJv2h3Ft+kUoO
-        cCzjdxmcAzcVZHT95pydXH46Ph2dHB8MTi8Go8H5+Z/n6Dzyj8HY4YFhCuwMO5u0jOxi7SMNZHOG
-        LCkyUsqsYr8LzdmZhgnSJCsMwru9ji19rEnHWwjPy7/vhk7V7THNmCcqzDUsiBlLhOTZ6qF6qqzD
-        WxZAht7Va4JAImF5usip8tdC/uUYVw2AH0RpJbwc4F5S6vuAu0KtK9NgZeigHlP/k7fNrOvSbExG
-        Os30E1eGI5UpfVr5gnkBueJamWVsEPgu7Xq09zYRR29JHG+l+mUcv8rnv/ss0arIafI9EjJG6jRP
-        fSsvTIpNi+B5fL5PzztgQk7JAOErZvi/DcP2DHFIytKgzT6Ruq9yq3xuhexmqVbIkOVJ2Gv7bW9B
-        gcY4ZyriWaqMDfte33PH1dlR6ZO717tFIXZzAVFB5MU+q4dtqzbI4vARFzh8BLfMZTe+seyvgmsL
-        mg1kgpU4wfBuEIXlAdcvpU/PvrD9AmueXURcbpCiUdbd272tArlYsAscwks/8f3galA+rqtHk19a
-        1LMMvQ6FxfJfLP4BAAD//+xYbW/bNhD+KwcECGTPpmr5rXHgD0WcAQXWoki2fakLWJEZW6gsKaLk
-        ZGj73/ccRVFSbHdru09Dk8CR73jk8bnj3UPRrc4lPGEi4lJKn+k95uh7OPLc9l562gvOzXi/FjHu
-        LWKT7N19EcXI1hylxG2P/8BTXIysWfAoxS7MMymSbOPiOPuc5SE4OZcB92IktvkuYqt0gw8dJp7C
-        w8+N3CW5xDbWkq6fEA62oT457zY9Oo/yS/LEYCA8ovNNfjmnoXgBY60YiokYUaUY1YqRGItpJR/X
-        8rHAXJV8Usv5cVzL2TsjH4hJLfdqudccP6zlQzGs5aNaPqo3MK3X5ceG3K7Lj17nRG6YRHa9yQtG
-        9HXMl/G97HHw9c2mRzeh+kivgkCmfJCOBX76jYE34/+rwP8M+vcGffzyXwcdlbIqG7OuTgCWUXdR
-        SFqgxEL4q7wTdNEj7rzUrt7V73YgbPnW34fi58H9sRji4CI2C80DaAEiQEyPEI5/tCMHH51jgf1a
-        WKmLXgHxe/zrf8fpxXooA3qCH2sb7czq3iZFFkhkVyS73L/76LO7UEmGNd00Bi5qltEFG7DLIvWU
-        aeAiTFx/vQ8VmAouEWPPAwG5Z4RxGCpCylRklW5WuDXH8C8mn7IyiwPOYmmzmPcgM/8ujLjn5ls/
-        pyTAQooet5Lv2bIyZNTufCUpyegBF72/SKUy4COpMHuQ+ffsAIhasYuJuZnQ5wzEPZME5k75Y1KZ
-        BKQCGfu4CjGjwVJhsCUQBbD6KPwowevvsYoPt9M0CgP9qtYwp8rhSAIfnFi+GDRHlVuDT0Ws/HvU
-        Db4H9FXBQ+CfeojMcgYZRTsfxmEC5tBwXoll7B3ODqMYSCt2Bu7hzpyBTGJeiw6TOeuDb5DKZF5k
-        MVIbT6qIcka34QPGHXVCMIBnZ7jSJIgn/q6SmKveMl6tVsuY75M5faIr7Ays6AvNid9dh5l0zs+e
-        vClSq/zfqcYG5cg5xfLRmDms1E/CbI4llQHDNafV7fVv11e/04Be3dL5Q5Hkl0v8lJO73VKCQ3hM
-        3XWXOJe/8FZVEkkRJRsH2R/gZidkvO98YG/AsGESu25pvdIOlE5pAB340SNHZlmPEezQnE8OfcLM
-        Zk+Ya82Of+kYcOhPmyj0BqQW+UJ81Jry6oXYrFXFwSRP1HFoTlVya3RQy63moJo3NM/qeUPzrKI3
-        NM9qekPzrKpbzUFdb2jalR04vdNviNYVSDMz0oBkUMF8DbgYI4MJL9SEizEyoBhVBRdjZEFpaKqO
-        V6HSUjFIFpWWhkGyqLQ0DJJFpaVhkCwqDU0JkkWlpSlBaiQT8Noikzgl+yX/mx0Wer7LzPgD3Qnf
-        mMQoGKXFHY6/6QFvQn0xNC2ga686nngSTzP6Q79F4AJkin0VElTMCJpMNI2Gp4zKaB21GZ2yKcN4
-        1GZ8yqYM8FGbySmbMiLWhhx6yx1Idyfb4XQS9MqI93TZLUPMrcaPVEJpmcCCmEbYRaenFtUh/fqi
-        JiHQpQ4WMLF7vUvBVzlubxMK9RdCCuzDtVzXbR4Db8CJMolqrr6lzxvTNOErOdMUx1/vwrhDTufz
-        DjQkT2aWehyls/9nKvs3AAAA//9CiNOiKQvsjpDVlDW1ADZlTS0GvilLbkcYOdnSuilriK0pCwAA
-        AP//7Jrfa4MwEMf/lVHoY1ysseqgdGVssIf+A32LF93GaBV/MPrf787Y0GVNB2MPDgI+iLl4x2GO
-        r3w/Xsp6KeulrJeyXsqe9ctLWS9l/6+UDc3WH6Tsd/8/NpyK7eq6/L1QuBYMGELGX9dIeB+oB6IW
-        rFBhMA5rgbvgEu4y17kx10/tcQW6mBJuivliUtuOpew6Ca9kyGk/tO33e0lG7eyim0itJiajan5p
-        5ZI6WUsAIkme1SpWUZqkeZjwIoKMQxYvyiwsl5jHBGGGK2EFfQcbpTBHi5Eo9473Z4VARbDfdaht
-        aHERvDQ6jPacwCpR8DCVKhRimUCaxFGWQ55wTF/KokxhrVbDW+bRZr54wkvvY3t5GH1OxvSjNuhb
-        9oGNYIuADNRAz0DqFKulbKlRuH/Q6Hja8PZhy3hQH4j8sAG56VdsE3bTr9gm9KZeMc4fpXmpEXnA
-        //XjzVaWZQ/wNhwg8sQ0n6Wn144oiLvZY99UdXG7w7kCRBKNJ40IUVw1R5cyjFzsZVhCuIapcFFW
-        wlBW9oIZ2M047f94vnwCAAD//8IsOEbLl9HyhZ4uHi1fsJQv6MUAvBUGb7QAXZ0OyXvVoKXsULYB
-        0ML8kkToQnx0U3A2t3CWSzjbYUbYSz5cax8NcDU8QQUCVgkDXA1PY1w6jOEtu9S8ssyi/DxI6w0i
-        lFIK3QUC4RIVevm5EBOqYUxocU9G8Yu0gUUfZq6OUm5iRRBkHAjFbvDqwKISxxKIO8qA3Q9y1zNi
-        LF2GGAY3FGhXRmJxWD54ZSVsdTFo8XROPqgtj+QQVNcaoTgXqgEcPLW1tQAAAAD//wMABb50ZnQ0
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:24.135+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:24.108+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_14095_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:24.134+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Inactive,
+        Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Inactive,
+        Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025
+        \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect Dojo link:*
+        http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 6fd481b0-9652-4843-b3f8-49b08e63af2d
+      - 48f2b856-2641-4a1e-a8de-211ecac8438f
       Atl-Traceid:
-      - 6fd481b096524843b3f849b08e63af2d
+      - 48f2b85626414a1ea8de211ecac8438f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:30 GMT
+      - Wed, 30 Apr 2025 16:25:29 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4445,7 +4817,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=337,atl-edge-internal;dur=15,atl-edge-upstream;dur=322,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="A2F9B6zp-0nyw6_2fnn0davOi1sfNJ0-xG79xiuWu5lUzvfZFp2Ldw==",cdn-downstream-fbl;dur=336,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=334,atl-edge;dur=259,atl-edge-internal;dur=17,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4454,10 +4826,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9832e15ad117dafc81b031983cbde91e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - A2F9B6zp-0nyw6_2fnn0davOi1sfNJ0-xG79xiuWu5lUzvfZFp2Ldw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 308fcaea9b2648dfa14c5e298c11d5b3
+      - f0e4588d85d5166da2df599793956721
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4484,26 +4864,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2rVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwFWFKfmlfARZMDmU6BTWFaM8SzlWRADXECAQ96FP+BQtd05S6FiwGnOU0gKWH6z
-        srsxygYwo/lCCsA5KknTAkWmVKZAKrZM54ta5RmyXAE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMAJ1EyQSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:29.991+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 0320fd32-be25-4d17-85e7-ae5afe10c71a
+      - 1fd49068-353b-4dc7-8f61-7282004148dc
       Atl-Traceid:
-      - 0320fd32be254d1785e7ae5afe10c71a
+      - 1fd49068353b4dc78f617282004148dc
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:30 GMT
+      - Wed, 30 Apr 2025 16:25:30 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4513,7 +4889,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=165,atl-edge-internal;dur=14,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="dzfLtqB-3OdsdApQIP30Rl1nui-hU65DYhnknKY3bzUE0DrXWjrJ1w==",cdn-downstream-fbl;dur=257,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=255,atl-edge;dur=169,atl-edge-internal;dur=16,atl-edge-upstream;dur=154,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4522,10 +4898,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 40867fef594010a8d9ec2cb0a5cb2350.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - dzfLtqB-3OdsdApQIP30Rl1nui-hU65DYhnknKY3bzUE0DrXWjrJ1w==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 795fb6921a8d34999fabf2f768ab6200
+      - 455b7ec3afe8f60f450cfa51743f2df6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4549,68 +4933,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbU/jRhD+Kyt/pCF+SQjBUlUhCHe0lFII8IFD0WJP7D2cXd/uOiR38N8745cE
-        QoIKVU9IeN9mZ3bmmWcmPxyY5VzGTuhokDFoiI8EZLFpST4B0zJRChPeUjloboWSpgWxsBOwvBWl
-        XCaQqaQ1BW1wD+JzyDUYkLY+GxXGqsmYLhz5nud7bQ3fCjB2OM/hTPPIigicliNIv9/z9gKcGMjG
-        OE2tzU3oujGMIbKx+qra3GbcGMFlW4J1UZN1eS7cwBXGFOA2F9zDHOVPh4OL4Tau9XGpNME44Q/H
-        oG2FibiFROl59YYYZygReMHOtudv+94w8EK/FwZee2+n8wva7ZGRpMSi4eU1HzSS5F28zyNDq2fX
-        kxhMpEVOjsPVfWYmPMtaLBbGChlZlguIgKkxe1D6vk3SkZKXOnunFYUUFC6ejfiUW67dqYAHtzRr
-        aWC95Xsdv/+bEd/h1wmGvZigVoIFqhxyc0+xKu4sjcIxzwy0nErwGN9VyracVCBwdJTOT2AKaKv3
-        1HKsQGTliBInlAW+0VmBScdrNnKtvuKLPujwWrp0dxnAxt00eQaS5asupbAWLzDOQjch9Y/yrFFj
-        +8A14dWISZ4JNDheeTnGo0RZtz/r9t9p7huRaV6yiEvX20Uzgu4s6P6/Wqrol1hEhX5v5vd+hsJZ
-        o7ETzDrBz9BYA/zp6TUc/U04DZqNsZhdVRyI0b+5fX2y05zkSaIhQb55lQT4AJUVVfp/CO7LC9Yj
-        /iXBXCOLsJQbdgcgWaQQ0GAhZkoymwrDSjIgmqlT4xD53VnjnJ1Nzult2tjdsBFs3Ohv2th77by3
-        uDzoNVxOHFoWNCfc9mtqJ1dqETURWF2jvMb3m1QVWXwoTJ7xeZ39uIwxsVcIM2KEyqQHbrF2VjXn
-        /cGsKtqyhrnVdZqYqRweqIKwUxp/TQtCJk5odUHWRBrQDRT8V37wg7bvB40fVh26YN7VjU05ECxy
-        INdCaWHnH3xwI+6WhfHflzYx4QkYlyRMc4nAhVQkadtMkyWCP+NKkxPBGigHnSZZRlvh1sgv//f7
-        XRw8btEBL3i2Qd7L+B0Q36/JeKLJtQ7zN6Hc75PnMCMHuYhOhLw/op1DyKktk1GDtRKBD+XeYkUq
-        OcCujN9lcA7cVPjV9cg5O7n8dHw6Ojk+GJxeDEaD8/O/ztF4pB+DrsMDwxTYGRY2aRnpxdRHFsjm
-        DElSZHQps4r9LjRnZxomyJKsMIjE9jqy9DElHe9ReF6efw+dqthjlDFMlJdrSBADlgjJs9VDdVNZ
-        u7fMhwytq+eEgETC4nSRU+KvRfzLLq7q/z4I0kp40b+9ZNT34XaFWVeawUrRQd2l/idrm1bX7dRK
-        Ok3zE1eKI5UpfVrZgnEBuWJaGWWsDziWdj3adxa88VZEV4UWnPLSj1/k8799lmhV5NT4HgkZI8uZ
-        ZdnKC5NizSJ4Hp/v0/cOmJBT0kz4ihn+tGFYnSEO6bI0aLNPdN0XuVV+t0J2s7hWyJBJ9JUV3Cod
-        eu2ddueRHI7+zlTEs1QZG/a9vueOK5lRaZu7171FYXZzAVFBHMY+q4dtqzbIYg8SF9iDBLfMZTe+
-        sezvgmsLmg1kghk5QTdvEIXFAdcvpU/P/mT7BeY+u4i43CBFHa27t3tbOfTxkV1gL17aieODq0H5
-        ua4+TZxpUrc0NBz+AwAA///sWftL40AQ/leWA6UtTZq0afoQ8eSKIJxyKHe/yEG3yTYN5lHy8g78
-        4++bzaMPTetVFA9OpTbJzu7szDff7EzcBDRAohJT+IaJGDEqe2R3mEPpIvQRc72uLrUgjAaZrQYo
-        X1QnzDpZ6gVAbQJK6WyO/0lT9DStkrMehOq7SSTUMHI6iGtOcHdxNic+6GCoukh8j+RW7sKFdBhN
-        1sXPjXBSj8Omv6gklfuYiMDlHiHpVkQZKk+msMZ1NUObHXvJySmmMVWtWWPLwvGdbn9A618GVMNm
-        ok3GkgVBm9248T07tyyxJAA+ZygTG+/3Ri82VDFeGsp4uaGMvYZ6cyOZLzYSIrKE5bglDUb3WGuS
-        CjZBKOPmhZipbNRmxPBskyXK34WuVjQhr3vqu8EBO5hIVmYT0DKjZAWl98qxBj6az21/1+ZZCxGL
-        23f4pxwUPFgR8JJTvC58Nz3Qug3TCLa8cD0BdhW5vY+d5IRLb8uvKzSuCU5WWaAFtq7UCJEeCmJV
-        3bDD7cyNkWIE5eEBEsScbA4QlQcG8uh0tcKU4WjDSH8RlYeZqEBDoR2hwa7QEBdo4EnCrfu4zR4W
-        rrVgqAMcBySdgiDZkmOtwGGcoYazIIjjkhXxOekxzWGtfOWBk4Kup2whuA3JjHsoqfLdsh8rha6Q
-        Dzyxnns2n5el5XgdkRjyTZYEdvkcj53ysb45A0YuII6bwLiM/vF+x1BOGNMH4QuXtK0YsyzTmeda
-        hdOuXJlpC599l6cwsnDhjFwZBtbx8CAqNg+5S38JUiCZ65C58oIhMWauLewNON0gpHA0xdJ/A4pC
-        dBlSXiWMN7jtu0GTNZqPPjCchOMKt89yxpvzhXkgX5jEF+br+OKgHPKELw7NYuvufW++MP/zxTvw
-        hfFv8YVZie7hi6cNk37V2Nuug+s6KbpR96DqpFENlUTAkmzpUNNpa6hW13QzqobYtkTVjiitUDew
-        rj2h1TXhtGpNGQALqk6KGn29zN8uBuPU9zmVtp921l9kcmpmhdGBRTC1Ks6AWGqXXdqnfbs3HAxn
-        +kATPWukWaN+dz7S5ybWqQZhhR3DBOHh3LYpGjDSCu3fn9cUQaVMc+18GyB9IFQnyoeRTNmRNoSm
-        D7mtG4Y5sIYD8OXMmg00LD/nYj60zuxTOctR7/yoe4G/XE7xeVBUhoqS34rVNFYeYAilq1LJqeZx
-        SJZSlpzHZCjIS6bnXoyvX64UTV0G1DLbfrPw8TXefjXx8TXefrXxoTX+AwAA//8CuhhYDqVAhr2h
-        g0XOwKSv4JuYllaanJwJzkCgXh5kEBpSikWBxo+slFxLi/ILUvWjgAVPMmgIFprTQFNrQFl41gXZ
-        AJ1QxD7MZIKrUDXBNTxtAh+eLoIW7qPFCEqCAQAAAP//omWCGS1G6OHi0WIESzGCXgzgaqaZwFtj
-        8MYK0DvpkExZDVoDAGUbAF2SX5IIXcGAbgqu9pgBrnLJwAh7AYdr1sgApwdwttdwtTNBRQhWCWOc
-        EvAWXmpeWWZRfh6kiQcRSimFLp+BcIkJvbL8EurNi0IMgxsKtCkjsTgsHzwXBJucBWYBiJOrYUxo
-        /UK2A8BLjfRh5uoo5SZWBKUWl+aADEbyLHgip6jEsQTicdCsc04+qE2PJI6q2QhFN1QD2LW1tbUA
-        AAAA//8DABdna3OtJQAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:18.266+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:18.244+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_10873_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:18.266+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Inactive, Verified, Risk Accepted |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:*
+        May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression
+        Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]\n*Defect
+        Dojo link:* http://localhost:8080/finding/257 (257)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 903f0edf-1916-4bc0-9ddc-1fd9b7be07a6
+      - ab5af273-88e5-45aa-92d1-232a373d5480
       Atl-Traceid:
-      - 903f0edf19164bc09ddc1fd9b7be07a6
+      - ab5af27388e545aa92d1232a373d5480
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:31 GMT
+      - Wed, 30 Apr 2025 16:25:30 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4620,7 +5003,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=267,atl-edge-internal;dur=13,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=291,atl-edge;dur=258,atl-edge-internal;dur=15,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="r60QjgEZwylBElP1rUBcT_mZuSyW2pNVQerhpTJJUQH8VwWTKxXlRg==",cdn-downstream-fbl;dur=295
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4629,10 +5012,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - r60QjgEZwylBElP1rUBcT_mZuSyW2pNVQerhpTJJUQH8VwWTKxXlRg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - fdee2fd7845f46d1292964f4095ee731
+      - fbe226db5f5acde40c545218da1fa969
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4659,26 +5050,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TfmzLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPATYfH5qXgkfQQYsnwKdwrJijGcpz4IY4AICHPIu/AGHqu3OWQoVA04LntJkyfJv
-        VnY3RtkAZrRYSAGYo5I0naPIlMoUSMWWab6oVZEhKxSwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAlEEuDSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:31.093+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 04ba64dd-5da1-471c-9093-092c1b71c9e8
+      - 0772f9ab-2802-4456-8bc5-f5c7010cd779
       Atl-Traceid:
-      - 04ba64dd5da1471c9093092c1b71c9e8
+      - 0772f9ab280244568bc5f5c7010cd779
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:31 GMT
+      - Wed, 30 Apr 2025 16:25:31 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4688,7 +5075,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=158,atl-edge-internal;dur=16,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="AWTIQzKvvf5ZFJ9Xkh3680TRwrrhR27G8ZZ6_bIHDJkO8DOwxjzSPQ==",cdn-downstream-fbl;dur=241,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=239,atl-edge;dur=155,atl-edge-internal;dur=14,atl-edge-upstream;dur=141,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4697,10 +5084,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c4fd63432996b55c90ff4db02c11a616.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - AWTIQzKvvf5ZFJ9Xkh3680TRwrrhR27G8ZZ6_bIHDJkO8DOwxjzSPQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 26d5b7f4be0a5cc2c7e27e6f2f31a1cf
+      - 33190c3695268ff0793ed79dc7cd8646
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4724,68 +5119,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbU/jRhD+Kyt/pCF+SQLBUlUhCHe0lFII8IFD0WJP7D2cXXd3HZI7+O+d8UsC
-        IaGFqickvG+zMzvzzDOT7w7Mci5jJ3Q0yBg0xEcCsti0JJ+AaZkohQlvqRw0t0JJ04JY2AlY3opS
-        LhPIVNKagja4B/E55BoMSFufjQpj1WRMF458z/O9toa/CjB2OM/hTPPIigicliNIv7/j7QU4MZCN
-        cZpam5vQdWMYQ2Rj9VW1uc24MYLLtgTroibr8ly4gSuMKcBtLriHOcqfDgcXw21c6+NSaYJxwu+O
-        QdsKE3ELidLz6g0xzlAi8ILetudv+94w8EJ/Jwy89l6v8xPa7ZGRpMSi4eU1HzSS5F28zyNDq2fX
-        kxhMpEVOjsPVfWYmPMtaLBbGChlZlguIgKkxe1D6vk3SkZKXOnunFYUUFC6ejfiUW67dqYAHtzRr
-        aWC95Xsdv/+LEd/g5wmGvZigVoIFqhxyc0+xKu4sjcIxzwy0nErwGN9VyracVCBwdJTOT2AKaKv3
-        1HKsQGTliBInlAW+0VmBScdrNnKtvuKLPujwWrp0dxnAxt00eQaS5asupbAWLzDOQjch9bfyrFFj
-        +8A14dWISZ4JNDheeTnGo0RZtz/r9t9p7huRaV6yiEvX20Uzgu4s6P6/Wqrol1hEhf7OzN/5EQpn
-        jcZOMOsEP0JjDfCnp9dw9DfhNGg2xmJ2VXEgRv/m9vXJTnOSJ4mGBPnmH5Og12zgy1RWVLzwoTxY
-        XrA+FV4yzzXSC0u5YXcAkkUKkQ4WYqYks6kwrGQJ4p86Zw6R+J01XtvZ9LDdDRvBxo3+po291z56
-        i8uDnYbLiUPLguaE235N7eQxLaLG0atrlNf4TJOqIosPhckzPq+zH5cfuMVKWVWY90eoql/LiuVW
-        12nioXJ4oApCSmnqNS0ImTih1QXpxkvtFUKc2Kj2kwZ0A8X4lR/8oO37QeOHVYcumHd1Y1MOBIsc
-        yLVQWtj5B13QiLtlYfz3pU1MeALGJQnTXCJwIRVJ2jbTZAnUz7jSQD9Yg9ig0+TEaCvcGvnl/36/
-        i4PHLTrgBc82yHsZvwPi+zUZTzS51mH+JpT7ffIcJt4gF9GJkPdHtHMIObVlMmqwViLwodxbrEgl
-        B9iV8bsMzoGbCr+6HjlnJ5efjk9HJ8cHg9OLwWhwfv7HORqP9GPQdXhgmAI7w8ImLSO9mOGY7Nmc
-        IUmKjC5lVrFfhebsTMMEWZIVBrHZXkeWPqak4z0Kz8vzb6FTFXuMMoaJ8nINCWLAEiF5tnqobipr
-        95YZkqF19ZwQkEhYnC5ySvy1iH/ZxVX93wdBWgkv+reXxPk+3K4Q6EozWCk6qLvU/2Rt0+q6nVpJ
-        p2l+4kpxpDKlTytbMC4gV0wro4xlAMfSrkd7bxNv9Ba88VaoX/rxi3z+t88SrYqcGt8jIWPkPbOs
-        TnlhUixNBM/j83363gETckoKCF8xw582DKszxCFdlgZt9omu+yK3yu9WyG4W1woZMom+soJbpUOv
-        3Wt3Hsnh6O9MRTxLlbFh3+t77riSGZW2uXvdWxRmNxcQFcRh7LN62LZqgyz2IHGBPUhwy1x24xvL
-        /iy4tqDZQCaYkRN08wZRWBxw/VL69Ox3tl9g7rOLiMsNUtTRunu7t5VDHx/ZBfbipZ04PrgalJ/r
-        6tPEmSZ1S0PD4d8AAAD//+xZ+2vbMBD+V8SgJQmxYyeO8yilKwuFwlpGy/ZLGUSxFcfUj+BXN+gf
-        v+/kRxK3SbqUlg6WhtS2dNLp9N13urObgAZIVGIKVxiIEaOyR3aHMZQuXB8+1+vqUgvCaJDZaoD0
-        RXXCrJOlXgDUJqCUzmb/nzRET9MqOetBqL6bREINI6cDv+YEdxdnc+KDDrqqi8T3SG61XbiRG0aD
-        dfG5EU7qcdj0F6Wkch0TEbjcIyTdiihD5skU1riuRmizYy85OcUwpqo1t9iy2PhOtz+g+S8DymEz
-        0SZjyYSgzW7c+J6dW5ZYEgCfM5SJhfd7oxcbqugvDWW83FDGXkO9uZHMFxsJHlnCctySBqNnrDVJ
-        BZvAlfHwQsxUNmozYni2yRLl30JXK5qQ9z313eCAFUwkK7MJaJlRsILSe+VYAz/N55a/a/GsBY/F
-        4zv8Uw5yHswIeMkhXue+mzvQug3TCLa8cD0BdhW5vY+d5ITL3ZaXKzSuCU5WUaAFtq7UCBEeCmJV
-        3bDD7cyNEUkExeEBAsScbA4QlQcG2tHpaoYpw9GGkf4iKg8zUYGGQjtCg12hIS7QwJOEW/dxmz0s
-        XGvBkAc4Dkg6BUGyJcdcgcM4Qw5nQRDHJSvic9JjmsNa+coDJwVdT9lCcBuSGfeQOeWrZT9WCl0h
-        HnhiPfZstpep5XgdkejyTSYJdtmOZqds1jdHQM8FxPEQGJfeP96/MRQTxvRD+MItLSvGKMt05rlW
-        sWlXroy0xZ59l6cwsnCxGbkyDKzjoSEqFg+5S38JUiCZ65C58oYhMGauLewNON3ApXA0xdR/A4pC
-        dBlSXCWMN7jtu0GTNZqPPjCchOMKt89yxpvzhXkgX5jEF+br+OKgGPKELw6NYuvb+958Yf7ni3fg
-        C+Pf4guzEt3DF08LJv2qsFfPg7dlRLqxnhElESAjazlUW6p3rUqAtQajqnvVGrRtElpVjiitsK3j
-        tvKEtq0Ip1XKSAdYUHZS5OjraX4954tT3+eU2n7amX+RyamYFUYHJsFUqjgDYqmAdmmf9u3ecDCc
-        6QNN9KyRZo363flIn5uYp+qEGXZ0E4SHc9smb0BPK7R/f15TBJkyjbXzbYDcA6E6Ud6NZMqKtCE0
-        fcht3TDMgTUcgC9n1mygYfo5F/OhdWafylGOeudH3Qt8cznF50GRGSpK/ihW01h5gCGUrkopp5r7
-        IVlKWXIek6EgL5meezEuv1wpmroMqGRWf7Pw8TWuv5r4+BrXX218aI3/AAAA//8CuhhYQKVAhr2h
-        g0XOwKSv4JuYllaanJwJzkCgXh5kWBpSvEWBxo+slFxLi/ILUvWjgAVPMmgIFprTQFNrQFl41gXZ
-        AJ1QxD7MZIKrUDXBNTxtAh+eLoIW7qPFCEqCAQAAAP//omWCGS1G6OHi0WIESzGCXgzgaqaZwFtj
-        8MYK0DvpkExZDVoDAGUbAF2SX5IIXcGAbgrOZhfOcgnX9JCBEfaSD2ezDKfPcLbX4F5GkzDGpcMY
-        3sJLzSvLLMrPgzTxIEIppdDlMxAuMaFXll9CvZlSiGFwQ4E2ZSQWh+WD54Jgk7PALABxcjWMCa1f
-        yHYAeKmRPsxcHaXcxIqg1OLSHJDBSJ4FT+QUlTiWQDwOmnXOyQc19pHEUTUboeiGagC7tra2FgAA
-        AP//AwBL/rcvrSUAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:18.266+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:18.244+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_10873_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:18.266+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Inactive, Verified, Risk Accepted |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:*
+        May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression
+        Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]\n*Defect
+        Dojo link:* http://localhost:8080/finding/257 (257)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 661e7173-1e6a-40e7-b6d0-37ee28e6d401
+      - 3144fcff-653c-48cf-8b7d-c3aed96ab323
       Atl-Traceid:
-      - 661e71731e6a40e7b6d037ee28e6d401
+      - 3144fcff653c48cf8b7dc3aed96ab323
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:32 GMT
+      - Wed, 30 Apr 2025 16:25:31 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4795,7 +5189,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=273,atl-edge-internal;dur=15,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="aXVMcKMzbFvBbuUq2PRCe0ITKB2F3rPod-DzPZFBCUP5rUexOd0zCw==",cdn-downstream-fbl;dur=357,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=354,atl-edge;dur=281,atl-edge-internal;dur=18,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4804,10 +5198,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - aXVMcKMzbFvBbuUq2PRCe0ITKB2F3rPod-DzPZFBCUP5rUexOd0zCw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - a95416e83f67218bc1afd286092ab5b7
+      - b4eb8576ba244995ecf6f6243c3eeaf1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4834,41 +5236,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 5c264f08-6512-4faa-9159-351a8fd99f7d
+      - 8f787235-4d47-42f9-8650-a6d07008b5c5
       Atl-Traceid:
-      - 5c264f0865124faa9159351a8fd99f7d
+      - 8f7872354d4742f98650a6d07008b5c5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:32 GMT
+      - Wed, 30 Apr 2025 16:25:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4878,7 +5267,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=277,atl-edge-internal;dur=15,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=329,atl-edge;dur=297,atl-edge-internal;dur=17,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="7aRLrs87DTBVhE6_3wWTDonTASYqTEDEq1qDpSyar0nymEVo_TrEkA==",cdn-downstream-fbl;dur=332
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4887,13 +5276,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a65725dd05dc27eea7ae75a2e122228e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 7aRLrs87DTBVhE6_3wWTDonTASYqTEDEq1qDpSyar0nymEVo_TrEkA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e06a5d55efb26c52fd53685fd233268f
+      - f618f6c00e51e333ff877d632f32f61a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4905,7 +5302,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/94]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -4914,28 +5311,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
-      (257)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
       Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -4949,27 +5346,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3341'
+      - '3316'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - aa1aa121-64b9-44fb-8198-e0a283ddef0d
+      - 3c548949-ab5d-49f9-8e58-dcd05b870bc3
       Atl-Traceid:
-      - aa1aa12164b944fb8198e0a283ddef0d
+      - 3c548949ab5d49f98e58dcd05b870bc3
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:33 GMT
+      - Wed, 30 Apr 2025 16:25:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4979,17 +5378,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=518,atl-edge-internal;dur=16,atl-edge-upstream;dur=502,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=496,atl-edge;dur=463,atl-edge-internal;dur=17,atl-edge-upstream;dur=444,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="r8DwgrEeOw861BIdIyYgOSbLf50ToU_z7F9-_LanLTxjL40YTn47Tw==",cdn-downstream-fbl;dur=500
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - r8DwgrEeOw861BIdIyYgOSbLf50ToU_z7F9-_LanLTxjL40YTn47Tw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7f008b6ac6a0f3e9422ccaffd8c45713
+      - e5a9dacd88e4fd918f0db8a726ae01ea
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5013,68 +5420,66 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbU/jRhD+Kyt/pCF+SQLBUlUhCHe0lFII8IFD0WJP7D2cXd/uOiR38N8745cE
-        QoIKVU9IeN9mZ3bmmWcmPxyY5VzGTuhokDFoiI8EZLFpST4B0zJRChPeUjloboWSpgWxsBOwvBWl
-        XCaQqaQ1BW1wD+JzyDUYkLY+GxXGqsmYLhz5nud7bQ3fCjB2OM/hTPPIigicliNIv7/j7QU4MZCN
-        cZpam5vQdWMYQ2Rj9VW1uc24MYLLtgTroibr8ly4gSuMKcBtLriHOcqfDgcXw21c6+NSaYJxwh+O
-        QdsKE3ELidLz6g0xzlAi8ILetudv+94w8EJ/Jwy89l6v8wva7ZGRpMSi4eU1HzSS5F28zyNDq2fX
-        kxhMpEVOjsPVfWYmPMtaLBbGChlZlguIgKkxe1D6vk3SkZKXOnunFYUUFC6ejfiUW67dqYAHtzRr
-        aWC95Xsdv/+bEd/h1wmGvZigVoIFqhxyc0+xKu4sjcIxzwy0nErwGN9VyracVCBwdJTOT2AKaKv3
-        1HKsQGTliBInlAW+0VmBScdrNnKtvuKLPujwWrp0dxnAxt00eQaS5asupbAWLzDOQjch9Y/yrFFj
-        +8A14dWISZ4JNDheeTnGo0RZtz/r9t9p7huRaV6yiEvX20Uzgu4s6P6/Wqrol1hEhf7OzN/5GQpn
-        jcZOMOsEP0NjDfCnp9dw9DfhNGg2xmJ2VXEgRv/m9vXJTnOSJ4mGBPnmVRLgA1RWVOn/IbgvL1iP
-        +JcEc40swlJu2B2AZJFCQIOFmCnJbCoMK8mAaKZOjUPkd2eNc3qbnLOzaWN3w0awcaO/aWPvtfPe
-        4vJgp+Fy4tCyoDnhto9TbrHOVfXh/Y6vqs+y3rjVdZpYpBweqILi7FMNuaYFIRMntLqAp7qs0G1a
-        RE30V9fIMjxqUlVk8aEwecbnNfPgMpplrxDixEa1nzSgGyj4r/zgB23fDxo/rDp0wbyrG5tyIFjk
-        QK6F0sLOP+jERtwtC+O/L21iwhMwLkmY5hKBC6lI0raZJksEf8aVJieCNVAOOk2yjLbCrZFf/u/3
-        uzh43KIDXvBsg7yX8Tsgvl+T8USTax3mb0K53yfPYUYOchGdCHl/RDuHkFNbJqMm3iUKHsq9xYpU
-        coBdGb/L4By4qTCk65FzdnL56fh0dHJ8MDi9GIwG5+d/naPxSD8GXYcHhimwMyxs0jLSi6mPLJDN
-        GZKkyOhSZhX7XWjOzjRMkCVZYRDd7XVk6WNKOt6j8Lw8/x46VbHHKGOYKC/XkCAGLBGSZ6uH6qay
-        dm+ZERlaV88JAYmExekip8Rfi/hO0N7bXXRxVf/3QZBWwov+7SWjvg+3K8y60gxWig7qLvU/Wdu0
-        um6nVtJpmp+4UhypTOnTyhaMC8gV08ooY33AsbTr0d7bxBu9BW+8FeqXfvwin//ts0SrIqfG90jI
-        GJnTLMtWXpgUaxbB8/h8n753wISckgLCV8zwpw3D6gxxSJelQZt9ouu+yK3yuxWym8W1QoZMoq+s
-        4Fbp0Gv32p1Hcjj6O1MRz1JlbNj3+p47rmRGpW3uXvcWhdnNBUQFcRj7rB62rdogiz1IXGAPEtwy
-        l934xrK/C64taDaQCWbkBN28QRQWB1y/lD49+5PtF5j77CLicoMUdbTu3u5t5dDHR3aBvXhpJ44P
-        rgbl57r6NHGmSd3S0HD4DwAAAP//7Flpa9tAEP0rSyDBNpYsX/IRQmpiAoU6lIT2Syh4vVrLojqM
-        rrSQH983q8NHYjt1SEihjnEk7c7u7MybtzsjJwYNkKjCFK4wECNGZY/sHmNoLYQ+Yq7daiotCKN+
-        auk+0hfdDtJGmrg+UBuDUhqb/X/QEG3DKOXEg9Q9Jw6lHoR2A3HNCe4OzubEBw101Rex55Lcyl24
-        UQ6jwVr43Eo7cTls+otSUrWOsfQd7hKS7mSYIvNkGqvclCPU2Zkbn19gGFM3qjtsmTu+0er2aP4R
-        tudU1slUKh1gz9nFxDq77cGL7ZL3V3bpvNwunYN2eXObmLtsgngrQDesKfvQM1YbJ5KNEah4eC1n
-        OhvUGfE32+SA4m/R1EsSUPdt/d2cjRWMFeeyMUiX0VYEpQ/KsQp+qs8tf9/iWQ3xiMf3+KcdFRqY
-        EWhSQ7wuODc9ULsLkhC2vHZcCe6Umb3P7PicCyGXsbpcgW9NcLzi+Bq4uFQjAPnntKk7QYNbqRNh
-        n5C0y/ZA/3OyOUBUHAfIo9PVDFOGgwsj/WVYHFXCHA25doQGq0RDlKOBxzEXP6M6e1g4YsFw0rZt
-        UHAC+mNLjrl8m3GGDE1AEIchEfI56TEdqYVqX7hvJyDjKVtIbkEy5S4Spmy17PtKoQnY3pXrO8tm
-        e5E4DtcRiS5fVRJhFe1otovm5uYI6LmAOB4C4yrYh4cdQ4w/pB/CF25pWRFGWSYz1xG50yaO2kdz
-        n31TZyyycO6MTBkGknHREOaLh9xnb8lFTDI3AXPUDcO2lzqWtDbgdIuQwsETU/8NKHLRZUC7JmG8
-        wi3P8ausUn30gOE4GJa4fZYz3pwvzCP5wiS+MF/HF0dtGU/44thNa929780X5n++eAe+6PxbfGGW
-        ogf44mk5pFuW7baz3F35TrOzq6Gsk1EiFIfAkioCUVlnq2unrGptNRi7am3GrmKDURYbCvPs6rir
-        xGaUymwk7dsZnIqOBSUmWX4YJZ7HKXE92ZtdkcmpVBWER6a4VIi4BGKpwPbZuuha7X6vP2v2DNkW
-        A0MMuq35oDk3MU/ZCTPs6SYJDyPLomhATxFYvz+tKYI8mMbaW+tXppa6HWbdSKaoN3ek0exzq9np
-        mD3R74EvZ2LWMzD9nMt5X1xaF2qU0/botHWNbyanedzP8z5Nyx5FehJpDzCE1tIpodSzOCRLaUvO
-        IzIU5BXTczfC5dVEM/SlTwWx7fcGH1/j7RcPH1/j7RcXH11j8JCVFZbzUtAVoM8mfD5PhHBO/gAA
-        AP//AmUgULcOMmwNKcWiQKNDVkqupUX5Ban6UcDyJRk0wArNaaCJM6AsPOuCbIBOF2IfRDLBVaia
-        4Bp8NoEPPqNLwAvuImipP1q+YE9JAAAAAP//okFKGi1f6OHi0fIFS/mCXgzAW2PwxgvQ1emQvFcN
-        muGHsg2AFuaXJELXJ6CbgrPZhbNcwtkeM8Je8uGaEzLA1QAFFQhYJQxwNUCNcekwhrfwUvPKMovy
-        8yCtOIhQSil0cQyES1To5edCTKiGMaHFPRnFL9K6Hn2YuTpKuYkVQanFpTkgg5HsBs+aFJU4lkDc
-        UZZfQr0ZXYhhcEOBdmUkFoflg2ecYNOwoDnlnHxQmx7JIaiuNUJxLlQDOHhqa2sBAAAA//8DACyr
-        L1+LJQAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:18.266+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:18.244+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_10873_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:32.381+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
+        (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3b02470b-a5f7-426c-bc8a-040b9dba7339
+      - 8f5fbbe1-7b98-4dec-a091-fd18f298219b
       Atl-Traceid:
-      - 3b02470ba5f7426cbc8a040b9dba7339
+      - 8f5fbbe17b984deca091fd18f298219b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:33 GMT
+      - Wed, 30 Apr 2025 16:25:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5084,7 +5489,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=274,atl-edge-internal;dur=13,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=270,atl-edge;dur=236,atl-edge-internal;dur=16,atl-edge-upstream;dur=221,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="LAd1z_SCAKEnEDfquDShzV3Hfg1vyKnWSbbDYp1fUPByGO_vVc8wgw==",cdn-downstream-fbl;dur=274
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -5093,10 +5498,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5538280951642fc71308aa997730220e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - LAd1z_SCAKEnEDfquDShzV3Hfg1vyKnWSbbDYp1fUPByGO_vVc8wgw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 43b06e8c419ff7fbf5e121bbc5032e10
+      - 62c865a8f9bea90e27a080927b48d401
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5122,21 +5535,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1608/transitions
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/transitions
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 316271f1-f901-46f5-bcb4-3b0d988c07b1
+      - 11368b03-3889-43e2-8ca5-353d51f20d5a
       Atl-Traceid:
-      - 316271f1f90146f5bcb43b0d988c07b1
+      - 11368b03388943e28ca5353d51f20d5a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:34 GMT
+      - Wed, 30 Apr 2025 16:25:33 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5146,17 +5561,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=549,atl-edge-internal;dur=24,atl-edge-upstream;dur=524,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="_yQ4Ybhd1ldn_OnE2JvhnG5LKL2epZyeYt1vxnLYTRs9pn2LqqM3rw==",cdn-downstream-fbl;dur=634,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=632,atl-edge;dur=556,atl-edge-internal;dur=25,atl-edge-upstream;dur=532,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 d4aa84013921cdd269ab20fbd29fbe1e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - _yQ4Ybhd1ldn_OnE2JvhnG5LKL2epZyeYt1vxnLYTRs9pn2LqqM3rw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - abced347a56bd2215cf94046d24e81d0
+      - 3240ea1f661e810daf51d547f6112a50
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5183,26 +5606,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtLmnVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Whe1Tfjrvf
-        /37HHUglPW57QwR5C6HzYjqtUaMKtXt3qQxGet9Im1oMZELqxndG7v/BF9jvGoU1+o81mm6FNmD/
-        1yUrZ7UZ0Cr8XXKHvW+cjTAFoCmkkBSby8di/VD+TDdDW8WKiOcRmsAEXqITO+P2bbyy3HejbWXc
-        UMdQNTSm/ooQEQNsPj81r2QYQQZslgBNYFkyJngmeBQDXECEY97HP2BfNu05S6FkIGguMp7mwL9Z
-        1d5Y7SLIab5QEnCGWtFsjpJrzTUozZbZbFHpnCPLNbAzQTCj4bbp5fhC1HIw4c4pObYPxJwqgvZ1
-        W5Dj+WFPzo6T6/uSHD8BAAD//wMA8o2SVSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:34.172+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 1e4d9120-2d12-4196-9103-f49bb075dc5e
+      - 0664f2a0-1022-4f5e-af33-389667af552a
       Atl-Traceid:
-      - 1e4d91202d1241969103f49bb075dc5e
+      - 0664f2a010224f5eaf33389667af552a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:34 GMT
+      - Wed, 30 Apr 2025 16:25:34 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5212,7 +5631,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=173,atl-edge-internal;dur=26,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=242,atl-edge;dur=155,atl-edge-internal;dur=15,atl-edge-upstream;dur=141,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="waUjs4EpE9dnz4P_CnsISozmz1MbLuqlVcFyjz9DAxxozeIq8wtSwA==",cdn-downstream-fbl;dur=245
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -5221,10 +5640,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ed78483d37e5338746e5a4b545e5818e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - waUjs4EpE9dnz4P_CnsISozmz1MbLuqlVcFyjz9DAxxozeIq8wtSwA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 629e8881d89b993ba5d261bcd598aa73
+      - 75cfc6c62aee2a3af24a78b07acdc4ee
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5248,67 +5675,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXW1PbRhT+Kzt6TG3dbMBoptOh4CS0lFLjJA+EYRbpWNog7aq7K18S8t97ji52
-        wDhT6DTwoL2d+3cu/uLAsuQycSJHg0xAQ/JaQJ6YnuQFmJ6JMyh4T5WguRVKmh4kwhZgeS/OuEwh
-        V2lvDtrgHSQTKDUYkLZ9G1fGqmJGDG8C3w98V8PfFRg7XZVwoXlsRQxOzxEkP9j3D0PcGMhnuM2s
-        LU3keQnMILaJ+qRcbnNujODSlWA9lGQ9Xgov9IQxFXgdgztYIf35dHw57ePZCI9qFYwTfXEM6laZ
-        mFtIlV41NiS4Q4rQD/f6ftAP/GnoR8F+NBi4o4O9n1Bvn5QkIRYVr9m8UEmi95CfT4o2ZrebBEys
-        RUmOw9MjZgqe5z2WCGOFjC0rBcTA1IwtlL5ziTpW8p3On6lFJQWFi+c3fM4t195cwMKr1doo2F4F
-        /iAY/WLEZ/i5wLBXBUolWKDIKTd3FKvq1tIqmvHcQM9pCE/Rrpq252QCgaPjbHUGc0Bd/a89xwpE
-        VokocSJZoY3OI5gM/O6i1OoTWvRCh7fUtbvrAHbups03INlY9U4Ka5GBcdayCam/12+NmtkF14RX
-        I4oyF6hw8shyjEeNsuFoORw9U93vRKazZB2XoX+AaoTDZTj8f6U00a+xiAKD/WWw/yMELjuJg3A5
-        CH+ExBbgX79uwzHYhdOwu5iJ5fumBmL0r663Xw66lzxNNaRYb7aSAA1QedWk/9Pi9nZd7O+6ONhx
-        Ee68GO26ONzWsymbzSkVpbpDOFE/aGslhUSLuDHpy9YZJQp622SqypMTYcqcr9p0wmOMrX2PcaMU
-        a0Vwi82oKeLPLwZNi9g0Ba9hpynV6+WxqigYtfIf6EDI1ImsrkibWAMaS/Vjq0kEoRsEYdckHrtt
-        XcoeX+wCVbgGVamF0sKuXmhwR+7Vnebf9wpR8BSMRxSmYyLwIBNp5pp5uqmWb/GkK6uhs5044Rr1
-        Ob8FKoxPpAbVkycdEezCaDAij2TcjEsRnwl595puTqCk+UXGHYZqZC3qu/WJVHKM4wu/zWEC3DS4
-        1O3KuTh79+b0/Obs9Hh8fjm+GU8mf07QPsxTgy7BB9MM2AV2AGkZyWXCMCXzFcNqInJiyqxivwnN
-        2YWGAssJqwwizH2qqgSYUI5/L3y/LD9HTtMVMXro/k1WPagWGIhUSJ4/ftROX617a5znqF27p8im
-        Etavq5LS9kkk1+POsENyMyi9EHwN8brzPpxtnofHDd5+5fEdjpsd5DrmjazjdqL7Twp3Y2GTMygk
-        7AYFCQvKbpUrfd5oc5tX0E811qzNUKTYiWqCrYoSB2Jpnwb93rosfC+wj4nWJeOhOz/Kb/+PWKpV
-        VdKg+FrIBIuYYZgr7BZAsrIyGSQ1Sk8nR/S9BSbknCQTzBKGPwUYdjNIImKWhS57Q+w+ylf191XE
-        rtZshYyYRH9Zwa3Ske/uuYN7cjr6PFcxzzNlbDTyR743a2huat28w+E1ErOrS4grKlHsrVr0rdpB
-        iz07qbBnh9fMY1eBseyvimsLmo1liolZoJt3kML6gRfU1OcXf7CjCksAu4y53EFFE6B3eHDdOPT+
-        nl3i7Frrievj9+P686H5dHGmTTsC0HIqLFYDIq1xhStkxKhgsnt2hTz6IVYATL1BGNRaEE7lPHEl
-        jvtuqubevMolItdiZfEevr8mFgPfX9PFC3ALYTW4SqcepjcnyAucZaksePjUzWyRE90mXLipA0bM
-        QvybQFrlHH26pJ9wtR0nIAXPCUmX8A8AAAD//+xZbW/aMBD+K9akVYBIGiCEl6rqUFmlSqOaNm0f
-        ui8Yx4FMQKK8UE3aj99zjhNeSqCjatVJEwiI7bPP57vnfA/RCpUaM1jlrpihzs7mycUlpnFMq1pi
-        S33w5812h9YfIPOvZJ1Mpa7PbJ9dHOyz3eo92S56vLKL/XS72Eft8uI2ccpsgnjLna5fU/ahNlYb
-        ppINEahovJETk/XqjGCcbWNA/po1zAIE1HPLfLXDxg6GCncBiT8DRhkJSh+VYxV8VPdt/9DmWQ3x
-        iOYf+DJOCg2sCG9SUzwvOLdPoPY1SCPY8safS2CnzOx9Nk0uuBAyTNTPtfNtCA7XGF8DFhdqBAB/
-        DZumH5xzd+XHSCCSkm0H8O+RzeFE+a2ATnS8XmHMcH9hpD/qcn1jibQ3aO3IG9zCG2LtDTxJkH7j
-        OnuY+WLGcImfTgHBKeCPhRxrLaeMM1Q0AoK4E4mIe6THeKA2anziy2kKMB6zmeQuJFccCdTMdsu+
-        rxUaAe3ncjOzbPfnhVZ/0yMx5LO6z7t5P7qneXdjewaMnEEcjfBxFez94wdDiN+nD/IvPNK2YswS
-        ppO5L/ShjXyVR/WZfVNXLbKwPoxMGQaQmaMj0puH3O0i5CIhmbuA+eqBIe2tfFe6W+70BSGF+yeW
-        /hun0KJhQFmTfLzC3YW/rLJK9fcCPpwE/cJv92LGi+OFcyJeOIQXzvPw4qSU8QgvTk1am8f72njh
-        /MeLV8AL+9/CC6cQPYIXj9mOdlHw7xa7ZTRIwy7rKMguqpCSCL6k+BhijHaGWmW8mF1wVrsSBeeQ
-        W6FsYBkHYZXxZFaxpgqAGdUeuhDfrOV3S704XSw4Fa/vDlZXZHJiooLoxDKX+IgreCxxXbfuZdtt
-        dTvdSaNjyZboWaLXbnq9hudgnWIQVjgwTJI/DFyXogEjReD++rChCOpgmusgN67OQJoopdUwksn5
-        WVtajS53G7btdES3A7yciEnHwvIel15XXLmXapb3rcH75g3emZyx4Etd9xlG1hSbaWw8wBBG06SC
-        0szikCxlhJzHZCjIK6Tn8xg/r0eGZYZLoht2efa3r/EuUf/2Nd4l+t+6xsAhN+OsNR90DddnI+55
-        qRC+CiAq6zIGOUOx+2BJAz+mURDK83sAjyD+VEca/dGE3iJ0aQX999p+EskuA1W7jFu2C2450uD+
-        ZBj5AwAA//8aLUYoTTCDsxgBAAAA///C7+LRYoTWLqZLMYJeDOBqppnAW2PwxgrQO+mQTFkNmhGH
-        sg2ALskvSYTO56Obgqs9ZoCrXDIwwl7A4ZoaMsDpAZztNVztTFARglXCGKcEvIWXmleWWZSfB2ni
-        QYRSSqGLSSBcYkKvLL+EepOaEMPghgJtykgsDssHT/jAZlaBWQDi5GoYE1q/kO0A8MIbfZi5Okq5
-        iRVBqcWlOSCDkTwLnqopKnEsgXgcNGUMms4BeR0ujqrZCEU3VAPYtbW1tQAAAAD//wMApLa4Zrsk
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:33.443+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:33.442+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
+        (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 8496a555-41ae-4464-8997-d77aa74ffb02
+      - 17f5b17d-1005-4ea9-bf39-62933c07a02e
       Atl-Traceid:
-      - 8496a55541ae44648997d77aa74ffb02
+      - 17f5b17d10054ea9bf3962933c07a02e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:35 GMT
+      - Wed, 30 Apr 2025 16:25:34 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5318,7 +5745,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=340,atl-edge-internal;dur=24,atl-edge-upstream;dur=316,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=303,atl-edge;dur=270,atl-edge-internal;dur=13,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="3-YXd7fPFYr2zQOTXZayBhAE7rpPwwlXG3STmuo_wlOmiq6YrW8brg==",cdn-downstream-fbl;dur=307
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -5327,10 +5754,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 3-YXd7fPFYr2zQOTXZayBhAE7rpPwwlXG3STmuo_wlOmiq6YrW8brg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 20705b6b9d3bdf20e8b39a2b6867fcb7
+      - 89edea0a4c59a15080236ef24f321729
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5357,41 +5792,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 2fbb338a-f95d-4c26-baa3-e26c4a56e097
+      - f79f1e78-2469-4410-92bc-67f97188cec4
       Atl-Traceid:
-      - 2fbb338af95d4c26baa3e26c4a56e097
+      - f79f1e782469441092bc67f97188cec4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:35 GMT
+      - Wed, 30 Apr 2025 16:25:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5401,7 +5823,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=301,atl-edge-internal;dur=15,atl-edge-upstream;dur=287,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="BvbbzR5xVrIHwpIGI9r33C6apS6C86thr3CuNiFCVCH512UZQtv_mg==",cdn-downstream-fbl;dur=396,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=393,atl-edge;dur=306,atl-edge-internal;dur=32,atl-edge-upstream;dur=266,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -5410,13 +5832,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd759629cc514da7a59a47ab24885b18.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - BvbbzR5xVrIHwpIGI9r33C6apS6C86thr3CuNiFCVCH512UZQtv_mg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 50af36e9cfce0924797abc94a5b72675
+      - 3a1dc2748a96c6fc33fbe9e8f1b08fee
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5428,7 +5858,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/94]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -5437,28 +5867,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
-      (257)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
       Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -5472,27 +5902,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3341'
+      - '3316'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 84766835-08f8-4a53-88c2-3a294a9b0155
+      - a248cbea-a05f-4a07-9680-16d784689dbe
       Atl-Traceid:
-      - 8476683508f84a5388c23a294a9b0155
+      - a248cbeaa05f4a07968016d784689dbe
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:35 GMT
+      - Wed, 30 Apr 2025 16:25:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5502,17 +5934,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=253,atl-edge-internal;dur=13,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=292,atl-edge;dur=259,atl-edge-internal;dur=14,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="6cmhwiF-y5Ydgx4YEEncuNoKe-KGee8c0eWKqzJRHIRu3GZAZedazQ==",cdn-downstream-fbl;dur=296
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 771067dca4682f83a6c9963c412d66cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 6cmhwiF-y5Ydgx4YEEncuNoKe-KGee8c0eWKqzJRHIRu3GZAZedazQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 124d0cc2134ff6c71104c504840ead93
+      - 318928042f65573f6449a6791b836fdc
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5536,67 +5976,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf6mNp6swGjmU6HgpPQUkqNIR8IwxzSWrog3al3J78k5L93V7Ls
-        8KJModPAB0l3ty+3++yz6y8OLEsuEydyNMgENCRvBeSJ6UlegOmZOIOC91QJmluhpOlBImwBlvfi
-        jMsUcpX25qAN7kEygVKDAWnXZ+PKWFXMSOFN4PuB72r4uwJjp6sSzjSPrYjB6TmC7Ae7/n6IHwby
-        GX5m1pYm8rwEZhDbRH1SLrc5N0Zw6UqwHlqyHi+FF3rCmAq8VsEdrFD+dDo+n/ZxbYRLtQvGib44
-        Bn2rTMwtpEqvmjsk+IUSoR/u9P2gH/jT0I+C3WgwcEd7Oz+h3z45SUYsOl6reaWTJO+hPp8cba69
-        /kjAxFqUFDhcPWCm4HneY4kwVsjYslJADEzN2ELpO5ekYyUvdP5CLyopKF08v+Fzbrn25gIWXu3W
-        1sH1VuAPgtEvRnyGnwtMe1WgVYIFmpxyc0e5qm4tvUUznhvoOY3gMd6rlu05mUDg6DhbncAc0Ff/
-        a8+xApFVIkqcSFZ4R+cRTAZ+u1Fq9Qlv9MqAr6XrcNcJbMNNH9+AZHurCymsRQXG2dgmpP5enzVq
-        ZhdcE16NKMpcoMPJo5tjPmqUDUfL4eiF7n4nM+1NNnkZ+nvoRjhchsP/10qT/RqLaDDYXQa7P8Lg
-        srU4CJeD8EdYXAP869encAy6cBp2bQzajZlYXjbkiLC4ukaYpKmGFPnmSRHgBVReNeX/vNadro3d
-        ro29jo2wc2PUtbH/1M+GNptVIqW6QzhRP+g5mBl7iVGnAmkO1ORCSdIibi755ckalQ7G32SqypMj
-        Ycqcr9YFhssLbrEZNST+cjJoWsS2KXiNOk2lXr8eqoqSEZCrH2hByNSJrK7IdqwBL0v88aRJBKEb
-        BGHbJB6HbUNljze6QBVuQFVqobSwq1deuBX36k7z73uFKHgKxiMJ0yoRuJCJNHPNPN2y5XtcaWk1
-        dJ4WTrgpg5zfAhEjVcDjmaALvEEXRoMRRSTjZlyK+ETIu7e0cwQlzS8ybhFT42hR721WpJJjHF/4
-        bQ4T4KZBoV6/OWcnF++OT29Ojg/Hp+fjm/Fk8ucE74d1ajAkeGCaATvDDiAtI7tMGKZkvmLIJiIn
-        pcwq9pvQnJ1pKJBOWGUQYe5zrBJgQTn+vfD9svwcOU1XxOxh+LdV9YAtMBGpkDx/fGg9fa3DW+M8
-        R+9awsHMphI2p6uSyvZZJNfjzrBFcjMovRJ8jfCm8z6cbV6Gxy3efuXxHY6bLeRa5Y2tw/VE958c
-        bsfCpmbQSNgOChIWVN0qV/q08eY2r6CfamSo7VCk2JFqkq2KEgdiaZ8H/U4XLexsaOF7GX8Yzo/y
-        2/8DlmpVlTQovhUyQRIzDGuF3QJIVlYmg6RG6fHkgJ63wISckwGCWcLwpwDDpgVJRMqy0GXvSN1H
-        +aZ+vonY1UatkBGTGC8ruFU68t0dd3BPQceY5yrmeaaMjUb+yPdmjcxN7Zu3P7xGYXZ1DnFFFMXe
-        q0Xfqg5Z7NlJhT07vGYeuwqMZX9VXFvQbCxTLMwCw9whCpsDXlBLn579wQ4qpAB2HnPZIUUToLe/
-        d90E9P6enePsWvuJ74eX4/rxoXm0eaaPdaen16mwyAYkWuMK31ARI8Jk9+wKdfRDZAAsvUEY1F4Q
-        TuU8cSWO+26q5t68yiUi1yKzeA/PX5OKge9v5OIFuIWwGlylUw/LmxPkBc6yRAseHnUzW+Qkt00X
-        ftQJI2Uh/k0grXKOMV3ST7j6HkcgBc8JSefwDwAAAP//7Fltb9owEP4r1qRVgEgaIISXqupQWaVK
-        o5o2bR+6LxjHgUxAUF6oJu3H7znHCZAS6KhaddLUCojts8/nu+d8T8I1KjVmsMpdPkOdnc3ji0tM
-        45hWtcSW+uDPm+0OrT9Anl/LOplKXZ/ZPrs42Ge71XuyXfR4ZRf76Xaxj9rlxW3ilNkE8ZY5Xb+m
-        7ENtrDZMJBsiUNF4Iycm69UZwTjbxYDsb9YwcxBQzy3z1Q4bOxgq3AUk/gwYZSQofVSOVfBR3bf9
-        Q5tnNcQjmn/gyzgpNLAivElN8bzg3D2B2tcgCWHLG38ugZ0ytffZNL7gQshVrH5unG9LcLjB+Bqw
-        OFcjAPhr2DT94Jy7az9CnpCUbDuAf49sDifKbgV0ouPNCmOG+wsj/VGX6xtLqL1Ba0fe4ObeEGlv
-        4HGM9BvV2cPMFzOGK/t0CghOAH9sxbHWcso4Q0UjIIg7kQi5R3qMB2qjxie+nCYA4zGbSe5Ccs2R
-        QM10t+z7RqER0H4utzPLbn9WT/W3PRJDPqv7vJv1o3uadTd2Z8DIGcTRCB9Xwd4/fjCE+H36IP/C
-        I20rwiyrZDL3hT60ka/yqD6zb+qqRRbWh5EqwwAyc3SEevOQu12suIhJ5i5gvnpgSHtr35Xujjt9
-        QUjh/oml/8YptOgqoKxJPl7h7sJfVlml+nsBH46Dfu63ezHjxfHCOREvHMIL53l4cVLKeIQXpyat
-        7eN9bbxw/uPFK+CF/W/hhZOLHsGLx2xHOy/4i8VuWb3TsMs6crKLCqE4hC8pPob4ocJQO6emCh1W
-        GWFmlXEOVs45ZOYpG1jGk1m5MioAZlR77GH+ihVdlCwWnIrXdwerKzI5MVFBeGKZS3zEFTyWuK5b
-        97Lttrqd7qTRsWRL9CzRaze9XsNzsE4+CCscGCbJHwauS9GAkSJwf33YUgR1MM11kBtXppYmSmk1
-        jGQyftaWVqPL3YZtOx3R7QAvJ2LSsbC8x6XXFVfupZrlfWvwvnmD/1TOWPClrvsMI22KzCQyHmAI
-        o2lSQWmmcUiWMlacR2QoyCuk5/MIP69HhmWulkQ3FHn2t69xkah/+xoXif63rjFwyE0Zas0HXcP1
-        2Yh7XiKErwKIyrqUQU5R7D5Y0sCPSRis5Pk98EUQf6ojjV40oTcPXVpBv17bTyLZZaBql3HLdtkL
-        CzsH7lCjfhFf/gAAAP//Gi1faJaSBrR8AQAAAP//ItPFo+ULrV1Ml/IFvRiAt8bgjRWgq9Mhea8a
-        NCMOZRsALcwvSYTO56ObgrPZhbNcwtkeM8Je8uGaGjLA1QAFFQhYJQxwNUCNcekwhrfwUvPKMovy
-        8yBNPIhQSil0MQmES1To5edCTKiGMaHFPRnFL9I6GH2YuTpKuYkVQanFpTkgg5HsBs+cFJU4lkDc
-        UZZfQr3JVYhhcEOBdmUkFoflgyee4PO5+UXg6RyQlXCHoLrWCMW5UA3g4KmtrQUAAAD//wMArnub
-        RrskAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:33.443+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:33.442+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
+        (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 0a04a1ec-062a-4c8e-a5fb-dd81749fa507
+      - be462415-35de-45f1-b6d6-f4be34657610
       Atl-Traceid:
-      - 0a04a1ec062a4c8ea5fbdd81749fa507
+      - be46241535de45f1b6d6f4be34657610
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:36 GMT
+      - Wed, 30 Apr 2025 16:25:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5606,7 +6046,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=286,atl-edge-internal;dur=16,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="tzmHWlqONzYBXXqlEZFhCmKNkTqwUyqQx2-PeZgtd3dTWmzWP8WrVQ==",cdn-downstream-fbl;dur=371,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=368,atl-edge;dur=281,atl-edge-internal;dur=17,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -5615,10 +6055,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9832e15ad117dafc81b031983cbde91e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - tzmHWlqONzYBXXqlEZFhCmKNkTqwUyqQx2-PeZgtd3dTWmzWP8WrVQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 3c81c7f81eb651e65b242969093dae3d
+      - 9c3c8ddc2d89414b7d93e48d0cec54e1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5645,26 +6093,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TfmzLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPATYfH5qXgkfQQYsnwKdwrJijGcpz4IY4AICHPIu/AGHqu3OWQoVA04LnhZJTtNv
-        VnY3RtkAZrRYSAGYo5I0naPIlMoUSMWWab6oVZEhKxSwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAC0dfxSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:36.470+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 303313ef-4814-4857-8c94-3d374720c249
+      - 868daadc-f67a-4abd-a4ad-44d54f5d3c8f
       Atl-Traceid:
-      - 303313ef481448578c943d374720c249
+      - 868daadcf67a4abda4ad44d54f5d3c8f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:36 GMT
+      - Wed, 30 Apr 2025 16:25:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5674,7 +6118,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=161,atl-edge-internal;dur=15,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=197,atl-edge;dur=163,atl-edge-internal;dur=15,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="4V9YsMmni3XgGoxsz3ISlNQM1aeK_4VQQgobNKK-do0W62uzas4Ttg==",cdn-downstream-fbl;dur=201
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -5683,10 +6127,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 4bbf91f2f9edc22eb68408b6405ae452.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 4V9YsMmni3XgGoxsz3ISlNQM1aeK_4VQQgobNKK-do0W62uzas4Ttg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 18c90c269e7f7bc0402eb49b31472d7d
+      - c2ecc7937faf1fe55ea2cc7b7a3fd835
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5710,79 +6162,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/pCF+SQLBM50OA+GOllIKAT5wTEbYG1uHI/kkGZJe+O/d9UuA
-        gGmh04MZrLfVrnaffXb57sA85zJ2QkeDjEFDfCAgi01H8hmYjolSmPGOykFzK5Q0HYiFnYHlnSjl
-        MoFMJZ070Ab3ID6FXIMBaeuzUWGsmk3pwonveb7X1fCtAGPHixxONI+siMDpOIL0+1veTg8nBrIp
-        TlNrcxO6bgxTiGysvqoutxk3RnDZlWBd1GRdngs3cIUxBbjNBbewQPnj8ehsvElruFSaYJzwu2PQ
-        tsJE3EKi9KJ6Q4wzlAi8YLDp+Zu+Nw680N8Kg0G3v+P/hHZ7ZCQpsWh4ec0HjSR5F+/zgtWz60kM
-        JtIiJ8fh6i4zM55lHRYLY4WMLMsFRMDUlN0rfdsl6UjJc52904pCCgoXzyb8jluu3TsB925p1qOB
-        9Zbv9fzhL0b8BT/PMOzFDLUSLFDlmJtbilVxY2kUTnlmoONUgof4rlK246QCgaOjdHEEd4C2eg8d
-        xwpEVo4ocUJZ4BudNZj0vGYj1+orvuiDDq+lS3eXAWzcTZMnIHl81bkU1uIFxlnpJqT+Vp41amrv
-        uSa8GjHLM4EGx2svx3iUKOsP5/3hO819IzLNS1Zx6XvbaEbQnwf9/1dLFf0Si6jQ35r7Wz9C4bzR
-        2AvmveBHaKwB/vDwEo5+G06Dto1eszEV84uKHBEWV9cIkyTRkCDf/GMSDJoNfJnKiooXPpQHjxe8
-        ngrPmecS6YWl3LAbAMkihUgHCzFTktlUGFayBPFPnTP7SPzOK17banvYdstG0LoxbNvYeemjt7h8
-        a9hwOXFoWdCccNPHKbdY56r68H7/VtXnsd641XWaWKQc7qmC4uxTDbmkBSETJ7S6gIe6rNBtWkRN
-        kNfXyDI8alJVZPG+MHnGFzXz4DKaZS8Q4sRGtZ80oBsoxi/84Pe7veGqpq07dMW86xttORCsciDX
-        QmlhFx90YiPuloXx35c2MeMJGJckTHOJwIVUJGnX3CWPQP2MKw30g1cQG/SanJhshBsTv/qLPzhf
-        btAJL3iyQ+7L+A0Q4VNmr/c6bfj322DuD8l1mHmjXERHQt4e0M4+5NSXyagJeAmD+3JvtSKVHGFb
-        xm8yOAVuKhDpeuScHJ1/OjyeHB3ujY7PRpPR6ekfp2g88o9B3+GBcQrsBCubtIz0YopjtmcLhiwp
-        MrqUWcV+FZqzEw0zpElWGIR39zW29DEnHW8pPC//th06VbXHMGOcKDGrlz9jQYxYIiTP1g/VXWXt
-        3jIlMrSuIVKEQCJhdbrIKfNfhfzzNq5qAD+I0kp41cA9Z873AXeNQde6wUrRXt2m/idrm17Xpd6Y
-        lPSa7ieuFEcqU/q4sgXjAnLNtDLKWAdwLO3raB+0EcdgRRxvhfq5H7/Ip7+7LNGqyKnzPRAyRuo0
-        j+UpL0yKtYngeXi6S98bYELekQLCV8zwfxuGVRjikC5Lgy77RNd9kRvldyNkV6trhQxZnoSDrt/1
-        luRo9HOmIp6lythw6A09d1qdnZQ2uTuDaxRiV2cQFURe7LO637SqRRabj7jA5iO4Zi678o1lfxZc
-        W9BsJBPMxBm6t0UUVgdcv5Q+Pvmd7RaY8+ws4rJFilpZd2f7unLkcsnOsAkv7cTx3sWo/FxWnya+
-        NKlbFhqOhcX0Xy7/BgAA///sWG1v2zYQ/isHBAhkz6Zq+a1x4A9FnAEF1qJItn2pC1iRGVuoLCmi
-        5GRo+9/3HEVRUmx3a7tPQ5PAke945PG5491D0a3OJTxhIuJSSp/pPeboezjy3PZeetoLzs14vxYx
-        7i1ik+zdfRHFyNYcpcRtj//AU1yMrFnwKMUuzDMpkmzj4jj7nOUhODmXAfdiJLb5LmKrdIMPHSae
-        wsPPjdwlucQ21pKunxAOtqE+Oe82PTqP8kvyxGAgPKLzTX45p6F4AWOtGIqJGFGlGNWKkRiLaSUf
-        1/KxwFyVfFLL+XFcy9k7Ix+ISS33arnXHD+s5UMxrOWjWj6qNzCt1+XHhtyuy49e50RumER2vckL
-        RvR1zJfxvexx8PXNpkc3ofpIr4JApnyQjgV++o2BN+P/q8D/DPr3Bn388l8HHZWyKhuzrk4AllF3
-        UUhaoMRC+Ku8E3TRI+681K7e1e92IGz51t+H4ufB/bEY4uAiNgvNA2gBIkBMjxCOf7QjBx+dY4H9
-        Wlipi14B8Xv863/H6cV6KAN6gh9rG+3M6t4mRRZIZFcku9y/++izu1BJhjXdNAYuapbRBRuwyyL1
-        lGngIkxcf70PFZgKLhFjzwMBuWeEcRgqQspUZJVuVrgcx/AvJp+yMosDzmJps5j3IDP/Loy45+Zb
-        P6ckwEKKHreSr9OyMmTU7nwlKcnoAVe/v0ilMuAjqTB7kPn37ACIWrGLibmZ0OcMxD2TBOZO+WNS
-        mQSkAhn7uAoxo8FSYbAlEAWw+ij8KMHr77GKD7fTNAoD/arWMKfK4UgCH5xYvhg0R5Vbg09FrPx7
-        1A2+B/RVwUPgn3qIzHIGGUU7H8ZhAubQcF6JZewdzg6jGEgrdgbu4c6cgUxiXosOkznrg2+QymRe
-        ZDFSG0+qiHJGt+EDxh11QjCAZ2e40iSIJ/6ukpir3jJerVbLmO+TOX2iK+wMrOgLzYnfXYeZdM7P
-        nrwpUqv836nGBuXIOcXy0Zg5rNRPwmyOJZUBwzWn1e31b9dXv9OAXt3S+UOR5JdL/JSTu91SgkN4
-        TN11lziXv/BWVRJJESUbB9kf4GYnZLzvfGBvwLBhErtuab3SDpROaQAd+NEjR2ZZjxHs0JxPDn3C
-        zGZPmGvNjn/pGHDoT5so9AakFvlCfNSa8uq916xVxcEkT9RxaE5Vcmt0UMut5qCaNzTP6nlD86yi
-        NzTPanpD86yqW81BXW9o2pUdOL3Tb4jWFUgzM9KAZFDBfA24GCODCS/UhIsxMqAYVQUXY2RBaWiq
-        jleh0lIxSBaVloZBsqi0NAySRaWlYZAsKg1NCZJFpaUpQWokE/DaIpM4Jfsl/5sdFnq+y8z4A90J
-        35jEKBilxR2Ov+kBb0J9MTQtoGuvOp54Ek8z+kO/ReACZIp9FRJUzAiaTDSNhqeMymgdtRmdsinD
-        eNRmfMqmDPBRm8kpmzIi1oYcessdSHcn2+F0EvTKiPd02S1DzK3Gj1RCaZnAgphG2EWnpxbVIf36
-        oiYh0KUOFjCxe71LwVc5bm8TCvUXQgrsw7Vc120eA2/AiTKJaq6+pc8b0zThKznTFMdf78K4Q07n
-        8w40JE9mlnocpbP/Zyr7NwAAAP//QojToikL7I6Q1ZQ1tQA2ZU0tBr4pS25HGDnZ0ropa4itKQsA
-        AAD//+yaUWuDMBDHv8oo9DEuaqw6KF0ZG+yhX6Bv6cVsY9gWrYx++90ZG7qs6WDswUHABzEX7zjM
-        8Zf/L0jZIGWDlA1SNkjZs34FKRuk7P+VsrHd+oOU/e7/ZxZccV1dn78XC9+C5VfI+Ds0Et576oE4
-        BidUWIzDWeD2He6Cz1zn1lw/tccX6GNKuC3mi0ntOpbycJDwSoac8UPbrq4lGbWTi24itZqYjF3z
-        SyuX1MlCAhBJ8qzmmUqLvNjEOa9SKDmUWaLLWM8wjw3CDFfCKvoOlkphjhYjUe4d788KgR3Bfteh
-        tr7FVfTSmDDacwKrRMXjQqpYiFkORZ6l5QY2Ocf0Wla6gIWa92+Zpstp8oSX2cdquR18TsbMozbq
-        WvaBjWBJRAZqZGYgdYrtpWypUbi/1+h42vD2YcV4tN8S+eECcuOv2CXsxl+xS+iNvWKcP8oQVAPy
-        gP/rx5uV1LoDeOsPEHlihs8y02tNFMTd5LFrdvvqdo1zBYgkGk4aEaK4ao8uZRi42MuwhPANU+Gj
-        rISPNBR2YDfDtP/j+fIJAAD//8IsOEbLl9HyhZ4uHi1fsJQv6MUAvBUGb7QAXZ0OyXvVoKXsULYB
-        0ML8kkToQnx0U3A2t3CWSzjbYUbYSz5cax8NcDU8QQUCVgkDXA1PY1w6jOEtu9S8ssyi/DxI6w0i
-        lFIK3QUC4RIVevm5EBOqYUxocU9G8Yu0gUUfZq6OUm5iRRBkHAjFbvDqwKISxxKIO8qA3Q9y1zNi
-        LF2GGAY3FGhXRmJxWD54ZSVsvTFo8XROPqgtj+QQVNcaoTgXqgEcPLW1tQAAAAD//wMA8sprU3Q0
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:24.135+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:24.108+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_14095_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:24.134+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Inactive,
+        Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Inactive,
+        Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025
+        \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect Dojo link:*
+        http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - ff32a42c-5aa0-4c3c-9c95-a07a80facf5a
+      - 44aec7a5-ca8b-4495-b794-b13b4b23dd9d
       Atl-Traceid:
-      - ff32a42c5aa04c3c9c95a07a80facf5a
+      - 44aec7a5ca8b4495b794b13b4b23dd9d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:36 GMT
+      - Wed, 30 Apr 2025 16:25:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5792,7 +6278,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=283,atl-edge-internal;dur=37,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=313,atl-edge;dur=280,atl-edge-internal;dur=14,atl-edge-upstream;dur=266,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="NBs6eU_paryLzRhgcZxGzcdAgylKbrGo_ZHUySXdnsC8Bj70ckuvEQ==",cdn-downstream-fbl;dur=316
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -5801,10 +6287,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - NBs6eU_paryLzRhgcZxGzcdAgylKbrGo_ZHUySXdnsC8Bj70ckuvEQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 1e25b5a19ccdb2635953c094b6ec1ead
+      - 9faa208fb358925a5af1f0e977053b37
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5831,41 +6325,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 7c712788-f717-4ef2-84d2-a66e716ed145
+      - c36c4e59-b8bd-4372-be5b-3f879bb7b4b3
       Atl-Traceid:
-      - 7c712788f7174ef284d2a66e716ed145
+      - c36c4e59b8bd4372be5b3f879bb7b4b3
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:37 GMT
+      - Wed, 30 Apr 2025 16:25:37 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -5875,7 +6356,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=264,atl-edge-internal;dur=15,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="U8NDeClRBfAhYg7yeeofbn4aSzZGqbvkJ_XIXd1OsHtWY2q4Be1jMw==",cdn-downstream-fbl;dur=450,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=448,atl-edge;dur=363,atl-edge-internal;dur=16,atl-edge-upstream;dur=345,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -5884,13 +6365,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c80d7d73c19744418338fdf12216d306.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - U8NDeClRBfAhYg7yeeofbn4aSzZGqbvkJ_XIXd1OsHtWY2q4Be1jMw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 534c074c25712d211eb5c6b73b51cada
+      - 62eb802bf1bd59ecd8bf6bd6e9316dbd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -5902,28 +6391,27 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/95] in [Security
-      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
-      / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
-      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
-      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
-      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
-      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
-      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
-      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Active,
-      Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5] in [Security How-to|http://localhost:8080/product/2]
+      / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n||
+      Severity || CVE || CWE || Component || Version || Title || Status ||\n| High
+      | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
+      | pg | 5.1.0 | [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]
+      | Active, Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
       | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
       Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
       Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -5932,31 +6420,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:* http://localhost:8080/finding/258
-      (258)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (258)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -5965,25 +6451,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -5995,27 +6479,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7123'
+      - '6786'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 877abf8d-b3fc-4978-8396-027d859b99e0
+      - cf2c1c52-7da0-48b2-9bd9-503e9725966b
       Atl-Traceid:
-      - 877abf8db3fc49788396027d859b99e0
+      - cf2c1c527da048b29bd9503e9725966b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:37 GMT
+      - Wed, 30 Apr 2025 16:25:38 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6025,17 +6511,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=515,atl-edge-internal;dur=13,atl-edge-upstream;dur=502,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="c6h1HKQFP0Qj1f7j0Hdt-b81DW5Qg35mC5_5ZFHz98tXUOfX-AboQg==",cdn-downstream-fbl;dur=602,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=598,atl-edge;dur=513,atl-edge-internal;dur=16,atl-edge-upstream;dur=496,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f497fa2422d5b3ba3b34ed87ffef89a6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - c6h1HKQFP0Qj1f7j0Hdt-b81DW5Qg35mC5_5ZFHz98tXUOfX-AboQg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 0add37d90eac62083294ddaec1f02f3b
+      - db88438dc5eefd82cf47e341ae3506b8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6059,78 +6553,112 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbU/jRhD+Kyt/pCF+yQvBUlUhLndHy1EKgfvAoWixJ/Yezq5vdw1JL/z3zvgN
-        CMmpUPVAwvs2O7MzzzwzfHdgkXMZO6GjQcagIX4vIItNR/I5mI6JUpjzjspBcyuUNB2IhZ2D5Z0o
-        5TKBTCWdO9AG9yA+g1yDAWnrs1FhrJrP6MKp73m+19XwrQBjJ8scTjWPrIjA6TiC9PtDb7+HEwPZ
-        DKeptbkJXTeGGUQ2Vl9Vl9uMGyO47EqwLmqyLs+FG7jCmALc5oJbWKL8yWR8PtmlNVwqTTBO+N0x
-        aFthIm4hUXpZvSHGGUoEXjDY9fxd35sEXugPw2DQ7e/7v6DdHhlJSiwaXl7zRiNJ3sX7vKB9dj2J
-        wURa5OQ4XD1gZs6zrMNiYayQkWW5gAiYmrF7pW+7JB0peaGzV1pRSEHh4tmU33HLtXsn4N4tzXo0
-        sN7yvZ4/+s2Iv+HXOYa9mKNWggWqnHBzS7EqbiyNwhnPDHScSvAI31XKdpxUIHB0lC6P4Q7QVu+h
-        41iByMoRJU4oC3yjswaTntds5Fp9xRe90eG1dOnuMoCNu2nyBCSPr7qQwlq8wDitbkLqH+VZo2b2
-        nmvCqxHzPBNocLz2coxHibL+aNEfvdLcH0SmeUkbl763h2YE/UXQ/3+1VNEvsYgK/eHCH/4MhYtG
-        Yy9Y9IKfobEG+MPDSzj623AaNBszsbisOBCjf3X98mSvOcmTREOCfPMiCfABKiuq9H8T3B8v2Iz4
-        5wTzGVmEpdywGwDJIoWABgsxU5LZVBhWkgHRTJ0a75DfnQ3OGWxzznDbxt6WjWDrxmjbxv5L5/2I
-        y4ejhsuJQ8uC5oS7fk3t5EotoiYC62uU1/h+k6oii98Jk2d8WWc/Lt9zi5WyqjCvD11Vvx4rlltd
-        p4mHyuGhKggppamfaUHIxAmtLkg3XmovEeLERrWfNKAbKPgv/OD3u71RW9PWHdoy7/rGthwI2hzI
-        tVBa2OUbXdCIu2Vh/PelTcx5AsYlCdNcInAhFUnaNXfJI4I/4kqTE8EGKAe9JlmmO+HO1K/+4g/O
-        Vzt0wgue7JD7Mn4DRPgbUp54cqPH/G0w90fkOkzJcS6iYyFv39POO8ipL5NRA7YSgvflXrsilRxj
-        W8ZvMjgDbioA63rknB5ffDg6mR4fHY5PzsfT8dnZn2doPPKPQd/hgUkK7BQrm7SM9GLuIw1kS4Ys
-        KTK6lFnFfheas1MNc6RJVhgEZ3cTW/qYk463Ep6Xf9sLnaraY5gxTpSYG1gQI5YIybP1Q3VXWbu3
-        TJEMravnBIFEQnu6yCnzN0K+t9cdDFvIVw3gG1FaCbcN3HNKfR1w16h1rRusFB3Wbep/srbpdV3q
-        jUlJr+l+4kpxpDKlTypbMC4g10wro4wFAsfSbkb7oCWOH0V0Xaglled+/CKf/h6wRKsip873vZAx
-        Ep95rFt5YVIsWgTPo7MD+t4AE/KONBO+Yob/2zAszxCHdFkadNkHuu6L3Cm/OyG7aq8VMmR5Eg66
-        ftdbkaPRz5mKeJYqY8ORN/LcWXV2Wtrk7g+uUYhdnUNUEHmxj+p+16otsth8xAU2H8E1c9mVbyz7
-        q+DagmZjmWAmztG9W0ShPeD6pfTJ6Sd2UGDOs/OIyy1S1Mq6+3vXlSNXK3aOTXhpJ44PL8fl53P1
-        aeJLk7qXoeFEWEz/1eofAAAA///sWNtu2zgQ/ZUBAgSy1qZq+dY48EMQZ4EFtkXR7O5LXcCKzNhC
-        dXF0cVK0/fc9Q1GUFFtdtN23NgkceYZDDs8MZw5FtyqX8ISJiEspfaZ3mGPg4shz03rpKi84N+PD
-        RsS4t4htcnAORRgjW3OUEqc9/j1PcTE2Zv6jFFGQp1Ik6dbBcfY4ywNwci4DzsVY7PIoZKv9Fh8q
-        TDyFi5+3MkpyiW1sJN08IRxsQwOy3mz7dB7ml+SK4VC4ROfb/HJBI/ECxkoxElMxpkoxrhVjMRGz
-        Sj6p5ROBuSr5tJbz46SWs3daPhTTWu7Wcrc5flTLR2JUy8e1fFxvYFavy48NuVmXH91eR27oRHbc
-        6QtG9Aoc5yD7HHp1r6FTcZ59Y5z1+P8rzr9i/L0xnrzsijHqYFUU5raKN8vIXhaSliigEP4u7wRd
-        9In7KrVrc/W7GwpTnNX3kfh1LH8sZDiWiM1SdXlaos0Tkx+E4z/tyMJH71RgvxZWstEJIH6Hf4Pv
-        OKxYD6deTfBjTaGdWfZtUqS+RHaF0ubuPEAXjYJMMqz7bWPgsuYQNnq9WRapl+n2LILE8TaHIANB
-        wRVh4rqgF/eMMA5DRTeZaKz32zXuxDH8i8mjtMxin7NYmizmPcjUuwtC7qj5zssp8bFQRo87ybdo
-        WRkyandeJilJ6QGXyo+Em7/PZzDD7H7q3bMDoGFFFBMzL6HOGWh5Kgm8nPLHpDLxKfNl7OGiw3wF
-        SwX+jkADwNnD4IMEa7/HKh7c3u/DwFcvYjUvqhwOJfDBiWXa3xxVbg0+FXHm3aNQMMsfZAUPgX/Z
-        Q6iX08hkFHkwDhLwgobzmVjF7vHsMIqBdMbOwD3cZ1PQQcxr0GGqZnzwNFKpzIs0RmrjKSvCnNFt
-        +IBxJ50QDODZGS4sCeKJv+sk9uU+X8Xr9XoV820xp090jZ2B83yhBfGb6SCV1vnZkztDapX/e9VY
-        vxy5oFg+ajOLlepJ6M2xpDJguBa0vr358+b6LxrS1S2dPxRJfrnCTzm5Y5cSHMJTattZ4Vz+xlvN
-        klCKMNlayH4f9zYh40PvPXsD/gyT2HFK67VyoHRKAWjBjz5ZMk37jGCPFnxy6BNm1nvCXBt2/EtP
-        g0P/mEShV6CsyBfio9aUV6+75q0qDp7YUceh6arkxuiolhvNUTVvaJ7V84bmWUVvaJ7V9IbmWVU3
-        mqO63tC0KztweqPe3mwqkOZ6pAZJo4L5GnAxRhoTXqgJF2OkQdGqCi7GyIDS0FQdr0KlpWKQDCot
-        DYNkUGlpGCSDSkvDIBlUGpoSJINKS1OC1Egm4LVDJnFKDkq6Nz8u9HxTmfMHuhO+Xfl8DpCYxR2O
-        v+4BrwJ17dMtwDYXGVc8iac5/a3eEXAB0sW+CgkqZghNKppGoy6jMlonbcZdNmUYT9pMumzKAJ+0
-        mXbZlBExNmTRa+5AqjuZDqeSoF9GvK/KbhlibjVemCW0LxNYENMIs+isa1EV0q8vqhMCXepoAR27
-        P6K95+cct9cJBeoLIQUOwUZu6jaPgW/BiVKJap59S5/XpvuEL9xMUyxvEwVxj6ze5wg0JE/mhnqc
-        pLM/N5X9FwAA//+ipCkL7H2Q1ZQ1tQA2ZU0tBr4pS26/FznZ0ropa0heUxYAAAD//+yaz2rDMAzG
-        X2UUenTmJE6TDEpXxgY79AV6c+W4G6N/SBpG335SnJjg1R3slIMhhxJLlRGV+Mr3C1I2SNkgZbtp
-        CVLW3exByg79ClI2SNlpSNnYpv4hZX+7+5mlUFzP1mf7x2Js611qCV8deEAghBvqA0G470BYesPN
-        sNb50AVfoM9K5z5ihNua8nKR8EGOWu8njy1p17hs2sNBkg07u+kVUquJuDjV/zRqSZ2sJABRHu9q
-        mam0yItdnPMqhZJDmSW6jPUC69ggrHAnrKLfwVoprNFgJMq96/PoInAilO8+stb1vor2tQmjnAGb
-        EhWPC6liIRY5FHmWljvY5RzLa1npAlZq2X3LPF3Pkzd8TB47yGPvYjJmXjVR27BvbARLIrJHI7MD
-        qVPsLGVDjcL8TqPjtOHHlw3j0flIXIeLv03/xi4/N/0bu/zd1G+Mi0kZNqsHGvD/+vVhI7VuAT67
-        ASITzLBTZq1tiXF4mr229elcPW5x4QBxQv2kEf+Jp3Z0qUJPvd5GIYRvmQofQyUsQ1X3S306a+QH
-        AAD//xotRgahi0eLEVq7mC7FCHoxgKt5ZgJvhcEbKUDvpEMyZTVooTqUbQB0SX5JInSZPbopuNph
-        BrjKJQMj7AUcrpWNBjg9gLOdBvcZug5cDThjnBLwll1qXllmUX4epGkHEUophe7xgHCJCb0yYLOf
-        3FWCGMt5IYbBDQXalJFYHJYPXq8IW0EMzAIQJ1fDmND6hWwHgPfD6MPM1VHKTawIggw8oXgWvNiw
-        qMSxBOJx0NLonHxQIx9JHFWzEYpuqAawa2trawEAAAD//wMABt1YR1I0AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:24.135+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:24.108+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_14095_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:38.071+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
+        Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 765a25f8-f98c-4ba5-8f30-f2589f83dbd7
+      - aecfdb29-48e1-44f4-96c1-d03a6bbdca52
       Atl-Traceid:
-      - 765a25f8f98c4ba58f30f2589f83dbd7
+      - aecfdb2948e144f496c1d03a6bbdca52
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:38 GMT
+      - Wed, 30 Apr 2025 16:25:38 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6140,7 +6668,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=388,atl-edge-internal;dur=14,atl-edge-upstream;dur=374,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=281,atl-edge;dur=248,atl-edge-internal;dur=13,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="nIqRRCGGTlMzeNpo6g0Zn0N5L6FyopMWmfdeLYAl9r0xoMcqDsm7aA==",cdn-downstream-fbl;dur=285
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -6149,10 +6677,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 73e04d645babcbb9ee8f20cc865b009c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - nIqRRCGGTlMzeNpo6g0Zn0N5L6FyopMWmfdeLYAl9r0xoMcqDsm7aA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 283f68495e5cada83a8db537dbef85a7
+      - a4a55d50fb67a55aa1e3957cea6275aa
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6178,21 +6714,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1609/transitions
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/transitions
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 4742bc7a-a5cd-4ea1-bd11-af070e779d59
+      - 0b058833-c8b9-4c92-85f3-307203a1f453
       Atl-Traceid:
-      - 4742bc7aa5cd4ea1bd11af070e779d59
+      - 0b058833c8b94c9285f3307203a1f453
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:38 GMT
+      - Wed, 30 Apr 2025 16:25:39 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6202,17 +6740,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=512,atl-edge-internal;dur=15,atl-edge-upstream;dur=497,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="llTdNCugFM5vV2w-qUIPCFzaKFB9pYxKDJ0fFKbEQ2QU9mmjYDiZTA==",cdn-downstream-fbl;dur=652,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=648,atl-edge;dur=569,atl-edge-internal;dur=18,atl-edge-upstream;dur=550,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2e5e63ac90c6eb4f962029f46116f994.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - llTdNCugFM5vV2w-qUIPCFzaKFB9pYxKDJ0fFKbEQ2QU9mmjYDiZTA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - d19e80d2201c18388853fe817d364b4c
+      - 070c0cbf43916c3675f8530668c04bb9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6239,26 +6785,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TfmzLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPATYfH5qXgkfQQYsnwKdwrJijGcpz4IY4AICHPIu/AGHqu3OWQoVA04Lni4Tlqff
-        rOxujLIBzGixkAIwRyVpOkeRKZUpkIot03xRqyJDVihgZwKvo+G2HUR8ISoxan9npYjtA9GniqB5
-        3ZbkeH7YkzVxcn1fkeMnAAAA//8DAOfhbewgAgAA
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:39.814+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - a1a477a0-3375-4297-aa2b-f4d7a0ce1a4f
+      - e0131558-4612-4325-a786-911db62f8f34
       Atl-Traceid:
-      - a1a477a033754297aa2bf4d7a0ce1a4f
+      - e013155846124325a786911db62f8f34
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:39 GMT
+      - Wed, 30 Apr 2025 16:25:39 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6268,7 +6810,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=142,atl-edge-internal;dur=13,atl-edge-upstream;dur=129,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=204,atl-edge;dur=170,atl-edge-internal;dur=15,atl-edge-upstream;dur=156,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="xb4gQjscBSUBxmsaGCDdgbtPN1xPJZ3YMVidrC6-BUx688gqKLnRqQ==",cdn-downstream-fbl;dur=207
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -6277,10 +6819,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - xb4gQjscBSUBxmsaGCDdgbtPN1xPJZ3YMVidrC6-BUx688gqKLnRqQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 709058bde50cbac0c38159e123e44305
+      - 4b1e9e10edef4671c49f4878ab9583e1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6304,66 +6854,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16094
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18195
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/TENsOSEEz3Q6DIQ7WkppCPCBYzLC3tg6HMknySHpwX/vym+B
-        kNBCpzc3c7Fe9kW7zz67fHdgkTEROYGjQESgIDrmkEa6LdgMdFuHCcxYW2agmOFS6DZE3MzAsHaY
-        MBFDKuP2HJTGM4hGkCnQIEx1N8y1kbOpVTihnke9joJvOWgzXmZwrlhoeAhO2+HWPu17+z1caEin
-        uEyMyXTguhFMITSR/Co7zKRMa85ER4Bx0ZJxWcZd3+Va5+DWCu5hifJn4+HFeIf2qYdbhQvaCb47
-        Gn3LdcgMxFItyzdEuEIJ3/N3dzy6Q72x7wW0H/iDDt3b/Qn9tjoKIwYdL9R80Ekr76I+z2+eXS0i
-        0KHimQ0c7h4QPWNp2iYR14aL0JCMQwhETsmDVPcdKx1KcanSd3qRC27TxdIJmzPDlDvn8OAWbq0c
-        rI6o16WDXzT/C36eYdrzGVq1sECTY6bvba7yO2O/gilLNbSdUvAE31XItp2EI3BUmCxPYQ7oq/fU
-        dgxHZGWIEicQOb7RWYNJ16sPMiW/4os+GPBKugh3kcA63HbxDCSrV10Kbgwq0E5j2yL1t+KullPz
-        wJTFq+azLOXocLT2csxHgbLeYNEbvNPdNzJTv6TJS8/bQzf83sLv/b9WyuwXWESDtL+g/R9hcFFb
-        7PqLrv8jLFYAf3p6DUe6Dad+fTDli6uSAzH7N7evb3brmyyOFcTIN/9YBLv1Ab5MpnnJCx+qg5WC
-        zaXwknmukV5IwjS5AxAklIh0MBARKYhJuCYFS1j+qWrmCInf2RC1/raH7W058LceDLYd7L+O0Vtc
-        vttwueXQoqE5wQ7FJTPY58r+8P74lt1n1W/cUp2yLFJ8Hsrc5pnaHnJtN7iIncCoHJ6qtmK1KR7W
-        SV7fs57hVZ3IPI2OuM5StqyYB7fRLXOFELdsVMVJAYbB5vhVHGi/0xv06zisB7Rh3vWDbTXgNzWQ
-        KS4VN8sPBrEWd4vG+O9bG5+xGLRrJXSthONGwuOko+fxCqifcaeGvr8BsX63rolJK2hNaPk/7Q/2
-        J63Hlr3h+c9ObPhSdgeW8DeUvOXJjRGj22BOBzZ0WHnDjIenXNwf25MjyOxcJsI64QUMHoqzZkdI
-        McSxjN2lMAKmSxCp6ss5P738dHI2OT05HJ5dDCfD0eiPETqP/KMxdnhhnAA5x84mDLF2scSx2tMl
-        QZbkqVVKjCS/csXIuYIZ0iTJNcK7s4ktKdak4z1yz8u+TQOn7PaYZsyTLcwNLIgZi7lg6fqlaqqs
-        wluURIreVWsLgVhAczvPbOVvhPzLMa4cAD+I0lK4GeBeMuf7gLvGoGvTYGnosBpT/5O39azrdisj
-        3Xr6iUrDoUylOit9wbyAWHOtyDL2AfwWZjPadxvieCuj60INqbyM4xfx/N8BiZXMMzv5HnMRIXXq
-        VXvKcp1gb7LwPBkd2N87IFzMrWWLr4jg3zYE2zNEgVWW+B3yyar7IlrFbysgN41aLgIyxfglgdfp
-        drxHG2sMdSpDliZSm2DgDTx3Wl6fFG65+/1blCM3FxDmlr/IZ/mwY+QWWZw/ohznD/+WuOSGakP+
-        zJkyoMhQxFiMM4zwFlFoLri0kD47/50c5Fj25CJkYouUnWbd/b3bMpaPj+QC5/DCT/w+vBoWP9fl
-        T51iu6jGGfs55iaFvwEAAP//7FnbTttAEP2VFVIRieKNkziEBCGKSCPxkKoCtQ+gSmzW68TCsSPf
-        aFU+vmfWG5OYmKpURTwgUGJ7b+OZs2fPTOjiSsMJV5iIEZuyB3aDOawuSI1Ovs5QW0HwDHOXh0hd
-        +DzK23kWhABsCjZpb/f/TlM4duFqGifvFV/6aax4FM/b2NKCkO5DlxMVtNGVL9JlQON0pPCtY0Xz
-        XKp5Fgi48gdlodr8sQp9ERB2rlScI9lkFjuY0MAW2w/SYwzu826jxnkm0u1uXxt6EVLCmqsWeUer
-        /xa79JM7dialWhHYHsjJzbWLR03tJXrGmuNMsTEQiYcTNeNs2GJEVGwb7Ou/RYeXaNf3Pf6f3w92
-        jzWlsDE4hRHTwtQ/jmMH+GjseunnXpk1gTk8vsGX9aLwY0UgSU/xbwDc9nvzKspieHHiBwrUoApP
-        78/TY422jY7jR8pqglrKZSNwmaEC7kdt4eZ+Aj6EIul3D8FmHvkYUFmfbhS7Wz35LcMRzMhUpMzm
-        0I1NyI0hFHK3DHliQn6/ICYUmC+cM+QUEu04vWUsPFqJzmpQ1CpLOTz/7XH+KbgoUIbytpvW2cxo
-        A0Xo8UULW3fdjFZ45qRs3pgAPRcYjYdApN6ho6ozWxsPEmicmoY4VxYdZL582rFo9URO5+5GlIjS
-        RvRB4MItbdAE5qyyWeBLE8Gpr88IE8CvWj+Qz01kirdiUcwCNMS8jPzFcgUeoDGfI+brGwZez31X
-        uVtYusR+gqjC0n+DEDN0FdGxQAA/EO7SDxvsoPGwBIDTaATQPtXu/TLHrCqyOlHfcTYP7TQW8k4n
-        JpRqVLuW2Wilwa5rcMrcrDqiFMZrL9R1rBPKdl0+aJdrbgnMqgwRaSrkgk7SQssk2XIpSGTt1SkB
-        8jalVFH8QiVGe/BUSEmJ4IV70nd7R4OjWWdgq54c2nLY73rDjneIdcpOWOGZboqgcOa6tE/QU0bu
-        z48bhkCu0VzP1qS0+xWfx0U3GrOuizgK2YhwO45zOJBHg35vOJOzgY3lPaG8I3nqnuhZPvTOPnQn
-        +C/GWUsRGo1iWcWjhGeJdQ9HWF1O4ocXW5A8Za2ESMhRGK8ZHrkMLs+nls1XISVu1frW27e4WiB7
-        +xZXC2xv3WJwk1sUQEzGcg7os6nwvExKX28g0mhFeaVgtmtKYkZ7n7I4Wqn2NThHUiHA7DQq8KK1
-        3Lq0gilr7851nDo+deqKJE5ZJIkNr7/TyKsB5p1GXsPidxrZQSNVGqhTaE4pxErdgteZF5vyF/0S
-        Za5tWBKlwvyOVp2lTorZdbxkd3cT3I7S5W8AAAD//4Kox+kBnE01uM/QdeBqwxnjlIA37lLzyjKL
-        8vMgDTiIUEopdBIXwiUm9MryS6g34g8xDG4o0KaMxOKwfPCAJGyYHpgFIE6uhjGh9QvZDgBPeOvD
-        zNVRyk2sCEotLs0BGYzkWfBoYlGJYwnE46C5j5x8UDsfKA4AAAD//4KJo2o2QtEN1QB2bW1tLQAA
-        AP//AwAxg4LmMyAAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18195","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195","key":"NTEST-1850","fields":{"statuscategorychangedate":"2025-04-30T18:25:27.134+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:27.123+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:12.710+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_14424_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:27.134+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/6]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]
+        | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:*
+        May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [Regular Expression
+        Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]\n*Defect
+        Dojo link:* http://localhost:8080/finding/259 (259)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 0865d261-f7a5-4b9b-9e8f-df3edeccbb3a
+      - 30d07c07-e551-4e71-a819-5f5064548627
       Atl-Traceid:
-      - 0865d261f7a54b9b9e8fdf3edeccbb3a
+      - 30d07c07e5514e71a8195f5064548627
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:39 GMT
+      - Wed, 30 Apr 2025 16:25:40 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6373,7 +6908,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=329,atl-edge-internal;dur=13,atl-edge-upstream;dur=316,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="BfNd3MenLpNvCrUumMRMzp7SZQHdeTwNHREvQo50-pO3AnEo_lG3AA==",cdn-downstream-fbl;dur=307,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=53,cdn-upstream-fbl;dur=305,atl-edge;dur=233,atl-edge-internal;dur=15,atl-edge-upstream;dur=218,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -6382,10 +6917,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 35f3ad5aa26e63a13ffedf420998e698.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - BfNd3MenLpNvCrUumMRMzp7SZQHdeTwNHREvQo50-pO3AnEo_lG3AA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 5db13ffa3a7657af885f4c0232ce2f6c
+      - e752ff054dd4a0bb80a5fee09483f930
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6412,41 +6955,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - f4eaff08-d4a6-4161-89db-4325a81f6b4c
+      - a3fc4e76-e9e7-4e38-a30e-65b44be3c6da
       Atl-Traceid:
-      - f4eaff08d4a6416189db4325a81f6b4c
+      - a3fc4e76e9e74e38a30e65b44be3c6da
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:40 GMT
+      - Wed, 30 Apr 2025 16:25:40 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6456,7 +6986,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=303,atl-edge-internal;dur=13,atl-edge-upstream;dur=290,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="Ip7T2SUNhbRlmsU3OppGTK96Z6T318Flv52AbtU9uMymH0CkMgINGQ==",cdn-downstream-fbl;dur=357,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=354,atl-edge;dur=269,atl-edge-internal;dur=15,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -6465,13 +6995,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9a3eef6ee6df44793fb3d5e366a7238.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Ip7T2SUNhbRlmsU3OppGTK96Z6T318Flv52AbtU9uMymH0CkMgINGQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - a6fee6cbbbb4b8f69a758b45f674c91e
+      - cf4e4fc8ec24014b74d37f23cc0cbdbe
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6483,22 +7021,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/96] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/6] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]\n*Defect
       Dojo link:* http://localhost:8080/finding/259 (259)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -6512,27 +7049,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1955'
+      - '1927'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16094
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18195
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 8b1f9493-f3e6-455a-be89-2099670acaee
+      - ae375aa9-6a26-4616-9aef-a420d1bd3e4a
       Atl-Traceid:
-      - 8b1f9493f3e6455abe892099670acaee
+      - ae375aa96a2646169aefa420d1bd3e4a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:40 GMT
+      - Wed, 30 Apr 2025 16:25:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6542,17 +7081,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=490,atl-edge-internal;dur=20,atl-edge-upstream;dur=471,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=510,atl-edge;dur=477,atl-edge-internal;dur=15,atl-edge-upstream;dur=462,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="THvb0ca_sYwxEpeXQxCByBI7hgQHhurnQkrdFlCl-EjxfTDw-fz8Gw==",cdn-downstream-fbl;dur=517
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 995d6494814d695ff2add6899f970080.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - THvb0ca_sYwxEpeXQxCByBI7hgQHhurnQkrdFlCl-EjxfTDw-fz8Gw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - bad5722f98206a65031cccacbd7a08eb
+      - 8bb2f2457e8c4afa04b73facd45ff150
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6576,66 +7123,50 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16094
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18195
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/TENsOSEEz3Q6DIQ7WkppCPCBYzLC3tg6HMknySHpwX/vym+B
-        kNBCpzfMYFvSvmj32Wc33x1YZExETuAoEBEoiI45pJFuCzYD3dZhAjPWlhkoZrgUug0RNzMwrB0m
-        TMSQyrg9B6VxD6IRZAo0CFOdDXNt5GxqFU6o51Gvo+BbDtqMlxmcKxYaHoLTdri1T/vefg8/NKRT
-        /EyMyXTguhFMITSR/Co7zKRMa85ER4Bx0ZJxWcZd3+Va5+DWCu5hifJn4+HFeIf2qYdLhQvaCb47
-        Gn3LdcgMxFItyztE+IUSvufv7nh0h3pj3wtoP/AHHbq3+xP6bXUURgw6Xqj5oJNW3kV9nt9cu/qI
-        QIeKZzZwuHpA9IylaZtEXBsuQkMyDiEQOSUPUt13rHQoxaVK3+lFLrhNF0snbM4MU+6cw4NbuLVy
-        sNqiXpcOftH8L/h5hmnPZ2jVwgJNjpm+t7nK74x9C6Ys1dB2SsETvFch23YSjsBRYbI8hTmgr95T
-        2zEckZUhSpxA5HhHZw0mXa/eyJT8ijf6YMAr6SLcRQLrcNuPZyBZ3epScGNQgXYa2xapvxVntZya
-        B6YsXjWfZSlHh6O1m2M+CpT1Bove4J3uvpGZ+iZNXnreHrrh9xZ+7/+1Uma/wCIapP0F7f8Ig4va
-        YtdfdP0fYbEC+NPTazjSbTj1t210640pX1yV5IiwuLlFmMSxghj55h+LYLfewJvJNC954UN1sFKw
-        uRReMs810gtJmCZ3AIKEEpEOBiIiBTEJ16RgCcs/Vc0cIfE7G6LW33axvS0b/taNwbaN/dcxeovL
-        dxsutxxaNDQn2KH4yQz2ubI/vD++ZfdZ9Ru3VKcsixSvhzK3eaa2h1zbBS5iJzAqh6eqrVhtiod1
-        ktfXrGd4VCcyT6MjrrOULSvmwWV0y1whxC0bVXFSgGGwOX4VB9rv9Ab9Og7rAW2Yd31jWw34TQ1k
-        ikvFzfKDQazF3aIx/vvWxmcsBu1aCV0r4biQ8Djp6Hm8AupnXKmh729ArN+ta2LSCloTWv6n/cH+
-        pPXYsic8/9mODV/K7sASvq3s9VlnG/7pNpjTgQ0dVt4w4+EpF/fHducIMjuXibBOeAGDh2KvWRFS
-        DHEsY3cpjIDpEkSqenPOTy8/nZxNTk8Oh2cXw8lwNPpjhM4j/2iMHR4YJ0DOsbMJQ6xdLHGs9nRJ
-        kCV5apUSI8mvXDFyrmCGNElyjfDubGJLijXpeI/c87Jv08Apuz2mGfNkC7O8+QsWxIzFXLB0/VA1
-        VVbhLUoiRe9qIkUIxAKa03lmK38j5Htep7vn15AvB8APorQUbga4l8z5PuCuMejaNFgaOqzG1P/k
-        bT3rut3KSLeefqLScChTqc5KXzAvINZcK7KMfQDfhdmM9t2GON7K6LpQQyov4/hFPP87ILGSeWYn
-        32MuIqROvWpPWa4T7E0WniejA/u8A8LF3Fq2+IoI/rYh2IUhCqyyxO+QT1bdF9Eqnq2A3DRquQjI
-        FOOXBIiYjvdoY42hTmXI0kRqEwy8gedOy+OTwi13v3+LcuTmAsLc8hf5LB92jNwii/NHlOP84d8S
-        l9xQbcifOVMGFBmKGItxhhHeIgrNAZcW0mfnv5ODHMueXIRMbJGy06y7v3dbxvLxkVzgHF74ie+H
-        V8PicV0+6hTbj2pqsa9jblL4GwAA///sWW1P2zAQ/isWEqitGjdtU/qCEKvokPjQaQJtH0CTcB2n
-        jZY0VZqETePH7znHDW1omMY0xAcEapOcfb7cnZ97zqWLa51OuIIiRmjKHtgtdFgdgBpVvvZQW0Hp
-        ucxcvkTrwudR1srSYImETYAmrd3x30iFY+eupnnyXvHQT2LFo3jewpYWlOk+eDlBQQtD+SIJA5qn
-        I4VvHSvSc6XmaSDgyh/UhWrzJ2rpi4By51rFGZpNZrHaBU1ssqMgOcHkHu/UK5xnIt3q9LShY9Ti
-        TDXJN5r7swfyaWPj0VFDO4WescYkVWyCBMTDCzXjbNhkhEtsN7c3f4s2L5Jb33f5f34d2D3RCMIm
-        gBBGwApT/ziP1fBR3/fSz70yayDF8PgWX9aLoo0VkThaxb/l267fG9dRGsOLF36ggAQq9/TRPDnR
-        ybU1cPKIUA0gSbFsBOgyO5/7UUu4mb8G/IGA9DrHAC+PfIxU2RQzit2dVn7HUHEZmYoO2dTY2ITc
-        GEIhd4uQr03I7xcEfAL6lnOGFkJCjmItY+HRSlSagUirNOHw/NdH/VNAT6AMwu2KNj3KaCuLMOKz
-        5rHuRgwpPHNaiLcUYOQCs/EQGak35KjszObWgzUoTYUgzpRFdcuXTwfmUk9kVGa3okQINqIPSi7c
-        jqWEvhGqwyzwpYng1NclwQTwi6YL5HMTmfytWBSzAIKYF5G/DFdCJjTnU8R8fcMA45nvKncnl66w
-        n8ChsPTfZIiZuoqoClCC14Qb+ss6q9UfQiRwEo2QtE+peq/oMcsErIrDt50qQdFqUvFOYiG/6waF
-        Wo7SUKfouEoCu9BRFlTxYLvgwRv3VA2sav/swpgdPllmHSJJhFxQ4cypyzoNQ0Gc6qCq8JO3qYOK
-        4hcSL9qDZ0JK6vsu3dOe2x30B7N231ZdObTlsNfxhm3vGOsUg7DCM8MUpcLYdWmfYKSM3J8ftgwB
-        OyNdzx5BaS8rPo/zYTRncwziKDQfwm07znFfDvq97nAmZ30by3tCeQN55p5qLYfd8WHnAv/5PCsU
-        S0NJLCt/tObp2rqHI6wOJ67D8y1InrJWQqzJUZivER6tCy7Pp5bNV0vq08rHWW/f4vJ52Nu3uHye
-        9tYtBgS5+XmHaVDOkfpsKjwvldLXG4hIWX6akgPYDfUso4OPaRytVOsG0CKp7zc7jc5zIS22Lq1g
-        TrH3tzZOFZ46VWciTtW5oFNgdmwA/x1fXi2T3vHlNSx+x5c9+FKGgYKIFbwFVs/zvfeLfngy1zYW
-        jBJhfjYra6lkXJW4VEnFOvuRb+uk8jcAAAD//0JVj6vtCSoQsEoY4Gp7GuPSYQxv3KXmlWUW5edB
-        GnAQoZRS6JwthEtU6OXnQkyohjGhxT0ZxS/SdLM+zFwdpdzEiqDU4tIckMFIdoPH8opKHEsg7ijL
-        L6HeRAPEMLihQLsyEovD8sHjoLDZAdBUR04+qDmP5BC4awEAAAD//wK71gjFuVAN4OCpra0FAAAA
-        //8DALyqeQYiIAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18195","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195","key":"NTEST-1850","fields":{"statuscategorychangedate":"2025-04-30T18:25:27.134+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"},"customfield_10035":null,"resolution":{"self":"https://defectdojo.atlassian.net/rest/api/2/resolution/10000","id":"10000","description":"Work
+        has been completed on this issue.","name":"Done"},"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":"2025-04-30T18:25:27.123+0200","workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:12.710+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":"10000_*:*_1_*:*_14424_*|*_10002_*:*_1_*:*_0","priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:41.188+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10002","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Done","id":"10002","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/3","id":3,"key":"done","colorName":"green","name":"Done"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/6]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/259]\n*Defect
+        Dojo link:* http://localhost:8080/finding/259 (259)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18195/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - b3c69a5b-15a5-428f-92c6-5b7187611ca9
+      - 03d72ed3-54ef-40a9-a702-747d0647d9e4
       Atl-Traceid:
-      - b3c69a5b15a5428f92c65b7187611ca9
+      - 03d72ed354ef40a9a702747d0647d9e4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:40 GMT
+      - Wed, 30 Apr 2025 16:25:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6645,7 +7176,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=255,atl-edge-internal;dur=16,atl-edge-upstream;dur=239,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=308,atl-edge;dur=275,atl-edge-internal;dur=16,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ZSmreBAWlF0N_uJqsjnI2aF4EbViqHizdroI-r06XZAlFJhbdP9AqA==",cdn-downstream-fbl;dur=313
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -6654,10 +7185,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ZSmreBAWlF0N_uJqsjnI2aF4EbViqHizdroI-r06XZAlFJhbdP9AqA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f725f513b4da2b5f3a3c7acd5e1b7be1
+      - 41ead92f5369ef5b951f3cc8f2b50e80
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6683,21 +7222,23 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1610/transitions
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1850/transitions
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 3a389596-79b9-4b56-b5ad-dcece10ec233
+      - dece76e9-f5d5-4903-a0d0-b368e4cfea73
       Atl-Traceid:
-      - 3a38959679b94b56b5addcece10ec233
+      - dece76e9f5d54903a0d0b368e4cfea73
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - text/html;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:41 GMT
+      - Wed, 30 Apr 2025 16:25:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6707,17 +7248,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=549,atl-edge-internal;dur=16,atl-edge-upstream;dur=534,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=637,atl-edge;dur=603,atl-edge-internal;dur=17,atl-edge-upstream;dur=587,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="mbOaSVxe_ee35YqoRGlelFmOn-WzBGDeXbcTW_5FtK2Bft15gEGkXQ==",cdn-downstream-fbl;dur=642
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ae39d1ac6bb931d0ff3d636fc3e249de.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - mbOaSVxe_ee35YqoRGlelFmOn-WzBGDeXbcTW_5FtK2Bft15gEGkXQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f940c5364d1edb7bc9839132caabba2e
+      - 8f0afaa6d7c94497db2897920c63e3fb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6744,26 +7293,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtr1nZb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUjDHW4HTRh58753bDptUaLwrX23KfeaO6e4SQ16MiGtcr3m+3/wFQ47JbBF97FG3a/QeBz+
-        umRljdQjGoG/S+5wcMqaAGcAWQopJNXm8rFaP9Q/083YNaEi7DlCE5jAS3Bir+2+C1fW+z7aVtqO
-        bQg1o9LtV4SwEKDz+al5xX0EKdAigSyBZU0py2csD2KACwhwyLvwBxxq1Z2zGdQUWFZGdlnk36zo
-        boy0AcyzciE4YIFSZLM58lzKXIKQdDkrFo0sc6SlBHom8DoabtXA4wtR8lH7Oyt4bB+IPlUEzeu2
-        Isfzw56siZPr+5ocPwEAAP//AwDQt9GjIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:42.944+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 027da40e-0b77-4218-9a28-bb0ad7834ef3
+      - d965b00a-817f-4870-bc7c-b8e06dc09735
       Atl-Traceid:
-      - 027da40e0b7742189a28bb0ad7834ef3
+      - d965b00a817f4870bc7cb8e06dc09735
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:41 GMT
+      - Wed, 30 Apr 2025 16:25:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6773,7 +7318,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=163,atl-edge-internal;dur=14,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=218,atl-edge;dur=185,atl-edge-internal;dur=13,atl-edge-upstream;dur=170,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="9nlN03wwezWHAAH99ui8h1RFrmAfY7A23iAGrwldhg_dB1J7Lkxktg==",cdn-downstream-fbl;dur=223
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -6782,10 +7327,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 9nlN03wwezWHAAH99ui8h1RFrmAfY7A23iAGrwldhg_dB1J7Lkxktg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 8b77c1f1eaf00e005a4960ac85894f5f
+      - d10f894fff6e0e6308b2fa9599de872f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6809,78 +7362,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWVMbRxD+K1P74Eo50l4SIK3LlSJYtnEIIUK2HzBFDbut1ZjdmfXMrI4Y/nu6
-        95DMISeQiqGKnauP6f76m+arA8uCy8SJHA0yAQ3JawFZYjqS52A6Jp5BzjuqAM2tUNJ0IBE2B8s7
-        8YzLFDKVduagDe5BMoZCgwFpm7NxaazKp6TwIvD9wHc1fCnB2MmqgBPNYyticDqOIPvBrj/s4cRA
-        NsXpzNrCRJ6XwBRim6jPyuU248YILl0J1kNL1uOF8EJPGFOC1yq4ghXKH09Gp5MureFS5YJxoq+O
-        Qd9KE3MLqdKr+g4JzlAi9MOdrh90A38S+lGwG/UG7s7e8Gf02ycnyYhFxys1T3SS5D3U54frazeT
-        BEysRUGBw9V9ZnKeZR2WCGOFjC0rBMTA1JQtlL5ySTpW8r3OHulFKQWli2cXfM4t195cwMKr3No4
-        2GwFfi8Y/GLEX/Ayx7SXOVolWKDJCTdXlKvy0tIomvLMQMepBQ/xXpVsx5kJBI6OZ6sjmAP66t90
-        HCsQWQWixIlkiXd07sCk52/bCNqNQqvPeNUnZqKRrvJQZbbNA02+Qc/muu+lsBYVGGdtmyD8W3XW
-        qKldcE1ANiIvMoEOJ3dCgomq4NcfLPuDR7r7nZS1N1knrO/voRthfxn2/18rNSwqkKLBYHcZ7P4I
-        g8vWYi9c9sIfYbFB/s3NfTiGLRynYvmh5kBM8tn5/ZO99iRPUw0p8s0/FsFOu4EXUFlZ88LDR3e3
-        bext2Qi3bgy2bQzvu1PTZr1KpFS9EE7UDXDKLT4cNeE+vj5rOt8QuFer01R91fBAlRS4gEj5Iy0I
-        mTqR1SXcNDxN2rSI66h9vbdGnuFRM1NllrwSpsj4qqlYXEa37AeEBlVxEw0NeFmiiXuPRNB3e4Og
-        fSTuhm0blYVrKru7sQZVoYXSwq6eGMRW3Ktemn//Voicp2A8kjCtEoELM5HOXDNPN6T4Flda9gyd
-        +/URrlGf8Usg/nugNIg2HgxEsA2jwYAiMuNmVIj4SMir17TzCgrqX2Tc5rHK7qLaW69IJUfYvvDL
-        DMbATY0N3Yyck6P3bw6PL44OD0bHp6OL0Xj8xxjvh3VqMCR4YDIDdoJELy0ju0wYpmS2YkgaIiOl
-        zCr2TmjOTjTkyBqsNIha9yHyCLCgHP9a+H7xZS9y6lcRs4fh31TVLbbARKRC8uzuoab7asJbIT1D
-        75o5ZTaVsD5dFlS2DyL5drtTN0pPBF8tvH5gb/c2j8PjBm+/8vgK280Wcq3y2tZB09H9J4fbtrCu
-        GTQStv2AhAVVt8qUPq69ucxK6KYaeWPTFCn2StXJVnmBDbG0D4N+Z00L30vsXaE1ZdwO5yf57e8+
-        S7UqC2oUXwuZIDEahrXCLgEkK0ozg6RC6eF4n76XwISck2WCWcLwXwGGrxkkESmbhS57Q+o+yefV
-        93nEztZqhYxYkUY7buD61xRsjHWmYp7NlLHRwB/43rQ+e1H55A13zlGInZ1CXBI1sbdq0bVqiyw+
-        yUmJT3J4zjx2FhjL/iy5tqDZSKZYkDmGd4sorA94QSV9fPI72y+x9NlpzOUWKWrwvOHeeR3I62t2
-        ij1r5SeODz6Mqs/H+tPmlybN00/DibDIAiRa4QlHqIgRUbJrdoY6uiFWPj1qg7DygvAp54krsc13
-        UzX35mUmEbEWGcW7ff6cVAz7a7F4AW4urAZX6dTDquaEdIGdKrGBN+y7M5tnJFWk+KdKE6kI8WcM
-        ubKA10iAjZaYDpJhXfbTSdphzzL7goVuELghY89S++Il6/0NAAD//+xYbW/TSBD+KyNVQo5JN9SJ
-        k15O/VC1ICFRhK4HXwhSXGdLDI6d+qUUcfz3e2Z3vV43MYhy961tlTozO7uzz8zOPGvxDMZKMRZT
-        MaFGMWkVExGKWSMPW3koMFcjn7ZyfgxbOXtn5Edi2sqDVh6448etfCzGrXzSyiftBmbtuvzoyO26
-        /BgMenLDJPIomD5jRE/BIm7lkEOv2D7ti/PsF+Nsxv9XcX6M8UNjHB73xRh1sCkKc1/Fm2Xkn9eS
-        zlFAIXwhrwT9MSRur9Stzc3v+kjY4qy+j8Xjsfy9kOFYIjbnqtOjCX/KiTkQwvFTO/LwMdgX2B+F
-        lXx0Aojf49/hAw4r1sOpVxP8XlPoZpZ/mddFLJFdqfS5Ox+ii26SUjKs24/OwPOWQ/jo9XZZpF5p
-        2rNI8lG0uk1KEBRcAMIgAL24ZoRxGBrWyURjuf24JDA6+JdRRIXO4pizWNos5j3IIrpKUu6o1Tqq
-        KI+xUElf1qAmFbi1MWTUrqJSUl7QDa5tXwkX5ZjPYInZ4yK6ZgfAxepNRky9hDpnYOeFJNBzqr7k
-        jUlMZSyzCNcY5itYKonXBBoA6p4mnyXI+zVWieD2dpsmsXpvaXhR43AqgQ9OLLN/d5TeGnyqszK6
-        RqFgsn9Y1jwE/pU3qVnOIFPSJoJxkoMXOM6XYpEFu7PDKAPSJTsD93DfLUAHMa9Fh6ma9SEySBWy
-        qosMqY2nsk4rRtfxAeP2OiEYwIMD3FtyxBN/Z3kWy221yJbL5SLju2BF3+gMOwPn+U4nxC9yk0J6
-        Tw7ughlSS/8fNGNjPfKEQJyNmcdK9STM5ljSGDBcJ7S8fP7q+dnfdESnl/Tkps6rPxf40ZOPfC3B
-        Idyn9kcLnMunvNUyT6XAVcFD9se4vgmZ3Q4+sDfgzzDJRiNtvVQOaKcUgB78GJIni2LICA7ohE8O
-        fcPMZk+Ya8WOfx8YcOidTRS6AGVFvhAfNVfevB2ad6o4eGJPHYemr5Jbo51abjU71dzR3KvnjuZe
-        RXc092q6o7lX1a1mp647mm5lB05v1NudVQPS3Iw0IBlUMJ8DF2NkMOGFXLgYIwOKUTVwMUYWFEfT
-        dLwGlY6KQbKodDQMkkWlo2GQLCodDYNkUXE0GiSLSkejQXKSCXitkUmckoea7s13Cz3fVOb8ge6E
-        b6cxnwMkZn2F4296wEWirn2mBfj2IhOIO3E3p7fqVQEXIFPsm5CgYqbQFMI1GvcZ6WjttZn02egw
-        7rUJ+2x0gPfaTPtsdESsDXn0mjuQ6k62w6kkGOqID1XZ1SHmVhOlZU5bncCCmEbYRWd9i6qQ/nhR
-        kxDoUjsLmNi93GyjuOK4vc4pUV8IKXCbrOSqbfMY+Bc4USFRzctf6fPGdJvzhZtpihetNkk2IG/w
-        zwY0pMrnlnrspbOPVNY5wG7B+ymVxe3jQVQ2PAaVDY//Hyr7LwAAAP//IqUpS26/FznZ0ropazja
-        lAWrAgAAAP//7JpNasMwEIWvUgpZypVjObYXIQ2lhS5ygeyUkd2W4tj4h5Lbd8ZyRKxGKRQKXgiy
-        MNEoIwbr8cL7vJX1VtZb2SuqPrFmE12fWLNLZfdW9jwvb2W9lZ2HlQ3N1l+s7M/sPjbxtR3dukL9
-        UFzGel0j4XMAEwg1sEsN3mEtcNeCMASGvcMk6OcpuApdiTp3UR/c9Jwk0XZQKbtOwjvFbTrtbPuy
-        lBTF3l/NCmnUxFNUzR/DWnInGwlAFMirWscqSpP0ECY8jyDjkMXLIguLFfYxRdjhRllO78FWKezR
-        YiXavdPjxUGgIvLtNsg1zD4P3hpdRnvOMJHIeZhKFQqxSiBN4ig7wCHh2L6QeZHCRq2HX1lE28Xy
-        BT96HyvlcUwxGdNftUHfsi8cBFsGFI8GWgNpUqyWsqVB4f7Bo+Ntw8enHeNBfaTQ3IbC5n9imyqb
-        /4ltKm3uJ0ZhUpp+GqkG/L9+utvJougBPoYLRCGYZqu0rO2rIxU+901V5w97FBwgCmi8aURF4qq5
-        utRhhESvoxDCJabCRUgJQ0g1o6h7Gfm3F+YbAAD//0JPMKPFCD1cPFqMYClG0IsBXM0zE3grDN5o
-        AXonHZIpq0HLt6FsA6BL8ksSoavS0U3B1Q4zwFUuGRhhL+BwLXA0wOkBnO00uM/QdeBqwBnjlIC3
-        7FLzyjKL8vMgrTeIUEopdEsEhEtM6JUBm/3kLhbEWO4LMQxuKNCmjMTisHzwskXYGl1gFoA4uRrG
-        hNYvZDsAvH1EH2aujlJuYkUQZOAJxbPgBYdFJY4lEI+DFj6DFiWCvA4XR9VshKIbqgHs2traWgAA
-        AAD//wMABMBt5IEzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:39.163+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:39.163+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
+        Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - fb313064-991a-4e3f-90fc-b4f631e51fb8
+      - 3757980e-8a1c-4060-bb53-dffe1f597db3
       Atl-Traceid:
-      - fb313064991a4e3f90fcb4f631e51fb8
+      - 3757980e8a1c4060bb53dffe1f597db3
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:42 GMT
+      - Wed, 30 Apr 2025 16:25:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6890,7 +7478,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=286,atl-edge-internal;dur=18,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="2kJF5_kaHDbt9y6BLu-R91l6Z-XiqtwU-d_DESXFrQtYuxQhUnpXmA==",cdn-downstream-fbl;dur=327,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=325,atl-edge;dur=242,atl-edge-internal;dur=15,atl-edge-upstream;dur=227,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -6899,10 +7487,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 2kJF5_kaHDbt9y6BLu-R91l6Z-XiqtwU-d_DESXFrQtYuxQhUnpXmA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 9accc9910c5811500d68ccbe44b440ca
+      - 34c5a2259c157bcdcbda186982009763
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -6929,41 +7525,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - fcc11a89-4df0-4454-b3f5-2ba1b4c1a1f2
+      - 63424d6b-8c68-4697-9e29-b54e2fdbac2e
       Atl-Traceid:
-      - fcc11a894df04454b3f52ba1b4c1a1f2
+      - 63424d6b8c6846979e29b54e2fdbac2e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:42 GMT
+      - Wed, 30 Apr 2025 16:25:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -6973,7 +7556,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=278,atl-edge-internal;dur=14,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="rgbFQMP5twFLvcqQoNf1EsZQka8oA_IpalfMTZCgHmczefZzi3URkg==",cdn-downstream-fbl;dur=394,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=389,atl-edge;dur=306,atl-edge-internal;dur=16,atl-edge-upstream;dur=290,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -6982,13 +7565,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 603f7fca6e96da4aaee2b5219f231c92.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - rgbFQMP5twFLvcqQoNf1EsZQka8oA_IpalfMTZCgHmczefZzi3URkg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - e214e6c95adc7510a836a6ed57516c7b
+      - 81df23db505dbf55485f0232f14c7493
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -7000,28 +7591,27 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/95] in [Security
-      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
-      / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
-      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
-      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
-      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
-      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
-      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
-      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Active,
-      Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5] in [Security How-to|http://localhost:8080/product/2]
+      / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n||
+      Severity || CVE || CWE || Component || Version || Title || Status ||\n| High
+      | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
+      | pg | 5.1.0 | [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]
+      | Active, Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
       | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
       Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
       Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -7030,31 +7620,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:* http://localhost:8080/finding/258
-      (258)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (258)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -7063,25 +7651,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -7093,27 +7679,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7123'
+      - '6786'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - a80bfa15-5f3f-4f99-a266-9b6097b4863f
+      - 7b52759c-4830-4a86-b030-071371ad3fd2
       Atl-Traceid:
-      - a80bfa155f3f4f99a2669b6097b4863f
+      - 7b52759c48304a86b030071371ad3fd2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:43 GMT
+      - Wed, 30 Apr 2025 16:25:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -7123,17 +7711,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=275,atl-edge-internal;dur=14,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="2VsQ-IDe2h3xMwPQ1djsHZKfoKyD_hZu7dmObU688f2znNCo5LpNGQ==",cdn-downstream-fbl;dur=386,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=71,cdn-upstream-fbl;dur=382,atl-edge;dur=288,atl-edge-internal;dur=24,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a4888bfa57444daa340ca8dc53629170.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 2VsQ-IDe2h3xMwPQ1djsHZKfoKyD_hZu7dmObU688f2znNCo5LpNGQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 83e532419195facd920792fb4ee345df
+      - ae44e1e462c2399d94c76d23a6961fa5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -7157,78 +7753,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16093
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18193
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+ZDqpxEuSLTGT6biO0rh1XVdWkgfH44HJFYWYBBgA1NE4/727
-        PKT4UFq709gzJglgD+x+++36swOrgsvEiRwNMgENyWsBWWI6kudgOiaeQ847qgDNrVDSdCARNgfL
-        O/GcyxQylXYWoA3uQTKBQoMBaZuzcWmsymek8DLw/cB3NXwqwdjpuoBTzWMrYnA6jiD7wZ4/6uGH
-        gWyGn3NrCxN5XgIziG2iPiqX24wbI7h0JVgPLVmPF8ILPWFMCV6r4BrWKH8yHZ9Nu7SGS5ULxok+
-        OwZ9K03MLaRKr+s7JPiFEqEfDrp+0A38aehHwV7UG7qD/dGP6LdPTpIRi45Xap7oJMl7qM8PN9du
-        PhIwsRYFBQ5XD5jJeZZ1WCKMFTK2rBAQA1MztlT62iXpWMm3OnukF6UUlC6eXfIFt1x7CwFLr3Jr
-        62CzFfi9YPiTEX/ByxzTXuZolWCBJqfcXFOuyitLb9GMZwY6Ti14hPeqZDvOXCBwdDxfH8MC0Ff/
-        S8exApFVIEqcSJZ4R+cOTHp+u1Fo9RFv9MSAN9JVuKsEtuGmj69Asr3VWymsRQXG2dgmpP5WnTVq
-        ZpdcE16NyItMoMPJnZtjPiqU9Yer/vCR7n4jM+1NNnnp+/voRthfhf3/10qd/QqLaDDYWwV738Pg
-        qrXYC1e98HtYbAD+5ct9OAa7cBq2GzOxeldzIGb//OL+yV57kqephhT55h+LYNBu4M1UVta88PDR
-        vV0b+zs2wp0bw10bo/vu1LRZrxIpVR3CibpBw5WUEi3i2vPP99aoUDDaZq7KLHklTJHxdVNOuLzk
-        FltPTdmPL/26IWxbgFer01TY1euhKin0lavvaUHI1ImsLsk2KrXvEDNU3k00NOBliT/uNYmg7/aG
-        Qdsk7oZtQ2V3N3aBKtyAqtBCaWHXTwxBK+5Vnebf9wqR8xSMRxKmVSJwYS7SuWsW6ZYt3+BKS6uh
-        c79wwg3qM34FRIwPlAbxyYOBCHZhNBhSRObcjAsRHwt5/Zp2XkFB84uMWwxVyFpWe5sVqeQYxxd+
-        lcEEuKlxqZs35/T47S9HJ5fHR4fjk7Px5Xgy+WOC98M6NRgSPDCdAzvFDiAtI7tMGKZktmbIJiIj
-        pcwq9qvQnJ1qyJFOWGkQc+5DrBJgQTn+jfD94tN+5NRdEbOH4d9W1S22wESkQvLs7qFm+mrCWyE/
-        Q++ab8psKmFzuiyobB9E8u1xpx6Ungi+WnjTeW/PNo/D4xZvP/P4GsfNFnKt8trWYTPR/SeH27Gw
-        rhk0EraDgoQlVbfKlD6pvbnKSuimGjlrOxQp9krVyVZ5gQOxtA+DfrCLFgYbWvhWxm+H84P8+veA
-        pVqVBQ2Kr4VMkNYMw1phVwCSFaWZQ1Kh9GhyQM8rYEIuyADBLGH4rwDDbgZJRMrmoct+IXUf5PPq
-        +Txi5xu1QkasSKOBG7j+DQUbY52pmGdzZWw09Ie+N6vPXlY+eaPBBQqx8zOIS6Im9kYtu1btkMVe
-        nZTYq8ML5rHzwFj2Z8m1Bc3GMsWCzDG8O0Rhc8ALKumT09/ZQYmlz85iLndI0eTnjfYv6kDe3LAz
-        nFkrP/H98N24eryvH21+6aNp/fQ6FRZZgEQrPOEbKmJElOyGnaOOboiVTy1pGFZeED7lInEljvlu
-        qhbeoswkItYio3i3z1+QilF/IxYvwc2F1eAqnXpY1ZyQLnCEJTbwRn13bvOMpIoU/1RpIhUh/kwg
-        VxbwGgmw8QrTQTKsy344TTvsWWZfsNANAjdk7FlqX7xkvb8BAAD//+xYbW/TSBD+KyNVQo5JN9SJ
-        k15O/VC1ICFRhK4HXwhSXGdLDI6d+qUUcfz3e2Z3vV43MYhy961tlTozO7uzz8zOPGvxDMZKMRZT
-        MaFGMWkVExGKWSMPW3koMFcjn7ZyfgxbOXtn5Edi2sqDVh6448etfCzGrXzSyiftBmbtuvzoyO26
-        /BgMenLDJPIomD5jRE/BYG7lkEOvrgG0L86zX4yzGf9fxfkxxg+NcXjcF2PUwaYozH0Vb5aRf15L
-        OkcBhfCFvBL0x5C4vVK3Nje/6yNhi7P6PhaPx/L3QoZjidicq06PJvwpJ+ZACMdP7cjDx2BfYH8U
-        VvLRCSB+j3+HDzisWA+nXk3we02hm1n+ZV4XsUR2pdLn7nyILrpJSsmwbj86A89bDuGj19tlkXql
-        ac8iyUfR6jYpwUNwAQiDAPTimhHGYWhYJxON5fbjksDo4F9GERU6i2POYmmzmPcgi+gqSbmjVuuo
-        ojzGQiV9WYOaVODWxpBRu4pKSXlBN7gyfiVclGM+gyVmj4vomh0AF6s3GTH1EuqcgZ0XkkDPqfqS
-        NyYxlbHMIlxjmK9gqSReE2gAqHuafJYg79dYJYLb222axOq9peFFjcOpBD44scz+3VF6a/Cpzsro
-        GoWCyf5hWfMQ+FfepGY5g0xJmwjGSQ5e4DhfikUW7M4OowxIl+wM3MNttQBVxLwWHaZq1ofIIFXI
-        qi4ypDaeyjqtGF3HB4zb64RgAA8OcG/JEU/8neVZLLfVIlsul4uM74IVfaMz7Ayc5zudEL/ITQrp
-        PTm4C2ZILf1/0IyN9cgTAnE2Zh4r1ZMwm2NJY8BwndDy8vmr52d/0xGdXtKTmzqv/lzgR08+8rUE
-        h3Cf2h8tcC6f8lbLPJUCVwUP2R/j+iZkdjv4wN6AP8MkG4209VI5oJ1SAHrwY0ieLIohIzigEz45
-        9A0zmz1hrhU7/n1gwKF3NlHoApQV+UJ81Fx583Zo3qni4Ik9dRyavkpujXZqudXsVHNHc6+eO5p7
-        Fd3R3KvpjuZeVbeanbruaLqVHTi9Ue9mVg1IczPSgGRQwXwOXIyRwYQXcuFijAwoRtXAxRhZUBxN
-        0/EaVDoqBsmi0tEwSBaVjoZBsqh0NAySRcXRaJAsKh2NBslJJuC1RiZxSh5qujffLfR8U5nzB7oT
-        vp3GfA6QmPUVjr/pAReJuvaZFuDbi0wg7sTdnN6qVwVcgEyxb0KCiplCUwjXaNxnpKO112bSZ6PD
-        uNcm7LPRAd5rM+2z0RGxNuTRa+5AqjvZDqeSYKgjPlRlV4eYW02UljltdQILYhphF531LapC+uNF
-        TUKgS+0sYGL3crON4orj9jqnRH0hpMBtspKrts1j4F/gRIVENS9/pc8b023OF26mKV602iTZgLzB
-        PxvQkCqfW+qxl84+UlnnALsF76dUFrePB1HZ8BhUNjz+f6jsvwAAAP//IqUpS26/FznZ0ropazja
-        lAWrAgAAAP//7JrPasMwDMZfZQx6dOY0TpMcSlfGBjv0BXpz5WQbI03IH0bfflKcmtSrOxgMcjD0
-        EGqpEiIWX/l+Xsp6Keul7JWtfiHNLvb6hTSbbnYvZc/z8lLWS9l5SNnQpP4iZX9697Gxr23r1uXe
-        hWLq3nWNhM8BKyDMwQ41eId1IAxoYR1wVwY3Dvp5Cq5Al6POXdQHN83IrpPwTo7aaCtPnWnbn2z7
-        spRkxd5f9Qpp1MRTVM0fzVpSJxsJQAzHq1rHKkqT9BAmPI8g45DFyyILixXWMUFY4UZYTu/BVims
-        0WIkyr3T46QRqIh8u014DbPPg7dGh1HOmTISOQ9TqUIhVgmkSRxlBzgkHMsXMi9S2Kj18CuLaLtY
-        vuBH57FSHkcXkzH9VRv0LfvCQbBlQPZooHcgTYrVUrY0KMwfNDreNnx82jEe1EcyzW1abP4d27jZ
-        /Du2cbW5d4yLSWnyaqQa8P/66W4ni6IH+BguEJlgmozSa21fHSnwuW+qOn/Y48IBooDGm0a4JJ6a
-        q0sVRkj0OgohXMtUuAgpYQipZlzqfo382wvzDQAA//9CTzCjxQg9XDxajGApRtCLAVzNMxN4Kwze
-        SAF6Jx2SKatB67qhbAOgS/JLEqGr0tFNwdncwlku4VrJaGCEveTD2RzD6TOc7TS4l9EkjHHpMIa3
-        7FLzyjKL8vMgTTuIUEopdEsEhEtM6JUBm/3kLhbEWKwLMQxuKNCmjMTisHzwskXY+mBgFoA4uRrG
-        hNYvZDsAvH1EH2aujlJuYkUQZOAJxbPgBYdFJY4lEI+DFj6DFiWCvA4XR9VshKIbqgHs2traWgAA
-        AAD//wMALt23QIEzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18193","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193","key":"NTEST-1849","fields":{"statuscategorychangedate":"2025-04-30T18:25:39.163+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:10.039+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:39.163+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/5]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/260]\n*Defect
+        Dojo link:* http://localhost:8080/finding/260 (260)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/258]\n*Defect Dojo link:*
+        http://localhost:8080/finding/258 (258)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1849/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18193/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f2868fe7-814c-44fa-961e-9f0489d9568c
+      - 38ab8b22-d755-43c7-bb68-b60f217e1aef
       Atl-Traceid:
-      - f2868fe7814c44fa961e9f0489d9568c
+      - 38ab8b22d75543c7bb68b60f217e1aef
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:43 GMT
+      - Wed, 30 Apr 2025 16:25:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -7238,7 +7869,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=16,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=283,atl-edge;dur=251,atl-edge-internal;dur=13,atl-edge-upstream;dur=237,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="AMigyvEaAqwRxCcAOLpW4ZTnBCk3F_MAf7jx6zM0QbtMtlUHO6Qikw==",cdn-downstream-fbl;dur=287
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -7247,10 +7878,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b3ac893abff0a2c3dda216fe4cd9157a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - AMigyvEaAqwRxCcAOLpW4ZTnBCk3F_MAf7jx6zM0QbtMtlUHO6Qikw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 8d736a28dae9f790336cf81ee8dba72c
+      - 04641e041aa2e03c9bbfb9356c0f9cfb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -7277,26 +7916,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2T9WPrDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCANd7gdNCnJm/e9K2ezFiUK39p3m3CvuXOKm8SgJxPSKtdrvv8HX+GwUwJbdB9r1P0Kjcfh
-        r0tW1kg9ohH4u+QOB6esCTAFoAkkMK02l4/V+qH+mW7GrgkVKZ8jNIEJvAQn9truu3Blve+jbaXt
-        2IZQMyrdfkVIGQKsKE7NK+4jyIBlU6BTWNaMlem8TIMY4AICHPIu/AGHWnXnLIWaQUnzgCdFln+z
-        orsx0gYwpflCcMAMpaDzAnkqZSpBSLacZ4tG5imyXAI7E3gdDbdq4PGFKPmo/Z0VPLYPRJ8qguZ1
-        W5Hj+WFP1sTJ9X1Njp8AAAD//wMAUOcjziACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:45.239+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 4882bfdf-1944-472b-99e9-3efb35e3fe38
+      - eb910215-808a-48bd-8368-ca03456f7187
       Atl-Traceid:
-      - 4882bfdf1944472b99e93efb35e3fe38
+      - eb910215808a48bd8368ca03456f7187
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:43 GMT
+      - Wed, 30 Apr 2025 16:25:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -7306,7 +7941,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=185,atl-edge-internal;dur=16,atl-edge-upstream;dur=171,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=191,atl-edge;dur=159,atl-edge-internal;dur=14,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="JvZHQk6NEbaTNLPMSewEJaI7R_SQdIMMs0sJKnKvHfmYL4iEUKn_fQ==",cdn-downstream-fbl;dur=197
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -7315,10 +7950,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JvZHQk6NEbaTNLPMSewEJaI7R_SQdIMMs0sJKnKvHfmYL4iEUKn_fQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 52201ab0f45f1a7f453e018cc1c7f4c5
+      - 367d852d576722f6709fd2c13ed88579
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -7342,67 +7985,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16092
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18191
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvybbMmU7HtZXEreu6spI8OB4PTK5IxCTAAKCO2Pnv3eUh
-        xYfS2p3GfiCuPbD77YfVrQPLksvEiRwNMgENyWsBeWJ6khdgeibOoOA9VYLmVihpepAIW4DlvTjj
-        MoVcpb05aIN7kEyg1GBA2vZsXBmrihkpvAp8P/BdDZ8rMHa6KuFM89iKGJyeI8h+sOvvhzgxkM9w
-        mllbmsjzEphBbBP1Sbnc5twYwaUrwXpoyXq8FF7oCWMq8DoFN7BC+dPp+Hzax7URLtUuGCe6dQz6
-        VpmYW0iVXjV3SHCGEqEf7vT9oB/409CPgt1oMHBHezs/od8+OUlGLDpeq3mhkyTvoT6fHG2u3U4S
-        MLEWJQUOVw+YKXie91gijBUytqwUEANTM7ZQ+sYl6VjJdzp/pheVFJQunl/xObdce3MBC692a+Ng
-        uxX4g2D0ixFf4OcC014VaJVggSan3NxQrqprS6NoxnMDPacRPMZ71bI9JxMIHB1nqxOYA/rqf+05
-        ViCySkSJE8kK7+g8gMnA37YRdBulVp/wqi/MRCtd56HObJcHmnyDns1130lhLSowzto2Qfj3+qxR
-        M7vgmoBsRFHmAh1OHoQEE1XDbzhaDkfPdPc7Ketusk7Y0N9DN8LhMhz+v1YaWNQgRYPB7jLY/REG
-        l53FQbgchD/CYov8r18fwzHs4DgTy/cNB2KSLy4fnxx0J3maakiRb/6xCHa6DbyAyquGF54+urtt
-        Y2/LRrh1Y7RtY/+xOw1tNqtESvUL4UT9oOVKirwWceP57aM1qgcMqslUlSdHwpQ5X7VVg8uYQvse
-        00OV1JrgFh+jhsSfX/PNE7F5FLxGnaaKroeHqqJk1M5/oAUhUyeyuiJvYg14WaKJR49EELpBEHaP
-        xMOwbaOycE1lDzfWoCq1UFrY1Qsv3Il79Uvz798KUfAUjEcSplMicCETaeaaebohxbe40rFn6Dyu
-        j3CN+pxfA/HfE6VBtPFkIIJtGA1GFJGMm3Ep4hMhb17TzhGU1L/IuMNQjaxFvbdekUqOsX3h1zlM
-        gJsGl7odOWcn794cn16dHB+OT8/HV+PJ5M8J3g/r1GBI8MA0A3aGRC8tI7tMGKZkvmJIGiInpcwq
-        9pvQnJ1pKJA1WGUQYe5T5BFgQTn+nfD9svwSOc2riNnD8G+q6h5bYCJSIXn+8FDbfbXhrXGeo3ft
-        nDKbSlifrkoq2yeRXLc7ww7JTaP0QvA1wusH9n5v8zw8bvD2K49vsN3sINcpb2wdth3df3K4awub
-        mkEjYdcPSFhQdatc6dPGm+u8gn6qkbM2TZFiR6pJtipKbIilfRr0O9toYWdNC9/L+P1wfpTf/h+w
-        VKuqpEbxtZAJkphhWCvsGkCysjIZJDVKjycH9L0GJuScDBDMEoY/BRi+ZpBEpCwLXfaG1H2Ur+rv
-        q4hdrNUKGTGJ8bKCW6Uj391xB3cUdIx5rmKeZ8rYaOSPfG/WyFzVvnn7w0sUZhfnEFdEUeytWvSt
-        2iKLT3NS4dMcXjKPXQTGsr8qri1oNpYpFmaBYd4iCusDXlBLn579wQ4qpAB2HnO5RYoaPW9/77IJ
-        6N0dO8fetfYTx4fvx/XnQ/Pp8kyTtgWg4VRYZAMSrXGFI1TEiDDZHbtAHf0QGQBLbxAGtReEUzlP
-        XIntvpuquTevconItcgs3v3zl6Ri4PtruXgBbiGsBlfp1MPy5gR5gS0r0YKHR93MFjnJbdKFkzph
-        pCzEvwmkVc4xpkv6CVff4wik4Dkh6Rz+BgAA///sWW1v2jAQ/ivWpFWASBoghJeq6lBZpUqjmjZt
-        H7ovGMeBTEBQXqgm7cfvOccJkBLoqFp10gQCYvvs8/nuOd9DuEalxgxWuctnqLOzeXxxiWkc06qW
-        2FIf/Hmz3aH1B8j8a1knU6lbMttnFwf7bLd6T7aLHq/sYj/dLvZRu7y4TZwymyDeMqfr15R9qI3V
-        holkQwQqGm/kxGS9OiMYZ7sYkL1mDTMHAfXcMl/tsLGDocJdQOLPgFFGgtJH5VgFH9V92z+0eVZD
-        PKL5B76Mk0IDK8Kb1BTPC87dE6h9DZIQtrzx5xLYKVN7n03jCy6EXMXq58b5tgSHG4yvAYtzNQKA
-        v4ZN0w/Oubv2I+QJScm2A/j3yOZwouxWQCc63qwwZri/MNIfdbm+sYTaG7R25A1u7g2R9gYex0i/
-        UZ09zHwxY7jET6eA4ATwx1Ycay2njDNUNAKCuBOJkHukx3igNmp84stpAjAes5nkLiTXHAnUTHfL
-        vm8UGgHt53I7s+z2Z4VWf9sjMeSzus+7WT+6p1l3Y3cGjJxBHI3wcRXs/eMHQ4jfpw/yLzzStiLM
-        skomc1/oQxv5Ko/qM/umrlpkYX0YqTIMIDNHR6g3D7nbxYqLmGTuAuarB4a0t/Zd6e640xeEFO6f
-        WPpvnEKLrgLKmuTjFe4u/GWVVaq/F/DhOOjnfrsXM14cL5wT8cIhvHCehxcnpYxHeHFq0to+3tfG
-        C+c/XrwCXtj/Fl44uegRvHjMdrTzgr9Y7JbVOw17u96JQ7iMol2IGCoOzQmxQoedU1OFDqtMwso5
-        h8wKZQPLOAirjCezcmVUAMyo9tCF+HYtX6zoomSx4FS8vjtYXZHJiYkKwhPLXOIjruCxxHXdupdt
-        t9XtdCeNjiVbomeJXrvp9Rqeg3XyQVjhwDBJ/jBwXYoGjBSB++vDliKog2mugxS4OgNpopRWw0gm
-        o2FtaTW63G3YttMR3Q7wciImHQvLe1x6XXHlXqpZ3rcG75s3eKdyxoIvdd1nGGlTZCaR8QBDGE2T
-        CkozjUOylLHiPCJDQV4hPZ9H+Hk9MixztSS6oUinv32Ni3z829e4yOe/dY0BUG7KWWs+6Bquz0bc
-        8xIhfBVAVNalDHIKb/fBkgZ+TMJgJc/vATyC+FMdafR/Enrz0KUV9N9r+0kkuwxU7TJu2c655VCD
-        +5Nh5A8AAAD//xotRihNMIOzGAEAAAD//8Lv4tFihNYupksxgl4M4GqmmcBbY/DGCtA76ZBMWQ2a
-        +IayDYAuyS9JhM7no5uCs9mFs1zCNQdkYIS95MPZLMPpM5ztNbiX0SSMcekwhrfwUvPKMovy8yBN
-        PIhQSil0MQmES0zoleWXUG9SE2IY3FCgTRmJxWH54Akf2MwqMAtAnFwNY0LrF7IdAF54ow8zV0cp
-        N7EiKLW4NAdkMJJnwVM1RSWOJRCPg6aMQdM5IK/DxVE1G6HohmoAu7a2thYAAAD//wMAEH/jIrsk
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18191","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191","key":"NTEST-1848","fields":{"statuscategorychangedate":"2025-04-30T18:25:33.443+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:07.393+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t13:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:33.442+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/4]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/97]\n\n\n|| Severity || CVE ||
+        CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/257]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/257]\n*Defect Dojo link:* http://localhost:8080/finding/257
+        (257)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/256]\n*Defect
+        Dojo link:* http://localhost:8080/finding/256 (256)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1848/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18191/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a356969f-9d38-42cb-921a-43c9428cf268
+      - 42f56751-bc5a-46be-b88a-9c0e83f852db
       Atl-Traceid:
-      - a356969f9d3842cb921a43c9428cf268
+      - 42f56751bc5a46beb88a9c0e83f852db
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:44 GMT
+      - Wed, 30 Apr 2025 16:25:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -7412,7 +8055,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=289,atl-edge-internal;dur=14,atl-edge-upstream;dur=276,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="l5Hbb2edRfWPrHdvcmf-sE6D5M92TMjAaMZqrLayNxedy0pMUUdUfA==",cdn-downstream-fbl;dur=312,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=310,atl-edge;dur=224,atl-edge-internal;dur=15,atl-edge-upstream;dur=209,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -7421,10 +8064,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2e5e63ac90c6eb4f962029f46116f994.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - l5Hbb2edRfWPrHdvcmf-sE6D5M92TMjAaMZqrLayNxedy0pMUUdUfA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 59194a9ce2e9c48a22ab3a75dcdea72a
+      - d7854d07453969a75ff5190428bb40a7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"838\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:40344\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:42964\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,111 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:16:44 GMT
+      - Wed, 30 Apr 2025 16:25:45 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/98", "url_api": "http://localhost:8080/api/v2/tests/98/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      98, "url_ui": "http://localhost:8080/test/98", "url_api": "http://localhost:8080/api/v2/tests/98/"},
+      "finding_count": 2, "findings": {"new": [{"id": 261, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/261",
+      "url_api": "http://localhost:8080/api/v2/findings/261/"}, {"id": 262, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/262",
+      "url_api": "http://localhost:8080/api/v2/findings/262/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1310\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:42972\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/98\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/98/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 98, \\\"url_ui\\\": \\\"http://localhost:8080/test/98\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/98/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 261, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/261\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/261/\\\"},
+        {\\\"id\\\": 262, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/262\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/262/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 261,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/261/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/261\"\n        },\n
+        \       {\n          \"id\": 262,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/262/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/262\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        98,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/98/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/98\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/98/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/98\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:25:45 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_but_push_all.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_but_push_all.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtLlrVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Whe1Tfjrvf
-        /37HHUglPW57QwR5C6HzYjqtUaMKtXt3qQxGet9Im1oMZELqxndG7v/BF9jvGoU1+o81mm6FNmD/
-        1yUrZ7UZ0Cr8XXKHvW+cjTAFoCmkkBSby8di/VD+TDdDW8WKiOcRmsAEXqITO+P2bbyy3HejbWXc
-        UMdQNTSm/ooQEQMsz0/NKxlGkAGbJ0ATWJaMCT4TPIoBLiDCMe/jH7Avm/acpVAyEDQTnKf5gn6z
-        qr2x2kWQ02yhJOActaKzHCXXmmtQmi1n80WlM44s08DOBMGMhtuml+MLUcvBhDun5Ng+EHOqCNrX
-        bUGO54c9OTtOru9LcvwEAAD//wMALyaExyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:46.307+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - a9bff1bf-8ca7-4fd1-b323-6ca82c67ece6
+      - a1eb0eeb-128c-474e-b22e-51d39ec8abfe
       Atl-Traceid:
-      - a9bff1bf8ca74fd1b3236ca82c67ece6
+      - a1eb0eeb128c474eb22e51d39ec8abfe
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:44 GMT
+      - Wed, 30 Apr 2025 16:25:46 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=141,atl-edge-internal;dur=14,atl-edge-upstream;dur=126,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="I9vwyciRp2gEM26o7b6OvjMCZiIpud5WNPXllk5doiu4p4QV8RZ9Nw==",cdn-downstream-fbl;dur=241,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=59,cdn-upstream-fbl;dur=238,atl-edge;dur=159,atl-edge-internal;dur=16,atl-edge-upstream;dur=144,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 04a2159f61dab28d4b7610df116a191a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - I9vwyciRp2gEM26o7b6OvjMCZiIpud5WNPXllk5doiu4p4QV8RZ9Nw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 51c443cc8eaf969a6234f759b445ebf8
+      - 4f08c9ccd305a21ddfaf3ef5d735f4b5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 04c875b8-5a87-4c8f-982c-e447bc856f9f
+      - 91f6dacf-c1da-4cb5-945a-d6de016009fd
       Atl-Traceid:
-      - 04c875b85a874c8f982ce447bc856f9f
+      - 91f6dacfc1da4cb5945ad6de016009fd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:45 GMT
+      - Wed, 30 Apr 2025 16:25:46 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=349,atl-edge-internal;dur=37,atl-edge-upstream;dur=313,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="5X9Jv12v-gQYK-b9S6H9JXRNBtjZpMihFqVhCcjLJPdntgAMpu7-Xg==",cdn-downstream-fbl;dur=337,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=335,atl-edge;dur=262,atl-edge-internal;dur=16,atl-edge-upstream;dur=247,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 72fcd81c14e3eb0facf41fedad65e9e4.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 5X9Jv12v-gQYK-b9S6H9JXRNBtjZpMihFqVhCcjLJPdntgAMpu7-Xg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 9a9c9e050175c3e84ec13b12c20a299e
+      - b619e9f3ce34157570e61336e5643d9a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/263]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/263 (263)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/99]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1302'
+      - '1322'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16095","key":"NTEST-1611","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16095"}'
+      string: '{"id":"18197","key":"NTEST-1851","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18197"}'
     headers:
       Atl-Request-Id:
-      - 0c74bda3-deeb-4f75-9c59-e9309c4904a6
+      - 09a3e2a8-7238-47bf-8685-f0f32c0575a7
       Atl-Traceid:
-      - 0c74bda3deeb4f759c59e9309c4904a6
+      - 09a3e2a8723847bf8685f0f32c0575a7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:46 GMT
+      - Wed, 30 Apr 2025 16:25:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=860,atl-edge-internal;dur=20,atl-edge-upstream;dur=847,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=738,atl-edge;dur=706,atl-edge-internal;dur=16,atl-edge-upstream;dur=690,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="bCH5LBzvpHuKGhs2xnP9WBh_UbH6N5K0mMSiErl3QlSiM62YbXZFOg==",cdn-downstream-fbl;dur=743
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e9bcf307d6ed54e3e501e39bc538dcfc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - bCH5LBzvpHuKGhs2xnP9WBh_UbH6N5K0mMSiErl3QlSiM62YbXZFOg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 97bea8adb9325852357a3cc3cc806ef8
+      - 339e5e8ba8a9ed9745e18d79131cbdfc
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1611
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1851
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfSGEsFJVXUloaSmlEEA6ipDZnWxMvPae7SVJOf57x/sW
-        IOydoOrpJC7r8bw/83geHFhmVMRO6CgQMSiIDxjwWHcETUF3dDSDlHZkBooaJoXuQMxMCoZ2ohkV
-        CXCZdO5BaZRBfAqZAg3CVHejXBuZTq3BG9/zfK+n4FMO2kxWGZwoGhkWgdNxmPXvD7y9HfzQwKf4
-        OTMm06HrxjCFyMTyTvao4VRrRkVPgHHRk3FpxtzAZVrn4NYG5rBC/ePJ+GzS9Qe+j0dFCNoJHxyN
-        seU6ogYSqVZlDjF+oUbgBTtdz+/63iTwQn8Q9gc9b2/wA8bt2SCtE4OBF2beGaTVd9GeFzRpVx8x
-        6EixzBYOTz8QnVLOOyRm2jARGZIxiIDIKVlINe9Z7UiKc8XfGEUumG0X5Tf0nhqq3HsGC7cIax1g
-        JfK9bX/4k2b/wI8ptj1P0auFBbqcUD23vcpvjf0VTinX0HFKxUPMq9DtODOGwFHRbHUE94Cxeo8d
-        xzBEVoYocUKRY47OC5hse20CvxZkSt5hqu/sRKVd9KHobN0H+/EEPet0zwUzBg1op/FtIfx7cVfL
-        qVlQZYGsWZpxhgHHL0qCjSrg1x8u+8M3hvuFltWZNA3re7sYRtBfBv3/10sJiwKk6NAfLP3Bt3C4
-        rD1uB8vt4Ft4rJD/+LgJx6CG45QtL0oOxCZfXW/e3K5v0iRRkCDffHUIdmoBJiB5XvLC61cHbYLd
-        FkHQKhi2CfY2wylpszy1pFS8EE7Y9SuutJVXLCojf9g4s/OARdUzmfN4xHTG6aqaGjzGFpoLbI+d
-        pMoFNfgYlST+9pkvn4j1o+CW5pSd6OLnvsxtM4rgL+0BE4kTGpXbaCIFmKylic1HYqc36DePxMuy
-        tVFZ0FDZS0EDqkwxqZhZvTPhWt3tv+2tYClNQLtWQ9dGGB5wuejp+2TNiUdyUXNn39mcjqDBPKe3
-        YNnvlcGwpPFqGfw2hPpDW48Z1eOMRUdMzA+sZASZ3V5EVCOowNWikDUnQooxLi/0lsMpUF2iUlW/
-        nJOj818Oj2+ODvfHx2fjm/Hp6Z+nmB9OqcaC4IXJDMgJ0rwwxPolTBMp+IogZTBujRIjyW9MUXKi
-        IEXOILlGfPVeow4fx8nxPjPPyz6J0CnfROwdFn89U8+4AtuQMEH5y0vV7lWVt0A5x+iqb9vXREBz
-        O8/s0LbheHcwrHFcrknvhF6p3Dyvzzebt6FxDbefaTTHZbOGXG289LVf7XP/KeB6KXTr3SyotwEB
-        FuqR5FIdl9Hc8hy6iULGWq9Ekoxk2WyZZrgOC/M66HfaSGGnIYUvdfx5Of8W639bE2Y4bIXk6iPN
-        /JDsSzlnQC6ZQY415AyiXAE54DT5bKuDxeEyonwmtQmH3tBzp0zESHtuMNi+LgyOiuJhXneSWFiF
-        W+SrmuQ7/PN9oX6GS5/lIFRDtqiCHOVARpgPHv5BV8T3OsSCsUli/3KMoiv8rzvw+0Wkto/RAnop
-        Mwp6UiUuwpja1jJczCz8Xbzam5mUF3GXdi6snXMxF3LxtEgnSsY5PvVjkeBgp9gmd4I1tj6LCmG8
-        5Fe56BrZUqWsMhBcE5dc+dqQv3KqDCiyNtmiCmuffqH98cMJOYuoaLlvd053b69J6kkaZyttINWY
-        RpxJhljbCovzokG2YCllQjMDPYQj1kvPbiVVcduNDfujNczQ8r8AAAD//+xZbUvcQBD+K4sgKJiY
-        u8t5dwWxh7TQD9KiUEGEY7PZeKF3m5AXo1j/e5/Z3dvG9GKLFPGD4IeY3Z2dmcw888ycmjNhognQ
-        yyIpFStlxRobWhWwsTThlSC8DlizTMWSrSVXJRa52WElwNxrFUnGhQC4ypjdppzVyBdR3OdAJ+xT
-        ShqO4Lc0OsOnvtGdJSl0uZSKwotxJzdD4wmLoAmZBa7HUpVkxVqfYVlBkM2xWhJiAq1/SHVAikF4
-        WjFDRBhfNfyeTGQ519rVJQKbccVaCqJtVHLl44OXZLOz0PjgWpET6DbyETSwGpYbFUlgWcNBWzVt
-        2dyy/hypiOIDl5H1NlyapvGzhpe5TgrkoLzz82WuAxqXLCBzYe9e8ArMK6oRUou9r5fzi2/exZmH
-        Oq1T1V2SZxTJlAx7PF6nap/t7f9EoKyq7APC8E+KM3Z1vlvj+mBuELZhrioA7JprERvsbnUsuLMQ
-        Oj7aWQj6TgSOauiPpInV9o191CPoI8eBUwY+5mJJ+W3rb7uEd4G8rNdrTjVr529wTV4nBpoVLyxw
-        xEROkG/Ecb/Ex+N4NJ1Mo8EkkCMxC8RsPExmg+QI97hNuOGZbZJCYh7HuANFDhUvvv/YUgSAQrKe
-        bX1NrvgoonqbhinbfoUSPI/HgzA8mojpZDyaRSKaBLg+4TKZipP4WEvZHc13h5/xZ855a64svHqe
-        eVX6dek1cIQ39Am3/byOVqkgT3k55yU5Cud1GQFLxOMpksLPFfm820a/fY27ffjb17jbx791jYFR
-        selVLRM8ReiDyCRJLUSqE4jw3HSOBuGuwAWx8VNdZLk8vAL2iOXvTKM5ElZd6tINdqy2nT6Gfbga
-        9vWUoespC4vv7zDyagHzDiOvofE7jGyBkS4M9DG10BEyx1dgzo1JygcaeNvnAJpkFbdz/K6UXubV
-        i0t9059guB35eplZr2W9lM2Z3FkY9Z0YOZIn1W1aZMqwPPMqru2PSObff/HebVb9v2GmEeaE4ia0
-        ad8zPerZTFSRAkblh82jrS8vVkD/4Ha4kXuws+Z357KsVyS4Zawe0hTVvDKG06iYBjlkunv/9PDw
-        yWl7QGv7+Pj4CwAA//8DAK3wx7azHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18197","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18197","key":"NTEST-1851","fields":{"statuscategorychangedate":"2025-04-30T18:25:47.646+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1851/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:47.341+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:47.428+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/263]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/263 (263)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/99]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1851/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18197/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f9a52c9c-c08c-47ce-9cf9-20fe0fbdb7df
+      - 82c08659-679e-42fa-9823-181e7e37e505
       Atl-Traceid:
-      - f9a52c9cc08c47ce9cf920fe0fbdb7df
+      - 82c08659679e42fa9823181e7e37e505
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:46 GMT
+      - Wed, 30 Apr 2025 16:25:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=304,atl-edge-internal;dur=21,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=324,atl-edge;dur=292,atl-edge-internal;dur=19,atl-edge-upstream;dur=272,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="mABwK6D-SingVTUtRtWtS5omJVuidqYqOdRBFLt3L2gYwIAmLv4gAQ==",cdn-downstream-fbl;dur=329
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 771067dca4682f83a6c9963c412d66cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - mABwK6D-SingVTUtRtWtS5omJVuidqYqOdRBFLt3L2gYwIAmLv4gAQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 05701db5ebfc559d2595872e6dcb5954
+      - 9a427da558585e30b7bd735e0a438a67
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16095
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18197
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeSSEMFJVbUloaSmlEEBaipCZuZmYeOxZ20OSsvz3Xs8r
-        kJBdQdUVUhj7+r6Pj++jA4uMitgJHQUiBgXxIQMe65agKeiWjqaQ0pbMQFHDpNAtiJlJwdBWNKUi
-        AS6T1gMojTKIzyBToEGY6myUayPTiTV463ue73UUfMpBm/Eyg1NFI8MicFoOs/79vre/iwsNfILL
-        qTGZDl03hglEJpb3skMNp1ozKjoCjIuejEsz5gYu0zoHtzYwgyXqn4xH5+O23/d93CpC0E746GiM
-        LdcRNZBItSxziHGFGoEX7LY9v+1748AL/X7Y63e8/f4PGLdng7RODAZemHlnkFbfRXte0KRdLWLQ
-        kWKZLRzufiA6pZy3SMy0YSIyJGMQAZETMpdq1rHakRQXir8xilww2y7Kb+kDNVS5DwzmbhHWKsBK
-        5Htdf/CTZv/Ajym2PU/Rq4UFuhxTPbO9yu+M/QonlGtoOaXiEeZV6LacKUPgqGi6PIYHwFi9p5Zj
-        GCIrQ5Q4ocgxR2cNJl2vFmRK3mNG7yx4pV2Uu2hgXW67eAaSVVYXghmDBrTT+LZI/b04q+XEzKmy
-        eNUszTjDgOO1zLEfBcp6g0Vv8MZwv9CZOpOmLz1vD8MIeoug9/96KbtfYBEd+v2F3/8WDhe1x26w
-        6AbfwmMF8KenTTj623Aa1IIJW1yWHIjdv77ZPNmtT9IkUZAg33z1EuzWAsxM8rzkhdeP9rcJ9rYI
-        gq2CwTbB/mY4JW2Wu5aUihfCCds+LqnBh6Mk3Ldf3JLOVwTuluaUvZbF54HMbeF8S8pXdoOJxAmN
-        yuGp4mlrTbGorNrjxp6NDI/qqcx5PGQ643RZXWXcxrDMJWLGXu+qGgowWcsfm4/Ebqffax6J9bI1
-        VLYu2AaqoAFVpphUzCzfWcRa3e297a1gKU1Au1ZD10YYbnA57+iHZEWWx3Jek2rP2bw2QYN5Tu/A
-        0uIrF8Oyyatl8Lch1B/YekypHmUsOmZidmglQ8js9CKiuotFb+eFrNkRUoxweKF3HM6A6hIZqvpy
-        To8vfjk6uT0+OhidnI9uR2dnf55hfnhLNRYED4ynQE6R/4Uh1i9hmkjBlwS5hHFrlBhJfmOKklMF
-        KZIJyTVitvMap/h4nRzvM/O87JMInfJNxN5h8Vd36gVXYBsSJihfP1TNXlV5C5xzjK5a274mAprT
-        eWYv7TYc7/UHNY7LMemd0CuVm3f35WTzNjSu4PYzjWY4bNaQq42Xvg6qee4/BVwPhW49mwX1mCDA
-        Qj2SXKqTMpo7nkM7Ucgaq5FIkqEsmy3TDMdhYV4H/W5DCl9q7LpSQxgvy/m3WP3tjJnhsBOS6480
-        80NyIOWMAbliBnnOkHOIcgXkkNPks60OFofLiPKp1CYceAPPnTARI5W6Qb97UxgcFsXDvO4lsbAK
-        d8hXNcl3+PN9oX6OQ5/lIFRDtqiCHOZAhpgobv5Bl8T3WsSCsUni4GqEomv81+77vSJS28doDp2U
-        GQUdqRIXYUxtaxlObBb+Lh7tTE3Ki7hLO5fWzoWYCTl/XqRTJeMcZ4CRSPBip9gmd4zFtz6LCmG8
-        5Fc5bxu5pUpZZSC4IS659rUhf+VUGVBkZXKLKqx8+oX2xw+n5DyiYst5O4y6+/tNUs/SOF9qA6nG
-        NOJMMsTaTljsFw2yBUspE5oZ6CAcsV56eiepired2LA/XMEMLf8LAAD//+xZbUvcQBD+K4sgKJiY
-        u8t5dwWxh7TQD9KiUEGEY7PZeKF3m5AXo1j/e5/Z3dvG9GKLFPGD4IeY3Z2Xzcwzz8ypORMmmgC9
-        LJJSsVJWrLGhVQEbSxNeCcLrgDXLVCzZWnJVYpGbHVYC3L1WkWRcCICrjNltylmNfBHFfQ50wj6l
-        pKnTfsuiM3zqG91ZkkGXS6kovBh3cjM0nvAIlpBbIIEsVUlWrPUZlhUE2RyrJSEm0PqHVAdkGISn
-        FTNkgPFVw+/JRZZzbV1dIrAZV6xlINpGJVc+PnhJPjsPzR1cK7oE0kZ3BAusheXGRBJY1rigrZa2
-        fG55f45URPHBlZH3NlyapvGzhpe5TgrkoLzz82WuAxpKFpC5sLoXvAL7iWqE1GLv6+X84pt3ceah
-        TutUdUryjCKZkmGPx+tU7bO9/Z8IlFWVfUAY/klxxq7Od2tcH/cZhG38qwoAu+ZvxMi6Wx0L7iwE
-        fQuhI6rdE45q6I+kidX2jX3UI+gjx4HT+aRkdxEdH4CLJSW/KQtlvV5zqlk7f4NrunVioFnxwgJH
-        TOQE+Ua8+Ut8PI5H08k0GkwCORKzQMzGw2Q2SI6gx22Chme2SQqJeRxDB4ocKl58/7FlCACFZD3b
-        E5tc8VFE9TYNU7YvCyV4Ho8HYXg0EdPJeDSLRDQJoD7hMpmKk/hYS9kdzXeHn/Fnznlrriy8ep55
-        Vfp16TW4CG/oE277eR2tUkE35eWcl3RROK/LCFgiHk+RFH6u6M67/fXbt7jboL99i7sN/lu3GBgV
-        m37RMsFThD6ITJLUQqQ6gQjPTTdqEO4KXBAbP9VFlsvDK2CPWP7ONBowYdWlLmmwY7Xt9DHsw9Ww
-        r6cMXU9ZWHx/h5FXC5h3GHkNi99hZAuMdGGgj6mFjpA5/gJ3bkxSPtAk3D4HsCSruJ3jd6X0UbKg
-        D5eC4XaA6xsKBb0O9FI251n3RB+XG/UuOJIn1W1aZMoQOfMqru2PSObff7m926z6fwNSI8wJhSa0
-        ad8zPerZTDWRAsbkh82jrS8vNkD/4Ha4kXuws+Z357KsVyS45awe0hTVvDKO06iYBjnkunv/9PDw
-        yWl7QFv7+Pj4CwAA//8DAAktQbGzHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18197","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18197","key":"NTEST-1851","fields":{"statuscategorychangedate":"2025-04-30T18:25:47.646+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1851/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:47.341+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:47.428+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/263]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/263 (263)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/99]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1851/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18197/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 276d0d7f-9c02-4e68-a461-6659dc53b2e5
+      - a9edd810-4408-4023-8fcb-26d37cd69982
       Atl-Traceid:
-      - 276d0d7f9c024e68a4616659dc53b2e5
+      - a9edd810440840238fcb26d37cd69982
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:46 GMT
+      - Wed, 30 Apr 2025 16:25:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=307,atl-edge-internal;dur=12,atl-edge-upstream;dur=295,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="4KEYHWqBvRb37qUXMTAyXK902AclcHFi_BE0RmyZq6N7Q0oiSC3AMA==",cdn-downstream-fbl;dur=503,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=500,atl-edge;dur=415,atl-edge-internal;dur=14,atl-edge-upstream;dur=400,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 57f0537bdb26692a5be92bbbe93e4ea2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 4KEYHWqBvRb37qUXMTAyXK902AclcHFi_BE0RmyZq6N7Q0oiSC3AMA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 029fd18d2d5536363a8da6395d416f75
+      - 41c01f988292fac52906b2d36d18c081
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrlrVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCGcAWQopJOXm8rFcP1Q/083Q1rEi/HmEJjCBl+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0XxHCY4AWxal5JcIIUqDzBLIElhWlnM04i2KAC4hwzPv4B+wr3Z6zGVQUeJZzVqSULr9Z
-        2d5Y5SLIsnwhBeAclcxmBQqmFFMgFV3O5ota5QxproCeCYIZDbe6F+MLUYnBhDsnxdg+EHOqCNrX
-        bUmO54c9OTtOru8rcvwEAAD//wMApX+jFSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:49.321+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 31582d73-fb3c-47ee-b687-1a3f71d32e14
+      - ba0e8568-f21d-4489-bd2b-4a7f88f11e27
       Atl-Traceid:
-      - 31582d73fb3c47eeb6871a3f71d32e14
+      - ba0e8568f21d4489bd2b4a7f88f11e27
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:47 GMT
+      - Wed, 30 Apr 2025 16:25:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=166,atl-edge-internal;dur=13,atl-edge-upstream;dur=154,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=176,atl-edge;dur=143,atl-edge-internal;dur=15,atl-edge-upstream;dur=129,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="SYhPPRybGbdTnMo7iDodAdPS5xcEakb0laL6XYxF_du2RjWQ38zz6Q==",cdn-downstream-fbl;dur=179
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a183b6545fea485604515ba7931cb9b8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - SYhPPRybGbdTnMo7iDodAdPS5xcEakb0laL6XYxF_du2RjWQ38zz6Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 226ee4ee20ff0feac1c0ff7e79155084
+      - 72ea4759aee751b8a2a155e9881ffda7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - b4e1329e-8bbb-4b85-bbb0-1bffa4c67392
+      - 367477bf-4de3-479a-9517-30348af63c4e
       Atl-Traceid:
-      - b4e1329e8bbb4b85bbb01bffa4c67392
+      - 367477bf4de3479a951730348af63c4e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:47 GMT
+      - Wed, 30 Apr 2025 16:25:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=323,atl-edge-internal;dur=16,atl-edge-upstream;dur=308,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=332,atl-edge;dur=299,atl-edge-internal;dur=17,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="HDo7FrhZw_tDDe0i4lCQRxFgDKe9qE1m-Uy3ugXgF4MvZhXMnwJ-1A==",cdn-downstream-fbl;dur=336
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1b7fa09f50c08a88d619f90eef5ee94a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - HDo7FrhZw_tDDe0i4lCQRxFgDKe9qE1m-Uy3ugXgF4MvZhXMnwJ-1A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4f84db2c2e588b461d942f5cbf5b4029
+      - cb68eec149bf5710ec075902af517d4b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/264]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/264 (264)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/99]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1302'
+      - '1322'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16096","key":"NTEST-1612","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16096"}'
+      string: '{"id":"18199","key":"NTEST-1852","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18199"}'
     headers:
       Atl-Request-Id:
-      - 8f279ec8-fde1-46fb-b8ae-88e6f8381aef
+      - b6ce82b6-d7ec-4b26-8e79-b2f78e911b23
       Atl-Traceid:
-      - 8f279ec8fde146fbb8ae88e6f8381aef
+      - b6ce82b6d7ec4b268e79b2f78e911b23
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:48 GMT
+      - Wed, 30 Apr 2025 16:25:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=741,atl-edge-internal;dur=13,atl-edge-upstream;dur=729,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="cU4J2O01Ch14sMIRwgaLXmuOhykilt41kOJHAlwvODq0TsgF3lojiw==",cdn-downstream-fbl;dur=779,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=775,atl-edge;dur=690,atl-edge-internal;dur=17,atl-edge-upstream;dur=674,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0730d54c3f7ca2a2e0c1b4cda1ebc0aa.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - cU4J2O01Ch14sMIRwgaLXmuOhykilt41kOJHAlwvODq0TsgF3lojiw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 2256c3a46f2088799dcec95c0a59acd2
+      - a9b301f7ccd90c8ce862aea6b08546f6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1612
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1852
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9kHIhZWq6kpCy5VSCgGkowiZ3cnGF6+9Z3vzKMf/3vE+
-        EkiyV0HV00lc1uN5f/N5Hh1YZFTETugoEDEoiI8Z8Fi3BE1Bt3Q0gZS2ZAaKGiaFbkHMTAqGtqIJ
-        FQlwmbRmoDTKIL6ATIEGYaq7Ua6NTMfW4L3veb7XUfA5B21GywzOFY0Mi8BpOcz693veYQ8/NPAx
-        fk6MyXToujGMITKx/CQ71HCqNaOiI8C46Mm4NGNu4DKtc3BrA1NYov7ZaHg5avs9P8CjIgTthI+O
-        xthyHVEDiVTLMocYv1Aj8IKDtue3fW8UeKHfC7v9zv5h9weM27NBWicGAy/MvDFIq++iPc9GVaZd
-        fcSgI8UyWzg8fU90SjlvkZhpw0RkSMYgAiLHZC7VtGO1IymuFH9lFLlgtl2U39MZNVS5MwZztwhr
-        HWAl8r19v/+TZn/Djym2PU/Rq4UFuhxRPbW9yh+M/RWOKdfQckrFE8yr0G05E4bAUdFkeQozwFi9
-        p5ZjGCIrQ5Q4ocgxR2cDJvteLciU/IQZvbHglXZR7qKBdbntxzOQrLO6EswYNKCdlW+L1N+Ku1qO
-        zZwqi1fN0owzDDjeyBz7UaCs2190+68M9yudqTNZ9aXrvcMwgu4i6P6/XsruF1hEh35v4fe+hcNF
-        7XE/WOwH38JjBfCnp204+k04DWrBmC2uSw7E7t/ebd/cr2/SJFGQIN9sDQEmIHlejv9udwdNgl6T
-        4F2DIGgU9JsEh9txlrRZnlpSKl4IJ2z7FVfaligWlSk9bp3ZQcFq64nMeTxgOuN0WY0THs+pwaen
-        pOzXj375IKyfALc0p+xgFz+PZG5LX4R6Yw+YSJzQqNz6RqPmGjFjx7uqhgJM1vLHrkfC63v1I7FZ
-        thWVbQqaQBWsQJUpJhUzyzeWoFZ3u697K1hKE9Cu1dC1EYYHXM47epasyfJUzmtS7TrbYxOsMM/p
-        A1ha3DEYlk12lsFvQqjft/WYUD3MWHTKxPTYSgaQ2e1FRDWCClzNC9nqREgxxOWFPnC4AKpLVKrq
-        l3N+evXLydn96cnR8OxyeD+8uPjjAvPDKdVYELwwmgA5R/4Xhli/hGkiBV8S5BLGrVFiJPnAFCXn
-        ClIkE5JrRFxnF6f4OE6O94V5XvZ5Fjrlm4i9w+KvZ+oFV2AbEiYo37xU7V5VeQvcc4yu+rZ9TQSs
-        bueZHdomHPsHfo3jck16I/RK5dW7+3KzeR0a13D7mUZTXDZryNXGS19H1T73nwKul0K33s2Cek0Q
-        YKEeSS7VWRnNA8+hnShkrPVKJMlAls2WaYbrsDC7QX+wIoWvNXZTaUUYL8v5l1j/2xsxw2EvJLcf
-        aRaE5EjKKQNywwxyrCGXEOUKyDGnyRdbHSwOlxHlE6lN2EcSc8dMxEiEbtDr3hUGB0XxMK9PklhY
-        hXvkXzXJd/jn+0L9Epc+y0GohmxRBTnIgQwwUTz8nS6J77WIBeMqiaObIYpu8b92z+8Wkdo+RnPo
-        pMwo6EiVuAhjalvLcGOz8HfxamdiUl7EXdq5tnauxFTI+fMinSsZ57gDDEWCg51im9wRFt/6LCqE
-        8ZJf5bxtZEOVsspAcEdccutrQ/7MqTKgyNpkgyqsffqF9sf35+QyoqLhvl1G3cPDVVLP0rhcagOp
-        xjTiTDLE2l5YnBcNsgVLKROaGeggHLFeevIgqYqbbmzZH6xhhpb/AQAA///sWW1r2zAQ/iuiUGih
-        dp3EXZJB6ULZYB/KRgsrlEJQZLkxS2Tjl7pl63/fc5KiuV7UjTJKPxT6wbWk09357rnnLmrGhIkm
-        QC9bSKlYJWvW2tCqgY2VCa8U4XXA2mUmlmwtuaqwyM0OKwHmXquFZFwIgKtM2G3GWYN8EeV9AXTC
-        PqWk4QhhR6MzfOob3VmSQpdLqSi8GHdyczSesAiakFkggSxTaV6u9RmWlwTZHKsVISbQ+rtUB6QY
-        hGc1M0SE8VXL78lEVnCtXVMhsBlXrKMg2kYlVyE+eEU2OwuND64VOYFuIx9BA6thtVGRBFYNHLRV
-        047NHevPkYooPnAZWW/DpW3bMG95VeikQA7Ku7BYFjqgcckcMuf27jmvwbwWDUJqvvflcnbxNbg4
-        C1Cndaq6S4qcIpmSYY8n60zts739nwiUVZ2/Rxj+SXGOXJ3v1zgf9xnEXfyrSwC7Zl/EBvtbfZw3
-        8i3Ejqj2TziqoT+SJlbbN/qoR+Qjx5G7Ez7mYkn5betvt4T3Eb5q1mtONWvnb3BNXicGmpfPLHDE
-        RE6Qb8R6PyfHR8loMp4sBuNIjsQ0EtOjYTodpDQ8cZtwwxPbJIXELElwB4ocKl5y/6GjCACFZD3Z
-        E5tcCVFE9TYNU7YviyV4Hk8GcfxuLCbjo9F0IRbjCNenXKYTcZIcaym7o9nu8BP+zLlgzZWF1yAw
-        r6qwqYIWjgiGIeF2WDSLVSbIU0HBeUWOwnldRsAS8XiKpAgLRT7v99evX+N+g/76Ne43+K9dY2BU
-        YnpVywRPEfogMmnaCJHpBCI8N72kQbgrcEFs/NiUeSEPr4A9Yvk702jAhFWXunSDHattp4+xD1dj
-        X08Zu56ytPj+BiMvFjBvMPISGr/ByBYY6cOAj6nFjpA5vgJzbkxS/qBJuH2OoEleczvH70vxUbLI
-        h0vRcDvA+YZCkdcAL2VzlvVP+LjcyLvgSJ5Ut1mZK8PyzKuksT8imX//xXu3ef3/xptGmBOKm9Cm
-        fcv1qGczUUUKGJV/bB5tfXm2AvoHt8ON3IOdNb87l1WzIsEdY/WQpqxntTGcRsU0yCHT3fvHh4eP
-        TtsDWtuHh4dfAAAA//8DAD7F9+WzHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18199","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18199","key":"NTEST-1852","fields":{"statuscategorychangedate":"2025-04-30T18:25:50.653+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1852/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:50.366+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:50.453+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/264]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/264 (264)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/99]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1852/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18199/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 947853c2-4204-463a-bcba-cc2961b79dab
+      - cd18d5e2-4642-44c5-bd2a-7aa3c2546b25
       Atl-Traceid:
-      - 947853c24204463abcbacc2961b79dab
+      - cd18d5e2464244c5bd2a7aa3c2546b25
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:48 GMT
+      - Wed, 30 Apr 2025 16:25:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=322,atl-edge-internal;dur=15,atl-edge-upstream;dur=307,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=302,atl-edge;dur=269,atl-edge-internal;dur=15,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="qsBkjTD2-KrnV6sWPT6KN5tYJ_VO71QsWCNvlSNpVYHopAUGAe8jhg==",cdn-downstream-fbl;dur=305
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 22067fb5d7eb764108747a104222f50a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qsBkjTD2-KrnV6sWPT6KN5tYJ_VO71QsWCNvlSNpVYHopAUGAe8jhg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 5f00821bacb56169cfb691fb13fb9e3d
+      - bf4c281268de91a7d9c39d2a58753a4c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16096
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18199
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeRCyYaSq2pLQ0lKakgDSUoTMzM3EG489a3vyKMt/7/U8
-        EshjV1B1hRTGvr7v4+P76MAioyJ2QkeBiEFBfMqAx7ohaAq6oaMJpLQhM1DUMCl0A2JmUjC0EU2o
-        SIDLpDEDpVEG8SVkCjQIU52Ncm1kOrYG733P872Wgk85aDNaZjBQNDIsAqfhMOvf73jHHVxo4GNc
-        TozJdOi6MYwhMrH8KFvUcKo1o6IlwLjoybg0Y27gMq1zcGsDU1ii/sWoPxw1/Y4f4FYRgnbCR0dj
-        bLmOqIFEqmWZQ4wr1Ai84Kjp+U3fGwVe6HfCdrd1eNz+AeP2bJDWicHACzNvDNLqu2jPs1GVaVeL
-        GHSkWGYLh7vviU4p5w0SM22YiAzJGERA5JjMpZq2rHYkxZXir4wiF8y2i/J7OqOGKnfGYO4WYa0D
-        rES+d+h3f9LsH/gxxbbnKXq1sECXI6qntlf5g7Ff4ZhyDQ2nVDzDvArdhjNhCBwVTZbnMAOM1Xtq
-        OIYhsjJEiROKHHN0NmBy6NWCTMmPmNEbC15pF+UuGliX2y6egWSd1ZVgxqAB7ax8W6T+XpzVcmzm
-        VFm8apZmnGHA8Ubm2I8CZe3uot19Zbhf6Eydyaovbe8dhhG0F0H7//VSdr/AIjr0Owu/8y0cLmqP
-        h8HiMPgWHiuAPz1tw9Hfh9OgFozZ4rrkQOz+7d32ycP6JE0SBQnyzVcvwVEtwMwkz0te2H20s0/w
-        bo8g2Cvo7hMcb4dT0ma5a0mpeCGcsOnjkhp8OErCff3FLel8TeBuaU7Za1l8nsjcFs63pHxjN5hI
-        nNCoHJ4qnrbWFIvKqj1u7dnI8KieyJzHPaYzTpfVVcZtDMtcI2bs9a6qoQCTtfyx65Hwul79SGyW
-        bUVlm4J9oApWoMoUk4qZ5RuLWKu77de9FSylCWjXaujaCMMNLuctPUvWZHku5zWptp3taxOsMM/p
-        A1ha3HExLJvsLIO/D6F+19ZjQnU/Y9E5E9NTK+lBZqcXEdVdLHo7L2SrHSFFH4cX+sDhEqgukaGq
-        L2dwfvXL2cX9+dlJ/2LYv+9fXv55ifnhLdVYEDwwmgAZIP8LQ6xfwjSRgi8Jcgnj1igxkvzGFCUD
-        BSmSCck1Yra1i1N8vE6O95l5XvZpFjrlm4i9w+Kv79QLrsA2JExQvnmomr2q8hY45xhdtbZ9TQSs
-        TueZvbT7cOwf+TWOyzHpjdArlVfv7svJ5nVoXMPtZxpNcdisIVcbL32dVPPcfwq4HgrdejYL6jFB
-        gIV6JLlUF2U0DzyHZqKQNdYjkSQ9WTZbphmOw8LsBv3RihS+1NhNpRVhvCzn32L9dzBihsNBSG4/
-        0CwIyYmUUwbkhhnkOUOGEOUKyCmnyWdbHSwOlxHlE6lN2EUSc8dMxEilbtBp3xUGe0XxMK+PklhY
-        hQfkq5rkO/z5vlAf4tBnOQjVkC2qIHs5kB4mipt/0CXxvQaxYFwlcXLTR9Et/mt2/HYRqe1jNIdW
-        yoyCllSJizCmtrUMJzYLfxePtiYm5UXcpZ1ra+dKTIWcPy/SQMk4xxmgLxK82Cm2yR1h8a3PokIY
-        L/lVzptG7qlSVhkI7ohLbn1tyF85VQYUWZvcowprn36h/eH9gAwjKvact8Ooe3y8SupZGsOlNpBq
-        TCPOJEOsHYTFftEgW7CUMqGZgRbCEeulJw+SqnjfiS37vTXM0PK/AAAA///sWW1L3EAQ/iuLICiY
-        mLvL9e4KYg9poR+kRaGCCMdms/FC7zYhL0ax/nef2d3bxvRiixTxg+CHmN2dnZnMPPPMnJozYaIJ
-        0MsiKRUrZcUaG1oVsLE04ZUgvA5Ys0zFkq0lVyUWudlhJcDcKxVJxoUAuMqY3aSc1cgXUdzlQCfs
-        U0qaOu23NDrFp77WnSUpdLGUisKLcSc3Q+MJi6AJmQUSyFKVZMVan2FZQZDNsVoSYgKtf0p1QIpB
-        eFoxQwYYXzX8jkxkOdfa1SUCm3HFWgqibVRy5eODl2Szs9D44EqRE+g28hE0sBqWGxVJYFnDQVs1
-        bdncsv4MqYjiA5eR9TZcmqbxs4aXuU4K5KC89fNlrgMalywgc2HvXvAK7CeqEVKLvW8X8/Pv3vmp
-        hzqtU9VdkmcUyZQMezxep2qf7e3/QqCsquwjwvBPijN2db5b4/q4zyBs419VANg1fyNG1t3qWHBn
-        IehbCB1R7Z5wVEN/JE2stm/sox5BHzkO3J1PSnYX0fEBuFhS8puyUNbrNaeatfM3uCavEwPNihcW
-        OGIix8g34s1f46NxPJpOptFgEsiRmAViNh4ms0FCwxO3CTc8s01SSMzjGHegyKHixXefWooAUEjW
-        sz2xyRUfRVRv0zBl+7JQgufxeBCGHyZiOhmPZpGIJgGuT7hMpuI4PtJSdkfz3eEX/Jlz3porC6+e
-        Z16Vfl16DRzhDX3CbT+vo1UqyFNeznlJjsJ5XUbAEvF4gqTwc0U+7/bXb1/jboP+9jXuNvhvXWNg
-        VGz6RcsETxD6IDJJUguR6gQiPDfdqEG4S3BBbPxcF1kuDy+BPWL5O9NowIRVl7p0gx2rbaePYR+u
-        hn09Zeh6ysLi+zuMvFrAvMPIa2j8DiNbYKQLA31MLXSEzPEXmHNtkvKeJuH2OYAmWcXtHL8rpY+S
-        BX24FAy3A1zfUCjoNaCXsjnLuif6uNyod8GRPKlu0iJThsiZV3Ftf0Qy//6L926y6v8NSI0wJxQ3
-        oU37kelRz2aqiRQwKt9vHm19ebEC+ge3w43cg501vz2TZb0iwS1j9ZCmqOaVMZxGxTTIIdPd+6eH
-        h09O2wNa24eHh0cAAAD//wMAvM6RgbMcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18199","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18199","key":"NTEST-1852","fields":{"statuscategorychangedate":"2025-04-30T18:25:50.653+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1852/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:50.366+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t1z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:50.453+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/264]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/264 (264)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/99]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1852/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18199/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3206ae39-513c-44b3-95f3-5ba9919d1a02
+      - 63d08bc5-1d33-453e-b3b5-497593ebc64e
       Atl-Traceid:
-      - 3206ae39513c44b395f35ba9919d1a02
+      - 63d08bc51d33453eb3b5497593ebc64e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:49 GMT
+      - Wed, 30 Apr 2025 16:25:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=12,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="zfooMFI38V4CuOkbtwTHnOk7lNwRLwGp8FozffcJfknMZ4lpckAK6A==",cdn-downstream-fbl;dur=359,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=356,atl-edge;dur=274,atl-edge-internal;dur=18,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 40867fef594010a8d9ec2cb0a5cb2350.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - zfooMFI38V4CuOkbtwTHnOk7lNwRLwGp8FozffcJfknMZ4lpckAK6A==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - f2a5a30708b5d019d3fb5e17e42a5715
+      - 5e4a382eae385c7443f46b8a9bfef409
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"838\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:40716\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:47952\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,111 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:16:49 GMT
+      - Wed, 30 Apr 2025 16:25:51 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/99", "url_api": "http://localhost:8080/api/v2/tests/99/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      99, "url_ui": "http://localhost:8080/test/99", "url_api": "http://localhost:8080/api/v2/tests/99/"},
+      "finding_count": 2, "findings": {"new": [{"id": 263, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/263",
+      "url_api": "http://localhost:8080/api/v2/findings/263/"}, {"id": 264, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/264",
+      "url_api": "http://localhost:8080/api/v2/findings/264/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1310\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:47956\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/99\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/99/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 99, \\\"url_ui\\\": \\\"http://localhost:8080/test/99\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/99/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 263, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/263\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/263/\\\"},
+        {\\\"id\\\": 264, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/264\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/264/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 263,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/263/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/263\"\n        },\n
+        \       {\n          \"id\": 264,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/264/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/264\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        99,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/99/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/99\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/99/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/99\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:25:51 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_no_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_no_push_to_jira.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:40724\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:47958\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,215 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:16:49 GMT
+      - Wed, 30 Apr 2025 16:25:51 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/100", "url_api": "http://localhost:8080/api/v2/tests/100/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      100, "url_ui": "http://localhost:8080/test/100", "url_api": "http://localhost:8080/api/v2/tests/100/"},
+      "finding_count": 2, "findings": {"new": [{"id": 265, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/265",
+      "url_api": "http://localhost:8080/api/v2/findings/265/"}, {"id": 266, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/266",
+      "url_api": "http://localhost:8080/api/v2/findings/266/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:47970\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/100\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/100/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 100, \\\"url_ui\\\": \\\"http://localhost:8080/test/100\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/100/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 265, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/265\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/265/\\\"},
+        {\\\"id\\\": 266, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/266\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/266/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 265,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/265/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/265\"\n        },\n
+        \       {\n          \"id\": 266,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/266/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/266\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        100,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/100/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/100\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/100/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/100\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:25:51 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added_empty has occurred.", "title": "Created/Updated
+      0 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/100", "url_api": "http://localhost:8080/api/v2/tests/100/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      100, "url_ui": "http://localhost:8080/test/100", "url_api": "http://localhost:8080/api/v2/tests/100/"},
+      "finding_count": 0, "findings": {"new": [], "reactivated": [], "mitigated":
+      [], "untouched": [{"id": 265, "title": "Zap1: Cookie Without Secure Flag", "severity":
+      "Low", "url_ui": "http://localhost:8080/finding/265", "url_api": "http://localhost:8080/api/v2/findings/265/"},
+      {"id": 266, "title": "Zap2: Cookie Without Secure Flag", "severity": "Low",
+      "url_ui": "http://localhost:8080/finding/266", "url_api": "http://localhost:8080/api/v2/findings/266/"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1321'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added_empty
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1321\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added_empty\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
+        \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
+        \"172.18.0.9:47976\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \ \"data\": \"{\\\"description\\\": \\\"Event scan_added_empty has occurred.\\\",
+        \\\"title\\\": \\\"Created/Updated 0 findings for Security How-to: 1st Quarter
+        Engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/100\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/100/\\\", \\\"product_type\\\":
+        {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 100, \\\"url_ui\\\": \\\"http://localhost:8080/test/100\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/100/\\\"}, \\\"finding_count\\\":
+        0, \\\"findings\\\": {\\\"new\\\": [], \\\"reactivated\\\": [], \\\"mitigated\\\":
+        [], \\\"untouched\\\": [{\\\"id\\\": 265, \\\"title\\\": \\\"Zap1: Cookie
+        Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/265\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/265/\\\"}, {\\\"id\\\":
+        266, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\", \\\"severity\\\":
+        \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/266\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/266/\\\"}]}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added_empty
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        0,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [],\n      \"reactivated\":
+        [],\n      \"untouched\": [\n        {\n          \"id\": 265,\n          \"severity\":
+        \"Low\",\n          \"title\": \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/265/\",\n          \"url_ui\": \"http://localhost:8080/finding/265\"\n
+        \       },\n        {\n          \"id\": 266,\n          \"severity\": \"Low\",\n
+        \         \"title\": \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/266/\",\n          \"url_ui\": \"http://localhost:8080/finding/266\"\n
+        \       }\n      ]\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\":
+        \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
+        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
+        {\n      \"id\": 100,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/100/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/100\"\n    },\n    \"title\":
+        \"Created/Updated 0 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/100/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/100\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:25:51 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_no_push_to_jira_but_push_all_issues.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_no_push_to_jira_but_push_all_issues.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrlnVr3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCGcAWQopJOXm8rFcP1Q/083Q1rEi/HmEJjCBl+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0XxHCY4AuFqfmlQgjSIHOE8gSKCpKOZtxFsUAFxDhmPfxD9hXuj1nM6go8CznrEiLnH6z
-        sr2xykWQZflSCsA5KpnNFiiYUkyBVLSYzZe1yhnSXAE9EwQzGm51L8YXohKDCXdOirF9IOZUEbSv
-        25Iczw97cnacXN9X5PgJAAD//wMAMxxvICACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:52.373+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - a92cfdfa-0e7e-4e15-b9ea-e2af9b1ef139
+      - ce8a05aa-be87-4e9b-92b8-41359747a923
       Atl-Traceid:
-      - a92cfdfa0e7e4e15b9eae2af9b1ef139
+      - ce8a05aabe874e9b92b841359747a923
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:49 GMT
+      - Wed, 30 Apr 2025 16:25:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=171,atl-edge-internal;dur=15,atl-edge-upstream;dur=157,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="N-lM2T8ef-HzfGmYOQMGFvLFnxlXUoBGLQ9sPkVXhOAsUlXh0FfkWQ==",cdn-downstream-fbl;dur=250,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=248,atl-edge;dur=162,atl-edge-internal;dur=16,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9d71affbaf22baf23eab459f3d2ee77a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - N-lM2T8ef-HzfGmYOQMGFvLFnxlXUoBGLQ9sPkVXhOAsUlXh0FfkWQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 45a45e65fa51737c8e30add6846440ef
+      - 853865838dbf24342bf391b4dae1ab54
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 3e9ad213-5443-4a1e-a66c-f3090965b4a5
+      - 89d7f4ba-6f18-4349-a16c-cc28c4bdcd43
       Atl-Traceid:
-      - 3e9ad21354434a1ea66cf3090965b4a5
+      - 89d7f4ba6f184349a16ccc28c4bdcd43
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:50 GMT
+      - Wed, 30 Apr 2025 16:25:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=306,atl-edge-internal;dur=23,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=344,atl-edge;dur=311,atl-edge-internal;dur=16,atl-edge-upstream;dur=295,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="VHIpWCg_Wnl17mTKJ08Q-vSlk-WvYt2d7LLJX1sJds5IAE1GUmhSJg==",cdn-downstream-fbl;dur=347
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - VHIpWCg_Wnl17mTKJ08Q-vSlk-WvYt2d7LLJX1sJds5IAE1GUmhSJg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 5fd423f640a1ff1353d5c1a8548be684
+      - 64f6cd87f64a33e7b301cae9bc48bc92
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/267]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/267 (267)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16097","key":"NTEST-1613","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16097"}'
+      string: '{"id":"18201","key":"NTEST-1853","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18201"}'
     headers:
       Atl-Request-Id:
-      - 94f60f48-9595-4c80-a950-ab3e9e65e7ca
+      - 9e29963f-6fc2-4d3c-a21c-a5ef0b07199d
       Atl-Traceid:
-      - 94f60f4895954c80a950ab3e9e65e7ca
+      - 9e29963f6fc24d3ca21ca5ef0b07199d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:51 GMT
+      - Wed, 30 Apr 2025 16:25:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=942,atl-edge-internal;dur=16,atl-edge-upstream;dur=926,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="zbC-sHTDKlVhq1matjCZweIehewWyTyChJ4Oa4PGbO3uDWOA76TUOA==",cdn-downstream-fbl;dur=756,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=753,atl-edge;dur=680,atl-edge-internal;dur=22,atl-edge-upstream;dur=659,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 64d5385c423c2207e3680beec4636de8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - zbC-sHTDKlVhq1matjCZweIehewWyTyChJ4Oa4PGbO3uDWOA76TUOA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 5b1e69ac6ad1728ae2010b541d14bda3
+      - 315543f832a2d8ce4dde2595cd976e61
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1613
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1853
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltibLjOAKGoYvdLV2WZYmTAs2CgJHOMmuK1Egqtpfmv++o
-        FzsvVYtkWFEgtXi89+ce3p0Hq5zJxIs8DTIBDclbDiIxHckyMB0TzyFjHZWDZpYraTqQcJuBZZ14
-        zmQKQqWdW9AGZZCcQq7BgLT13bgwVmUzZ/CaBgENehr+LsDY6TqHE81iy2PwOh53/ukw2N/DDwNi
-        hp9za3MT+X4CM4htoj6qHrOCGcOZ7EmwPnqyPsu5H/rcmAL8xsAC1qh/PJ2cTbt0SPt4VIZgvOjO
-        MxhbYWJmIVV6XeWQ4BdqhEG42w1olwbTMIjoMNqlvT6lP2DcgQvSObEYeGnmlUE6fR/tBeEm7foj
-        ARNrnrvC4ekbYjImRIck3FguY0tyDjEQNSNLpRc9px0rea7FC6MoJHftYuKa3TLLtH/LYemXYW0D
-        rEU06NPRT4b/Az9m2PYiQ68OFuhyyszC9aq4se5XNGPCQMerFA8xr1K34805AkfH8/UR3ALGGtx3
-        PMsRWTmixItkgTl6T2DSDxpBrtVHzOiVBa+1y3KXDWzK7T4egGSb1bnk1qIB4218O6T+Vt41amaX
-        TDu8Gp7lgmPAyZPMsR8lygaj1WD0wnC/0Jkmk01fBoEDejhYhYP/10vV/RKL6JAOV3T4LRyuGo/9
-        cNUPv4XHGuD398/hSNtwGrYJ+o1gxlcXFTkiLC6vECZpqiFFvvnqEOw2AsxMiaLihc9fHbYJ9loE
-        Yatg1CbYfx5ORZvVqSOl8oXwoi7FT2bx4agI9+WDW9H5lsD9ypx2Y1n+PFCFKxx1pPzeHXCZepHV
-        BdzXPO2saR5XVbt7duYiw6tmrgqRjLnJBVvXo4zHGJa9QMy48a6roQGTdfzx/JEIeqOg3zwST8u2
-        obKngjZQhRtQ5Zorze36lUVs1P3By94KnrEUjO80TGOE44FQy565TbdkeaSWDakOvOdjE26GQLAb
-        cLTo8P90I2iDLm1DKB25esyZmeQ8PuJy8dZJxpC77UXGTRfL3i5L2eZEKjnB5YXdCDgFZipk6PqX
-        d3J0/svh8fXR4cHk+GxyPTk9/eMU88MpNVgQvDCdAzlB/peWOL+EG6KkWBPkEi6cUWIVecc1Iyca
-        MiQTUhjEbO9znEJxnLzgEw+CXPcjr3oTsXdY/O1MPeIKbEPKJRNPL9W7V13eEucCo2voBvuaStjc
-        LnI3tG043g/2GhxXa9IroVcpb97dx5vNy9C4hdvPLF7gstlArjFe+Tqo97n/FHCzFPrNbhY2a4IE
-        B/VYCaWPq2huRAHdVCNrbFciRcaqarbKclyHpf086HfbSGF3Qwpf6vjjcv4lt/92ptwK2InI5QeW
-        04gcKLXgQN5zizxnyRnEhQbyVrD0k6sOFkeomIm5MjYaBaPAn3GZIJX64XDvqjQ4LouHeX1UxMEq
-        2iFf1STf4Z/vS/UzXPocB6EaskUd5LgAMsZ88PB3tiY06BAHxk0SB+8nKLrE/7pDOigjdX2Ml9DL
-        uNXQUzr1EcbMtZbjxubg7+PV3txmooy7snPh7JzLhVTLh0U60SopcAeYyBQHO8M2+VOssfNZVgjj
-        Jb+qZdeqlirltYHwivjkkhpL/iyYtqDJ1mSLKmx90lL7w5sTchYz2XLfLaM4R3ST1YM8ztbGQmYw
-        jyRXHMG2E5XnZYdcxTLGpeEWeohHLJiZ3yimk7Ybz+yPtzjbif4FAAD//+xZbWvbMBD+K6JQaKF2
-        ncRpkkHpQtlgH8pGCyuUQpBluTGLZeOXuqXrf99zkqKlXtyNMko/FPLBiaS70/nuuecu12rOhAkn
-        YC+LpFSskjVrbWzVAMfKxFeC+Dpg7TIVS5ZJrioscrPDSsB9r1UkGRcC6Cpjdpty1iBhRHlfAJ6w
-        TylpCrW/YdEZ3vWNbi3JoMulVBRfjDu5OTpP3AiW0LXAAlmqkrzM9BmWl4TZHKsVQSbg+odUB2QY
-        hKc1M2yA8VXL7+mKrODauqZCZDOu2IaB6BuVXPl44xXd2d3Q+OBakRNIG/kIFlgLq7WJJLBq4KCt
-        lm7ceeP258hFVB+4jG5v46VtWz9veVXorEASyju/WBY6oqFkAZkLq3vBa9CfqEFMLfa+Xs4vvnkX
-        Zx4Ktc5Vp6TIKZQpG/Z4nKVqn+3t/0SgrOr8A8LwT44zdoW+W+T6cG4Q9i040ksAWJeAfM3siKt1
-        toaOkHYWAieju9DHNQLHNfTb05Rr+8Y+dhw4Y57U7C5y4wVwsaTsN3WharKMU9Ha+Rtek9eJgubl
-        CyscUZET5BsR5y/x8TgeTSfTaDAJ5EjMAjEbD5PZIDmCHrcJGp7ZJikk5nEMHahyKHnx/ccNQwAo
-        JOvZptjkio8qqrdpmLKNWShB9Hg8CMOjiZhOxqNZJKJJAPUJl8lUnMTHWsruaL47/IyPOedlXFl8
-        9TzzU+U3ldfCEd7QJ+D2iyZapYI85RWcV+QonNd1BDQRj6dICr9Q5PNug/32Le526G/f4m6H/9Yt
-        BhTFpmG0VPAUoQ8mkySNEKlOIMJz044aILsCGcTGT02ZF/LwChAjlr8zjSZMWHWpSxrsXG07fwz7
-        cDXsayrDvklF6LC7tMD/ji+vFknv+PIaFr/jyxZ86cKAI2SOv8DqG5N7DzQKt88BFOY1t4P8rpRe
-        5tWLS72UbLgd+fqmQkEfByVA2LoQ9HHQUd+JkSN5Ut2mZa4MkTM/xY39F8l8/Sfv5ZmR8LB+tHD/
-        Avjd+APscC33YCfjd+eyalYkeEO3HpqU9bw2dtzm9f+b1BphTih0oV38nuuZ03q8SrNimuSQSmfI
-        U2uHT8y1B7R7Hh8ffwEAAP//AwCQ79ATtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18201","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18201","key":"NTEST-1853","fields":{"statuscategorychangedate":"2025-04-30T18:25:53.620+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1853/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:53.353+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t27:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:53.433+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/267]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/267 (267)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1853/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18201/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 4ef5be8d-0a56-4e62-be1a-fcd6a1ceb9a6
+      - 3c67ae84-9827-4fdd-828d-27968a917349
       Atl-Traceid:
-      - 4ef5be8d0a564e62be1afcd6a1ceb9a6
+      - 3c67ae8498274fdd828d27968a917349
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:51 GMT
+      - Wed, 30 Apr 2025 16:25:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=339,atl-edge-internal;dur=19,atl-edge-upstream;dur=321,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=288,atl-edge;dur=255,atl-edge-internal;dur=14,atl-edge-upstream;dur=241,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="4h9lw7KhhtWck7bM9QCrHb2Uc5-A9JkZzFym3x0okxcWw_SJysofzw==",cdn-downstream-fbl;dur=292
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 4h9lw7KhhtWck7bM9QCrHb2Uc5-A9JkZzFym3x0okxcWw_SJysofzw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 19ea9256d15a14e5b337d2605d37f818
+      - 56200b731b472d7dc953ede9c4ef2b71
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16097
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18201
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltibLjOAKGoYvdrVuWZYnTAs2KgJHOMmuK1Egqttfmv++o
-        N7dx1CEZVhRILR7v7bnnjvfBg03OZOJFngaZgIbkJQeRmJ5kGZieiZeQsZ7KQTPLlTQ9SLjNwLJe
-        vGQyBaHS3h1ogzJILiDXYEDa+m5cGKuyhTN4Q4OABgMNfxVg7Hybw7lmseUxeD2PO/90HBwf4YcB
-        scDPpbW5iXw/gQXENlHv1YBZwYzhTA4kWB89WZ/l3A99bkwBfmNgBVvUP5vPLud9OqZDPCpDMF70
-        wTMYW2FiZiFVelvlkOAXaoRBeNgPaJ8G8zCI6Dg6pIMhpd9h3IEL0jmxGHhp5plBOn0f7QVhm3b9
-        kYCJNc8dcHj6gpiMCdEjCTeWy9iSnEMMRC3IWunVwGnHSl5p8cQoCslduZi4YXfMMu3fcVj7ZVi7
-        AGsRDYZ08oPhf8P3GZa9yNCrowW6nDOzcrUqbq37FS2YMNDzKsVXmFep2/OWHImj4+X2FO4AYw3u
-        e57lyKwcWeJFssAcvQc0GQaNINfqPWb0TMBr7RLusoAN3O7jE5LssrqS3Fo0YLzWt2Pqr+VdoxZ2
-        zbTjq+FZLjgGnDzIHOtRsmw02YwmTwz3C5VpMmnrMgoc0cPRJhz9v16q6pdcRId0vKHjr+Fw03gc
-        hpth+DU81gS/v9+nI+3iadgIFnzzupqBWP3rd/s3h81NlqYaUpw3e02ACShRVO3/uLvDLsG4S3DU
-        IQg7BZMuwfF+nNXYrE7dUCpfCC/q03pWupJoHlcpfdg7c42CaJulKkQy5SYXbFu3Ex6vmcWnpxrZ
-        T2/96kHYPQF+ZU67xi5/nqjCQV+G+sYdcJl6kdWF841G7WvkjGvvGg0NmKybH/uPRDCYBMPmkXgI
-        WzvKHgq6SBW2pMo1V5rb7TMhaNT90dPeCp6xFIzvNExjhOOBUOuBuUt3w/JUrZuhOvL22yZsOS/Y
-        Lbix+EhjuGnyKAy0i6F04vBYMjPLeXzK5eqlk0whd9uLjBsGlbxal7L2RCo5w+WF3Qq4AGYqVur6
-        l3d+evXTq7Ob01cns7PL2c3s4uL3C8wPu9QgIHhhvgRyjvNfWuL8Em6IkmJLcJZw4YwSq8gvXDNy
-        riHDYUIKg4wbPDZTKLaTF3zkQZDrYeRVbyLWDsHf9dRnswLLkHLJxMNL9e5Vw1vyXmB09berayqh
-        vV3krmm7eHwcHDU8rtakZ1KvUm7f3c83m6excUe3H1m8wmWzoVxjvPJ1Uu9z/yngZin0m90sbNYE
-        CY7qsRJKn1XR3IoC+qnGibVbiRSZqqrYKstxHZb2cdIftkPhS4V9qNQOjM/h/FPu/h3MuRVwEJHr
-        tyynETlRasWBvOEWZ6wllxAXGshLwdKPDh0ER6iYiaUyNpoEk8BfcJngIPTD8dG70uC0BA/zeq+I
-        o1V0QP5Vk3yDf74t1S9x6XMzCNVwWtRBTgsgU0wUD39jW0KDHnFkbJM4eTND0TX+1x/TURmpq2O8
-        hkHGrYaB0qmPNGautBw3Nkd/H68OljYTZdyVndfOzpVcSbX+FKRzrZICd4CZTLGxMyyTP0fwnc8S
-        IYyX/KzWfas6UMprA+E74pNraiz5o2DagiY7kx2qsPNJS+23L87JZcxkx323jGIf0TarT/K43BoL
-        mcE8klxxJNtBVJ6XFXKIZYxLwy0MkI8ImFneKqaTrht79qc7nh1E/wAAAP//7FldS9xAFP0rgyAo
-        mJjdzbq7BbGLtNAHaVGoIMIymUzc0N1JyIdRrP+9587MTmO6sUWK+CD4EDMz9yv3nnvu7LWaM2HS
-        CdjLIikVK2XFGptbFcCxNPmVIL8OWLNMxZKtJVclFrnZYSXA32sVScaFALrKmN2mnNUoGFHc54An
-        7FNKGpLgtyw6w7e+0aMlGXS5lIryi3EnN8PkCY9gCbkFFshSlWTFWp9hWUGYzbFaEmQCrn9IdUCG
-        QXhaMcNEGF81/J5cZDnX1tUlMptxxVoGYm5UcuXji5fks/PQxOBaURBIG8UIFlgLy42JJLCsEaCt
-        lrZ8bnl/jlpE90HIyHubL03T+FnDy1xXBYpQ3vn5MtcZDSULyFxY3QtegXpFNXJqsff1cn7xzbs4
-        89Coda06JXlGqUzVsMfjdar22d7+TyTKqso+IA3/5Dhj1+i7Ta6P/AzCNgBWBZBd0y+ig92tfaQ3
-        6FsIHVPtnnBcQ38kzay2b+zjHkEfOw6cTsSYiyUVuG3A7R7ehfiyXq85Na2dv+E1RZ0oaFa8sMMR
-        FTlBvRHt/RIfj+PRdDKNBpNAjsQsELPxMJkNkiPocZug4ZltklJiHsfQgS6Hlhfff2wZAkAhWc8O
-        xaZWfHRRvU3DlB3MQgmix+NBGB5NxHQyHs0iEU0CqE+4TKbiJD7WUnZH893hZ/yZc96aK4uvnmde
-        lX5deg0C4Q19Am4/r6NVKihSXs55SYHCed1HQBPxeIqi8HNFMe8O2G/f4u6E/vYt7k74b91iYFRs
-        hlVLBU+R+mAySVILkeoCIjw3w6RBuCuQQWz8VBdZLg+vgD1i+bvS6IYJq650SYO9V9vOH8M+XA37
-        hsrQDZWFxfd3GHm1hHmHkdew+B1GtsBIFwb6mFroCJnjK3DnxhTlA12F2+cAlmQVtxf5XSl9lCzo
-        w6VguB3g+m6Fgl4Heimb86x7oo/LjXoXHMmT6jYtMmVYnnkV1/ZXJPPvv0TvNqv+3/2mEeaEQhPG
-        tO+ZvuvZXKmiBIzJD5tH219ebID+xe1wI/dgZ83vzmVZr0hwy1l9S1NU88o4TnfFdJNDrrv3Tw8P
-        n5y2B7S1j4+PvwAAAP//AwCBaEfYtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18201","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18201","key":"NTEST-1853","fields":{"statuscategorychangedate":"2025-04-30T18:25:53.620+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1853/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:53.353+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t27:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:53.433+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/267]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/267 (267)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1853/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18201/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 415520dd-394a-4a06-b988-58920b6f61e8
+      - 10bdb329-8c69-45c2-b892-d429f5b13924
       Atl-Traceid:
-      - 415520dd394a4a06b98858920b6f61e8
+      - 10bdb3298c6945c2b892d429f5b13924
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:52 GMT
+      - Wed, 30 Apr 2025 16:25:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=273,atl-edge-internal;dur=13,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="UOt4ftFH3IVHPdzi13779PalgKy5palXQFH83fB3uzOSYcsUw_6gTg==",cdn-downstream-fbl;dur=332,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=330,atl-edge;dur=254,atl-edge-internal;dur=22,atl-edge-upstream;dur=233,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f82a4020c8fc9b14a403737c65661074.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - UOt4ftFH3IVHPdzi13779PalgKy5palXQFH83fB3uzOSYcsUw_6gTg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 0c9a352103efb26a1df9e0f3bd0d2e16
+      - b2be2d76fd72ec076afb18982bb8f546
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2b9WPLDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCANd7gdNGHkzfvesdmsRYnCt/bdJtxr7pziJjHoyYS0yvWa7//BVzjslMAW3ccadb9C43H4
-        65KVNVKPaAT+LrnDwSlrApwCpAkkMK02l4/V+qH+mW7GrgkVYc8RmsAEXoITe233Xbiy3vfRttJ2
-        bEOoGZVuvyKEhQAty1PzivsIUqD5FNIpLGtKWTZnWRADXECAQ96FP+BQq+6cTaGmwNKC5TTJivKb
-        Fd2NkTaAWVosBAfMUYp0XiLPpMwkCEmX83zRyCJDWkigZwKvo+FWDTy+ECUftb+zgsf2gehTRdC8
-        bityPD/syZo4ub6vyfETAAD//wMAzbxs/yACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:54.922+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 88911fe7-adf0-4adc-90cc-7dcc8b794a45
+      - cd392491-2293-4afa-a8ec-e86eb69d204a
       Atl-Traceid:
-      - 88911fe7adf04adc90cc7dcc8b794a45
+      - cd39249122934afaa8ece86eb69d204a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:52 GMT
+      - Wed, 30 Apr 2025 16:25:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=13,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="RXHQehAdblUOTogSQcpbDDcamjZyifSTb1uaNro6N55zH0Rl_AenDQ==",cdn-downstream-fbl;dur=255,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=252,atl-edge;dur=166,atl-edge-internal;dur=17,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ed78483d37e5338746e5a4b545e5818e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - RXHQehAdblUOTogSQcpbDDcamjZyifSTb1uaNro6N55zH0Rl_AenDQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - b1d8f1f03a15ad293c464bb0902870d4
+      - 6da0288aeb611de26ec1187732228831
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 6c050289-dcc8-4880-a2c9-cc546ea50530
+      - fbc00e08-a996-4896-899e-bff2dfee55a2
       Atl-Traceid:
-      - 6c050289dcc84880a2c9cc546ea50530
+      - fbc00e08a9964896899ebff2dfee55a2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:52 GMT
+      - Wed, 30 Apr 2025 16:25:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=14,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=359,atl-edge;dur=327,atl-edge-internal;dur=13,atl-edge-upstream;dur=314,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="TENArDj5YgUWFDRwZ0mrWVtSzvaWuS7IU6b4u8euVQpYbo6dQ4T0fg==",cdn-downstream-fbl;dur=364
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 895116b5366f3f5264f7b6361d3fd564.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - TENArDj5YgUWFDRwZ0mrWVtSzvaWuS7IU6b4u8euVQpYbo6dQ4T0fg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 6e0af1909439173a728a52b0b5102879
+      - afbd4d69586ca88c3889c288b29c49c1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/268]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/268 (268)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16098","key":"NTEST-1614","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16098"}'
+      string: '{"id":"18203","key":"NTEST-1854","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18203"}'
     headers:
       Atl-Request-Id:
-      - 44eef325-581a-4244-a2a8-af21a9f8ebe8
+      - 2e56b896-934a-4b05-addb-fbc796e0dbf8
       Atl-Traceid:
-      - 44eef325581a4244a2a8af21a9f8ebe8
+      - 2e56b896934a4b05addbfbc796e0dbf8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:53 GMT
+      - Wed, 30 Apr 2025 16:25:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=1022,atl-edge-internal;dur=14,atl-edge-upstream;dur=1007,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="vtcSK0tTLdRMlB9PtqmuCyzJ1xiM9bHPvX9CpCi-xsb-jedWhSt_Lw==",cdn-downstream-fbl;dur=717,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=60,cdn-upstream-fbl;dur=715,atl-edge;dur=633,atl-edge-internal;dur=16,atl-edge-upstream;dur=618,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 05df0d22c8cc3d4b946b6f2dc43d6b9c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - vtcSK0tTLdRMlB9PtqmuCyzJ1xiM9bHPvX9CpCi-xsb-jedWhSt_Lw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 2bfaf1d2c48be5de9f6a1a1f79e3fd9c
+      - f512abd5ff57690689b92248659694cb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1614
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1854
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfSGEsFJVXUlouVKaQgDpKELO7mRj4rW3tpck5fjvHe9L
-        AoS9E1Q9ncRlPZ73Zx7PgwPLjIrYCR0FIgYF8REDHuuWoCnolo5mkNKWzEBRw6TQLYiZScHQVjSj
-        IgEuk9Y9KI0yiM8gU6BBmOpulGsj06k1eOt7nu91FPydgzbjVQYjRSPDInBaDrP+/Z530McPDXyK
-        nzNjMh26bgxTiEws72SHGk61ZlR0BBgXPRmXZswNXKZ1Dm5tYA4r1D8dD8/Hbb/nd/GoCEE74YOj
-        MbZcR9RAItWqzCHGL9QIvGCv7flt3xsHXuj3wr3dTv9g/weM27NBWicGAy/MvDNIq++iPS9Yp119
-        xKAjxTJbODz9QHRKOW+RmGnDRGRIxiACIqdkIdW8Y7UjKS4Uf2MUuWC2XZTf0ntqqHLvGSzcIqxN
-        gJXI93b9/k+a/QM/ptj2PEWvFhbockz13PYqnxj7K5xSrqHllIrHmFeh23JmDIGjotnqBO4BY/Ue
-        W45hiKwMUeKEIsccnRcw2fVqQabkHWb0zoJX2kW5iwbW5bYfT0CyyepCMGPQgHbWvi1Sfyvuajk1
-        C6osXjVLM84w4PhF5tiPAmXd/rLbf2O4X+hMncm6L11vH8MIusug+/96KbtfYBEd+r2l3/sWDpe1
-        x91guRt8C48VwB8ft+HoN+E0qAVTtrwsORC7f32zfXO3vkmTREGCfPPVIdirBZiZ5HnJC69f7TUJ
-        9hsEQaOg3yQ42A6npM3y1JJS8UI4YduvuNK2RLGojPxh68wOClZbz2TO4wHTGaerapzweEENPj0l
-        Zb999MsHYfMEuKU5ZQe7+Hkoc1v6ItQre8BE4oRG5dY3GjWXiBk73lU1FGCylj9eeyS6vYP6kXhZ
-        tjWVvRQ0gSpYgypTTCpmVu8sQa3u2vfvDW8FS2kC2rUaujbC8IDLRUffJxuyPJGLmlS7zvbYBGvM
-        czoBS4uvDIZlk1fL4Dch1O/besyoHmYsOmFifmQlA8js9iKiGkEFrhaFbH0ipBji8kInHM6A6hKV
-        qvrljE4ufjk+vT05Phyeng9vh2dnf5xhfjilGguCF8YzICPkf2GI9UuYJlLwFUEuYdwaJUaSj0xR
-        MlKQIpmQXCPiOq9xio/j5HifmedlahI65ZuIvcPib2bqGVdgGxImKH95qdq9qvIWuOcYXfVt+5oI
-        WN/OMzu0TTjued0ax+Wa9E7olcrrd/f5ZvM2NG7g9jON5rhs1pCrjZe+Dqt97j8FXC+Fbr2bBfWa
-        IMBCPZJcqtMymgnPoZ0oZKzNSiTJQJbNlmmG67Awr4N+r4kU9tak8KWOPy/nX2Lzb2fMDIedkFx/
-        olkQkkMp5wzIFTPIsYacQ5QrIEecJp9tdbA4XEaUz6Q2Yd/re+6UiRiJ0A16/ZvC4KAoHuZ1J4mF
-        VbhDvqpJvsM/3xfq57j0WQ5CNWSLKshBDmSA+eDh73RFfK9FLBjXSRxeDVF0jf+1kbmLSG0fowV0
-        UmYUdKRKXIQxta1luLFZ+Lt4tTMzKS/iLu1cWjsXYi7k4mmRRkrGOe4AQ5HgYKfYJneMNbY+iwph
-        vORXuWgb2VClrDIQ3BCXXPvakD9zqgwosjHZoAobn36h/enDiJxHVDTct8sozpG/zupJHucrbSDV
-        mEecSYZg2wmL86JDtmIpZUIzAx3EIxZMzyaSqrjpxpb9wQZnO+G/AAAA///sWW1L3EAQ/iuLICiY
-        GO9y3l1B7CEt9IO0KFQQ4dhsNl7o3SbkxSj2/nuf2d3bxvRiixTxg+CHmN2dnZnMPPPM3I2aMWHC
-        CdjLIikVK2XFGhtbFcCxNPGVIL4OWLNIxYKtJFclFrnZYSXA3hsVScaFALrKmN2lnNVIGFE85IAn
-        7FNKGpLgtzQ6x7e+1a0lKXS1kIrii3EnN0PnCYugCZkFFshSlWTFSp9hWUGYzbFaEmQCrn9IdUCK
-        QXhaMcNEGF82/IFMZDnX2tUlIptxxVoKom9Ucunji5dks7PQ+OBGkRPoNvIRNLAalhsVSWBZw0Fb
-        NW3Z3LL+ArmI6gOXkfU2Xpqm8bOGl7nOCiShvPfzRa4jGpfMIXNu757zCtQrqhFT872vV7PLb97l
-        uYdCrXPVXZJnFMqUDXs8XqVqn+3t/0SgLKvsA8LwT44zcoW+W+T6cA4teQvnqgLIrukX0cHuVkeD
-        OwuhI6SdhaDvROC4hv5Imllt39jHPYI+dhw4ZeBjLhaU4LYAt2t4F8nLerXiVLR2/obX5HWioFnx
-        wgpHVOQU+Ua090t8MoqHk/EkOhoHciimgZiOBsn0KDnGPW4Tbnhmm6SQmMUx7kCVQ8mLHz62FAGg
-        kKxnm2KTKz6qqN6mYco2ZqEE0ePxURgej8VkPBpOIxGNA1yfcJlMxGl8oqXsDme7g8/4M+e8FVcW
-        Xz3PvCr9uvQaOMIb+ATcfl5Hy1SQp7yc85IchfO6joAm4vEMSeHninzebbDfvsbdDv3ta9zt8N+6
-        xsCo2DSrlgqeIfTBZJKkFiLVCUR4bppJg3DXIIPY+KkuslweXgN7xOJ3ptGECasudekGO1fbzh/D
-        PlwN+5rK0DWVhcX3dxh5tYB5h5HX0PgdRrbASBcG+pha6AiZ4ysw59Yk5SONwu1zAE2yittBfldK
-        L/PqxaW+8U8w2I58vcys17JeyuZM7iwM+04MHcmT6i4tMmVYnnkV1/ZXJPPvv3jvLqv+33zTCHNC
-        cRPatO+ZnvVsRqpIAaPy4+bR1pcXK6B/cTvcyD3YWfH7C1nWSxLcMlZPaYpqVhnDaVZMkxwy3b1/
-        enjw5LQ9oLVdr9e/AAAA//8DAAQo/AW0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18203","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18203","key":"NTEST-1854","fields":{"statuscategorychangedate":"2025-04-30T18:25:56.133+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1854/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:55.896+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:55.971+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/268]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/268 (268)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1854/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18203/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 38dbfdf2-afe7-494c-8e32-fb1599ca3ca9
+      - 5e3a7099-e0e8-414b-88ee-be347490ac3e
       Atl-Traceid:
-      - 38dbfdf2afe7494c8e32fb1599ca3ca9
+      - 5e3a7099e0e8414b88eebe347490ac3e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:54 GMT
+      - Wed, 30 Apr 2025 16:25:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=393,atl-edge-internal;dur=15,atl-edge-upstream;dur=380,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=293,atl-edge;dur=260,atl-edge-internal;dur=16,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="H5FGtnA_AU4Ce3O4YDL897ko_G-9ifK4J4aF-_9RyLWWLqKcojHR6A==",cdn-downstream-fbl;dur=298
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8139bc666c011a53bdc5037ba6d5931e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - H5FGtnA_AU4Ce3O4YDL897ko_G-9ifK4J4aF-_9RyLWWLqKcojHR6A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7440c0f11e9a2eb08fbf90faa8f702cb
+      - f8f52a4418f5095388a13dba465ac88c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16098
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18203
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfSGEsFJVXUlouVKakgDSUYTM7mRj4rW3tpck5fjvHe9L
-        AoG9E1Q9ncRlPZ73Zx7PgwPLjIrYCR0FIgYF8REDHuuWoCnolo5mkNKWzEBRw6TQLYiZScHQVjSj
-        IgEuk9Y9KI0yiM8gU6BBmOpulGsj06k1eON7nu91FPydgzaTVQYjRSPDInBaDrP+/Z530McPDXyK
-        nzNjMh26bgxTiEws72SHGk61ZlR0BBgXPRmXZswNXKZ1Dm5tYA4r1D+dDMeTtt/zu3hUhKCd8MHR
-        GFuuI2ogkWpV5hDjF2oEXrDX9vy2700CL/R74d5up3+w/wPG7dkgrRODgRdm3hmk1XfRnhes064+
-        YtCRYpktHJ5+IDqlnLdIzLRhIjIkYxABkVOykGresdqRFOeKvzGKXDDbLspv6D01VLn3DBZuEdYm
-        wErke7t+/yfN/oEfU2x7nqJXCwt0OaF6bnuV3xr7K5xSrqHllIrHmFeh23JmDIGjotnqBO4BY/Ue
-        W45hiKwMUeKEIsccnS2Y7Hq1IFPyDjN6Z8Er7aLcRQPrctuPJyDZZHUumDFoQDtr3xapvxV3tZya
-        BVUWr5qlGWcYcLyVOfajQFm3v+z23xjuFzpTZ7LuS9fbxzCC7jLo/r9eyu4XWESHfm/p976Fw2Xt
-        cTdY7gbfwmMF8MfHl3D0m3AaNAl2a8GULS9KckRYXF0jTJJEQYJ889Uh2KsFmJnkeckLr1/tNQn2
-        GwRBo6DfJDh4GU5Jm+WpJaXihXDCto+f1ODDURLu2we3pPMNgbulOWXHsvh5KHNbON+S8qU9YCJx
-        QqNyeKx42lpTLCqr9vDizEaGV/VM5jweMJ1xuqpGGY8xLHOBmLHjXVVDASZr+eO1R6LbO6gfie2y
-        ralsW9AEqmANqkwxqZhZvbOItbpr3783vBUspQlo12ro2gjDAy4XHX2fbMjyRC5qUu06L8cmWA8B
-        p7dgadHif3sjaIKu34RQv2/rMaN6mLHohIn5kZUMILPbi4jqLha9XRSy9YmQYojLC73lcAZUl8hQ
-        1S9ndHL+y/Hpzcnx4fB0PLwZnp39cYb54ZRqLAhemMyAjJD/hSHWL2GaSMFXBLmEcWuUGEk+MkXJ
-        SEGKZEJyjZjtvMYpPo6T431mnpep29Ap30TsHRZ/M1PPuALbkDBB+falaveqylvgnGN0Nd1gXxMB
-        69t5Zoe2Ccc9r1vjuFyT3gm9Unn97j7fbN6Gxg3cfqbRHJfNGnK18dLXYbXP/aeA66XQrXezoF4T
-        BFioR5JLdVpGc8tzaCcKWWOzEkkykGWzZZrhOizM66DfayKFvTUpfKnjz8v5l9j825kww2EnJFef
-        aBaE5FDKOQNyyQzynCFjiHIF5IjT5LOtDhaHy4jymdQm7Ht9z50yESOVukGvf10YHBTFw7zuJLGw
-        CnfIVzXJd/jn+0J9jEuf5SBUQ7aoghzkQAaYDx7+TlfE91rEgnGdxOHlEEVX+F8bub+I1PYxWkAn
-        ZUZBR6rERRhT21qGG5uFv4tXOzOT8iLu0s6FtXMu5kIunhZppGSc4w4wFAkOdoptcidYY+uzqBDG
-        S36Vi7aRDVXKKgPBNXHJla8N+TOnyoAiG5MNqrDx6Rfanz6MyDiiouG+XUZxjvx1Vk/yGK+0gVRj
-        HnEmGYJtJyzOiw7ZiqWUCc0MdBCPWDA9u5VUxU03XtgfbHC2E/4LAAD//+xZbWvbMBD+K6JQaKF2
-        3cRpkkHpQtlgH8pGCyuUQpBluTGLZeOXuqXLf99zkqKlXtyNMko/FPLBiaS70/nuuecuN2rGhAkn
-        YC+LpFSskjVrbWzVAMfKxFeC+Dpg7SIVC5ZJrioscrPDSsB9b1QkGRcC6Cpjdpdy1iBhRPlQAJ6w
-        TylpCrW/YdE53vWtbi3JoKuFVBRfjDu5OTpP3AiW0LXAAlmqkrzM9BmWl4TZHKsVQSbg+odUB2QY
-        hKc1M2yA8WXLH+iKrODauqZCZDOu2IaB6BuVXPp44xXd2d3Q+OBGkRNIG/kIFlgLq7WJJLBq4KCt
-        lm7ceeP2F8hFVB+4jG5v46VtWz9veVXorEASynu/WBQ6oqFkDplzq3vOa9CfqEFMzfe+Xs0uv3mX
-        5x4Ktc5Vp6TIKZQpG/Z4nKVqn+3t/0SgLOv8A8LwT44zcoW+W+T6cA4tec+CI70EgHUJyNfMjrha
-        Z2voCGlnIXAyugt9XCNwXEO/PU25tm/sY8eBM+ZJze4iN14AFwvKflMXqibLOBWtnb/hNXmdKGhe
-        vrDCERU5Rb4Rcf4Sn4zi4WQ8iY7GgRyKaSCmo0EyPUqOocdtgoZntkkKiVkcQweqHEpe/PBxwxAA
-        Csl6tik2ueKjiuptGqZsYxZKED0eH4Xh8VhMxqPhNBLROID6hMtkIk7jEy1ldzjbHXzGx5zzMq4s
-        vnqe+anym8pr4Qhv4BNw+0UTLVNBnvIKzityFM7rOgKaiMczJIVfKPJ5t8F++xZ3O/S3b3G3w3/r
-        FgOKYtMwWip4htAHk0mSRohUJxDhuWlHDZBdgwxi46emzAt5eA2IEYvfmUYTJqy61CUNdq62nT+G
-        fbga9jWVYd+kInTYXVrgf8eXV4ukd3x5DYvf8WULvnRhwBEyx19g9a3JvUcahdvnAArzmttBfldK
-        L/PqxaVeSjbYjnx9U6Ggj4MSIGxdCPo46LDvxNCRPKnu0jJXhsiZn+LG/otkvv6T9/LMSHhcP1q4
-        fwH8bvwBdriWe7CT8fsLWTVLEryhWw9NynpWGzvu8vr/TWqNMCcUutAufs/1zGk9XqVZMU1ySKUz
-        5Km1gyfm2gPaPavV6hcAAAD//wMA0XyvfLQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18203","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18203","key":"NTEST-1854","fields":{"statuscategorychangedate":"2025-04-30T18:25:56.133+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1854/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:55.896+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:55.971+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/268]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/268 (268)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1854/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18203/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3c51c541-7292-429b-8791-fe5021ad61fa
+      - 7d0820e7-00a5-49ba-8710-a0f09c14679b
       Atl-Traceid:
-      - 3c51c5417292429b8791fe5021ad61fa
+      - 7d0820e700a549ba8710a0f09c14679b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:54 GMT
+      - Wed, 30 Apr 2025 16:25:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=321,atl-edge-internal;dur=15,atl-edge-upstream;dur=307,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="LxceReoEDufGa_Xn1P8ugxHgFLYFBo7KtEkLUOKOGpn_aGTFWbli3A==",cdn-downstream-fbl;dur=323,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=321,atl-edge;dur=247,atl-edge-internal;dur=18,atl-edge-upstream;dur=230,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9d71affbaf22baf23eab459f3d2ee77a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - LxceReoEDufGa_Xn1P8ugxHgFLYFBo7KtEkLUOKOGpn_aGTFWbli3A==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - a43f2b499e207e2898996ab0d6e38d07
+      - 16a19ddf2d39b19667810ff878a8f033
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:40740\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:47978\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:16:54 GMT
+      - Wed, 30 Apr 2025 16:25:57 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/101", "url_api": "http://localhost:8080/api/v2/tests/101/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      101, "url_ui": "http://localhost:8080/test/101", "url_api": "http://localhost:8080/api/v2/tests/101/"},
+      "finding_count": 2, "findings": {"new": [{"id": 267, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/267",
+      "url_api": "http://localhost:8080/api/v2/findings/267/"}, {"id": 268, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/268",
+      "url_api": "http://localhost:8080/api/v2/findings/268/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:47994\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/101\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/101/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 101, \\\"url_ui\\\": \\\"http://localhost:8080/test/101\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/101/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 267, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/267\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/267/\\\"},
+        {\\\"id\\\": 268, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/268\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/268/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 267,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/267/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/267\"\n        },\n
+        \       {\n          \"id\": 268,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/268/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/268\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        101,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/101/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/101\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/101/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/101\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:25:57 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -959,26 +1046,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtLlnZb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Whe1Tfjrvf
-        /37HHUglPW57QwR5C6HzYjqtUaMKtXt3qQxGet9Im1oMZELqxndG7v/BF9jvGoU1+o81mm6FNmD/
-        1yUrZ7UZ0Cr8XXKHvW+cjTAFoCmkkBSby8di/VD+TDdDW8WKiOcRmsAEXqITO+P2bbyy3HejbWXc
-        UMdQNTSm/ooQEQNsPj81r2QYQQYsS4AmsCwZE3wmeBQDXECEY97HP2BfNu05S6FkIGgusixlnH+z
-        qr2x2kWQ03yhJGCGWtHZHCXXmmtQmi1n2aLSOUeWa2BngmBGw23Ty/GFqOVgwp1TcmwfiDlVBO3r
-        tiDH88OenB0n1/clOX4CAAD//wMAjwC0tyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:57.468+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - d1d2da2e-05d6-4796-bed5-6d9d0eb1513f
+      - 8e87b336-5261-489b-92e4-e98a9d5e6383
       Atl-Traceid:
-      - d1d2da2e05d64796bed56d9d0eb1513f
+      - 8e87b3365261489b92e4e98a9d5e6383
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:55 GMT
+      - Wed, 30 Apr 2025 16:25:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -988,7 +1071,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=180,atl-edge-internal;dur=14,atl-edge-upstream;dur=166,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=183,atl-edge;dur=150,atl-edge-internal;dur=16,atl-edge-upstream;dur=134,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="eICMfGlfipST20ThJ5mpZjBHB251h6OH2Sf8ZBKgtsHV3xMdD0w5Kw==",cdn-downstream-fbl;dur=186
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -997,10 +1080,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - eICMfGlfipST20ThJ5mpZjBHB251h6OH2Sf8ZBKgtsHV3xMdD0w5Kw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c064d981d11722e47e6304cea73bbcaf
+      - 0d16bf58bd4f55f9a98bf93cef02d7df
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1024,61 +1115,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16097
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18201
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa2/bNhT9K4Q+bZltibLjuAKGoYudrV2WZYmTAM2KgJGuZcYUqZFUbK/Nf9+l
-        Xm7juEUyrAjgiI/7PvfwfvBglTOZeJGnQSagITniIBLTkSwD0zHxHDLWUTloZrmSpgMJtxlY1onn
-        TKYgVNq5B23wDJIzyDUYkLa+GxfGqmzmFN7QIKBBT8PfBRg7XedwqllseQxex+POPh0Grw5wYUDM
-        cDm3NjeR7ycwg9gm6k71mBXMGM5kT4L10ZL1Wc790OfGFOA3ChawRvmT6eR82qVD2set0gXjRR88
-        g74VJmYWUqXXVQwJrlAiDML9bkC7NJiGQUSH0T7t9Sn9Af0OnJPOiEXHSzUvdNLJ+6gvCNuw60UC
-        JtY8d4nD3dfEZEyIDkm4sVzGluQcYiBqRpZKL3pOOlbyQotnelFI7srFxA27Z5Zp/57D0i/d2jhY
-        H9GgT0c/Gf4P/Jhh2YsMrTpYoMkpMwtXq+LWuq9oxoSBjlcJvsG4StmON+cIHB3P18dwD+hr8NDx
-        LEdk5YgSL5IFxug9gkk/aA5yre4wohcmvJYu010WsEm3W3wCkk1UF5JbiwqM19p2SP2tvGvUzC6Z
-        dng1PMsFR4eTR5FjPUqUDUarweiZ7n6hMk0kbV0GgQN6OFiFg//XSlX9EotokA5XdPgtDK4ai/1w
-        1Q+/hcUa4A8P23Cku3AaNgczvrqsOBCrf/1++2a/ucnSVEOKfPPVJthvDjAyJYqKF56+Otx1cLDj
-        INx5MNp18GrbnYo2q11HSuUL4UVdiktm8eGoCPf5jVvR+YbA/Uqddm1Zfh6qwiWOOlK+chtcpl5k
-        dQEPNU87bZrHVdY+bO05z/CqmatCJGNucsHWdSvjNrplLxEzrr3rbGjAYB1/bD8SQW8U9JtH4nHa
-        Wip7fLALVGELqlxzpbldvzCJjbg/eN5bwTOWgvGdhGmUcNwQatkz9+mGLI/VsiHVgbfdNmGLecFu
-        wdHiE43h2OTJNNBdCKUjl485M5Ocx8dcLo7cyRhyN73IuKliWdtledbuSCUnOLywWwFnwEyFDF1/
-        eafHF7+8Obk5fnM4OTmf3EzOzv44w/iwSw0mBC9M50BOkf+lJc4u4YYoKdYEuYQLp5RYRd5yzcip
-        hgzJhBQGMdt7ilMotpMXfORBkOt+5FVvItYOk7/pqc+4AsuQcsnE40v17FWnt8S5QO/qtatrKqG9
-        XeSuaXfh+FVw0OC4GpNeCL1KuH13P59snofGDdx+ZvECh80Gco3yytZhPc/9J4ebodBvZrOwGRMk
-        OKjHSih9UnlzKwrophpZYzMSKTJWVbFVluM4LO3ToN9vSeFLhX0s1BLG5+n8S27+9qbcCtiLyPU7
-        ltOIHCq14ECuuEWes+Qc4kIDORIs/eiyg8kRKmZiroyNRsEo8GdcJkilfjg8eF8qHJfJw7juFHGw
-        ivbIVyXJd/jzfSl+jkOf4yAUQ7aonRwXQMYYKG7+ztaEBh3iwNgGcXg1waNr/Ncd0kHpqatjvIRe
-        xq2GntKpjzBmrrQcJzYHfx+v9uY2E6XflZ5Lp+dCLqRafpqkU62SAmeAiUyxsTMskz/F5DubZYbQ
-        X/KrWnat2pGlvFYQvic+uabGkj8Lpi1oslG5QxQ2Nmkp/e71KTmPmdxx3w2j2Ee0jeqTOM7XxkJm
-        MI4kVxzBtheV+2WFXMYyxqXhFnqIR0yYmd8qppNdN7b0jzc424v+BQAA///sWW1L3EAQ/iuLICiY
-        mLvLeXcFsYe00A/SolBBhGOz2Xihd5uQF6NY/3uf2d3bxvRiixTxg+CHmN2dl83MM8/MXas5Eyac
-        gL0sklKxUlassbFVARxLE18J4uuANctULNlaclVikZsdVgL8vVaRZFwIoKuM2W3KWY2EEcV9DnjC
-        PqWkKdR+y6IzfOsb3VqSQZdLqSi+GHdyM3Se8AiWkFtggSxVSVas9RmWFYTZHKslQSbg+odUB2QY
-        hKcVM2yA8VXD78lFlnNtXV0ishlXrGUg+kYlVz6+eEk+Ow/NHVwrugTSRncEC6yF5cZEEljWuKCt
-        lrZ8bnl/jlxE9cGVkfc2Xpqm8bOGl7nOCiShvPPzZa4jGkoWkLmwuhe8Av2JasTUYu/r5fzim3dx
-        5qFQ61x1SvKMQpmyYY/H61Tts739nwiUVZV9QBj+yXHGrtB3i1wf+RmEbQCsCiC7JnBEybpbHQ3u
-        LAR9C6Fjqt0Tjmvoj6SZ1faNfdwj6GPHgdP5pGZ3IR0fgIslZb+pC2W9XnMqWjt/w2u6daKgWfHC
-        CkdU5AT5RsT5S3w8jkfTyTQaTAI5ErNAzMbDZDZIjqDHbYKGZ7ZJCol5HEMHqhxKXnz/sWUIAIVk
-        PdsUm1zxUUX1Ng1TtjELJYgejwdheDQR08l4NItENAmgPuEymYqT+FhL2R3Nd4ef8WfOeWuuLL56
-        nnlV+nXpNbgIb+gTcPt5Ha1SQTfl5ZyXdFE4r+sIaCIeT5EUfq7ozrsN9tu3uNuhv32Lux3+W7cY
-        GBWbhtFSwVOEPphMktRCpDqBCM9NO2oQ7gpkEBs/1UWWy8MrYI9Y/s40mjBh1aUuabBzte38MezD
-        1bCvqQxdU1lYfH+HkVcLmHcYeQ2L32FkC4x0YaCPqYWOkDn+AnduTFI+0CjcPgewJKu4HeR3pfRR
-        sqAPl4LhdoDrmwoFvQ70UjbnWfdEH5cb9S44kifVbVpkyhA58yqu7a9I5t9/ub3brPp/E1IjzAmF
-        JrRp3zM969mMNZECxuSHzaOtLy82QP/idriRe7Cz5nfnsqxXJLjlrJ7SFNW8Mo7TrJgmOeS6e//0
-        8PDJaXtAW/v4+PgLAAD//wMAIfkpUbQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18201","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18201","key":"NTEST-1853","fields":{"statuscategorychangedate":"2025-04-30T18:25:53.620+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1853/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:53.353+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t27:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:53.433+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/267]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/267 (267)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1853/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18201/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 049542cc-10b2-404f-8627-0c3eb274cf7e
+      - 96c489e3-8c8b-4b45-9c80-a60897e5c83f
       Atl-Traceid:
-      - 049542cc10b2404f86270c3eb274cf7e
+      - 96c489e38c8b4b459c80a60897e5c83f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:55 GMT
+      - Wed, 30 Apr 2025 16:25:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1088,7 +1162,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=304,atl-edge-internal;dur=20,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="VhIcHrec922lQeGSeGVKTvbacJnmi21zMnGtlcaLFUYQl38xFp3OMw==",cdn-downstream-fbl;dur=354,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=352,atl-edge;dur=269,atl-edge-internal;dur=14,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1097,10 +1171,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f4931915c262d78fa3e94b48faa4f55a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - VhIcHrec922lQeGSeGVKTvbacJnmi21zMnGtlcaLFUYQl38xFp3OMw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 207c1a01f6cfd5b93a4c942f97957b4a
+      - 80feaeb46ecd9faf91fd081bb20889e7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1127,41 +1209,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 3f22f623-a23b-40d3-b4e1-38451da2f998
+      - 40b21243-d262-4935-bd8f-5d64604f72b1
       Atl-Traceid:
-      - 3f22f623a23b40d3b4e138451da2f998
+      - 40b21243d2624935bd8f5d64604f72b1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:56 GMT
+      - Wed, 30 Apr 2025 16:25:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1171,7 +1240,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=357,atl-edge-internal;dur=18,atl-edge-upstream;dur=340,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=320,atl-edge;dur=286,atl-edge-internal;dur=19,atl-edge-upstream;dur=269,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0KIcQ37oWGsREV3aOR9_QdONN63pPJU8hIf_yOgBRcM5uLXEh5_Cfw==",cdn-downstream-fbl;dur=323
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1180,13 +1249,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 535c2b5354e6ba6798fd64420ee97a2c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0KIcQ37oWGsREV3aOR9_QdONN63pPJU8hIf_yOgBRcM5uLXEh5_Cfw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4db0a1d7e42e7edf19b0f752e378bc12
+      - c0318c6e03857bceba01c726b3fc2f8e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1199,7 +1276,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/267]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/267 (267)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1207,7 +1284,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -1219,27 +1296,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1288'
+      - '1308'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16097
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18201
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 6631c579-d2d1-4036-89f2-67c0d33c020a
+      - ae5a9139-6013-46b9-8455-4087049db188
       Atl-Traceid:
-      - 6631c579d2d1403689f267c0d33c020a
+      - ae5a9139601346b984554087049db188
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:56 GMT
+      - Wed, 30 Apr 2025 16:25:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1249,17 +1328,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=286,atl-edge-internal;dur=14,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=316,atl-edge;dur=284,atl-edge-internal;dur=17,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Gj-1UPdBZnGHAwsIrvjKsTnJGAdxq929GSFbP8ONROYqi2firuFo9Q==",cdn-downstream-fbl;dur=320
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 848ee9f48eafd6caa6bf5371a2f79f28.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Gj-1UPdBZnGHAwsIrvjKsTnJGAdxq929GSFbP8ONROYqi2firuFo9Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 95229b1a2e683eee8860d6c8f74517ef
+      - 13c1db5e6471961cd6d5a9ac184e80c5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1283,61 +1370,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16097
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18201
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltibLjOAKGoYvdrVuWZYnTAs2KgJHOMmuK1Egqttfmv++o
-        N7dx1CEZVhRILR7v7bnnjvfBg03OZOJFngaZgIbkJQeRmJ5kGZieiZeQsZ7KQTPLlTQ9SLjNwLJe
-        vGQyBaHS3h1ogzJILiDXYEDa+m5cGKuyhTN4Q4OABgMNfxVg7Hybw7lmseUxeD2PO/90HBwf4YcB
-        scDPpbW5iXw/gQXENlHv1YBZwYzhTA4kWB89WZ/l3A99bkwBfmNgBVvUP5vPLud9OqZDPCpDMF70
-        wTMYW2FiZiFVelvlkOAXaoRBeNgPaJ8G8zCI6Dg6pIMhpd9h3IEL0jmxGHhp5plBOn0f7QVhm3b9
-        kYCJNc8dcHj6gpiMCdEjCTeWy9iSnEMMRC3IWunVwGnHSl5p8cQoCslduZi4YXfMMu3fcVj7ZVi7
-        AGsRDYZ08oPhf8P3GZa9yNCrowW6nDOzcrUqbq37FS2YMNDzKsVXmFep2/OWHImj4+X2FO4AYw3u
-        e57lyKwcWeJFssAcvQc0GQaNINfqPWb0TMBr7RLusoAN3O7jE5LssrqS3Fo0YLzWt2Pqr+VdoxZ2
-        zbTjq+FZLjgGnDzIHOtRsmw02YwmTwz3C5VpMmnrMgoc0cPRJhz9v16q6pdcRId0vKHjr+Fw03gc
-        hpth+DU81gS/v9+nI+3iadgIFnzzupqBWP3rd/s3h81NlqYaUpw3e02ACShRVO3/uLvDLsG4S3DU
-        IQg7BZMuwfF+nNXYrE7dUCpfCC/q03pWupJoHlcpfdg7c42CaJulKkQy5SYXbFu3Ex6vmcWnpxrZ
-        T2/96kHYPQF+ZU67xi5/nqjCQV+G+sYdcJl6kdWF841G7WvkjGvvGg0NmKybH/uPRDCYBMPmkXgI
-        WzvKHgq6SBW2pMo1V5rb7TMhaNT90dPeCp6xFIzvNExjhOOBUOuBuUt3w/JUrZuhOvL22yZsOS/Y
-        Lbix+EhjuGnyKAy0i6F04vBYMjPLeXzK5eqlk0whd9uLjBsGlbxal7L2RCo5w+WF3Qq4AGYqVur6
-        l3d+evXTq7Ob01cns7PL2c3s4uL3C8wPu9QgIHhhvgRyjvNfWuL8Em6IkmJLcJZw4YwSq8gvXDNy
-        riHDYUIKg4wbPDZTKLaTF3zkQZDrYeRVbyLWDsHf9dRnswLLkHLJxMNL9e5Vw1vyXmB09berayqh
-        vV3krmm7eHwcHDU8rtakZ1KvUm7f3c83m6excUe3H1m8wmWzoVxjvPJ1Uu9z/yngZin0m90sbNYE
-        CY7qsRJKn1XR3IoC+qnGibVbiRSZqqrYKstxHZb2cdIftkPhS4V9qNQOjM/h/FPu/h3MuRVwEJHr
-        tyynETlRasWBvOEWZ6wllxAXGshLwdKPDh0ER6iYiaUyNpoEk8BfcJngIPTD8dG70uC0BA/zeq+I
-        o1V0QP5Vk3yDf74t1S9x6XMzCNVwWtRBTgsgU0wUD39jW0KDHnFkbJM4eTND0TX+1x/TURmpq2O8
-        hkHGrYaB0qmPNGautBw3Nkd/H68OljYTZdyVndfOzpVcSbX+FKRzrZICd4CZTLGxMyyTP0fwnc8S
-        IYyX/KzWfas6UMprA+E74pNraiz5o2DagiY7kx2qsPNJS+23L87JZcxkx323jGIf0TarT/K43BoL
-        mcE8klxxJNtBVJ6XFXKIZYxLwy0MkI8ImFneKqaTrht79qc7nh1E/wAAAP//7FldSxtBFP0rgyAo
-        uOsm2ZikIDZIC32QFoUKIoTJ7KxZmswu++Eq1v/ec2cm07jN2CJFfBB8WHdm7tfee+65k2s1ZcKk
-        E7CXzaVUrJI1a21u1QDHyuRXivw6YO0iEwu2klxVWORmh5UAf6/VXDIuBNBVJuw246xBwYjyvgA8
-        YZ9S0pCEcMOiM3zrGz1akkGXC6kovxh3cnNMnvAIlpBbYIEsU2lervQZlpeE2RyrFUEm4PqHVAdk
-        GIRnNTNMhPFly+/JRVZwbV1TIbMZV2zDQMyNSi5DfPGKfHYemhhcKwoCaaMYwQJrYbU2kQRWDQK0
-        1dINnze8P0ctovsgZOS9zZe2bcO85VWhqwJFKO/CYlHojIaSGWTOrO4Zr0G95g1yarb39XJ68S24
-        OAvQqHWtOiVFTqlM1bDHk1Wm9tne/k8kyrLOPyAN/+Q4Q9fou03OR356sW/BUVxCxroE5GteRjyx
-        szXyseHYMdXuCcc19EfSzGr7Rh/3iHzsOHI6EWMuFlTgtgFv9vAuxFfNasWpae38Da8p6kRB8/KF
-        HY6oyAnqjWjvl+R4mAzGo/G8N4rkQEwiMRn200kvPYIetwkantkmKSWmSQId6HJoecn9xw1DACgk
-        69mh2NRKiC6qt2mYsoNZLEH0eNKL46ORGI+Gg8lczEcR1KdcpmNxkhxrKbuD6W7/M/7MuWDFlcXX
-        IDCvqrCpghaBCPohAXdYNPNlJihSQcF5RYHCed1HQBPxeIqiCAtFMe8O2G/f4u6E/vYt7k74b91i
-        QFFihlVLBU+R+mAyadoIkekCIjw3w6QBsiuQQWz81JR5IQ+vgD1i8bvS6IYJq650SYO9V9vOH2Mf
-        rsa+oTJ2Q2Vp8f0dRl4tYd5h5DUsfoeRLTDShQEfU4sdIXN8Be7cmKJ8oKtw+xzBkrzm9iK/K8VH
-        ySIfLkX97QDnuxWKvA54KZuPahKEbF0YeBccyZPqNitzZVieeZU09lck8++/RO82r//f/aYR5oRC
-        E8a077m+61lfqaIEjMkP60fbX15sgP7F7XAt92Bnxe/OZdUsSfCGs/qWpqyntXGc7orpJodcd++f
-        Hu4/OW0PaGsfHx9/AQAA//8DAHt+J9a0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18201","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18201","key":"NTEST-1853","fields":{"statuscategorychangedate":"2025-04-30T18:25:53.620+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1853/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:53.353+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t27:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:53.433+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/267]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/267 (267)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1853/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18201/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - e9617f02-4e04-4c24-8366-232a3cb96186
+      - 5c7d381a-b10c-43cc-aeb4-1e9613b56c0c
       Atl-Traceid:
-      - e9617f024e044c248366232a3cb96186
+      - 5c7d381ab10c43ccaeb41e9613b56c0c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:56 GMT
+      - Wed, 30 Apr 2025 16:25:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1347,7 +1417,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=336,atl-edge-internal;dur=14,atl-edge-upstream;dur=323,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=299,atl-edge;dur=266,atl-edge-internal;dur=14,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="-wjLoxVeB8wPkuWO9TziqEtUIDcf-tW70xsJ68rtLQUBDwh4JspCyg==",cdn-downstream-fbl;dur=302
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1356,10 +1426,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 995d6494814d695ff2add6899f970080.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -wjLoxVeB8wPkuWO9TziqEtUIDcf-tW70xsJ68rtLQUBDwh4JspCyg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 087b25331a74223fb5d76b3eea3035e5
+      - 3c450836e3c083d15b66b0420c3a7e39
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1386,26 +1464,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2T9WPLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPARYUZyaV8JHkAHLpkCnsKwY4+mcp0EMcAEBDnkX/oBD1XbnLIWKAac5z4qEFsU3
-        K7sbo2wAU5ovpADMUEk6L1CkSqUKpGLLebaoVZ4iyxWwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMA+r3cbiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:25:59.741+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - af3cf264-4bcd-4b5d-bd6d-30912a714c07
+      - ce2fa487-a9ed-4daa-8e7e-4054599aec9e
       Atl-Traceid:
-      - af3cf2644bcd4b5dbd6d30912a714c07
+      - ce2fa487a9ed4daa8e7e4054599aec9e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:57 GMT
+      - Wed, 30 Apr 2025 16:25:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1415,7 +1489,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=169,atl-edge-internal;dur=20,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="olDypmnvFcSuKsvu1quldiyH_-zaGjKoZ7TRcHSvMnzLtop1H60uGA==",cdn-downstream-fbl;dur=247,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=59,cdn-upstream-fbl;dur=244,atl-edge;dur=158,atl-edge-internal;dur=20,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1424,10 +1498,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0835ebd52ef8594cd8aa4dac9cfbd9a8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - olDypmnvFcSuKsvu1quldiyH_-zaGjKoZ7TRcHSvMnzLtop1H60uGA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 8b80bac598fecfa0e9e819eeba60d73b
+      - 1bd9a3d78cb703d12edb57ae95f6b068
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1451,61 +1533,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16098
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18203
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfSGEsFJVXUlouVKakgDSUYTM7mRj4rW3tpck5fjvHe9L
-        AoG9E1Q9ncRlPZ73Zx7PgwPLjIrYCR0FIgYF8REDHuuWoCnolo5mkNKWzEBRw6TQLYiZScHQVjSj
-        IgEuk9Y9KI0yiM8gU6BBmOpulGsj06k1eON7nu91FPydgzaTVQYjRSPDInBaDrP+/Z530McPDXyK
-        nzNjMh26bgxTiEws72SHGk61ZlR0BBgXPRmXZswNXKZ1Dm5tYA4r1D+dDMeTtt/zu3hUhKCd8MHR
-        GFuuI2ogkWpV5hDjF2oEXrDX9vy2700CL/R74d5up3+w/wPG7dkgrRODgRdm3hmk1XfRnhes064+
-        YtCRYpktHJ5+IDqlnLdIzLRhIjIkYxABkVOykGresdqRFOeKvzGKXDDbLspv6D01VLn3DBZuEdYm
-        wErke7t+/yfN/oEfU2x7nqJXCwt0OaF6bnuV3xr7K5xSrqHllIrHmFeh23JmDIGjotnqBO4BY/Ue
-        W45hiKwMUeKEIsccnS2Y7Hq1IFPyDjN6Z8Er7aLcRQPrctuPJyDZZHUumDFoQDtr3xapvxV3tZya
-        BVUWr5qlGWcYcLyVOfajQFm3v+z23xjuFzpTZ7LuS9fbxzCC7jLo/r9eyu4XWESHfm/p976Fw2Xt
-        cTdY7gbfwmMF8MfHl3D0m3AaNAl2a8GULS9KckRYXF0jTJJEQYJ889Uh2KsFmJnkeckLr1/tNQn2
-        GwRBo6DfJDh4GU5Jm+WpJaXihXDCto+f1ODDURLu2we3pPMNgbulOWXHsvh5KHNbON+S8qU9YCJx
-        QqNyeKx42lpTLCqr9vDizEaGV/VM5jweMJ1xuqpGGY8xLHOBmLHjXVVDASZr+eO1R6LbO6gfie2y
-        ralsW9AEqmANqkwxqZhZvbOItbpr3783vBUspQlo12ro2gjDAy4XHX2fbMjyRC5qUu06L8cmWA8B
-        p7dgadHif3sjaIKu34RQv2/rMaN6mLHohIn5kZUMILPbi4jqLha9XRSy9YmQYojLC73lcAZUl8hQ
-        1S9ndHL+y/Hpzcnx4fB0PLwZnp39cYb54ZRqLAhemMyAjJD/hSHWL2GaSMFXBLmEcWuUGEk+MkXJ
-        SEGKZEJyjZjtvMYpPo6T431mnpep29Ap30TsHRZ/M1PPuALbkDBB+falaveqylvgnGN0Nd1gXxMB
-        69t5Zoe2Ccc9r1vjuFyT3gm9Unn97j7fbN6Gxg3cfqbRHJfNGnK18dLXYbXP/aeA66XQrXezoF4T
-        BFioR5JLdVpGc8tzaCcKWWOzEkkykGWzZZrhOizM66DfayKFvTUpfKnjz8v5l9j825kww2EnJFef
-        aBaE5FDKOQNyyQzynCFjiHIF5IjT5LOtDhaHy4jymdQm7Ht9z50yESOVukGvf10YHBTFw7zuJLGw
-        CnfIVzXJd/jn+0J9jEuf5SBUQ7aoghzkQAaYDx7+TlfE91rEgnGdxOHlEEVX+F8bub+I1PYxWkAn
-        ZUZBR6rERRhT21qGG5uFv4tXOzOT8iLu0s6FtXMu5kIunhZppGSc4w4wFAkOdoptcidYY+uzqBDG
-        S36Vi7aRDVXKKgPBNXHJla8N+TOnyoAiG5MNqrDx6Rfanz6MyDiiouG+XUZxjvx1Vk/yGK+0gVRj
-        HnEmGYJtJyzOiw7ZiqWUCc0MdBCPWDA9u5VUxU03XtgfbHC2E/4LAAD//+xZbWvbMBD+K6JQaKF2
-        3cRpkkHpQtlgH8pGCyuUQpBluTGLZeOXuqXLf99zkqKlXtyNMko/FPLBiaS70/nuuecuN2rGhAkn
-        YC+LpFSskjVrbWzVAMfKxFeC+Dpg7SIVC5ZJrioscrPDSsB9b1QkGRcC6Cpjdpdy1iBhRPlQAJ6w
-        TylpCrW/YdE53vWtbi3JoKuFVBRfjDu5OTpP3AiW0LXAAlmqkrzM9BmWl4TZHKsVQSbg+odUB2QY
-        hKc1M2yA8WXLH+iKrODauqZCZDOu2IaB6BuVXPp44xXd2d3Q+OBGkRNIG/kIFlgLq7WJJLBq4KCt
-        lm7ceeP2F8hFVB+4jG5v46VtWz9veVXorEASynu/WBQ6oqFkDplzq3vOa9CfqEFMzfe+Xs0uv3mX
-        5x4Ktc5Vp6TIKZQpG/Z4nKVqn+3t/0SgLOv8A8LwT44zcoW+W+T6cA4tec+CI70EgHUJyNfMjrha
-        Z2voCGlnIXAyugt9XCNwXEO/PU25tm/sY8eBM+ZJze4iN14AFwvKflMXqibLOBWtnb/hNXmdKGhe
-        vrDCERU5Rb4Rcf4Sn4zi4WQ8iY7GgRyKaSCmo0EyPUqOocdtgoZntkkKiVkcQweqHEpe/PBxwxAA
-        Csl6tik2ueKjiuptGqZsYxZKED0eH4Xh8VhMxqPhNBLROID6hMtkIk7jEy1ldzjbHXzGx5zzMq4s
-        vnqe+anym8pr4Qhv4BNw+0UTLVNBnvIKzityFM7rOgKaiMczJIVfKPJ5t8F++xZ3O/S3b3G3w3/r
-        FgOKYtMwWip4htAHk0mSRohUJxDhuWlHDZBdgwxi46emzAt5eA2IEYvfmUYTJqy61CUNdq62nT+G
-        fbga9jWVYd+kInTYXVrgf8eXV4ukd3x5DYvf8WULvnRhwBEyx19g9a3JvUcahdvnAArzmttBfldK
-        L/PqxaVeSjbYjnx9U6Ggj4MSIGxdCPo46LDvxNCRPKnu0jJXhsiZn+LG/otkvv6T9/LMSHhcP1q4
-        fwH8bvwBdriWe7CT8fsLWTVLEryhWw9NynpWGzvu8vr/TWqNMCcUutAufs/1zGk9XqVZMU1ySKUz
-        5Km1gyfm2gPaPavV6hcAAAD//wMA0XyvfLQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18203","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18203","key":"NTEST-1854","fields":{"statuscategorychangedate":"2025-04-30T18:25:56.133+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1854/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:55.896+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:55.971+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/268]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/268 (268)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1854/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18203/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 8db59f7f-364c-4628-9686-8e87bbe43b60
+      - 2094b0c0-544f-4577-a9c2-a31a9c1fcf75
       Atl-Traceid:
-      - 8db59f7f364c462896868e87bbe43b60
+      - 2094b0c0544f4577a9c2a31a9c1fcf75
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:57 GMT
+      - Wed, 30 Apr 2025 16:26:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1515,7 +1580,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=320,atl-edge-internal;dur=14,atl-edge-upstream;dur=306,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=351,atl-edge;dur=318,atl-edge-internal;dur=14,atl-edge-upstream;dur=304,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="dI2_wl6qU673ZsIUC8P8-BtbPNJzOS10dNGo9pLyb0kNisqPQZ-KAQ==",cdn-downstream-fbl;dur=355
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1524,10 +1589,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e9bcf307d6ed54e3e501e39bc538dcfc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - dI2_wl6qU673ZsIUC8P8-BtbPNJzOS10dNGo9pLyb0kNisqPQZ-KAQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e09f5b595aa00d287f19c206befec915
+      - 932ce84e45ecd502abc4ef47c0174e5d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1554,41 +1627,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - f7ea6001-ae66-4db2-8a46-84dafe3a888b
+      - bc90808d-f970-4daa-b99f-6dda68581baa
       Atl-Traceid:
-      - f7ea6001ae664db28a4684dafe3a888b
+      - bc90808df9704daab99f6dda68581baa
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:57 GMT
+      - Wed, 30 Apr 2025 16:26:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1598,7 +1658,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=278,atl-edge-internal;dur=14,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=342,atl-edge;dur=310,atl-edge-internal;dur=17,atl-edge-upstream;dur=293,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="H_1T1GFCKvWBjF0OffKoAKz9fN2PvVtMooi2_tFXu-YQQe9iVnlxRg==",cdn-downstream-fbl;dur=346
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1607,13 +1667,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e665d09233240df4d3172e59222e0ba2.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - H_1T1GFCKvWBjF0OffKoAKz9fN2PvVtMooi2_tFXu-YQQe9iVnlxRg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - b8c87114e9c0d1cbd81c23aef489ee03
+      - 3d4ef91eaccb37699332af19aa33d0d6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1626,7 +1694,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/268]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/268 (268)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1634,7 +1702,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -1646,27 +1714,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1288'
+      - '1308'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16098
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18203
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 1bb19a25-a7b1-49c8-83a4-5afb8d35e250
+      - f562e007-28dd-490a-af3b-70ec4235e81d
       Atl-Traceid:
-      - 1bb19a25a7b149c883a45afb8d35e250
+      - f562e00728dd490aaf3b70ec4235e81d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:58 GMT
+      - Wed, 30 Apr 2025 16:26:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1676,17 +1746,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=293,atl-edge-internal;dur=18,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=294,atl-edge;dur=261,atl-edge-internal;dur=19,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="G6kJU51h0YDioS9BApc2ZTYPUwgED-rIRgOTco_XvohEX1a5J-aOJA==",cdn-downstream-fbl;dur=298
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5538280951642fc71308aa997730220e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - G6kJU51h0YDioS9BApc2ZTYPUwgED-rIRgOTco_XvohEX1a5J-aOJA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c4707a63798ce448ca2ec7d372bb1d1c
+      - e2244d190f22d0635c206f36cde3ce05
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1710,61 +1788,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16098
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18203
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeSSEMFJVbUlo2VKaQgBpKULOzM3ExGNPbQ9JyvLfez2v
-        8MquoOoKKYwf933u8b13YJVRETuho0DEoCA+ZMBj3RI0Bd3S0RxS2pIZKGqYFLoFMTMpGNqK5lQk
-        wGXSugOl8QziU8gUaBCmuhvl2sh0ZhXe+J7nex0Ff+egzWSdwVjRyLAInJbDrH2/7+0PcKGBz3A5
-        NybToevGMIPIxPJWdqjhVGtGRUeAcdGScWnG3MBlWufg1goWsEb5k8nobNL2+34PtwoXtBPeOxp9
-        y3VEDSRSrcsYYlyhROAFu23Pb/veJPBCvx/udjuD/b0f0G/POmmNGHS8UPNOJ628i/q8oAm7WsSg
-        I8Uymzjc/UB0SjlvkZhpw0RkSMYgAiJnZCnVomOlIynOFX+jF7lgtlyU39A7aqhy7xgs3cKtjYPV
-        ke91/cFPmv0DP6ZY9jxFqxYWaHJC9cLWKp8a+xXOKNfQckrBI4yrkG05c4bAUdF8fQx3gL56Dy3H
-        MERWhihxQpFjjM4zmHS9+iBT8hYjemfCK+ki3UUB63TbxSOQbKI6F8wYVKCdxrZF6m/FXS1nZkmV
-        xatmacYZOhw/ixzrUaCsN1j1Bm909wuVqSNp6tLz9tCNoLcKev+vlbL6BRbRoN9f+f1vYXBVW+wG
-        q27wLSxWAH94eAlHfxtOg/pgxlYXJQdi9a+uX97s1jdpkihIkG++2gS79QFGJnle8sLrV/vbDva2
-        HARbDwbbDvZfulPSZrlrSal4IZyw7eOSGnw4SsJ9e+OWdL4hcLdUp2xbFp8HMreJ8y0pX9oNJhIn
-        NCqHh4qnrTbFojJr9y/2rGd4Vc9lzuMh0xmn66qVcRvdMheIGdveVTYUYLCWP157JHr9/fqReJ62
-        hsqeH2wDVdCAKlNMKmbW70xiLe7a9+8NbwVLaQLatRK6VsJwg8tlR98lG7I8lsuaVHvOy7YJGsxz
-        OgVLi680hmWTV9Pgb0OoP7D5mFM9ylh0zMTi0J4MIbPTi4jqKha1XRZnzY6QYoTDC51yOAWqS2So
-        6ssZH5//cnRyc3x0MDo5G92MTk//OMX4sEs1JgQvTOZAxsj/whBrlzBNpOBrglzCuFVKjCQfmaJk
-        rCBFMiG5Rsx2XuMUH9vJ8T4zz8vUNHTKNxFrh8nf9NQTrsAyJExQ/vxSNXtV6S1wztG7am3rmgho
-        bueZbdptOO57vRrH5Zj0TuiVws27+3SyeRsaN3D7mUYLHDZryNXKS1sH1Tz3nxyuh0K3ns2CekwQ
-        YKEeSS7VSenNlOfQThSyxmYkkmQoy2LLNMNxWJjXQb/bkMKXCvtcqCGMp+n8S2z+dibMcNgJydUn
-        mgUhOZBywYBcMoM8Z8gZRLkCcshp8tlmB5PDZUT5XGoTDryB586YiJFK3aA/uC4UDovkYVy3klhY
-        hTvkq5LkO/z5vhA/w6HPchCKIVtUTg5zIEMMFDd/p2viey1iwdgEcXA5wqMr/NdG7i88tXWMltBJ
-        mVHQkSpxEcbUlpbhxGbh7+LVztykvPC71HNh9ZyLhZDLx0kaKxnnOAOMRIKNnWKZ3Akm39osMoT+
-        kl/lsm3klixllYLgmrjkyteG/JlTZUCRjcotorCx6RfSnz6MyVlExZb7dhjFPvKbqB7FcbbWBlKN
-        ccSZZAi2nbDYLypkM5ZSJjQz0EE8YsL0fCqpirfdeKF/uMHZTvgvAAAA///sWW1L3EAQ/iuLICiY
-        GO9y3l1B7CEt9IO0KFQQ4dhsNl7o3SbkxSj2/nuf2d3bxvRiixTxg+CHmN2dl83MM8/M3agZEyac
-        gL0sklKxUlassbFVARxLE18J4uuANYtULNhKclVikZsdVgL8vVGRZFwIoKuM2V3KWY2EEcVDDnjC
-        PqWkKdR+y6JzfOtb3VqSQVcLqSi+GHdyM3Se8AiWkFtggSxVSVas9BmWFYTZHKslQSbg+odUB2QY
-        hKcVM2yA8WXDH8hFlnNtXV0ishlXrGUg+kYllz6+eEk+Ow/NHdwougTSRncEC6yF5cZEEljWuKCt
-        lrZ8bnl/gVxE9cGVkfc2Xpqm8bOGl7nOCiShvPfzRa4jGkrmkDm3uue8Av2JasTUfO/r1ezym3d5
-        7qFQ61x1SvKMQpmyYY/Hq1Tts739nwiUZZV9QBj+yXFGrtB3i1wf+UFL3gLAqgCyawJHlKy71dHg
-        zkLQtxA6pto94biG/kiaWW3f2Mc9gj52HDidT2p2F9LxAbhYUPabulDWqxWnorXzN7ymWycKmhUv
-        rHBERU6Rb0Scv8Qno3g4GU+io3Egh2IaiOlokEyPkmPocZug4ZltkkJiFsfQgSqHkhc/fGwZAkAh
-        Wc82xSZXfFRRvU3DlG3MQgmix+OjMDwei8l4NJxGIhoHUJ9wmUzEaXyipewOZ7uDz/gz57wVVxZf
-        Pc+8Kv269BpchDfwCbj9vI6WqaCb8nLOS7oonNd1BDQRj2dICj9XdOfdBvvtW9zt0N++xd0O/61b
-        DIyKTcNoqeAZQh9MJklqIVKdQITnph01CHcNMoiNn+oiy+XhNbBHLH5nGk2YsOpSlzTYudp2/hj2
-        4WrY11SGrqksLL6/w8irBcw7jLyGxe8wsgVGujDQx9RCR8gcf4E7tyYpH2kUbp8DWJJV3A7yu1L6
-        KFnQh0vBYDvA9U2Fgl4Heimb86x7oo/LDXsXHMmT6i4tMmWInHkV1/ZXJPPvv9zeXVb9vwmpEeaE
-        QhPatO+ZnvVsxppIAWPy4+bR1pcXG6B/cTvcyD3YWfH7C1nWSxLcclZPaYpqVhnHaVZMkxxy3b1/
-        enjw5LQ9oK1dr9e/AAAA//8DAKoRrxW0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18203","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18203","key":"NTEST-1854","fields":{"statuscategorychangedate":"2025-04-30T18:25:56.133+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1854/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:25:55.896+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:25:55.971+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/268]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/268 (268)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/101]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1854/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18203/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - e31b2051-4a13-43f3-beec-35f37ad41c58
+      - 2d7fb5d6-eb9b-467b-8197-e40475cdf5e3
       Atl-Traceid:
-      - e31b20514a1343f3beec35f37ad41c58
+      - 2d7fb5d6eb9b467b8197e40475cdf5e3
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:58 GMT
+      - Wed, 30 Apr 2025 16:26:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1774,7 +1835,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=296,atl-edge-internal;dur=13,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="a_rXMU0DRQpeJ7l0U6FUylbl07nr43n_OrZKZtgYNSpdX-SCZW0dbQ==",cdn-downstream-fbl;dur=330,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=327,atl-edge;dur=251,atl-edge-internal;dur=19,atl-edge-upstream;dur=232,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1783,14 +1844,125 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 476cbc24d5f1a673aca06385c3863276.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - a_rXMU0DRQpeJ7l0U6FUylbl07nr43n_OrZKZtgYNSpdX-SCZW0dbQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 8c86f1ef563cee8f1317e7880469faef
+      - dd84aab8b51a186b9a7f68c6f60f91b2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added_empty has occurred.", "title": "Created/Updated
+      0 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/101", "url_api": "http://localhost:8080/api/v2/tests/101/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      101, "url_ui": "http://localhost:8080/test/101", "url_api": "http://localhost:8080/api/v2/tests/101/"},
+      "finding_count": 0, "findings": {"new": [], "reactivated": [], "mitigated":
+      [], "untouched": [{"id": 267, "title": "Zap1: Cookie Without Secure Flag", "severity":
+      "Low", "url_ui": "http://localhost:8080/finding/267", "url_api": "http://localhost:8080/api/v2/findings/267/"},
+      {"id": 268, "title": "Zap2: Cookie Without Secure Flag", "severity": "Low",
+      "url_ui": "http://localhost:8080/finding/268", "url_api": "http://localhost:8080/api/v2/findings/268/"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1321'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added_empty
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1321\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added_empty\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
+        \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
+        \"172.18.0.9:47318\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \ \"data\": \"{\\\"description\\\": \\\"Event scan_added_empty has occurred.\\\",
+        \\\"title\\\": \\\"Created/Updated 0 findings for Security How-to: 1st Quarter
+        Engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/101\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/101/\\\", \\\"product_type\\\":
+        {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 101, \\\"url_ui\\\": \\\"http://localhost:8080/test/101\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/101/\\\"}, \\\"finding_count\\\":
+        0, \\\"findings\\\": {\\\"new\\\": [], \\\"reactivated\\\": [], \\\"mitigated\\\":
+        [], \\\"untouched\\\": [{\\\"id\\\": 267, \\\"title\\\": \\\"Zap1: Cookie
+        Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/267\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/267/\\\"}, {\\\"id\\\":
+        268, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\", \\\"severity\\\":
+        \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/268\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/268/\\\"}]}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added_empty
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        0,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [],\n      \"reactivated\":
+        [],\n      \"untouched\": [\n        {\n          \"id\": 267,\n          \"severity\":
+        \"Low\",\n          \"title\": \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/267/\",\n          \"url_ui\": \"http://localhost:8080/finding/267\"\n
+        \       },\n        {\n          \"id\": 268,\n          \"severity\": \"Low\",\n
+        \         \"title\": \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/268/\",\n          \"url_ui\": \"http://localhost:8080/finding/268\"\n
+        \       }\n      ]\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\":
+        \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
+        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
+        {\n      \"id\": 101,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/101/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/101\"\n    },\n    \"title\":
+        \"Created/Updated 0 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/101/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/101\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:01 GMT
+      Transfer-Encoding:
+      - chunked
     status:
       code: 200
       message: OK

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_push_to_jira_false.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_push_to_jira_false.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:38478\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:47320\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,215 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:16:58 GMT
+      - Wed, 30 Apr 2025 16:26:01 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/102", "url_api": "http://localhost:8080/api/v2/tests/102/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      102, "url_ui": "http://localhost:8080/test/102", "url_api": "http://localhost:8080/api/v2/tests/102/"},
+      "finding_count": 2, "findings": {"new": [{"id": 269, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/269",
+      "url_api": "http://localhost:8080/api/v2/findings/269/"}, {"id": 270, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/270",
+      "url_api": "http://localhost:8080/api/v2/findings/270/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:47324\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/102\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/102/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 102, \\\"url_ui\\\": \\\"http://localhost:8080/test/102\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/102/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 269, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/269\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/269/\\\"},
+        {\\\"id\\\": 270, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/270\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/270/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 269,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/269/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/269\"\n        },\n
+        \       {\n          \"id\": 270,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/270/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/270\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        102,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/102/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/102\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/102/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/102\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:01 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added_empty has occurred.", "title": "Created/Updated
+      0 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/102", "url_api": "http://localhost:8080/api/v2/tests/102/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      102, "url_ui": "http://localhost:8080/test/102", "url_api": "http://localhost:8080/api/v2/tests/102/"},
+      "finding_count": 0, "findings": {"new": [], "reactivated": [], "mitigated":
+      [], "untouched": [{"id": 269, "title": "Zap1: Cookie Without Secure Flag", "severity":
+      "Low", "url_ui": "http://localhost:8080/finding/269", "url_api": "http://localhost:8080/api/v2/findings/269/"},
+      {"id": 270, "title": "Zap2: Cookie Without Secure Flag", "severity": "Low",
+      "url_ui": "http://localhost:8080/finding/270", "url_api": "http://localhost:8080/api/v2/findings/270/"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1321'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added_empty
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1321\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added_empty\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
+        \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
+        \"172.18.0.9:47328\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \ \"data\": \"{\\\"description\\\": \\\"Event scan_added_empty has occurred.\\\",
+        \\\"title\\\": \\\"Created/Updated 0 findings for Security How-to: 1st Quarter
+        Engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/102\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/102/\\\", \\\"product_type\\\":
+        {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 102, \\\"url_ui\\\": \\\"http://localhost:8080/test/102\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/102/\\\"}, \\\"finding_count\\\":
+        0, \\\"findings\\\": {\\\"new\\\": [], \\\"reactivated\\\": [], \\\"mitigated\\\":
+        [], \\\"untouched\\\": [{\\\"id\\\": 269, \\\"title\\\": \\\"Zap1: Cookie
+        Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/269\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/269/\\\"}, {\\\"id\\\":
+        270, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\", \\\"severity\\\":
+        \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/270\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/270/\\\"}]}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added_empty
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        0,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [],\n      \"reactivated\":
+        [],\n      \"untouched\": [\n        {\n          \"id\": 269,\n          \"severity\":
+        \"Low\",\n          \"title\": \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/269/\",\n          \"url_ui\": \"http://localhost:8080/finding/269\"\n
+        \       },\n        {\n          \"id\": 270,\n          \"severity\": \"Low\",\n
+        \         \"title\": \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/270/\",\n          \"url_ui\": \"http://localhost:8080/finding/270\"\n
+        \       }\n      ]\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\":
+        \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
+        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
+        {\n      \"id\": 102,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/102/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/102\"\n    },\n    \"title\":
+        \"Created/Updated 0 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/102/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/102\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:02 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_push_to_jira_is_false_but_push_all_issues.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_push_to_jira_is_false_but_push_all_issues.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TfmzLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPATYfH5qXgkfQQYsnwKdwrJijGcpz4IY4AICHPIu/AGHqu3OWQoVA04Lni+TLKXf
-        rOxujLIBzGixkAIwRyVpOkeRKZUpkIot03xRqyJDVihgZwKvo+G2HUR8ISoxan9npYjtA9GniqB5
-        3ZbkeH7YkzVxcn1fkeMnAAAA//8DAJKk13kgAgAA
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:02.310+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 22fd83fb-d064-4927-bfb7-cabb899e3c88
+      - 518f43ca-5b72-4c6d-a1ce-9413dd297418
       Atl-Traceid:
-      - 22fd83fbd0644927bfb7cabb899e3c88
+      - 518f43ca5b724c6da1ce9413dd297418
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:59 GMT
+      - Wed, 30 Apr 2025 16:26:02 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=180,atl-edge-internal;dur=13,atl-edge-upstream;dur=168,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=185,atl-edge;dur=152,atl-edge-internal;dur=13,atl-edge-upstream;dur=140,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="bmw16hsH1tgIFQrOiswivBWIhbUOVnzemn7TyOqLEpTDJsVnWOD_rw==",cdn-downstream-fbl;dur=189
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e665d09233240df4d3172e59222e0ba2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - bmw16hsH1tgIFQrOiswivBWIhbUOVnzemn7TyOqLEpTDJsVnWOD_rw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - eff6111d3b077c50efd12d26fff80c69
+      - 623a13ae552691ca72f837dcb33c0a6c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - d17c632b-674f-4437-b188-50c7ba4d5f28
+      - f7d9d1f7-7d09-4b0e-a800-dc8d7cff74b8
       Atl-Traceid:
-      - d17c632b674f4437b18850c7ba4d5f28
+      - f7d9d1f77d094b0ea800dc8d7cff74b8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:16:59 GMT
+      - Wed, 30 Apr 2025 16:26:02 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=298,atl-edge-internal;dur=15,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="rAzMONC273AckzRGp4mKZ6gTucORussBjGqp7GPgA7woURaGc58n6g==",cdn-downstream-fbl;dur=376,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=373,atl-edge;dur=288,atl-edge-internal;dur=19,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c1388c9ad241eb02cd4ddbe69b1a2d34.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - rAzMONC273AckzRGp4mKZ6gTucORussBjGqp7GPgA7woURaGc58n6g==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 6f3baf5813fad41d594537a2030a812a
+      - 4835c39f795d36929e323d21101e4757
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/271]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/271 (271)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16099","key":"NTEST-1615","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16099"}'
+      string: '{"id":"18205","key":"NTEST-1855","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205"}'
     headers:
       Atl-Request-Id:
-      - 17bccaae-5937-4ad5-a976-c1cbec054a3f
+      - d87fd118-8ed7-486f-acea-f755ada289cd
       Atl-Traceid:
-      - 17bccaae59374ad5a976c1cbec054a3f
+      - d87fd1188ed7486faceaf755ada289cd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:00 GMT
+      - Wed, 30 Apr 2025 16:26:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=693,atl-edge-internal;dur=14,atl-edge-upstream;dur=680,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=680,atl-edge;dur=658,atl-edge-internal;dur=19,atl-edge-upstream;dur=639,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="rzE7RZ1KTRnwto5udo2ZXGkh5HWimc-4tw6d-TmZ9xo9_YkY42Rjmw==",cdn-downstream-fbl;dur=685
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f5c1da639a075ecd7bb86ffc181e3dd8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - rzE7RZ1KTRnwto5udo2ZXGkh5HWimc-4tw6d-TmZ9xo9_YkY42Rjmw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 9e46edd9e0393829b5b81989e53fb08b
+      - 060ccbc62f772a7d295c96ecd78b6c40
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1615
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfSFAWKmqriTX0lJKIYB0FCGzO9mYeO2t7SVJOf57x/sW
-        SLJXQdXTSVzW43l/5vE8ObDIqIid0FEgYlAQf2TAY90RNAXd0dEUUtqRGShqmBS6AzEzKRjaiaZU
-        JMBl0nkEpVEG8TlkCjQIU92Ncm1kOrEG73zP872egr9y0Ga8zOBM0ciwCJyOw6x/f987PMQPDXyC
-        n1NjMh26bgwTiEwsH2SPGk61ZlT0BBgXPRmXZswNXKZ1Dm5tYAZL1D8djy7GXX/f38OjIgTthE+O
-        xthyHVEDiVTLMocYv1Aj8IK9rud3fW8ceKF/EHpeby/Y+w7j9myQ1onBwAsz7wzS6rtozwuatKuP
-        GHSkWGYLh6cfiE4p5x0SM22YiAzJGERA5ITMpZr1rHYkxaXib4wiF8y2i/I7+kgNVe4jg7lbhLUK
-        sBL53q4/+EGzv+H7FNuep+jVwgJdjqme2V7l98b+CieUa+g4peIx5lXodpwpQ+CoaLo8gUfAWL3n
-        jmMYIitDlDihyDFHZw0mu16bwK8FmZIPmOo7O1FpF30oOlv3wX68QM8q3UvBjEED2ml8Wwj/WtzV
-        cmLmVFkga5ZmnGHA8VpJsFEF/PqDRX/wxnC/0LI6k6Zhfe8Awwj6i6D//3opYVGAFB36+wt//2s4
-        XNQed4PFbvA1PFbIf37ehGNQw3HCFlclB2KTb243b+7WN2mSKEiQbzaGAOOUPC/Hfzv699oE+22C
-        gxZB0CoYtAkON+MsabM8taRUvBBO2PUrrrSVVywqU3raOLPzgEXVU5nzeMh0xumymho8xhaaK2yP
-        naTKBTX4GJUk/vaZL5+I1aPgluaUneji55HMbTOK4K/tAROJExqV22giBZispYltj0TgD+pHYr1s
-        bVQWNFS2LmhAlSkmFTPLdyZcq7v9t70VLKUJaNdq6NoIwwMu5z39mKw48UTOa+7sO5vTETSY5/Qe
-        LPttGQxLGlvL4Lch1B/YekypHmUsOmFi9tFKhpDZ7UVENYIKXM0LWXMipBjh8kLvOZwD1SUqVfXL
-        OTu5/On49O7k+Gh0ejG6G52f/36O+eGUaiwIXhhPgZwhzQtDrF/CNJGCLwlSBuPWKDGS/MIUJWcK
-        UuQMkmvEV28bdfg4To73mXleph5Cp3wTsXdY/NVMveIKbEPCBOXrl6rdqypvgXKO0VXftq+JgOZ2
-        ntmhbcXx4KDGcbkmvRN6pXLzvL7ebN6GxhXcfqTRDJfNGnK18dLXUbXP/aeA66XQrXezoN4GBFio
-        R5JLdVpGc89z6CYKGWu1EkkylGWzZZrhOizMdtDvNaTwpcauKzWE8bqcf4rVv50xMxx2QnLziWZ+
-        SI6knDEg18wgxxpyAVGugHzkNPlsq4PF4TKifCq1CQfewHMnTMRIe25w4N8WBodF8TCvB0ksrMId
-        8q+a5Bv8822hfoFLn+UgVEO2qIIc5kCGmCge/kaXxPc6xIKxSeLoeoSiG/yvu+/3i0htH6M59FJm
-        FPSkSlyEMbWtZbiYWfi7eLU3NSkv4i7tXFk7l2Im5Pxlkc6UjHN86kciwcFOsU3uGItvfRYVwnjJ
-        z3LeNbKlSlllILglLrnxtSF/5FQZUGRlskUVVj79QvvThzNyEVHRct/unHYNb7J6kcfFUhtINeYR
-        Z5Ih2HbC4rzokK1YSpnQzEAP8YgF09N7SVXcdmPD/nCFs53wHwAAAP//7FldS9xAFP0rgyAomJjd
-        zbq7BbGLtNAHaVGoIMIymUzc0N1JyIdRrP+9587MTmO6sUWK+CD4EDMz9yv3nnvu7LWaM2HSCdjL
-        IikVK2XFGptbFcCxNPmVIL8OWLNMxZKtJVclFrnZYSXA32sVScaFALrKmN2mnNUoGFHc54An7FNK
-        GpLgtyw6w7e+0aMlGXS5lIryi3EnN8PkCY9gCbkFssdSlWTFWp9hWUGYzbFaEmQCrn9IdUCGQXha
-        McNEGF81/J5cZDnX1tUlMptxxVoGYm5UcuXji5fks/PQxOBaURBIG8UIFlgLy42JJLCsEaCtlrZ8
-        bnl/jlpE90HIyHubL03T+FnDy1xXBYpQ3vn5MtcZDSULyFxY3QtegXpFNXJqsff1cn7xzbs489Co
-        da06JXlGqUzVsMfjdar22d7+TyTKqso+IA3/5Dhj1+i7Ta6P/AzCNgBWBZBdky2ig92tfaQ36FsI
-        HVPtnnBcQ38kzay2b+zjHkEfOw6cTsSYiyUVuG3A7R7ehfiyXq85Na2dv+E1RZ0oaFa8sMMRFTlB
-        vRHJ/RIfj+PRdDKNBpNAjsQsELPxMJkNkiPocZug4ZltklJiHsfQgS6Hlhfff2wZAkAhWc/OvqZW
-        fHRRvU3DlJ2/Qgmix+NBGB5NxHQyHs0iEU0CqE+4TKbiJD7WUnZH893hZ/yZc96aK4uvnmdelX5d
-        eg0C4Q19Am4/r6NVKihSXs55SYHCed1HQBPxeIqi8HNFMe/O0W/f4u4g/vYt7g7yb91iYFRshlVL
-        BU+R+mAySVILkeoCIjw3o6NBuCuQQWz8VBdZLg+vgD1i+bvS6CIJq650SYO9V9vOH8M+XA37hsrQ
-        DZWFxfd3GHm1hHmHkdew+B1GtsBIFwb6mFroCJnjK3DnxhTlA9142+cAlmQVtxf5XSl9lCzow6Vg
-        uB3g+m6Fgl4Heimb86x7oo/LjXoXHMmT6jYtMmVYnnkV1/ZXJPPvv0TvNqv+322mEeaEQhPGtO+Z
-        vuvZXKmiBIzJD5tH219ebID+xe1wI/dgZ83vzmVZr0hwy1l9S1NU88o4TnfFdJNDrrv3Tw8Pn5y2
-        B7S1j4+PvwAAAP//AwBCtuUjtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18205","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205","key":"NTEST-1855","fields":{"statuscategorychangedate":"2025-04-30T18:26:03.561+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:03.293+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:03.376+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/271]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/271 (271)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d7ab4082-baa8-4b2d-ba24-6efda3b59d23
+      - 93258a7d-4f5b-4cec-b084-5ce90492e41c
       Atl-Traceid:
-      - d7ab4082baa84b2dba246efda3b59d23
+      - 93258a7d4f5b4cecb0845ce90492e41c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:00 GMT
+      - Wed, 30 Apr 2025 16:26:04 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=274,atl-edge-internal;dur=15,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="K1XXSRdW7eLzjKIeYN8xX1E8g2E5T2KrZV0S4iMT0bgNEzT03PRNTw==",cdn-downstream-fbl;dur=372,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=366,atl-edge;dur=278,atl-edge-internal;dur=17,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c973663b623c0e82cd366d5ae7837bf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - K1XXSRdW7eLzjKIeYN8xX1E8g2E5T2KrZV0S4iMT0bgNEzT03PRNTw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 586125ff3b03c10f0c85459702a2311b
+      - a06f40362fc9ed79aeccc4bc2a4316bd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16099
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18205
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW/U/jNhj+V6z8tLG2iUMLJdI03WjZuDHGoHDSsRMyydvU1LEz26HtOP73vc5H
-        y1fuBNNOSCX26/f78eP3zoNlzmTiRZ4GmYCG5ICDSExHsgxMx8QzyFhH5aCZ5UqaDiTcZmBZJ54x
-        mYJQaecWtEEZJKeQazAgbX02LoxV2dQZvKJBQIOehr8LMHayyuFEs9jyGLyOx51/uhPs7eHCgJji
-        cmZtbiLfT2AKsU3UjeoxK5gxnMmeBOujJ+uznPuhz40pwG8MzGGF+seT8dmkS3foALfKEIwX3XkG
-        YytMzCykSq+qHBJcoUYYhINuQLs0mIRBRHejIOgNwsEPGHfggnROLAZemnljkE7fR3tBuE67XiRg
-        Ys1zVzjcfUdMxoTokIQby2VsSc4hBqKmZKH0vOe0YyXPtXhlFIXkrl1MXLFbZpn2bzks/DKsTYC1
-        iAbbdPiT4f/Ajxm2vcjQq4MFupwwM3e9Kq6t+4qmTBjoeJXiIeZV6na8GUfg6Hi2OoJbwFiD+45n
-        OSIrR5R4kSwwR+8JTLaDRpBrdYMZvbHgtXZZ7rKBTbnd4gFINlmdS24tGjDe2rdD6m/lWaOmdsG0
-        w6vhWS44Bpw8yRz7UaKsP1z2h68M9wudaTJZ96Uf7GIYYX8Z9v9fL1X3SyyiQ7qzpDvfwuGy8bgd
-        LrfDb+GxBvj9/XM40jachm2C7UYw5cuLihwRFpefECZpqiFFvvnqJRg0AsxMiaLihZeP7rQJdlsE
-        Yatg2CbYex5ORZvVriOl8oXwoi7FJbP4cFSE+/qLW9H5hsD9ypx217L83FeFKxx1pPzBbXCZepHV
-        BdzXPO2saR5XVbt7tuciw6NmpgqRjLjJBVvVVxm3MSx7gZhx17uuhgZM1vHHS49ESIfNI/G0bGsq
-        eypoA1W4BlWuudLcrt5YxEbd77/ureAZS8H4TsM0RjhuCLXomdt0Q5ZHatGQat97fm3C9SUQ7Boc
-        LTr8P50I2qBL2xBKh64eM2bGOY+PuJwfOMkIcje9yLjpYtnbRSlb70glxzi8sGsBp8BMhQxdf3kn
-        R+e/HB5fHR3uj4/Pxlfj09M/TjE/vKUGC4IHJjMgJ8j/0hLnl3BDlBQrglzChTNKrCLvuWbkREOG
-        ZEIKg5jtvcQpFK+TF3zmQZDrm8ir3kTsHRZ/c6cecQW2IeWSiaeH6tmrLm+Jc4HRNXSDfU0lrE8X
-        ubu0rTge7jY4rsakN0KvUl6/u48nm9ehcQO3n1k8x2GzgVxjvPK1X89z/yngZij0m9ksbMYECQ7q
-        sRJKH1fRXIsCuqlG1tiMRIqMVNVsleU4Dkv7MugHbaQwWJPClzr+uJx/yc3f1oRbAVsRufzIchqR
-        faXmHMgHbpHnLDmDuNBADgRLP7vqYHGEipmYKWOjYTAM/CmXCVKpH+7ST6XBUVk8zOtGEQeraIt8
-        VZN8hz/fl+pnOPQ5DkI1ZIs6yFEBZIT54ObvbEVo0CEOjOsk9j+MUXSJ/7o7tF9G6voYL6CXcauh
-        p3TqI4yZay3Hic3B38ejvZnNRBl3ZefC2TmXc6kWD4t0olVS4Awwlile7Azb5E+wxs5nWSGMl/yq
-        Fl2rWqqU1wbCT8Qnl9RY8mfBtAVNNiZbVGHjk5baH9+dkLOYyZbzbhh1Y/g6qwd5nK2MhcxgHkmu
-        OIJtKyr3yw65imWMS8Mt9BCPWDAzu1ZMJ20nntkfbXC2Ff0LAAD//+xZbWvbMBD+K6JQaKF2ncRp
-        kkHpQtlgH8pGCyuUQlBkuTGLZeOXuqXrf99zkqK5XtyNMko/FPLBiaS70/nuuecu12rOhAknYC9b
-        SqlYKSvW2NiqAI6lia8Y8XXAmlUiViyVXJVY5GaHlYD7XqulZFwIoKuM2G3CWY2EEcV9DnjCPqWk
-        KdR+y6IzvOsb3VqSQZcrqSi+GHdyM3SeuBEsoWuBBbJExVmR6jMsKwizOVZLgkzA9Q+pDsgwCE8q
-        ZtgA4+uG39MVWc61dXWJyGZcsZaB6BuVXPt44yXd2d3Q+OBakRNIG/kIFlgLy42JJLCs4aCtlrbu
-        3Lr9OXIR1Qcuo9vbeGmaxs8aXuY6K5CE8s7PV7mOaChZQObC6l7wCvRnWSOmFntfL+cX37yLMw+F
-        WueqU5JnFMqUDXs8ShO1z/b2fyJQ1lX2AWH4J8cZu0LfLXJ9ODcI2zhXFUB2TeCIknW3OhrcWQgd
-        Ie0sBH0ngj6uETiuod+eplzbN/ax48AZ86Rmd5EbL4CLFWW/qQtlnaacitbO3/CavE4UNCteWOGI
-        ipwg34g4f4mOx9FoOpkuB5NAjsQsELPxMJ4N4iPocZug4ZltkkJiHkXQgSqHkhfdf2wZAkAhWc82
-        xSZXfFRRvU3DlG3MQgmix6NBGB5NxHQyHs2WYjkJoD7mMp6Kk+hYS9kdzXeHn/Ex57yUK4uvnmd+
-        Kv269Bo4whv6BNx+Xi/XiSBPeTnnJTkK53UdAU3E4ymSws8V+bzbYL99i7sd+tu3uNvhv3WLgVGR
-        aRgtFTxF6IPJxHEtRKITiPDctKMG4a5ABrHxU11kuTy8AsSI1e9MowkTVl3qkgY7V9vOH8M+XA37
-        msqwb1IROuwuLPC/48urRdI7vryGxe/4sgVfujDgCJnjL7D6xuTeA43C7XMAhVnF7SC/K6WXefXi
-        Ui8lG25Hvr6pUNDHQQkQti4E7sqdhVHfiZEjeVLdJkWmDJEzP0W1/RfJfP0n72WpkfCwebRw/wL4
-        bf0BdriRe7CT8rtzWdZrEtzSrYcmRTWvjB23WfX/JrVGmBMKXWgXv2d65rQZr9KsmCY5pNIZ8tTa
-        4RNz7QHtnsfHx18AAAD//wMAZLnPhrQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18205","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205","key":"NTEST-1855","fields":{"statuscategorychangedate":"2025-04-30T18:26:03.561+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:03.293+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:03.376+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/271]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/271 (271)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - c5b57601-484e-4dbf-bdeb-5323b335a8fd
+      - 841ec1bc-d559-433e-aa8a-d9bd99d9351f
       Atl-Traceid:
-      - c5b57601484e4dbfbdeb5323b335a8fd
+      - 841ec1bcd559433eaa8ad9bd99d9351f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:01 GMT
+      - Wed, 30 Apr 2025 16:26:04 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=272,atl-edge-internal;dur=16,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="K5ZKXpOn0Dmo78hw3UOwoVI5VaVFaKDcujSwKvocxXg6mLQxy2ehSA==",cdn-downstream-fbl;dur=383,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=379,atl-edge;dur=295,atl-edge-internal;dur=19,atl-edge-upstream;dur=276,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 48f2e5da4dd7651bfa3bfd0054610cf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - K5ZKXpOn0Dmo78hw3UOwoVI5VaVFaKDcujSwKvocxXg6mLQxy2ehSA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 8088e60931d65640a0c2e80484033b31
+      - 321a894a7c87a39bfe0f34f7b410f834
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQzU7DMBCE38VX2nTt5qf1DRWJgqAgJb2AEHKctQg4dhQ7laqq744tKugRuK12
-        v9kZzYHUwuF20ISTN+97x2ezBhVK39h3mwivhXOtMIlBTyakaV2vxf4ffInDrpXYoPtYo+5XaDwO
-        f32yskbpEY3E3yl3OLjWmgBTAJpAAtNyc/lYrh+qn+tm7OowEf4coQlM4CV4Yq/tvgspq30f3Vba
-        jk0Q1WOrmy8J4UHAiuK0vBI+ggxYNgU6hWXFGE/nPA3GABcQ4KB3oQccqrY7ZylUDDgteAiZQ/bN
-        yu7GKBvAlOYLKQAzVJLOCxSpUqkCqdhyni1qlafIcgXszMDr6HDbDiJWiEqM2t9ZKeL6QPRpImhe
-        tyU5ngd7siZeru8rcvwEAAD//wMAA6fxuSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:05.005+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - cfe6f16a-1c0d-49ab-a049-c93710ea20ff
+      - 17fef744-c86e-4aae-8201-aa6018281a80
       Atl-Traceid:
-      - cfe6f16a1c0d49aba049c93710ea20ff
+      - 17fef744c86e4aae8201aa6018281a80
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:01 GMT
+      - Wed, 30 Apr 2025 16:26:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=179,atl-edge-internal;dur=14,atl-edge-upstream;dur=166,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=194,atl-edge;dur=161,atl-edge-internal;dur=14,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0RxIE_ThKsc4CohlMpcYW0Su4hULfiYR21j7B2ShTHmNYpzF1AX54A==",cdn-downstream-fbl;dur=198
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e665d09233240df4d3172e59222e0ba2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0RxIE_ThKsc4CohlMpcYW0Su4hULfiYR21j7B2ShTHmNYpzF1AX54A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - befb6e92089cd74eb4f97fbd5e5f24d5
+      - ad6cfbb29d1e4c28c13a2c39225a088b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 7617bf83-652a-4dc8-ad4c-31ae02050643
+      - 5a3338f8-5da5-4faf-afd4-61bd7303e053
       Atl-Traceid:
-      - 7617bf83652a4dc8ad4c31ae02050643
+      - 5a3338f85da54fafafd461bd7303e053
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:01 GMT
+      - Wed, 30 Apr 2025 16:26:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=282,atl-edge-internal;dur=14,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=422,atl-edge;dur=295,atl-edge-internal;dur=15,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="OgFqWZ2mGOZnQ7EX0Cy27fA0Sr8QMpTJ0UeHzclcxaZT7Pd76DOzgw==",cdn-downstream-fbl;dur=427
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5538280951642fc71308aa997730220e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - OgFqWZ2mGOZnQ7EX0Cy27fA0Sr8QMpTJ0UeHzclcxaZT7Pd76DOzgw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4728cfe594d181d680fe50ece6f09b79
+      - 236b5941c2584f420e386d70295f535f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/272]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/272 (272)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16100","key":"NTEST-1616","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16100"}'
+      string: '{"id":"18207","key":"NTEST-1856","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207"}'
     headers:
       Atl-Request-Id:
-      - 8c7f7722-ee6d-4cce-ad1b-93099b0d151f
+      - ee7fa16f-b7db-40bb-b1ed-dab86339a4b8
       Atl-Traceid:
-      - 8c7f7722ee6d4ccead1b93099b0d151f
+      - ee7fa16fb7db40bbb1eddab86339a4b8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:02 GMT
+      - Wed, 30 Apr 2025 16:26:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=603,atl-edge-internal;dur=20,atl-edge-upstream;dur=584,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="_6ZODG0BTvLx-IrIUYfe3RGw6c2QU08b-kFB9oZi3SbcUZnCqcqu9A==",cdn-downstream-fbl;dur=704,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=702,atl-edge;dur=628,atl-edge-internal;dur=17,atl-edge-upstream;dur=611,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 35f3ad5aa26e63a13ffedf420998e698.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - _6ZODG0BTvLx-IrIUYfe3RGw6c2QU08b-kFB9oZi3SbcUZnCqcqu9A==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 36a13bd506073abd27ae8ce7cc8ae9a6
+      - 946ad6e9e6fdf6530bbdf3f543259cc0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1616
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvcR1PAHD0MXuli7LssRJgWZFwEhnmTVFaiQV22vz33ek
-        XtzaUYdkWFEgtXi8t+eeO94HD9YFFakXewpECgrSVwx4qnuC5qB7OllATnuyAEUNk0L3IGUmB0N7
-        yYKKDLjMevegNMogvYBCgQZh6rtJqY3M59bgbRgEYTBQ8FcJ2sw2BZwrmhiWgNfzmPUfjvAKfmjg
-        c/xcGFPo2PdTmENiUvleDqjhVGtGxUCA8dGT8WnB/MhnWpfgNwaWsEH9s9n0ctbHsxEeuRC0F3/w
-        NMZW6oQayKTaVDmk+IUaURC96AdhPwxmURCHR3EQDUbB+LugMuucGAzcmXlmkFbfR3tB1KZdf6Sg
-        E8UKCxyeviQ6p5z3SMq0YSIxpGCQAJFzspJqObDaiRRXij8xilIwWy7Kb+k9NVT59wxWvgtrG2At
-        CoPDcPyjZn/DDzmWvczRq6UFupxRvbS1Ku+M/RXPKdfQ8yrFE8zL6fa8BUPiqGSxOYV7wFiDh55n
-        GDKrQJZ4sSgxR2+HJodBIyiUfI8ZPRPwWtvB7QrYwL1Dkm1WV4IZgwa01/q2TP3V3dVyblZUWb5q
-        lhecYcDpTuZYD8ey4Xg9HD8x3C9UpsmkrcswOMIwouE6Gv6/XqrqOy6iw3C0xnb6Cg7XjcfDaH0Y
-        fQ2PNcEfHvbpGHbxNGoEc7a+rmYgVv/m3f7Nw+YmzTIFGc6bvSbABCQvq/Z/3N2LLsGoS3DUIYg6
-        BeMuwff7cVZjszq1Q8m9EF7cD+tZaUuiWFKl9GHvzDYKoq0XsuTphOmC003dTni8ogafnmpkP731
-        qwdh+wT4lTllG9v9PJalhd6F+sYeMJF5sVGl9Y1GzTVyxrZ3jYYCTNbOj8ceicNw1DwSu7C1o2xX
-        0EWqqCVVoZhUzGyeCUGj7g+f9lawnGagfauhGyMMD7hcDfR9th2Wp3LVDNWht982Uct5Tu/AjsVH
-        GsNOk0dhCLsYGo4tHguqpwVLTplYvrKSCRR2exFJwyDHq5WTtSdCiikuL/SOwwVQXbFS1b+889Or
-        n0/Obk9Pjqdnl9Pb6cXF7xeYH3apRkDwwmwB5BznvzDE+iVMEyn4huAsYdwaJUaS10xRcq4gx2FC
-        So2MGzw2U0JsJy/4yIKgUCr2qjcRa4fgb3vqs1mBZciYoHz3Ur171fA63nOMrv62dc0EtLfLwjZt
-        J4/H7bJTrUnPpF6l3L67n282T2Pjlm4/0WSJy2ZDucZ45eu43uf+U8DNUug3u1nUrAkCLNUTyaU6
-        q6K54yX0M4UTa7sSSTKRVbFlXuA6LMzjpH/RDoUvFXZXqR0Yn8P5p9j+O5gxw+EgJjdvaRHF5FjK
-        JQPyhhmcsYZcQlIqIK84zT5adBAcLhPKF1KbeByMA3/ORIqD0I+OonfO4MSBh3m9l8TSKj4g/6pJ
-        vsE/3zr1S1z67AxCNZwWdZCTEsgEE8XD3+iGhEGPWDK2SRy/maLoBv/rj8Khi9TWMVnBIGdGwUCq
-        zEcaU1tahhubpb+PVwcLk3MXd2Xn2tq5EkshV5+CdK5kWuIOMBUZNnaOZfJnCL716RDCeMkvctU3
-        sgOlojYQvSM+uQm1IX+UVBlQZGuyQxW2PkOn/fblOblMqOi4b5dRu4a3WX2Sx+VGG8g15pEWkiHZ
-        DmJ37ipkEcspE5oZGCAfETC9uJNUpV039uxPtjw7iP8BAAD//+xZbUsbQRD+K4sgKHjnJbk0SUFs
-        kBb6QVoUKogQNnt75miyd9yLp1j/u8/sbrbxmrVFivhB8MN5uzs7MzfzzDOTKzVlwoQTsJfNpVSs
-        kjVrbWzVAMfKxFeK+Dpg7SITC7aSXFVY5GaHlQB7r9RcMi4E0FUm7CbjrEHCiPKuADxhn1LSkIRw
-        Q6NTfOtr3VqSQhcLqSi+GHdyc3SesAiakFlggSxTaV6u9BmWl4TZHKsVQSbg+qdUB6QYhGc1M0yE
-        8WXL78hEVnCtXVMhshlXbENB9I1KLkN88YpsdhYaH1wpcgLdRj6CBlbDaq0iCawaOGirphs2b1h/
-        hlxE9YHLyHobL23bhnnLq0JnBZJQ3obFotARjUtmkDmzd894Deo1bxBTs71vF9Pz78H5aYBCrXPV
-        XVLkFMqUDXs8WWVqn+3t/0KgLOv8I8LwT44zdIW+W+R85KcX+xYcxSVkrEtAvuZlxBM7WyMfG44d
-        U+2ecFxDfyTNrLZv9HGPyMeOI3cnfMzFghLcFuDNGt6F+KpZrTgVrZ2/4TV5nShoXr6wwhEVOUa+
-        Ee39mhwNk8F4NJ73RpEciEkkJsN+OumlNCpxm3DDM9skhcQ0SXAHqhxKXnL3aUMRAArJerYpNrkS
-        oorqbRqmbGMWSxA9nvTi+MNIjEfDwWQu5qMI16dcpmNxnBxpKbuD6W7/C/7MuWDFlcXXIDCvqrCp
-        ghaOCPohAXdYNPNlJshTQcF5RY7CeV1HQBPxeIKkCAtFPu822G9f426H/vY17nb4b11jQFFimlVL
-        BU8Q+mAyadoIkekEIjw3zaQBskuQQWz83JR5IQ8vgT1i8TvTaMKEVZe6dIOdq23nj7EPV2NfUxm7
-        prK0+P4OI68WMO8w8hoav8PIFhjpwoCPqcWOkDm+AnOuTVLe0yjcPkfQJK+5HeR3pfgoWeTDpai/
-        HeB8U6HIa4CXsvmoJkHI1oWBd8GRPKlusjJXhuWZV0ljf0Uy//6L927y+v/NN40wJxQ3oU37ketZ
-        z3qkihQwKt+vH219ebEC+he3w7Xcg50Vvz2TVbMkwRvG6ilNWU9rYzjNimmSQ6a7908P95+ctge0
-        tg8PD48AAAD//wMAP03ECbQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18207","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207","key":"NTEST-1856","fields":{"statuscategorychangedate":"2025-04-30T18:26:06.368+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:06.100+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:06.179+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/272]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/272 (272)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3fc73443-2e43-4f8b-ac9c-0fef84dd17d6
+      - f60ef251-0acc-4487-bf04-ab80ebbd1f72
       Atl-Traceid:
-      - 3fc734432e434f8bac9c0fef84dd17d6
+      - f60ef2510acc4487bf04ab80ebbd1f72
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:03 GMT
+      - Wed, 30 Apr 2025 16:26:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=288,atl-edge-internal;dur=14,atl-edge-upstream;dur=274,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=311,atl-edge;dur=277,atl-edge-internal;dur=18,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="DZSnOd_NvJ3wrHWM5nmTpFahJx12QY4zARM6rea9XyqzdNvzuijXJg==",cdn-downstream-fbl;dur=316
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 22067fb5d7eb764108747a104222f50a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - DZSnOd_NvJ3wrHWM5nmTpFahJx12QY4zARM6rea9XyqzdNvzuijXJg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 591d604cf988a35323b91dcdf5667a9d
+      - 8ce005a8c67a2dee1dd4c533c281a350
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16100
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18207
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfSGEdKWqupLQ0lKakgDSUYTM7mTji9fe2l6SlOO/d7xv
-        OQJ7J6h6OonLejzvzzyeBwfWGRWxEzoKRAwK4mMGPNYdQVPQHR0tIKUdmYGihkmhOxAzk4KhnWhB
-        RQJcJp17UBplEJ9DpkCDMNXdKNdGpnNr8Nb3PN/rKfg7B21mmwwmikaGReB0HGb9+wO8gh8a+Bw/
-        F8ZkOnTdGOYQmVh+kD1qONWaUdETYFz0ZFyaMTdwmdY5uLWBJWxQ/2w2ns66eDbAoyIE7YQPjsbY
-        ch1RA4lUmzKHGL9QI/CCg67nd31vFnihfxh6QW/gDb/zSrOFE4OBF2beGKTVd9GeFzRpVx8x6Eix
-        zBYOT98RnVLOOyRm2jARGZIxiIDIOVlJtexZ7UiKC8VfGUUumG0X5bf0nhqq3HsGK7cIaxtgJfK9
-        fX/4o2b/wA8ptj1P0auFBbqcUb20vcrvjP0VzinX0HFKxRPMq9DtOAuGwFHRYnMK94Cxeo8dxzBE
-        VoYocUKRY47ODkz2vVqQKfkBM3pjwSvtotxFA+ty74Bkm9WFYMagAe00vi1Sfyvuajk3K6osXjVL
-        M84w4Hgnc+xHgbL+cN0fvjLcz3SmzqTpS987xDCC/jro/79eyu4XWESH/mCN4/QVHK5rj/vBej/4
-        Gh4rgD8+Poej34bToE2wXwvmbH1ZkiPC4voGYZIkChLkmy8OwUEtwMwkz0teePnqoE1w2CIIWgXD
-        NsH3z8MpabM8taRUvBBO2PXxkxp8OErCff3glnS+JXC3NKfsWBY/j2RuC+dbUr6yB0wkTmhUDo8V
-        T1trikVl1R6endnI8KpeyJzHI6YzTjfVKOMxhmUuETN2vKtqKMBkLX+89Ejs+4P6kdgtW0Nlu4I2
-        UAUNqDLFpGJm88Yi1upu/3VvBUtpAtq1Gro2wvCAy1VP3ydbsjyVq5pU+87zsQmaIeD0DiwtWvzv
-        bgRt0PXbEOoPbT0WVI8zFp0ysTy2khFkdnsRUd3ForerQtacCCnGuLzQOw7nQHWJDFX9cianFz+f
-        nN2enhyNz6bj2/H5+R/nmB9OqcaC4IXZAsgE+V8YYv0SpokUfEOQSxi3RomR5FemKJkoSJFMSK4R
-        s72XOMXHcXK8j8zzMqVCp3wTsXdY/O1MPeEKbEPCBOW7l6rdqypvgXOO0dV0g31NBDS388wObSuO
-        h82yU65Jb4Reqdy8u083m9ehcQu3n2i0xGWzhlxtvPR1VO1z/yngeil0690sqNcEARbqkeRSnZXR
-        3PEcuolC1tiuRJKMZNlsmWa4DgvzMugPGlL4XGN3lRrCeFrOv8T2396MGQ57Ibl+T7MgJEdSLhmQ
-        K2aQ5wyZQpQrIMecJh9tdbA4XEaUL6Q24dAbeu6ciRip1A0Og5vC4KgoHub1QRILq3CPfFGTfIN/
-        vi3Up7j0WQ5CNWSLKshRDmSEieLh73RDfK9DLBibJI6uxii6xv+6A79fRGr7GK2glzKjoCdV4iKM
-        qW0tw43Nwt/Fq72FSXkRd2nn0tq5EEshV58WaaJknOMOMBYJDnaKbXJnWHzrs6gQxkt+kauukS1V
-        yioDwQ1xybWvDfkzp8qAIluTLaqw9ekX2u/fTcg0oqLlvl1G7RreZPVJHtONNpBqzCPOJEOw7YXF
-        edEhW7GUMqGZgR7iEQumF3eSqrjtxjP7oy3O9sJ/AQAA///sWW1r2zAQ/iuiUGihdp3EWZJB6ULZ
-        YB/KRgsrlEKQZbkxi2Xjl7ql63/vc5KipV7cjTJKPxTywYmku9P57rnnLldqzoQJJ2Avi6RUrJI1
-        a21s1QDHysRXgvg6YO0yFUuWSa4qLHKzw0rAfa9UJBkXAugqY3aTctYgYUR5VwCesE8paQq1v2HR
-        Kd71tW4tyaCLpVQUX4w7uTk6T9wIltC1wAJZqpK8zPQZlpeE2RyrFUEm4PqnVAdkGISnNTNsgPFV
-        y+/oiqzg2rqmQmQzrtiGgegblVz5eOMV3dnd0PjgSpETSBv5CBZYC6u1iSSwauCgrZZu3Hnj9mfI
-        RVQfuIxub+OlbVs/b3lV6KxAEspbv1gWOqKhZAGZC6t7wWvQn6hBTC32vl3Mz79756ceCrXOVaek
-        yCmUKRv2eJylap/t7f9CoKzq/CPC8E+OM3aFvlvk+sjPIOxbcKSXkLEuAfma2RFX62wNHSHtLARO
-        Rnehj2sEjmvot6cp1/aNfew4cMY8qdldSMcL4GJJ2W/qQtVkGaeitfM3vCavEwXNyxdWOKIix8g3
-        Is5f46NxPJpOptFgEsiRmAViNh4ms0FCoxK3CRqe2SYpJOZxDB2ocih58d2nDUMAKCTr2abY5IqP
-        Kqq3aZiyjVkoQfR4PAjDDxMxnYxHs0hEkwDqEy6TqTiOj7SU3dF8d/gFH3POy7iy+Op55qfKbyqv
-        hSO8oU/A7RdNtEoFecorOK/IUTiv6whoIh5PkBR+ocjn3Qb77Vvc7dDfvsXdDv+tWwwoik3DaKng
-        CUIfTCZJGiFSnUCE56YdNUB2CTKIjZ+bMi/k4SUgRix/ZxpNmLDqUpc02Lnadv4Y9uFq2NdUhn2T
-        itBhd2mB/x1fXi2S3vHlNSx+x5ct+NKFAUfIHH+B1dcm9+5pFG6fAyjMa24H+V0pvcyrF5d6Kdlw
-        O/L1TYWCPg5KgLB1IejjoKO+EyNH8qS6SctcGSJnfoob+y+S+fpP3sszI+F+/Wjh/gXwu/EH2OFa
-        7sFOxm/PZNWsSPCGbj00Ket5bey4yev/N6k1wpxQ6EK7+CPXM6f1eJVmxTTJIZXOkKfWDp+Yaw9o
-        9zw8PDwCAAD//wMA64eIs7QcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18207","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207","key":"NTEST-1856","fields":{"statuscategorychangedate":"2025-04-30T18:26:06.368+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:06.100+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:06.179+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/272]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/272 (272)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - c29dbace-dcee-406b-8400-fdb56d4311aa
+      - d46ff331-14a6-4396-a005-2ca570d90f98
       Atl-Traceid:
-      - c29dbacedcee406b8400fdb56d4311aa
+      - d46ff33114a64396a0052ca570d90f98
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:03 GMT
+      - Wed, 30 Apr 2025 16:26:07 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=256,atl-edge-internal;dur=13,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=291,atl-edge;dur=258,atl-edge-internal;dur=15,atl-edge-upstream;dur=243,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="9J8S9bJEFZPI8XknpFHHq6aFNduZc3eY8hjXUjnDAa3vtSIfTIobdA==",cdn-downstream-fbl;dur=295
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a78d8f4a6ccd81221651cd6112d5330a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 9J8S9bJEFZPI8XknpFHHq6aFNduZc3eY8hjXUjnDAa3vtSIfTIobdA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 810249bd56cd39008be6fcceaeffe876
+      - 1b087d8444958a7bce83266dc7aa91a2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:38490\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:54892\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:03 GMT
+      - Wed, 30 Apr 2025 16:26:07 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/103", "url_api": "http://localhost:8080/api/v2/tests/103/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      103, "url_ui": "http://localhost:8080/test/103", "url_api": "http://localhost:8080/api/v2/tests/103/"},
+      "finding_count": 2, "findings": {"new": [{"id": 271, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/271",
+      "url_api": "http://localhost:8080/api/v2/findings/271/"}, {"id": 272, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/272",
+      "url_api": "http://localhost:8080/api/v2/findings/272/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:54896\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/103\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/103/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 103, \\\"url_ui\\\": \\\"http://localhost:8080/test/103\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/103/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 271, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/271\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/271/\\\"},
+        {\\\"id\\\": 272, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/272\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/272/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 271,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/271/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/271\"\n        },\n
+        \       {\n          \"id\": 272,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/272/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/272\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        103,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/103/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/103\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/103/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/103\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:07 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -959,26 +1046,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL2q1b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmCzBGgCy4oxnmc8D2KACwhwyLvwBxyqtjtnKVQMOC04ZGnBsm9W
-        djdG2QDmdL6QAnCGStKsQJErlSuQii2z2aJW8xzZXAE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMA0BYdMSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:07.725+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - ed0143fd-24cd-4b04-ad14-56817878f186
+      - 1de801f5-61d6-494e-a5eb-fb21e0c330e4
       Atl-Traceid:
-      - ed0143fd24cd4b04ad1456817878f186
+      - 1de801f561d6494ea5ebfb21e0c330e4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:03 GMT
+      - Wed, 30 Apr 2025 16:26:07 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -988,7 +1071,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=188,atl-edge-internal;dur=16,atl-edge-upstream;dur=172,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="Jr9DzqPCvwSZMBlcrbmSKbiAWssK-CLt59UipD4vpLA9qZNQPCrT_A==",cdn-downstream-fbl;dur=248,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=245,atl-edge;dur=156,atl-edge-internal;dur=22,atl-edge-upstream;dur=133,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -997,10 +1080,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 603f7fca6e96da4aaee2b5219f231c92.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Jr9DzqPCvwSZMBlcrbmSKbiAWssK-CLt59UipD4vpLA9qZNQPCrT_A==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - dc6d4dc63902700da043a30962623811
+      - f87aae114d460459c7f2a91ee4bd85ec
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1024,129 +1115,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16099
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18205
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxt4lCgRJqmO1o27hhjUEC6DCGTnKamjp3ZDm3H5b/vOG/l
-        rfcKpl0hldjH5/3x43PvwSJnMvEiT4NMQEOyz0EkpiNZBqZj4ilkrKNy0MxyJU0HEm4zsKwTT5lM
-        Qai0cwfaoAySE8g1GJC2PhsXxqps4gxe0yCgQU/D3wUYO17mcKxZbHkMXsfjzj/dDnZ3cWFATHA5
-        tTY3ke8nMIHYJupW9ZgVzBjOZE+C9dGT9VnO/dDnxhTgNwZmsET9o/HodNyl23QLt8oQjBfdewZj
-        K0zMLKRKL6scElyhRhiEW92AdmkwDoOI7kRB0NsKt37AuAMXpHNiMfDSzDuDdPo+2gvCNu16kYCJ
-        Nc9d4XD3AzEZE6JDEm4sl7ElOYcYiJqQudKzntOOlTzT4o1RFJK7djFxze6YZdq/4zD3y7BWAdYi
-        GmzSwU+G/wM/Ztj2IkOvDhbocszMzPWquLHuK5owYaDjVYoHmFep2/GmHIGj4+nyEO4AYw0eOp7l
-        iKwcUeJFssAcvWcw2QzWCWgjyLW6xVTf2Ylau+xD2dmmD27xCD2rdM8ktxYNGK/17SD8W3nWqImd
-        M+2AbHiWC44BJ89Kgo0q4dcfLPqDN4b7hZY1mbQN6wc7GEbYX4T9/9dLBYsSpOiQbi/o9rdwuGg8
-        boaLzfBbeKyR//DwEo5hA8cJX5xXHIhNvrx6eXKzOcnSVEOKfPPVS7DVCDABJYqKF14/ur1OsLNG
-        EK4VDNYJdl+GU9FmtetIqXwhvKhLccksPhwV4b79flZ0viJwvzKn3e0rP/dU4QpHHSlfuA0uUy+y
-        uoCHmqedNc3jqmr3L/ZcZHjUTFUhkiE3uWDL+sbiNoZlzxEa7hbX1dCAyTqaeO2RCOmgeSSel20d
-        lYUtlT0XtKDKNVea2+U7i9io+/23vRU8YykY32mYxgjHDaHmPXOXrjjxUM0b7ux7L29H2GJesBtw
-        7PfKxXCk8WoZ6DqE0oGrx5SZUc7jQy5n+04yhNxNLzJuulj2dl7K2h2p5AiHF3Yj4ASYqZCh6y/v
-        +PDsl4Oj68ODvdHR6eh6dHLyxwnmh7fUYEHwwHgK5BhpXlri/BJuiJJiSZAyuHBGiVXkI9eMHGvI
-        kDNIYRCzvdeog+J18oLPPAhyfRt51ZuIvcPir+7UE67ANqRcMvH8UD171eUtcS4wunrt+ppKaE8X
-        ubu0a3E82GlwXI1J74Repdw+r08nm7ehcQW3n1k8w2GzgVxjvPK1V89z/yngZij0m9ksbKYBCQ7q
-        sRJKH1XR3IgCuqlG1liNRIoMVdVsleU4Dkv7Oui3WlL4UmOfK7WE8bScf8nV38aYWwEbEbn8xHIa
-        kT2lZhzIBbfIc5acQlxoIPuCpZ9ddbA4QsVMTJWx0SAYBP6EywSp1A936FVpcFgWD/O6VcTBKtog
-        X9Uk3+HP96X6KQ59joNQDdmiDnJYABliorj5O1sSGnSIA2ObxN7FCEWX+K+7TftlpK6P8Rx6Gbca
-        ekqnPsKYudZyHMwc/H082pvaTJRxV3bOnZ0zOZNq/rhIx1olBT71I5nixc6wTf4Yi+98lhXCeMmv
-        at61ak2V8tpAeEV8ckmNJX8WTFvQZGVyjSqsfNJS+9OHY3IaM7nmvJs53RjeZvUoj9OlsZAZzCPJ
-        FUewbUTlftkhV7GMcWm4hR7iEQtmpjeK6WTdiRf2hyucbUT/AgAA///sWW1L3EAQ/iuLICiYmLvL
-        eXcFsYe00A/SolBBhGOz2Xihd5uQF6NY/3uf2d3bxvRiixTxg+CHmN2dl83MM8/MXas5EyacgL0s
-        klKxUlassbFVARxLE18J4uuANctULNlaclVikZsdVgL8vVaRZFwIoKuM2W3KWY2EEcV9DnjCPqWk
-        KdR+y6IzfOsb3VqSQZdLqSi+GHdyM3Se8AiWkFsgeyxVSVas9RmWFYTZHKslQSbg+odUB2QYhKcV
-        M2yA8VXD78lFlnNtXV0ishlXrGUg+kYlVz6+eEk+Ow/NHVwrugTSRncEC6yF5cZEEljWuKCtlrZ8
-        bnl/jlxE9cGVkfc2Xpqm8bOGl7nOCiShvPPzZa4jGkoWkLmwuhe8Av2JasTUYu/r5fzim3dx5qFQ
-        61x1SvKMQpmyYY/H61Tts739nwiUVZV9QBj+yXHGrtB3i1wf+RmEbQCsCiC7JnBEybpbHQ3uLAR9
-        C6Fjqt0Tjmvoj6SZ1faNfdwj6GPHgdP5pGZ3IR0fgIslZb+pC2W9XnMqWjt/w2u6daKgWfHCCkdU
-        5AT5RsT5S3w8jkfTyTQaTAI5ErNAzMbDZDZIjqDHbYKGZ7ZJCol5HEMHqhxKXnz/sWUIAIVkPdv7
-        mlzxUUX1Ng1Ttv8KJYgejwdheDQR08l4NItENAmgPuEymYqT+FhL2R3Nd4ef8WfOeWuuLL56nnlV
-        +nXpNbgIb+gTcPt5Ha1SQTfl5ZyXdFE4r+sIaCIeT5EUfq7ozrt99Nu3uNuIv32Lu438W7cYGBWb
-        htFSwVOEPphMktRCpDqBCM9NO2oQ7gpkEBs/1UWWy8MrYI9Y/s40GiRh1aUuabBzte38MezD1bCv
-        qQxdU1lYfH+HkVcLmHcYeQ2L32FkC4x0YaCPqYWOkDn+AnduTFI+0MTbPgewJKu4HeR3pfRRsqAP
-        l4LhdoDrmwoFvQ70UjbnWfdEH5cb9S44kifVbVpkyhA58yqu7a9I5t9/ub3brPp/E1IjzAmFJrRp
-        3zM969mMNZECxuSHzaOtLy82QP/idriRe7Cz5nfnsqxXJLjlrJ7SFNW8Mo7TrJgmOeS6e//08PDJ
-        aXtAW/v4+PgLAAD//wMAyjI4KbQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18205","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205","key":"NTEST-1855","fields":{"statuscategorychangedate":"2025-04-30T18:26:03.561+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:03.293+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:03.376+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/271]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/271 (271)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 1e7226d0-51bf-4e3f-bf7d-569258f64807
+      - 82976acc-5999-4f58-a8a4-53641edd3548
       Atl-Traceid:
-      - 1e7226d051bf4e3fbf7d569258f64807
+      - 82976acc59994f58a8a453641edd3548
       Cache-Control:
       - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:17:04 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=298,atl-edge-internal;dur=15,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - 077135624e4d3c49d290fd93e511aa90
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpLlq1b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUglPW57QwR5C6HzYjKpUaMKtXt3mQxGet9Im1kMZETqxndG7v/BF9jvGoU1+o81mm6FNmD/
-        1yUrZ7UZ0Cr8XXKHvW+cjTAFoBlkMC42l4/F+qH8mW6GtooVEc8JGsEIXqITO+P2bbyy3HfJtjJu
-        qGOoGhpTf0WIiAGW56fmlQwJZMBmY6BjWJaMCT4VPIoBLiDCMe/jH7Avm/acpVAyEDQXwDMOy29W
-        tTdWuwhyOl8oCThDreg0R8m15hqUZsvpbFHpOUc218DOBMEkw23Ty/RC1HIw4c4pmdoHYk4VQfu6
-        Lcjx/LAnZ9Pk+r4kx08AAAD//wMAiwuGHiACAAA=
-    headers:
-      Atl-Request-Id:
-      - c1c36d00-c617-4698-b51d-30993e92ad15
-      Atl-Traceid:
-      - c1c36d00c6174698b51d30993e92ad15
-      Cache-Control:
-      - no-cache, no-store, no-transform
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:04 GMT
+      - Wed, 30 Apr 2025 16:26:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1156,7 +1162,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=173,atl-edge-internal;dur=19,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=308,atl-edge;dur=275,atl-edge-internal;dur=15,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Ufy4km4eMXu5svKICiD6Gf09ATbdTw-ySAhTBp1W5LeYFKg9-CW-dw==",cdn-downstream-fbl;dur=314
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1165,110 +1171,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Ufy4km4eMXu5svKICiD6Gf09ATbdTw-ySAhTBp1W5LeYFKg9-CW-dw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 5555424349b7317e715e08ff79eaa47b
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16100
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW/0/jNhT/V6z8tLG2+UIpXaRputGysTHGoIB0DCGTvKa+OnZmO7Qdx/++Z6dJ
-        j0LuBNNOJ3GNn9/3z/v4PXiwLKhIvdhTIFJQkB4y4KnuCJqD7uhkBjntyAIUNUwK3YGUmRwM7SQz
-        KjLgMuvcg9Iog/QMCgUahFnfTUptZD61Bm/DIAiDnoK/S9BmsirgVNHEsAS8jses/3CAV/BDA5/i
-        58yYQse+n8IUEpPKD7JHDadaMyp6AoyPnoxPC+ZHPtO6BL82MIcV6p9MxueTLp4N8MiFoL34wdMY
-        W6kTaiCTalXlkOIXakRBtNcNwm4YTKIgDvfjIOoNguF3QWXWOTEYuDPzxiCtvo/2gqhJe/2Rgk4U
-        K2zh8PQd0TnlvENSpg0TiSEFgwSInJKFVPOe1U6kuFD8lVGUgtl2UX5L76mhyr9nsPBdWJsA16Iw
-        2A2HP2r2D/yQY9vLHL1aWKDLCdVz26vyzthf8ZRyDR2vUjzCvJxux5sxBI5KZqtjuAeMNXjseIYh
-        sgpEiReLEnP0tmCyG9SCQskPmNEbC77WduV2DazLvQWSTVYXghmDBrTX+LZI/c3d1XJqFlRZvGqW
-        F5xhwOlW5tgPh7L+cNkfvjLcz3SmzqTpSz/YxzCi/jLq/79equ47LKLDcLDEcfoKDpe1x91ouRt9
-        DY9rgD8+Podj2IbTqE2wWwumbHlZkSPC4voGYZJlCjLkmy8OwV4twMwkLyteePnqoE2w3yKIWgXD
-        NsH3z8OpaLM6taTkXggv7ob4SQ0+HBXhvn5wKzrfELhfmVN2LN3PA1nawoWWlK/sAROZFxtVArYP
-        jZpL7Lgdzio4Z8/aVyyp6vjw7MzGisp6JkuejpguOF2th9tCQgEma/njpUdiNxzUj8R22Roq2xa0
-        gSpqQFUoJhUzqzcWsVb3+697K1hOM9C+1dC1EYYHXC56+j7bkOWxXNSk2veej03UDAGnd2Bp0eJ/
-        eyNog27YhtBwaOsxo3pcsOSYifmhlYygsNuLSOqeuU4unKw5EVKMcXmhdxzOgOoKB2r9yzs9vvj5
-        6OT2+OhgfHI+vh2fnf1xhvnhlGosCF6YzICcIv8LQ6xfwjSRgq8Icgnj1igxkvzKFCWnCnIkE1Jq
-        xGzvJU4JcZy84CMLgkKp2KveROwdFn8zU0+4AtuQMUH59qX17rUur0M1x+hqusG+ZgKa22Vhh7YV
-        x8Nm2anWpDdCr1Ju3t2nm83r0LiB2080meOyWUOuNl75Oljvc/8p4Hop9OvdLKrXBAEW6onkUp1U
-        0dzxErqZQo7YrESSjGTVbJkXuA4L8zLo99pIYa8hhc91/Gk5/xKbfzsTZjjsxOT6PS2imBxIOWdA
-        rphBVjPkHJJSATnkNPtoq4PF4TKhfCa1iYfBMPCnTKRIpX60H904gyNXPMzrgyQWVvEO+aIm+Qb/
-        fOvUz3HpsxyEasgW6yBHJZAR5oOHv9MVCYMOsWBskji4GqPoGv/rDsK+i9T2MVlAL2dGQU+qzEcY
-        U9tahhubhb+PV3szk3MXd2Xn0tq5EHMhF58W6VTJtMQdYCwyHOwc2+RPsMbWp6sQxkt+kYuukS1V
-        KtYGohvik+tQG/JnSZUBRTYmW1Rh4zN02u/fnZLzhIqW+3YZtWt4k9UneZyvtIFcYx5pIRmCbSd2
-        565DtmI5ZUIzAz3EIxZMz+4kVWnbjWf2Rxuc7cT/AgAA///sWW1r2zAQ/iuiUGihdp3EWZJB6ULZ
-        YB/KRgsrlEKQZbkxi2Xjl7ql63/vc5KipV7cjTJKPxTywYmku9P57rnnLldqzoQJJ2Avi6RUrJI1
-        a21s1QDHysRXgvg6YO0yFUuWSa4qLHKzw0rAfa9UJBkXAugqY3aTctYgYUR5VwCesE8pacqyv2HR
-        Kd71tW4tyaCLpVQUX4w7uTk6T9wIltC1wAJZqpK8zPQZlpeE2RyrFUEm4PqnVAdkGISnNTO1n/FV
-        y+/oiqzg2rqmQmQzrtiGgegblVz5eOMV3dnd0PjgSpETSBv5CBZYC6u1iSSwauCgrZZu3Hnj9mfI
-        RVQfuIxub+OlbVs/b3lV6KxAEspbv1gWOqKhZAGZC6t7wWuQnahBTC32vl3Mz79756ceCrXOVaek
-        yCmUKRv2eJylap/t7f9CoKzq/CPC8E+OM3aFvlvk+nBuEPYtONJLAFiXgHzN7IiZdbaGjpB2FgIn
-        o7vQxzUCxzX029OUa/vGPnYcOGOe1OwucuMFcLGk7Dd1oWqyjFPR2vkbXpPXiYLm5QsrHFGRY+Qb
-        Eeev8dE4Hk0n02gwCeRIzAIxGw+T2SChUYnbBA3PbJMUEvM4hg5UOZS8+O7ThiEAFJL1bFNscsVH
-        FdXbNEzZxiyUIHo8HoThh4mYTsajWSSiSQD1CZfJVBzHR1rK7mi+O/yCjznnZVxZfPU881PlN5XX
-        whHe0Cfg9osmWqWCPOUVnFfkKJzXdQQ0EY8nSAq/UOTzboP99i3uduhv3+Juh//WLQYUxaY9tFTw
-        BKEPJpMkjRCpTiDCc9OOGiC7BBnExs9NmRfy8BIQI5a/M40mTFh1qUsa7FxtO38M+3A17Gsqw75J
-        Reiwu7TA/44vrxZJ7/jyGha/48sWfOnCgCNkjr/A6muTe/c0CrfPARTmNbeD/K6UXubVi0u9lGy4
-        Hfn6pkJBHwclQNi6EPRx0FHfiZEjeVLdpGWuDJEzP8WN/RfJfP0n7+WZkXC/frRw/wL43fgD7HAt
-        92An47dnsmpWJHhDtx6alPW8Nnbc5PX/m9QaYU4odKFd/JHrmdN6mEqzYprkkEpnyFNrh0/MtQe0
-        ex4eHh4BAAD//wMAx2eGaLQcAAA=
-    headers:
-      Atl-Request-Id:
-      - b6ba0bce-0d7e-4d3d-bdf8-763d23cec8dd
-      Atl-Traceid:
-      - b6ba0bce0d7e4d3dbdf8763d23cec8dd
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:17:04 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=438,atl-edge-internal;dur=15,atl-edge-upstream;dur=423,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - c7a880de3628bcc1c73be6b7bfb9a123
+      - ef418bff39541c3eb824faa020f5fa32
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1295,26 +1209,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmB5AjSBZcUYz2Y8C2KACwhwyLvwBxyqtjtnKVQMOC045Ckrlt+s
-        7G6MsgHM6HwhBWCOStJZgSJTKlMgFVvO8kWt5hmyuQJ2JvA6Gm7bQcQXohKj9ndWitg+EH2qCJrX
-        bUmO54c9WRMn1/cVOX4CAAD//wMACuWOgyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:08.426+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 78ced468-51e5-4d1f-b4af-1068d6deffea
+      - 39275c83-af52-4f01-894d-2a8b81dd94fd
       Atl-Traceid:
-      - 78ced46851e54d1fb4af1068d6deffea
+      - 39275c83af524f01894d2a8b81dd94fd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:05 GMT
+      - Wed, 30 Apr 2025 16:26:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1324,7 +1234,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=145,atl-edge-internal;dur=13,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=194,atl-edge;dur=162,atl-edge-internal;dur=13,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="asPz7mdb6wd00b2skJXscbzSNm8SIn_AAUWTaCWDqceh3nP2knNUCg==",cdn-downstream-fbl;dur=199
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1333,10 +1243,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 cbe94ab27088fc4bb73abf8e3179b3d2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - asPz7mdb6wd00b2skJXscbzSNm8SIn_AAUWTaCWDqceh3nP2knNUCg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 05a1893a92f2afca29fdf4629bee1e9f
+      - cd6574bebc37cb00c7a54d7865381208
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1360,61 +1278,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16099
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18207
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW/U/jNhj+V6z8tLG2iUMLJdI03WjZuDHGoHDSsRMyydvU1LEz26HtOP73vc5H
-        y1fuBNNOSCX26/f78eP3zoNlzmTiRZ4GmYCG5ICDSExHsgxMx8QzyFhH5aCZ5UqaDiTcZmBZJ54x
-        mYJQaecWtEEZJKeQazAgbX02LoxV2dQZvKJBQIOehr8LMHayyuFEs9jyGLyOx51/uhPs7eHCgJji
-        cmZtbiLfT2AKsU3UjeoxK5gxnMmeBOujJ+uznPuhz40pwG8MzGGF+seT8dmkS3foALfKEIwX3XkG
-        YytMzCykSq+qHBJcoUYYhINuQLs0mIRBRHejIOgNwsEPGHfggnROLAZemnljkE7fR3tBuE67XiRg
-        Ys1zVzjcfUdMxoTokIQby2VsSc4hBqKmZKH0vOe0YyXPtXhlFIXkrl1MXLFbZpn2bzks/DKsTYC1
-        iAbbdPiT4f/Ajxm2vcjQq4MFupwwM3e9Kq6t+4qmTBjoeJXiIeZV6na8GUfg6Hi2OoJbwFiD+45n
-        OSIrR5R4kSwwR+8JTLaDRpBrdYMZvbHgtXZZ7rKBTbnd4gFINlmdS24tGjDe2rdD6m/lWaOmdsG0
-        w6vhWS44Bpw8yRz7UaKsP1z2h68M9wudaTJZ96Uf7GIYYX8Z9v9fL1X3SyyiQ7qzpDvfwuGy8bgd
-        LrfDb+GxBvj9/XM40jachm2C7UYw5cuLihwRFpefECZpqiFFvvnqJRg0AsxMiaLihZeP7rQJdlsE
-        Yatg2CbYex5ORZvVriOl8oXwoi7FJbP4cFSE+/qLW9H5hsD9ypx217L83FeFKxx1pPzBbXCZepHV
-        BdzXPO2saR5XVbt7tuciw6NmpgqRjLjJBVvVVxm3MSx7gZhx17uuhgZM1vHHS49ESIfNI/G0bGsq
-        eypoA1W4BlWuudLcrt5YxEbd77/ureAZS8H4TsM0RjhuCLXomdt0Q5ZHatGQat97fm3C9SUQ7Boc
-        LTr8P50I2qBL2xBKh64eM2bGOY+PuJwfOMkIcje9yLjpYtnbRSlb70glxzi8sGsBp8BMhQxdf3kn
-        R+e/HB5fHR3uj4/Pxlfj09M/TjE/vKUGC4IHJjMgJ8j/0hLnl3BDlBQrglzChTNKrCLvuWbkREOG
-        ZEIKg5jtvcQpFK+TF3zmQZDrm8ir3kTsHRZ/c6cecQW2IeWSiaeH6tmrLm+Jc4HRNXSDfU0lrE8X
-        ubu0rTge7jY4rsakN0KvUl6/u48nm9ehcQO3n1k8x2GzgVxjvPK1X89z/yngZij0m9ksbMYECQ7q
-        sRJKH1fRXIsCuqlG1tiMRIqMVNVsleU4Dkv7MugHbaQwWJPClzr+uJx/yc3f1oRbAVsRufzIchqR
-        faXmHMgHbpHnLDmDuNBADgRLP7vqYHGEipmYKWOjYTAM/CmXCVKpH+7ST6XBUVk8zOtGEQeraIt8
-        VZN8hz/fl+pnOPQ5DkI1ZIs6yFEBZIT54ObvbEVo0CEOjOsk9j+MUXSJ/7o7tF9G6voYL6CXcauh
-        p3TqI4yZay3Hic3B38ejvZnNRBl3ZefC2TmXc6kWD4t0olVS4Awwlile7Azb5E+wxs5nWSGMl/yq
-        Fl2rWqqU1wbCT8Qnl9RY8mfBtAVNNiZbVGHjk5baH9+dkLOYyZbzbhh1Y/g6qwd5nK2MhcxgHkmu
-        OIJtKyr3yw65imWMS8Mt9BCPWDAzu1ZMJ20nntkfbXC2Ff0LAAD//+xZbWvbMBD+K6JQaKF2ncRp
-        kkHpQtlgH8pGCyuUQpBluTGLZeOXuqXrf99zkqKlXtyNMko/FPLBiaS70/nuuecu12rOhAknYC+L
-        pFSskjVrbWzVAMfKxFeC+Dpg7TIVS5ZJrioscrPDSsB9r1UkGRcC6Cpjdpty1iBhRHlfAJ6wTylp
-        CrW/YdEZ3vWNbi3JoMulVBRfjDu5OTpP3AiW0LXAAlmqkrzM9BmWl4TZHKsVQSbg+odUB2QYhKc1
-        M2yA8VXL7+mKrODauqZCZDOu2IaB6BuVXPl44xXd2d3Q+OBakRNIG/kIFlgLq7WJJLBq4KCtlm7c
-        eeP258hFVB+4jG5v46VtWz9veVXorEASyju/WBY6oqFkAZkLq3vBa9CfqEFMLfa+Xs4vvnkXZx4K
-        tc5Vp6TIKZQpG/Z4nKVqn+3t/0SgrOr8A8LwT44zdoW+W+T6cG4Q9i040ksAWJeAfM3siKt1toaO
-        kHYWAieju9DHNQLHNfTb05Rr+8Y+dhw4Y57U7C5y4wVwsaTsN3WharKMU9Ha+Rtek9eJgublCysc
-        UZET5BsR5y/x8TgeTSfTaDAJ5EjMAjEbD5PZIDmCHrcJGp7ZJikk5nEMHahyKHnx/ccNQwAoJOvZ
-        ptjkio8qqrdpmLKNWShB9Hg8CMOjiZhOxqNZJKJJAPUJl8lUnMTHWsruaL47/IyPOedlXFl89Tzz
-        U+U3ldfCEd7QJ+D2iyZapYI85RWcV+QonNd1BDQRj6dICr9Q5PNug/32Le526G/f4m6H/9YtBhTF
-        pmG0VPAUoQ8mkySNEKlOIMJz044aILsCGcTGT02ZF/LwChAjlr8zjSZMWHWpSxrsXG07fwz7cDXs
-        ayrDvklF6LC7tMD/ji+vFknv+PIaFr/jyxZ86cKAI2SOv8DqG5N7DzQKt88BFOY1t4P8rpRe5tWL
-        S72UbLgd+fqmQkEfByVA2LoQ9HHQUd+JkSN5Ut2mZa4MkTM/xY39F8l8/Sfv5ZmR8LB+tHD/Avjd
-        +APscC33YCfjd+eyalYkeEO3HpqU9bw2dtzm9f+b1BphTih0oV38nuuZ03q8SrNimuSQSmfIU2uH
-        T8y1B7R7Hh8ffwEAAP//AwCer6+ItBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18207","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207","key":"NTEST-1856","fields":{"statuscategorychangedate":"2025-04-30T18:26:06.368+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:06.100+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:06.179+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/272]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/272 (272)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f3f8f2a4-045b-441c-9a7e-97317e83cfe8
+      - fd42bacc-ba5d-4c01-9605-eb0fdfd44741
       Atl-Traceid:
-      - f3f8f2a4045b441c9a7e97317e83cfe8
+      - fd42baccba5d4c019605eb0fdfd44741
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:05 GMT
+      - Wed, 30 Apr 2025 16:26:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1424,7 +1325,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=13,atl-edge-upstream;dur=281,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="3U1x8PPu_49BKbYGoG-l-51dIFE0QkA_IWx1gIBNb8i7exldANJ6ug==",cdn-downstream-fbl;dur=333,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=331,atl-edge;dur=246,atl-edge-internal;dur=21,atl-edge-upstream;dur=226,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1433,10 +1334,181 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 3U1x8PPu_49BKbYGoG-l-51dIFE0QkA_IWx1gIBNb8i7exldANJ6ug==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - bf978fe113546348acef33da80ac6899
+      - 0d4e716dcddcb7ab66d4948b3523e36e
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:09.263+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
+    headers:
+      Atl-Request-Id:
+      - 2e647762-cfc4-43c5-8f8b-74fc7dbd5bfc
+      Atl-Traceid:
+      - 2e647762cfc443c58f8b74fc7dbd5bfc
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:09 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="WpBRYPrXl6GkIVWoy-KUAaxcxXC7w6JdyWbiHdPXECxYzPSJdR2OSg==",cdn-downstream-fbl;dur=237,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=235,atl-edge;dur=158,atl-edge-internal;dur=15,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 f6567fa2210130239a3a2c737c9517ac.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - WpBRYPrXl6GkIVWoy-KUAaxcxXC7w6JdyWbiHdPXECxYzPSJdR2OSg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
+      X-Arequestid:
+      - 18d45538a97fb110da08fc1b5a1f7c95
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18205
+  response:
+    body:
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18205","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205","key":"NTEST-1855","fields":{"statuscategorychangedate":"2025-04-30T18:26:03.561+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:03.293+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:03.376+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/271]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/271 (271)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
+    headers:
+      Atl-Request-Id:
+      - afebda4f-d63f-4eca-9a2c-a52e5157c71c
+      Atl-Traceid:
+      - afebda4fd63f4eca9a2ca52e5157c71c
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:09 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=346,atl-edge;dur=312,atl-edge-internal;dur=29,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="byrS_FdTAOUIDGiTpiSEfnjHmgGK_9QeNhtFjxwySeS_DZQ86bMt6g==",cdn-downstream-fbl;dur=353
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 535c2b5354e6ba6798fd64420ee97a2c.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - byrS_FdTAOUIDGiTpiSEfnjHmgGK_9QeNhtFjxwySeS_DZQ86bMt6g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - 030d0bab8b1e6aa41b0525f433facc96
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1463,41 +1535,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 20c70270-4686-4550-a100-33025cec99ed
+      - b968576d-5495-47f7-b0c4-1ca872875bb1
       Atl-Traceid:
-      - 20c7027046864550a10033025cec99ed
+      - b968576d549547f7b0c41ca872875bb1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:06 GMT
+      - Wed, 30 Apr 2025 16:26:10 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1507,7 +1566,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=314,atl-edge-internal;dur=13,atl-edge-upstream;dur=302,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="YzXp175MzjCgROfU89wXtkH0xxNELNqxn5qEQV-gW1eOTHbpoFlVqw==",cdn-downstream-fbl;dur=382,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=380,atl-edge;dur=306,atl-edge-internal;dur=26,atl-edge-upstream;dur=281,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1516,13 +1575,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 bbfdc39b99d2b072cca90c3f38450aea.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - YzXp175MzjCgROfU89wXtkH0xxNELNqxn5qEQV-gW1eOTHbpoFlVqw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 83b6a4047d23b177aac97e5d1912e36f
+      - 5298cd169dc07b03ed6238cbc9f4afb9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1535,7 +1602,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/271]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/271 (271)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1543,7 +1610,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -1555,27 +1622,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1288'
+      - '1308'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16099
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18205
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 78ec9cff-63e7-4672-a3d0-42ca3cdd84d9
+      - 498b83bf-7643-4094-9873-984ee632cf2b
       Atl-Traceid:
-      - 78ec9cff63e74672a3d042ca3cdd84d9
+      - 498b83bf764340949873984ee632cf2b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:06 GMT
+      - Wed, 30 Apr 2025 16:26:10 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1585,17 +1654,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=255,atl-edge-internal;dur=13,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="Q1xLFId7OvgLMB_b2KnkEx1nReSCTjsWzWv3b5y4Cmi7rb5rircwyg==",cdn-downstream-fbl;dur=378,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=374,atl-edge;dur=290,atl-edge-internal;dur=17,atl-edge-upstream;dur=274,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9832e15ad117dafc81b031983cbde91e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Q1xLFId7OvgLMB_b2KnkEx1nReSCTjsWzWv3b5y4Cmi7rb5rircwyg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - f12f7f289311ee290fe8c9531e138999
+      - 3a2bd0951f4a3b777c6d59084f7b96b0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1619,61 +1696,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16099
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18205
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxt4lCgRJqmO1o27hhjUEC6DCGTnKamjp3ZDm3H5b/vOG/l
-        rfcKpl0hldjH5/3x43PvwSJnMvEiT4NMQEOyz0EkpiNZBqZj4ilkrKNy0MxyJU0HEm4zsKwTT5lM
-        Qai0cwfaoAySE8g1GJC2PhsXxqps4gxe0yCgQU/D3wUYO17mcKxZbHkMXsfjzj/dDnZ3cWFATHA5
-        tTY3ke8nMIHYJupW9ZgVzBjOZE+C9dGT9VnO/dDnxhTgNwZmsET9o/HodNyl23QLt8oQjBfdewZj
-        K0zMLKRKL6scElyhRhiEW92AdmkwDoOI7kRB0NsKt37AuAMXpHNiMfDSzDuDdPo+2gvCNu16kYCJ
-        Nc9d4XD3AzEZE6JDEm4sl7ElOYcYiJqQudKzntOOlTzT4o1RFJK7djFxze6YZdq/4zD3y7BWAdYi
-        GmzSwU+G/wM/Ztj2IkOvDhbocszMzPWquLHuK5owYaDjVYoHmFep2/GmHIGj4+nyEO4AYw0eOp7l
-        iKwcUeJFssAcvWcw2QzWCWgjyLW6xVTf2Ylau+xD2dmmD27xCD2rdM8ktxYNGK/17SD8W3nWqImd
-        M+2AbHiWC44BJ89Kgo0q4dcfLPqDN4b7hZY1mbQN6wc7GEbYX4T9/9dLBYsSpOiQbi/o9rdwuGg8
-        boaLzfBbeKyR//DwEo5hA8cJX5xXHIhNvrx6eXKzOcnSVEOKfPPVS7DVCDABJYqKF14/ur1OsLNG
-        EK4VDNYJdl+GU9FmtetIqXwhvKhLccksPhwV4b79flZ0viJwvzKn3e0rP/dU4QpHHSlfuA0uUy+y
-        uoCHmqedNc3jqmr3L/ZcZHjUTFUhkiE3uWDL+sbiNoZlzxEa7hbX1dCAyTqaeO2RCOmgeSSel20d
-        lYUtlT0XtKDKNVea2+U7i9io+/23vRU8YykY32mYxgjHDaHmPXOXrjjxUM0b7ux7L29H2GJesBtw
-        7PfKxXCk8WoZ6DqE0oGrx5SZUc7jQy5n+04yhNxNLzJuulj2dl7K2h2p5AiHF3Yj4ASYqZCh6y/v
-        +PDsl4Oj68ODvdHR6eh6dHLyxwnmh7fUYEHwwHgK5BhpXlri/BJuiJJiSZAyuHBGiVXkI9eMHGvI
-        kDNIYRCzvdeog+J18oLPPAhyfRt51ZuIvcPir+7UE67ANqRcMvH8UD171eUtcS4wunrt+ppKaE8X
-        ubu0a3E82GlwXI1J74Repdw+r08nm7ehcQW3n1k8w2GzgVxjvPK1V89z/yngZij0m9ksbKYBCQ7q
-        sRJKH1XR3IgCuqlG1liNRIoMVdVsleU4Dkv7Oui3WlL4UmOfK7WE8bScf8nV38aYWwEbEbn8xHIa
-        kT2lZhzIBbfIc5acQlxoIPuCpZ9ddbA4QsVMTJWx0SAYBP6EywSp1A936FVpcFgWD/O6VcTBKtog
-        X9Uk3+HP96X6KQ59joNQDdmiDnJYABliorj5O1sSGnSIA2ObxN7FCEWX+K+7TftlpK6P8Rx6Gbca
-        ekqnPsKYudZyHMwc/H082pvaTJRxV3bOnZ0zOZNq/rhIx1olBT71I5nixc6wTf4Yi+98lhXCeMmv
-        at61ak2V8tpAeEV8ckmNJX8WTFvQZGVyjSqsfNJS+9OHY3IaM7nmvJs53RjeZvUoj9OlsZAZzCPJ
-        FUewbUTlftkhV7GMcWm4hR7iEQtmpjeK6WTdiRf2hyucbUT/AgAA///sWW1L3EAQ/iuLICiYmLvL
-        eXcFsYe00A/SolBBhGOz2Xihd5uQF6NY/3uf2d3bxvRiixTxg+CHmN2dl83MM8/MXas5EyacgL0s
-        klKxUlassbFVARxLE18J4uuANctULNlaclVikZsdVgL8vVaRZFwIoKuM2W3KWY2EEcV9DnjCPqWk
-        KdR+y6IzfOsb3VqSQZdLqSi+GHdyM3Se8AiWkFsgeyxVSVas9RmWFYTZHKslQSbg+odUB2QYhKcV
-        M2yA8VXD78lFlnNtXV0ishlXrGUg+kYlVz6+eEk+Ow/NHVwrugTSRncEC6yF5cZEEljWuKCtlrZ8
-        bnl/jlxE9cGVkfc2Xpqm8bOGl7nOCiShvPPzZa4jGkoWkLmwuhe8Av2JasTUYu/r5fzim3dx5qFQ
-        61x1SvKMQpmyYY/H61Tts739nwiUVZV9QBj+yXHGrtB3i1wf+RmEbQCsCiC7JnBEybpbHQ3uLAR9
-        C6Fjqt0Tjmvoj6SZ1faNfdwj6GPHgdP5pGZ3IR0fgIslZb+pC2W9XnMqWjt/w2u6daKgWfHCCkdU
-        5AT5RsT5S3w8jkfTyTQaTAI5ErNAzMbDZDZIjqDHbYKGZ7ZJCol5HEMHqhxKXnz/sWUIAIVkPdv7
-        mlzxUUX1Ng1Ttv8KJYgejwdheDQR08l4NItENAmgPuEymYqT+FhL2R3Nd4ef8WfOeWuuLL56nnlV
-        +nXpNbgIb+gTcPt5Ha1SQTfl5ZyXdFE4r+sIaCIeT5EUfq7ozrt99Nu3uNuIv32Lu438W7cYGBWb
-        htFSwVOEPphMktRCpDqBCM9NO2oQ7gpkEBs/1UWWy8MrYI9Y/s40GiRh1aUuabBzte38MezD1bCv
-        qQxdU1lYfH+HkVcLmHcYeQ2L32FkC4x0YaCPqYWOkDn+AnduTFI+0MTbPgewJKu4HeR3pfRRsqAP
-        l4LhdoDrmwoFvQ70UjbnWfdEH5cb9S44kifVbVpkyhA58yqu7a9I5t9/ub3brPp/E1IjzAmFJrRp
-        3zM969mMNZECxuSHzaOtLy82QP/idriRe7Cz5nfnsqxXJLjlrJ7SFNW8Mo7TrJgmOeS6e//08PDJ
-        aXtAW/v4+PgLAAD//wMAyjI4KbQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18205","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205","key":"NTEST-1855","fields":{"statuscategorychangedate":"2025-04-30T18:26:03.561+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:03.293+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:03.376+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/271]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/271 (271)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1855/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18205/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 1eeed80d-f14c-4f87-9e37-1372d09f931e
+      - e7ed4f55-2632-4843-9557-c8f390a901d4
       Atl-Traceid:
-      - 1eeed80df14c4f879e371372d09f931e
+      - e7ed4f55263248439557c8f390a901d4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:06 GMT
+      - Wed, 30 Apr 2025 16:26:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1683,7 +1743,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=322,atl-edge-internal;dur=14,atl-edge-upstream;dur=308,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=297,atl-edge;dur=265,atl-edge-internal;dur=15,atl-edge-upstream;dur=250,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="T9JXJvJjSPmmR-XGhksRzVIvJuOVz0TefpHYWk1R2kn7HQaBFfcSBw==",cdn-downstream-fbl;dur=301
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1692,10 +1752,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e9bcf307d6ed54e3e501e39bc538dcfc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - T9JXJvJjSPmmR-XGhksRzVIvJuOVz0TefpHYWk1R2kn7HQaBFfcSBw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 1c8d7ef81d2f4b688e2bdf88ff0500ec
+      - 68d0c8efcca84104f6a0f8a7b35a34ec
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1722,26 +1790,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmB5AjSBZcUYz2Y8C2KACwhwyLvwBxyqtjtnKVQMOC04FCml+Tcr
-        uxujbAAzOl9IAZijknRWoMiUyhRIxZazfFGreYZsroCdCbyOhtt2EPGFqMSo/Z2VIrYPRJ8qguZ1
-        W5Lj+WFP1sTJ9X1Fjp8AAAD//wMAXR237CACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:11.414+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - ee48b4f8-bb77-4d69-8d25-5f926f094a90
+      - 282b00c3-2cfb-4fd9-a24d-fd8bced100a4
       Atl-Traceid:
-      - ee48b4f8bb774d698d255f926f094a90
+      - 282b00c32cfb4fd9a24dfd8bced100a4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:07 GMT
+      - Wed, 30 Apr 2025 16:26:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1751,7 +1815,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=200,atl-edge-internal;dur=12,atl-edge-upstream;dur=189,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=191,atl-edge;dur=158,atl-edge-internal;dur=13,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="U6eF5wSBR9Vd_iHBol0wWd0Cper4JmnvHvMbV4wfAQyJkcBJhdFPVg==",cdn-downstream-fbl;dur=194
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1760,10 +1824,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 7d27498ef63e76e5a81975299a76fae4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - U6eF5wSBR9Vd_iHBol0wWd0Cper4JmnvHvMbV4wfAQyJkcBJhdFPVg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a766c4d28f92e598708ef018820af871
+      - 69763d68dc297c4001326cc66cd9f14c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1787,61 +1859,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16100
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18207
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvcR1PAHD0MXuli7LssRJgWZFwEhnmTVFaiQV22vz33ek
-        XtzaUYdkWFEgtXi8t+eeO94HD9YFFakXewpECgrSVwx4qnuC5qB7OllATnuyAEUNk0L3IGUmB0N7
-        yYKKDLjMevegNMogvYBCgQZh6rtJqY3M59bgbRgEYTBQ8FcJ2sw2BZwrmhiWgNfzmPUfjvAKfmjg
-        c/xcGFPo2PdTmENiUvleDqjhVGtGxUCA8dGT8WnB/MhnWpfgNwaWsEH9s9n0ctbHsxEeuRC0F3/w
-        NMZW6oQayKTaVDmk+IUaURC96AdhPwxmURCHR3EQDUbB+LugMuucGAzcmXlmkFbfR3tB1KZdf6Sg
-        E8UKCxyeviQ6p5z3SMq0YSIxpGCQAJFzspJqObDaiRRXij8xilIwWy7Kb+k9NVT59wxWvgtrG2At
-        CoPDcPyjZn/DDzmWvczRq6UFupxRvbS1Ku+M/RXPKdfQ8yrFE8zL6fa8BUPiqGSxOYV7wFiDh55n
-        GDKrQJZ4sSgxR2+HJodBIyiUfI8ZPRPwWtvB7QrYwL1Dkm1WV4IZgwa01/q2TP3V3dVyblZUWb5q
-        lhecYcDpTuZYD8ey4Xg9HD8x3C9UpsmkrcswOMIwouE6Gv6/XqrqOy6iw3C0xnb6Cg7XjcfDaH0Y
-        fQ2PNcEfHvbpGHbxNGoEc7a+rmYgVv/m3f7Nw+YmzTIFGc6bvSbABCQvq/Z/3N2LLsGoS3DUIYg6
-        BeMuwff7cVZjszq1Q8m9EF7cD+tZaUuiWFKl9GHvzDYKoq0XsuTphOmC003dTni8ogafnmpkP731
-        qwdh+wT4lTllG9v9PJalhd6F+sYeMJF5sVGl9Y1GzTVyxrZ3jYYCTNbOj8ceicNw1DwSu7C1o2xX
-        0EWqqCVVoZhUzGyeCUGj7g+f9lawnGagfauhGyMMD7hcDfR9th2Wp3LVDNWht982Uct5Tu/AjsVH
-        GsNOk0dhCLsYGo4tHguqpwVLTplYvrKSCRR2exFJwyDHq5WTtSdCiikuL/SOwwVQXbFS1b+889Or
-        n0/Obk9Pjqdnl9Pb6cXF7xeYH3apRkDwwmwB5BznvzDE+iVMEyn4huAsYdwaJUaS10xRcq4gx2FC
-        So2MGzw2U0JsJy/4yIKgUCr2qjcRa4fgb3vqs1mBZciYoHz3Ur171fA63nOMrv62dc0EtLfLwjZt
-        J4/H7bJTrUnPpF6l3L67n282T2Pjlm4/0WSJy2ZDucZ45eu43uf+U8DNUug3u1nUrAkCLNUTyaU6
-        q6K54yX0M4UTa7sSSTKRVbFlXuA6LMzjpH/RDoUvFXZXqR0Yn8P5p9j+O5gxw+EgJjdvaRHF5FjK
-        JQPyhhmcsYZcQlIqIK84zT5adBAcLhPKF1KbeByMA3/ORIqD0I+OonfO4MSBh3m9l8TSKj4g/6pJ
-        vsE/3zr1S1z67AxCNZwWdZCTEsgEE8XD3+iGhEGPWDK2SRy/maLoBv/rj8Khi9TWMVnBIGdGwUCq
-        zEcaU1tahhubpb+PVwcLk3MXd2Xn2tq5EkshV5+CdK5kWuIOMBUZNnaOZfJnCL716RDCeMkvctU3
-        sgOlojYQvSM+uQm1IX+UVBlQZGuyQxW2PkOn/fblOblMqOi4b5dRu4a3WX2Sx+VGG8g15pEWkiHZ
-        DmJ37ipkEcspE5oZGCAfETC9uJNUpV039uxPtjw7iP8BAAD//+xZbUsbQRD+K4sgKHjnJbk0SUFs
-        kBb6QVoUKogQNnt75miyd9yLp1j/u8/sbrbxmrVFivhB8MN5uzs7MzfzzDOTKzVlwoQTsJfNpVSs
-        kjVrbWzVAMfKxFeK+Dpg7SITC7aSXFVY5GaHlQB7r9RcMi4E0FUm7CbjrEHCiPKuADxhn1LSkIRw
-        Q6NTfOtr3VqSQhcLqSi+GHdyc3SesAiakFlggSxTaV6u9BmWl4TZHKsVQSbg+qdUB6QYhGc1M0yE
-        8WXL78hEVnCtXVMhshlXbENB9I1KLkN88YpsdhYaH1wpcgLdRj6CBlbDaq0iCawaOGirphs2b1h/
-        hlxE9YHLyHobL23bhnnLq0JnBZJQ3obFotARjUtmkDmzd894Deo1bxBTs71vF9Pz78H5aYBCrXPV
-        XVLkFMqUDXs8WWVqn+3t/0KgLOv8I8LwT44zdIW+W+R85KcX+xYcxSVkrEtAvuZlxBM7WyMfG44d
-        U+2ecFxDfyTNrLZv9HGPyMeOI3cnfMzFghLcFuDNGt6F+KpZrTgVrZ2/4TV5nShoXr6wwhEVOUa+
-        Ee39mhwNk8F4NJ73RpEciEkkJsN+OumlNCpxm3DDM9skhcQ0SXAHqhxKXnL3aUMRAArJerYpNrkS
-        oorqbRqmbGMWSxA9nvTi+MNIjEfDwWQu5qMI16dcpmNxnBxpKbuD6W7/C/7MuWDFlcXXIDCvqrCp
-        ghaOCPohAXdYNPNlJshTQcF5RY7CeV1HQBPxeIKkCAtFPu822G9f426H/vY17nb4b11jQFFimlVL
-        BU8Q+mAyadoIkekEIjw3zaQBskuQQWz83JR5IQ8vgT1i8TvTaMKEVZe6dIOdq23nj7EPV2NfUxm7
-        prK0+P4OI68WMO8w8hoav8PIFhjpwoCPqcWOkDm+AnOuTVLe0yjcPkfQJK+5HeR3pfgoWeTDpai/
-        HeB8U6HIa4CXsvmoJkHI1oWBd8GRPKlusjJXhuWZV0ljf0Uy//6L927y+v/NN40wJxQ3oU37ketZ
-        z3qkihQwKt+vH219ebEC+he3w7Xcg50Vvz2TVbMkwRvG6ilNWU9rYzjNimmSQ6a7908P95+ctge0
-        tg8PD48AAAD//wMAP03ECbQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18207","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207","key":"NTEST-1856","fields":{"statuscategorychangedate":"2025-04-30T18:26:06.368+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:06.100+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:06.179+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/272]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/272 (272)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - db61f9ca-083b-412d-9281-4f40eafb590a
+      - d89d107c-387d-4c8b-8939-51db83ba1da6
       Atl-Traceid:
-      - db61f9ca083b412d92814f40eafb590a
+      - d89d107c387d4c8b893951db83ba1da6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:07 GMT
+      - Wed, 30 Apr 2025 16:26:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1851,7 +1906,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=296,atl-edge-internal;dur=13,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="ILffLxF2QkcFNhfjza3jfb00hj5XDXIKJlOg0vkieP8-iTDoFSeF-A==",cdn-downstream-fbl;dur=383,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=69,cdn-upstream-fbl;dur=380,atl-edge;dur=286,atl-edge-internal;dur=19,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1860,10 +1915,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c8780798b589dc6b55523ca0a9bc3c02.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ILffLxF2QkcFNhfjza3jfb00hj5XDXIKJlOg0vkieP8-iTDoFSeF-A==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 819e7e5d3f3c11acb46456269efc2eb0
+      - 59dbed23b594feecc38abf2d1579277e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1890,41 +1953,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 8e43342c-4704-4a69-9a46-9582fd6aedcc
+      - 722a88f2-1a92-4816-bc93-2cb59ce33852
       Atl-Traceid:
-      - 8e43342c47044a699a469582fd6aedcc
+      - 722a88f21a924816bc932cb59ce33852
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:07 GMT
+      - Wed, 30 Apr 2025 16:26:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1934,7 +1984,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=381,atl-edge-internal;dur=21,atl-edge-upstream;dur=359,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=348,atl-edge;dur=314,atl-edge-internal;dur=15,atl-edge-upstream;dur=296,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0BCQ00VeXksgZJ0pEyWCMESvbVSfW74h4wI5bSTFMkNH512BmjChPw==",cdn-downstream-fbl;dur=352
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1943,13 +1993,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 895116b5366f3f5264f7b6361d3fd564.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0BCQ00VeXksgZJ0pEyWCMESvbVSfW74h4wI5bSTFMkNH512BmjChPw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f918445acee8e0353774db10a40ef3ef
+      - 9e917f74226065a9fd824a215e155482
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1962,7 +2020,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/272]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/272 (272)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1970,7 +2028,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -1982,27 +2040,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1288'
+      - '1308'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16100
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18207
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 4dd46d96-4c8c-46d1-9d6b-17ad8e70a35b
+      - 2d81abdf-55b8-48e2-a402-ad90c1ddd95e
       Atl-Traceid:
-      - 4dd46d964c8c46d19d6b17ad8e70a35b
+      - 2d81abdf55b848e2a402ad90c1ddd95e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:08 GMT
+      - Wed, 30 Apr 2025 16:26:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2012,17 +2072,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=273,atl-edge-internal;dur=15,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=19,cdn-upstream-fbl;dur=350,atl-edge;dur=272,atl-edge-internal;dur=19,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="QamVrNosVD10HrA9RgxKBu4nD1x5vaxFbRj6F1Ed_YEqX5qSaRJI5A==",cdn-downstream-fbl;dur=354
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f4931915c262d78fa3e94b48faa4f55a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QamVrNosVD10HrA9RgxKBu4nD1x5vaxFbRj6F1Ed_YEqX5qSaRJI5A==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 0ef07da732e0fddf72f2495a22cac9e7
+      - dc5a719a14276c58a6f4e301e4020688
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2046,61 +2114,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16100
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18207
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvcRxPAHD0MXOli7LssRpgWZBwEhnmTVFaiQV20v733ek
-        Xtw6UYdkWFEgtXi89+ce3oMH64KK1Is9BSIFBekxA57qnqA56J5OFpDTnixAUcOk0D1ImcnB0F6y
-        oCIDLrPePSiNMkgvoFCgQZj6blJqI/O5NXgbBkEYDBT8VYI2s00B54omhiXg9Txm/YcjvIIfGvgc
-        PxfGFDr2/RTmkJhUvpcDajjVmlExEGB89GR8WjA/8pnWJfiNgSVsUP9sNr2c9fFshEcuBO3FD57G
-        2EqdUAOZVJsqhxS/UCMKooN+EPbDYBYFcXgYB9FgFIy/CyqzzonBwJ2ZFwZp9X20F0Rt2vVHCjpR
-        rLCFw9NXROeU8x5JmTZMJIYUDBIgck5WUi0HVjuR4krxZ0ZRCmbbRfktvaeGKv+ewcp3YW0DrEVh
-        sB+Of9Tsb/ghx7aXOXq1sECXM6qXtlflnbG/4jnlGnpepXiCeTndnrdgCByVLDancA8Ya/Cx5xmG
-        yCoQJV4sSszR24HJftAICiXfY0YvLHit7crtGtiUewck26yuBDMGDWiv9W2R+qu7q+XcrKiyeNUs
-        LzjDgNOdzLEfDmXD8Xo4fma4X+hMk0nbl2FwiGFEw3U0/H+9VN13WESH4WiN4/QVHK4bj/vRej/6
-        Gh5rgH/8+BiOYRdOoy7BfiOYs/WbihwRFtc3CJMsU5Ah3zwaAkxA8rIa/6etHnQJRl2Cww5B1CkY
-        dwm+fxxnRZvVqSUl90J4cT+sudK2RLGkSunh0ZkdFKy2XsiSpxOmC0439Tjh8YoafHoqyn7+6FcP
-        wvYJ8Ctzyg62+3kkS1t6F+pbe8BE5sVGldY3GjVvEDN2vOtqKMBkLX889Ujsh6PmkdgtW0tlu4Iu
-        UEUtqArFpGJm88ISNOr+8HlvBctpBtq3GroxwvCAy9VA32dbsjyVq4ZUh97jsYnaIeD0DiwtWvzv
-        bgRd0A27EBqObT0WVE8LlpwysTy2kgkUdnsRSYMgh6uVk7UnQoopLi/0jsMFUF2hUtW/vPPTq59P
-        zm5PT46mZ5fT2+nFxe8XmB9OqcaC4IXZAsg58r8wxPolTBMp+IYglzBujRIjyWumKDlXkCOZkFIj
-        4gZPcUqI4+QFH1gQFErFXvUmYu+w+NuZ+owrsA0ZE5TvXqp3r7q8Dvcco2voBvuaCWhvl4Ud2k4c
-        j9tlp1qTXgi9Srl9dz/fbJ6Hxi3cfqLJEpfNBnKN8crXUb3P/aeAm6XQb3azqFkTBFioJ5JLdVZF
-        c8dL6GcKGWu7EkkykVWzZV7gOizM06A/6CKFg5YUvtTxz8v5p9j+25sxw2EvJtfvaBHF5EjKJQPy
-        lhnkWEMuISkVkGNOsw+2OlgcLhPKF1KbeByMA3/ORIpE6EeH0Y0zOHHFw7zeS2JhFe+Rf9Uk3+Cf
-        b536JS59loNQDdmiDnJSAplgPnj4G92QMOgRC8Y2iaO3UxRd43/9UTh0kdo+JisY5MwoGEiV+Qhj
-        alvLcGOz8Pfx6mBhcu7iruy8sXauxFLI1adFOlcyLXEHmIoMBzvHNvkzrLH16SqE8ZJf5KpvZEeV
-        itpAdEN8ch1qQ/4oqTKgyNZkhypsfYZO+92rc3KZUNFx3y6jdg1vs/okj8uNNpBrzCMtJEOw7cXu
-        3HXIViynTGhmYIB4xILpxZ2kKu268cj+ZIuzvfgfAAAA///sWe9r2zAQ/VdEodBC7TqJsySD0oWy
-        wT6UjRZWKIWgyHJjFsvGP+qWrf/73kmqlnpRN8oo/VDoBzeS754ud0/vLldqzoRJJ3AvW0qpWC0b
-        1tncakCOtcmvFPl1wLpVJlYsl1zVWORmh7WA816ppWRcCLCrTNhNxlmLghHVXQl6wj6lpBEJ4Qai
-        U3zX17q1JEAXK6kovxh3dgt0njgRkNCxoAJZptKiyvU7rKiIszlWa6JM0PV3qQ4IGIxnDTNKhPF1
-        x+/oiKzkGl1bI7MZV2wDIPpGJdchvvGazuxOaGJwpSgI5I1iBAQWYf0AkQzWLQK0FenGmTdOf4Za
-        xO2DkNHpbb50XRcWHa9LXRUoQnkblqtSZzScLGBzYX0veAPptWyRU4u9Lxfz86/B+WmAi1rXqnNS
-        FpTKVA17PMkztc/29n8iUdZN8R5p+KfGGbuLvn/J+XhuEPsWnMQlAmwqUL7WZaQTe1tjJ0h7C5FP
-        Jkc+rRE5raG/PS25tm/0qePIgUGMuVhRgW/R+30mr9s853Rp7fyNrynqJEGL6pk3HEmRY9Qbyd7P
-        ydE4GU0n0+VgEsmRmEViNh6ms0FKoxK3CR6e2CYpJeZJAh+45XDlJXcfNoCAUMjWk02xqZUQt6je
-        pmnKNmaxhNDjySCO303EdDIezZZiOYngPuUynYrj5Ehb2R3Nd4ef8GfeC3KuLL8GgfmoDts66BCI
-        YBgScYdlu1xngiIVlJzXFCi8r+8RyEQ8nqAowlJRzPsN9utH3O/QXz/ifof/2hGDihLTrFopeILU
-        h5JJ01aITBcQ8blpJg2RXUIMYuPHtipKeXgJihGr35VGEyasutIlD3autl0/xj5ejX1NZeybVMSO
-        uytL/G/88mKZ9MYvL4H4jV+28EufBpwgc3oFqK9N7f2gUbh9juCwaLgd5PeteJWXl5e8kmy4nfl8
-        U6HIp0GJELYuRD4NOvK9MXIiT6qbrCqUUXnmo6S1vyKZf/8pekVuLPx4eLR0/wz63fgB7PDB7sFO
-        zm/PZN2uyfCGbz00qZp5Y3DcFM3/m7MaY84ofKFd/FbomZMb7RaVnuSQSwfkMdrhI7j2BR2e+/v7
-        XwAAAP//AwD9Ry7PtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18207","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207","key":"NTEST-1856","fields":{"statuscategorychangedate":"2025-04-30T18:26:06.368+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:06.100+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t2v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:06.179+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/272]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/272 (272)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/103]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1856/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18207/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d1114b0c-8eb0-49fd-9948-b36160ec4a77
+      - ccc22e57-e83f-490e-acf6-0451eef35aa4
       Atl-Traceid:
-      - d1114b0c8eb049fd9948b36160ec4a77
+      - ccc22e57e83f490eacf60451eef35aa4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:08 GMT
+      - Wed, 30 Apr 2025 16:26:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2110,7 +2161,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=293,atl-edge-internal;dur=18,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=325,atl-edge;dur=291,atl-edge-internal;dur=25,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="DFKV7NLvs8HTI21ZkEIEjKNiZdLwwjL6-6eQzegTVms_nNy8XZe4YQ==",cdn-downstream-fbl;dur=329
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2119,14 +2170,125 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - DFKV7NLvs8HTI21ZkEIEjKNiZdLwwjL6-6eQzegTVms_nNy8XZe4YQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e2ca69485ff7924b423ffaba8b47b437
+      - b4dcdc11d1342c9ddb517104df0b3870
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added_empty has occurred.", "title": "Created/Updated
+      0 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/103", "url_api": "http://localhost:8080/api/v2/tests/103/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      103, "url_ui": "http://localhost:8080/test/103", "url_api": "http://localhost:8080/api/v2/tests/103/"},
+      "finding_count": 0, "findings": {"new": [], "reactivated": [], "mitigated":
+      [], "untouched": [{"id": 272, "title": "Zap2: Cookie Without Secure Flag", "severity":
+      "Low", "url_ui": "http://localhost:8080/finding/272", "url_api": "http://localhost:8080/api/v2/findings/272/"},
+      {"id": 271, "title": "Zap1: Cookie Without Secure Flag", "severity": "Low",
+      "url_ui": "http://localhost:8080/finding/271", "url_api": "http://localhost:8080/api/v2/findings/271/"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1321'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added_empty
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1321\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added_empty\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
+        \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
+        \"172.18.0.9:54902\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \ \"data\": \"{\\\"description\\\": \\\"Event scan_added_empty has occurred.\\\",
+        \\\"title\\\": \\\"Created/Updated 0 findings for Security How-to: 1st Quarter
+        Engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/103\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/103/\\\", \\\"product_type\\\":
+        {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 103, \\\"url_ui\\\": \\\"http://localhost:8080/test/103\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/103/\\\"}, \\\"finding_count\\\":
+        0, \\\"findings\\\": {\\\"new\\\": [], \\\"reactivated\\\": [], \\\"mitigated\\\":
+        [], \\\"untouched\\\": [{\\\"id\\\": 272, \\\"title\\\": \\\"Zap2: Cookie
+        Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/272\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/272/\\\"}, {\\\"id\\\":
+        271, \\\"title\\\": \\\"Zap1: Cookie Without Secure Flag\\\", \\\"severity\\\":
+        \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/271\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/271/\\\"}]}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added_empty
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        0,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [],\n      \"reactivated\":
+        [],\n      \"untouched\": [\n        {\n          \"id\": 272,\n          \"severity\":
+        \"Low\",\n          \"title\": \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/272/\",\n          \"url_ui\": \"http://localhost:8080/finding/272\"\n
+        \       },\n        {\n          \"id\": 271,\n          \"severity\": \"Low\",\n
+        \         \"title\": \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/271/\",\n          \"url_ui\": \"http://localhost:8080/finding/271\"\n
+        \       }\n      ]\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\":
+        \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
+        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
+        {\n      \"id\": 103,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/103/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/103\"\n    },\n    \"title\":
+        \"Created/Updated 0 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/103/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/103\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:13 GMT
+      Transfer-Encoding:
+      - chunked
     status:
       code: 200
       message: OK

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_with_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_no_push_to_jira_reimport_with_push_to_jira.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:36678\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:54916\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:08 GMT
+      - Wed, 30 Apr 2025 16:26:13 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/104", "url_api": "http://localhost:8080/api/v2/tests/104/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      104, "url_ui": "http://localhost:8080/test/104", "url_api": "http://localhost:8080/api/v2/tests/104/"},
+      "finding_count": 2, "findings": {"new": [{"id": 273, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/273",
+      "url_api": "http://localhost:8080/api/v2/findings/273/"}, {"id": 274, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/274",
+      "url_api": "http://localhost:8080/api/v2/findings/274/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:54930\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/104\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/104/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 104, \\\"url_ui\\\": \\\"http://localhost:8080/test/104\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/104/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 273, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/273\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/273/\\\"},
+        {\\\"id\\\": 274, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/274\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/274/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 273,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/273/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/273\"\n        },\n
+        \       {\n          \"id\": 274,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/274/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/274\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        104,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/104/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/104\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/104/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/104\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:13 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -101,26 +206,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwFWFKfmlfARZMDyKdApLCvGeJbyLIgBLiDAIe/CH3Co2u6cpVAx4LTgsExYnn6z
-        srsxygYwo/OFFIA5KknTAkWmVKZAKrZM80Wt5hmyuQJ2JvA6Gm7bQcQXohKj9ndWitg+EH2qCJrX
-        bUmO54c9WRMn1/cVOX4CAAD//wMABvO90SACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:13.976+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 59077afb-22a8-4a27-9f74-5986c8c920c0
+      - 8d9d0527-cb1a-4d2a-96f1-8ca1fddae211
       Atl-Traceid:
-      - 59077afb22a84a279f745986c8c920c0
+      - 8d9d0527cb1a4d2a96f18ca1fddae211
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:09 GMT
+      - Wed, 30 Apr 2025 16:26:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +231,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=166,atl-edge-internal;dur=14,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=252,atl-edge;dur=166,atl-edge-internal;dur=13,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="LUMXLLr2zpBRWEt1nWwGbU2Y3W4DMB7y87pzSoKiklj13POO4s4_Gg==",cdn-downstream-fbl;dur=256
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,10 +240,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c8780798b589dc6b55523ca0a9bc3c02.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - LUMXLLr2zpBRWEt1nWwGbU2Y3W4DMB7y87pzSoKiklj13POO4s4_Gg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - a015f9772a52f6083616800f4537b2d5
+      - 3f882467fb66e1f42da509d1729c0d94
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -169,41 +278,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - c77246be-1736-4da5-85d1-34f500de0fd1
+      - 54b79c27-7b1d-4ad0-b3c2-488c30102267
       Atl-Traceid:
-      - c77246be17364da585d134f500de0fd1
+      - 54b79c277b1d4ad0b3c2488c30102267
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:09 GMT
+      - Wed, 30 Apr 2025 16:26:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -213,7 +309,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=278,atl-edge-internal;dur=15,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="N1Kvy4JCAaUBUam4S8BAPcX3xYR__sAPugrAT5iD0pZSpWEcbQJT-w==",cdn-downstream-fbl;dur=366,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=363,atl-edge;dur=287,atl-edge-internal;dur=18,atl-edge-upstream;dur=269,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -222,13 +318,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9041bc1ab42f996e0fd971e734eff2e2.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - N1Kvy4JCAaUBUam4S8BAPcX3xYR__sAPugrAT5iD0pZSpWEcbQJT-w==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - ef8766cf6b531f0c02035176759157dd
+      - e59d2f0a14c6a7fcf1fb04b5a29d8726
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -241,7 +345,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/273]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/273 (273)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/104]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -249,7 +353,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -261,7 +365,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -270,18 +374,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16101","key":"NTEST-1617","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16101"}'
+      string: '{"id":"18209","key":"NTEST-1857","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18209"}'
     headers:
       Atl-Request-Id:
-      - 11ecc806-5f65-4abe-89fb-323d18c1802e
+      - ed475edc-e055-46ca-84b6-4f8d565983a1
       Atl-Traceid:
-      - 11ecc8065f654abe89fb323d18c1802e
+      - ed475edce05546ca84b64f8d565983a1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:10 GMT
+      - Wed, 30 Apr 2025 16:26:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -291,7 +397,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=632,atl-edge-internal;dur=15,atl-edge-upstream;dur=616,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=769,atl-edge;dur=737,atl-edge-internal;dur=15,atl-edge-upstream;dur=722,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="rNNz-1FxlQyJrl2Zl5br0NkNdDQxY9QEwc5_Lb2-YxjvIS_oXaHdsQ==",cdn-downstream-fbl;dur=774
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -300,10 +406,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 22067fb5d7eb764108747a104222f50a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - rNNz-1FxlQyJrl2Zl5br0NkNdDQxY9QEwc5_Lb2-YxjvIS_oXaHdsQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a1307da3563e2fce778f9a58ed5dbd29
+      - 1f0bf9dff2993ba26623bb996a148bff
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -327,61 +441,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1617
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1857
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeRBCGKmqtiS0bCmlEEBaipCZuZmYeOyp7SHJsvz3Xs8r
-        QJitoOoKKYwf933u8X1wYJlRETuho0DEoCA+YMBj3RE0Bd3R0QxS2pEZKGqYFLoDMTMpGNqJZlQk
-        wGXSuQel8QziU8gUaBCmuhvl2sh0ahXe+J7nez0Ff+egzWSVwYmikWEROB2HWfv+wPd8XGjgU1zO
-        jMl06LoxTCEysbyTPWo41ZpR0RNgXLRkXJoxN3CZ1jm4tYI5rFD+eDI+m3Rxbxe3Che0Ez44Gn3L
-        dUQNJFKtyhhiXKFE4AU7Xc/v+t4k8EJ/N0R/g93gB/Tbs05aIwYdL9S800kr76I+L2jCrhYx6Eix
-        zCYOdz8QnVLOOyRm2jARGZIxiIDIKVlINe9Z6UiKc8Xf6EUumC0X5Tf0nhqq3HsGC7dwa+1gdeR7
-        2/7wJ80+w48plj1P0aqFBZqcUD23tcpvjf0Kp5Rr6Dil4CHGVch2nBlD4KhotjqCe0BfvceOYxgi
-        K0OUOKHIMUbnBUy2vfogU/IOI3pnwivpIt1FAet028UTkKyjOhfMGFSgnca2RepvxV0tp2ZBlcWr
-        ZmnGGTocv4gc61GgrD9c9odvdPcrlakjaerS9yyqg/4y6P+/VsrqF1hEg/5g6Q++hcFlbXE7WG4H
-        38JiBfDHx004+m04DeqDKVtelByI1b+63ry5Xd+kSaIgQb7ZaAIMQPK8bP/Xze20HQzaDnZbDoLW
-        g2Hbwd6mnyVtlruWlIoXwgm7Pi6pwYejJNy3N25J52sCd0t1yrZl8bkvc5s435Lypd1gInFCo3LA
-        8qFSc4EVt81ZOlfos/oVi8oEP2zsWV9RWM9kzuMR0xmnq6q5LSQUYLCWPzYeCW+vt7e3Uz8SL9PW
-        UNnLgzZQBQ2oMsWkYmb1ziTW4m7/bW8FS2kC2rUSulbCcIPLRU/fJ2uyPJKLmlT7zmbbBA3mOb0F
-        S4uvNIZlk1fT4Lch1B/afMyoHmcsOmJifmBPRpDZ6UVEdc2KSi6Ks2ZHSDHG4YXecjgFqkscqOrL
-        OTk6/+Xw+ObocH98fDa+GZ+e/nGK8WGXakwIXpjMgJwg/wtDrF3CNJGCrwhyCeNWKTGSfGSKkhMF
-        KZIJyTVitvcap/jYTo73hXlepj6HTvkmYu0w+eueesYVWIaECcpfXqpmryq9Bao5eletbV0TAc3t
-        PLNN+yqOcdjxBs2wU45J74ReKdy8u88nm7ehcQ23n2k0x2GzhlytvLS1X81z/8nheih069ksqMcE
-        ARbqkeRSHZfe3PIcuolCjliPRJKMZFlsmWY4DgvzOuh32khhpyGFr1X8eTr/Euu/rQkzHLZCcvWJ
-        Zn5I9qWcMyCXzCCrGXIGUa6AHHCafLHZweRwGVE+k9qEQ2/ouVMmYqRSN9jdvi4UjorkYVx3klhY
-        hVvkXyXJd/jzfSF+hkOf5SAUQ7aonBzlQEYYD27+TlfE9zrEgrEJYv9yjEdX+K878PuFp7aO0QJ6
-        KTMKelIlLsKY2tIynNgs/F282puZlBd+l3ourJ5zMRdy8TRJJ0rGOc4AY5FgY6dYJneCObY2iwyh
-        v+RXuega2ZKlrFIQXBOXXPnakD9zqgwoslbZIgprm34h/enDCTmLqGi5b4dRO6U0UT2J42ylDaQa
-        44gzyRBsW2GxX1TIZiylTGhmoId4xITp2a2kKm67saF/tMbZVvgPAAAA///sWW1r2zAQ/iuiUGih
-        dp3EaZJB6ULZYB/KRgsrlEKQZbkxi2Xjl7ql63/fc5KipV7cjTJKPxTywYmku9P57rnnLtdqzoQJ
-        J2Avi6RUrJI1a21s1QDHysRXgvg6YO0yFUuWSa4qLHKzw0rAfa9VJBkXAugqY3abctYgYUR5XwCe
-        sE8pacqyv2HRGd71jW4tyaDLpVQUX4w7uTk6T9wIltC1wAJZqpK8zPQZlpeE2RyrFUEm4PqHVAdk
-        GISnNTO1n/FVy+/piqzg2rqmQmQzrtiGgegblVz5eOMV3dnd0PjgWpETSBv5CBZYC6u1iSSwauCg
-        rZZu3Hnj9ufIRVQfuIxub+OlbVs/b3lV6KxAEso7v1gWOqKhZAGZC6t7wWuQnahBTC32vl7OL755
-        F2ceCrXOVaekyCmUKRv2eJylap/t7f9EoKzq/APC8E+OM3aFvlvk+nBuEPYtOIpLAFiXgHzN7IiZ
-        dbaGjpB2FoI+mhz0cY3AcQ399jTl2r6xjx0HzpgnNbuL3HgBXCwp+01dqJos41S0dv6G1+R1oqB5
-        +cIKR1TkBPlGxPlLfDyOR9PJNBpMAjkSs0DMxsNkNkiOoMdtgoZntkkKiXkcQweqHEpefP9xwxAA
-        Csl6tik2ueKjiuptGqZsYxZKED0eD8LwaCKmk/FoFoloEkB9wmUyFSfxsZayO5rvDj/jY855GVcW
-        Xz3P/FT5TeW1cIQ39Am4/aKJVqkgT3kF5xU5Cud1HQFNxOMpksIvFPm822C/fYu7Hfrbt7jb4b91
-        iwFFsWkPLRU8ReiDySRJI0SqE4jw3LSjBsiuQAax8VNT5oU8vALEiOXvTKMJE1Zd6pIGO1fbzh/D
-        PlwN+5rK0DWV3QWH3aUF/nd8ebVIeseX17D4HV+24EsXBhwhc/wFVt+Y3HugUbh9DqAwr7kd5Hel
-        9DKvXlzqpWTD7cjXNxUK+jgoAcLWhaCPg476TowcyZPqNi1zZYic+Slu7L9I5us/eS/PjISH9aOF
-        +xfA78YfYIdruQc7Gb87l1WzIsEbuvXQpKzntbHjNq//36TWCHNCoQvt4vdcz5zWw1SaFdMkh1Q6
-        Q55aO3xirj2g3fP4+PgLAAD//wMA7AYa1rQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18209","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18209","key":"NTEST-1857","fields":{"statuscategorychangedate":"2025-04-30T18:26:15.311+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1857/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:15.007+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t33:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:15.091+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/273]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/273 (273)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/104]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1857/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18209/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 2a093d7f-290f-4bfa-be90-1e4ec37ea7fb
+      - c3c1818a-fa75-4ed8-b098-a5780934d234
       Atl-Traceid:
-      - 2a093d7f290f4bfabe901e4ec37ea7fb
+      - c3c1818afa754ed8b098a5780934d234
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:10 GMT
+      - Wed, 30 Apr 2025 16:26:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -391,7 +488,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=314,atl-edge-internal;dur=14,atl-edge-upstream;dur=300,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="hERVturdx4JthaqwFWgJLJ90TumSb70Kq36EYrzwd3kfdDjR5KBHvQ==",cdn-downstream-fbl;dur=347,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=345,atl-edge;dur=259,atl-edge-internal;dur=12,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -400,10 +497,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 471c951325b4c2c11c6c583a1d28e92a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - hERVturdx4JthaqwFWgJLJ90TumSb70Kq36EYrzwd3kfdDjR5KBHvQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 7989f88cf125bcbd8bc251ff720f8fd3
+      - 1561cccccda2450c079c22227c85d5e6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -427,61 +532,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16101
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18209
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9kEIYaWqupLQcqWUQgDpKEJmd7Ix8dpb20uS4/jfO95X
-        II+roOrpJC7r8by/+TxPDswzKmIndBSIGBTERwx4rFuCpqBbOppASlsyA0UNk0K3IGYmBUNb0YSK
-        BLhMWo+gNMogPodMgQZhqrtRro1Mx9bgne95vtdR8HcO2owWGZwpGhkWgdNymPXv93zPxw8NfIyf
-        E2MyHbpuDGOITCwfZIcaTrVmVHQEGBc9GZdmzA1cpnUObm1gCgvUPx0NL0ZtPNvHoyIE7YRPjsbY
-        ch1RA4lUizKHGL9QI/CCvbbnt31vFHihvx9ivMF+8APG7dkgrRODgRdm3hmk1XfRnhc0aVcfMehI
-        scwWDk8/EJ1SzlskZtowERmSMYiAyDGZSTXtWO1IikvF3xhFLphtF+V39JEaqtxHBjO3CGsZYCXy
-        vV2//5Nmn+HHFNuep+jVwgJdjqie2l7l98b+CseUa2g5peIx5lXotpwJQ+CoaLI4gUfAWL3nlmMY
-        IitDlDihyDFHZwUmu14tyJR8wIzeWfBKuyh30cC63PbjBUiWWV0KZgwa0E7j2yL1t+KulmMzo8ri
-        VbM04wwDjlcyx34UKOv2593+G8P9SmfqTJq+dD2L6qA7D7r/r5ey+wUW0aHfm/u9b+FwXnvcDea7
-        wbfwWAH8+Xkdjv42nAa1YMzmVyUHYvdvbtdv7tY3aZIoSJBv1oYAE5A8L8d/s7u9bYLeNsH+FkGw
-        VdDfJjhYj7OkzfLUklLxQjhh26+40rZEsahM6WntzA4KVltPZM7jAdMZp4tqnPB4Rg0+PSVlv330
-        ywdh+QS4pTllB7v4eShzW/oi1Gt7wETihEbl1jcaNVeIGTveVTUUYLKWP9YeCe+gc3CwVz8Sq2Vr
-        qGxVsA1UQQOqTDGpmFm8swS1utt921vBUpqAdq2Gro0wPOBy1tGPyZIsT+SsJtWusz42QYN5Tu/B
-        0uKGwbBssrEM/jaE+n1bjwnVw4xFJ0xMj6xkAJndXkRUI6jA1ayQNSdCiiEuL/SewzlQXaJSVb+c
-        s5PLX45P706OD4enF8O74fn5H+eYH06pxoLghdEEyBnyvzDE+iVMEyn4giCXMG6NEiPJR6YoOVOQ
-        IpmQXCPiOps4xcdxcrwvzPMy9Tl0yjcRe4fFX87UK67ANiRMUL56qdq9qvIWuOcYXfVt+5oIaG7n
-        mR3ajTjGZcfrNctOuSa9E3qlcvPuvt5s3obGJdx+ptEUl80acrXx0tdhtc/9p4DrpdCtd7OgXhME
-        WKhHkkt1WkZzz3NoJwoZa7kSSTKQZbNlmuE6LMxm0O81pPC1xq4qNYTxupx/ieW/nREzHHZCcvOJ
-        Zn5IDqWcMiDXzCDHGnIBUa6AHHGafLHVweJwGVE+kdqEfa/vuWMmYiRCN9jfvS0MDoriYV4PklhY
-        hTvkXzXJd/jn+0L9Apc+y0GohmxRBTnIgQwwUTz8nS6I77WIBWOTxOH1EEU3+F+753eLSG0foxl0
-        UmYUdKRKXIQxta1luLFZ+Lt4tTMxKS/iLu1cWTuXYirk7GWRzpSMc9wBhiLBwU6xTe4Ii299FhXC
-        eMmvctY2ckuVsspAcEtccuNrQ/7MqTKgyNLkFlVY+vQL7U8fzshFRMWW+3YZtVtKk9WLPC4W2kCq
-        MY84kwzBthMW50WHbMVSyoRmBjqIRyyYntxLquJtN9bsD5Y42wn/AQAA///sWV1L3EAU/SuDICiY
-        mN3NursFsYu00AdpUaggwjKZTNzQ3UnIh1Gs/73nzsxOY7qxRYr4IPgQMzP3K/eee+7stZozYdIJ
-        2MsiKRUrZcUam1sVwLE0+ZUgvw5Ys0zFkq0lVyUWudlhJcDfaxVJxoUAusqY3aac1SgYUdzngCfs
-        U0oakuC3LDrDt77RoyUZdLmUivKLcSc3w+QJj2AJuQUWyFKVZMVan2FZQZjNsVoSZAKuf0h1QIZB
-        eFoxw0QYXzX8nlxkOdfW1SUym3HFWgZiblRy5eOLl+Sz89DE4FpREEgbxQgWWAvLjYkksKwRoK2W
-        tnxueX+OWkT3QcjIe5svTdP4WcPLXFcFilDe+fky1xkNJQvIXFjdC16BekU1cmqx9/VyfvHNuzjz
-        0Kh1rToleUapTNWwx+N1qvbZ3v5PJMqqyj4gDf/kOGPX6LtNro/8DMI2AFYFkF3TL6KD3a19pDfo
-        WwgdU+2ecFxDfyTNrLZv7OMeQR87DpxOxJiLJRW4bcDtHt6F+LJerzk1rZ2/4TVFnShoVrywwxEV
-        OUG9Ee39Eh+P49F0Mo0Gk0COxCwQs/EwmQ2SI+hxm6DhmW2SUmIex9CBLoeWF99/bBkCQCFZzw7F
-        plZ8dFG9TcOUHcxCCaLH40EYHk3EdDIezSIRTQKoT7hMpuIkPtZSdkfz3eFn/Jlz3pori6+eZ16V
-        fl16DQLhDX0Cbj+vo1UqKFJeznlJgcJ53UdAE/F4iqLwc0Ux7w7Yb9/i7oT+9i3uTvhv3WJgVGyG
-        VUsFT5H6YDJJUguR6gIiPDfDpEG4K5BBbPxUF1kuD6+APWL5u9LohgmrrnRJg71X284fwz5cDfuG
-        ytANlYXF93cYebWEeYeR17D4HUa2wEgXBvqYWugImeMrcOfGFOUDXYXb5wCWZBW3F/ldKX2ULOjD
-        pWC4HeD6boWCXgd6KZvzrHuij8uNehccyZPqNi0yZVieeRXX9lck8++/RO82q/7f/aYR5oRCE8a0
-        75m+69lcqaIEjMkPm0fbX15sgP7F7XAj92Bnze/OZVmvSHDLWX1LU1TzyjhOd8V0k0Ouu/dPDw+f
-        nLYHtLWPj4+/AAAA//8DAApbE4q0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18209","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18209","key":"NTEST-1857","fields":{"statuscategorychangedate":"2025-04-30T18:26:15.311+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1857/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:15.007+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t33:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:15.091+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/273]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/273 (273)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/104]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1857/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18209/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 8748e786-1dbb-4701-a92b-f41ad4babfb8
+      - d874b789-df91-40be-a267-b03a670873ab
       Atl-Traceid:
-      - 8748e7861dbb4701a92bf41ad4babfb8
+      - d874b789df9140bea267b03a670873ab
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:11 GMT
+      - Wed, 30 Apr 2025 16:26:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -491,7 +579,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=340,atl-edge-internal;dur=13,atl-edge-upstream;dur=327,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=290,atl-edge;dur=257,atl-edge-internal;dur=16,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="CMv26AOHIMgj3V9uNimlvidIyA-dUDQeQAv3wwnZtyM0iBHNfh1jNQ==",cdn-downstream-fbl;dur=294
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -500,10 +588,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - CMv26AOHIMgj3V9uNimlvidIyA-dUDQeQAv3wwnZtyM0iBHNfh1jNQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 68c9187d1347734f9e4b033717195706
+      - 57c92e652c75b4d3f398bb097de3cf88
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -530,26 +626,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwFWFKfmlfARZMDyKdApLCvGeJbyLIgBLiDAIe/CH3Co2u6cpVAx4LTglCbpMv9m
-        ZXdjlA1gRucLKQBzVJKmBYpMqUyBVGyZ5otazTNkcwXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAROu1WiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:16.645+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - acd4f78a-b5fb-4cf4-9d4a-3b62f48dc954
+      - b4510a34-5164-4c13-92d1-93b1c084ddb0
       Atl-Traceid:
-      - acd4f78ab5fb4cf49d4a3b62f48dc954
+      - b4510a3451644c1392d193b1c084ddb0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:11 GMT
+      - Wed, 30 Apr 2025 16:26:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +651,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=149,atl-edge-internal;dur=15,atl-edge-upstream;dur=135,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=198,atl-edge;dur=165,atl-edge-internal;dur=17,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0XSmYthoSDqYQjboMEiTJdpWPVX80V2iJCbj8GRNeFE4POf919Ymog==",cdn-downstream-fbl;dur=202
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,10 +660,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0XSmYthoSDqYQjboMEiTJdpWPVX80V2iJCbj8GRNeFE4POf919Ymog==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 966a888ceef8c8dbb80c7f6f310b9d4a
+      - 98e99e66d6fe4f697e88f5794f138fe9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -598,41 +698,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 4e73f16b-8913-43b3-86ff-6963520ec492
+      - 69f49a66-5201-4028-83c1-70c681fcc28e
       Atl-Traceid:
-      - 4e73f16b891343b386ff6963520ec492
+      - 69f49a665201402883c170c681fcc28e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:11 GMT
+      - Wed, 30 Apr 2025 16:26:17 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -642,7 +729,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=275,atl-edge-internal;dur=14,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=324,atl-edge;dur=290,atl-edge-internal;dur=18,atl-edge-upstream;dur=272,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="CFQuyLEG3Qw-ZRqQlVvqYVPO41lo5M29YtYjryiP3nOVB_Mo3icspQ==",cdn-downstream-fbl;dur=328
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -651,13 +738,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 edb5724c2fa0963fde9c6c5089b747ce.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - CFQuyLEG3Qw-ZRqQlVvqYVPO41lo5M29YtYjryiP3nOVB_Mo3icspQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 70c02515e45fc4b9319171e6cf8e1dd0
+      - e0f996ace8877c9867151737d992c949
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -670,7 +765,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/274]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/274 (274)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/104]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -678,7 +773,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -690,7 +785,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -699,18 +794,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16102","key":"NTEST-1618","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16102"}'
+      string: '{"id":"18211","key":"NTEST-1858","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18211"}'
     headers:
       Atl-Request-Id:
-      - 18a5756a-9fd4-40ea-b44d-0d29e491d304
+      - 3fcc3dfd-e2ff-4ab1-9824-b1e43a305964
       Atl-Traceid:
-      - 18a5756a9fd440eab44d0d29e491d304
+      - 3fcc3dfde2ff4ab19824b1e43a305964
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:12 GMT
+      - Wed, 30 Apr 2025 16:26:18 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -720,7 +817,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=706,atl-edge-internal;dur=14,atl-edge-upstream;dur=692,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=797,atl-edge;dur=765,atl-edge-internal;dur=17,atl-edge-upstream;dur=749,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="MJHndHvbha1Gy7Hwwn4VjnkEXvYOxYj7F7i55WZNybOmDy765VIL1Q==",cdn-downstream-fbl;dur=801
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -729,10 +826,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 800cba2437ee092ab9e4755c65d34a72.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MJHndHvbha1Gy7Hwwn4VjnkEXvYOxYj7F7i55WZNybOmDy765VIL1Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a399a352a22bd14ba38e46fb1e9e8178
+      - c44c6e8065036f287f0b546e09b8e5cf
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -756,61 +861,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1618
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1858
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxtXiilizRNd7RsbIx1tIB0GUImOU1NHTuzHdqOy3/fsdO0
-        vOVewbQrpBL7+Lw/fnzuPVgWVKRe7CkQKShIDxnwVLcEzUG3dDKDnLZkAYoaJoVuQcpMDoa2khkV
-        GXCZte5AaZRBegqFAg3CrM8mpTYyn1qD12EQhEFHwd8laDNZFTBSNDEsAa/lMes/7IVBhAsNfIrL
-        mTGFjn0/hSkkJpW3skMNp1ozKjoCjI+ejE8L5kc+07oEvzYwhxXqn0yG40kb9/q45ULQXnzvaYyt
-        1Ak1kEm1qnJIcYUaURDttYOwHQaTKIjD/TiMOt3e7ncYd2CDtE4MBu7MvDNIq++jPRdolfZ6kYJO
-        FCts4XD3A9E55bxFUqYNE4khBYMEiJyShVTzjtVOpDhT/I1RlILZdlF+Te+oocq/Y7DwXVjbANei
-        MNgN+z9q9g/8kGPbyxy9WligywnVc9ur8sbYr3hKuYaWVykeYV5Ot+XNGAJHJbPVMdwBxho8tDzD
-        EFkFosSLRYk5es9gshvUgkLJW8zonQVfa7tyuwbW5baLRyDZZnUmmDFoQHsb3xapv7mzWk7NgiqL
-        V83ygjMMOH2WOfbDoazbX3b7bwz3M52pM9n0pRvsYxhRdxl1/18vVfcdFtFh2FuGva/hcFl73I2W
-        u9HX8LgG+MPDSziGTTiNmgS7tWDKlucVOSIsLq8QJlmmIEO++eIl2KsFmJnkZcULrx/tNQn2GwRR
-        o6DfJPj+ZTgVbVa7lpTcC+HF7RCX1ODDURHu2y9uRedbAvcrc8peS/d5IEtbuNCS8oXdYCLzYqNK
-        wPahUXOOHbeXswrO2bP2FUuqOt6/2LOxorKeyZKnA6YLTlfry20hoQCTtfzx2iMRdvfqR+J52TZU
-        9lzQBKpoA6pCMamYWb2ziLW6333bW8FymoH2rYaujTDc4HLR0XfZliyP5aIm1a738tpEm0vA6Q1Y
-        WrT4fz4RNEE3bEIoPudYjxnVw4Ilx0zMD61kAIWdXkRS98x1cuFkmx0hxRCHF3rD4RSornCg1l/e
-        6Pjs56OT6+Ojg+HJeHg9PD394xTzw1uqsSB4YDIDMkL+F4ZYv4RpIgVfEeQSxq1RYiT5lSlKRgpy
-        JBNSasRs5zVOCfE6ecEnFgSF3o+96k3E3mHxt3fqCVdgGzImKH9+aD17rcvrUM0xuppusK+ZgM3p
-        srCXtgnHUbjBcTUmvRN6lfLm3X062bwNjVu4/USTOQ6bNeRq45Wvg/U8958CrodCv57NonpMEGCh
-        nkgu1UkVzQ0voZ0p5IjtSCTJQFbNlnmB47Awr4N+r4kU9jak8LmOPy3nX2L7tzNhhsNOTC4/0iKK
-        yYGUcwbkghlkNUPGkJQKyCGn2SdbHSwOlwnlM6lN3A/6gT9lIkUq9aP97pUzOHDFw7xuJbGwinfI
-        FzXJN/jzrVMf49BnOQjVkC3WQQ5KIAPMBzd/pysSBi1iwbhJ4uBiiKJL/NfuhV0Xqe1jsoBOzoyC
-        jlSZjzCmtrUMJzYLfx+PdmYm5y7uys65tXMm5kIuHhdppGRa4gwwFBle7Bzb5E+wxtanqxDGS36R
-        i7aRDVUq1gaiK+KTy1Ab8mdJlQFFtiYbVGHrM3TaHz+MyDihouG8HUbtlLLJ6lEe45U2kGvMIy0k
-        Q7DtxG7fdchWLKdMaGagg3jEgunZjaQqbTrxwv5gi7Od+F8AAAD//+xZbWvbMBD+K6JQaKF2ncRp
-        kkHpQtlgH8pGCyuUQpBluTGLZeOXuqXrf99zkqKlXtyNMko/FPLBiaS70/nuuecu12rOhAknYC+L
-        pFSskjVrbWzVAMfKxFeC+Dpg7TIVS5ZJrioscrPDSsB9r1UkGRcC6Cpjdpty1iBhRHlfAJ6wTylp
-        yrK/YdEZ3vWNbi3JoMulVBRfjDu5OTpP3AiW0LXAAlmqkrzM9BmWl4TZHKsVQSbg+odUB2QYhKc1
-        M7Wf8VXL7+mKrODauqZCZDOu2IaB6BuVXPl44xXd2d3Q+OBakRNIG/kIFlgLq7WJJLBq4KCtlm7c
-        eeP258hFVB+4jG5v46VtWz9veVXorEASyju/WBY6oqFkAZkLq3vBa5CdqEFMLfa+Xs4vvnkXZx4K
-        tc5Vp6TIKZQpG/Z4nKVqn+3t/0SgrOr8A8LwT44zdoW+W+T6cG4Q9i040ksAWJeAfM3siJl1toaO
-        kHYWAieju9DHNQLHNfTb05Rr+8Y+dhw4Y57U7C5y4wVwsaTsN3WharKMU9Ha+Rtek9eJgublCysc
-        UZET5BsR5y/x8TgeTSfTaDAJ5EjMAjEbD5PZIDmCHrcJGp7ZJikk5nEMHahyKHnx/ccNQwAoJOvZ
-        ptjkio8qqrdpmLKNWShB9Hg8CMOjiZhOxqNZJKJJAPUJl8lUnMTHWsruaL47/IyPOedlXFl89Tzz
-        U+U3ldfCEd7QJ+D2iyZapYI85RWcV+QonNd1BDQRj6dICr9Q5PNug/32Le526G/f4m6H/9YtBhTF
-        pj20VPAUoQ8mkySNEKlOIMJz044aILsCGcTGT02ZF/LwChAjlr8zjSZMWHWpSxrsXG07fwz7cDXs
-        ayrDvklF6LC7tMD/ji+vFknv+PIaFr/jyxZ86cKAI2SOv8DqG5N7DzQKt88BFOY1t4P8rpRe5tWL
-        S72UbLgd+fqmQkEfByVA2LoQ9HHQUd+JkSN5Ut2mZa4MkTM/xY39F8l8/Sfv5ZmR8LB+tHD/Avjd
-        +APscC33YCfjd+eyalYkeEO3HpqU9bw2dtzm9f+b1BphTih0oV38nuuZ03qYSrNimuSQSmfIU2uH
-        T8y1B7R7Hh8ffwEAAP//AwAOhGqTtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18211","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18211","key":"NTEST-1858","fields":{"statuscategorychangedate":"2025-04-30T18:26:17.891+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1858/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:17.552+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:17.642+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/274]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/274 (274)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/104]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1858/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18211/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - c4c207af-ff08-4fb0-8c05-7aa7f05e5dbf
+      - d3da27c1-dfe9-4857-afda-ef8d0318985f
       Atl-Traceid:
-      - c4c207afff084fb08c057aa7f05e5dbf
+      - d3da27c1dfe94857afdaef8d0318985f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:12 GMT
+      - Wed, 30 Apr 2025 16:26:18 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -820,7 +908,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=286,atl-edge-internal;dur=13,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=389,atl-edge;dur=355,atl-edge-internal;dur=15,atl-edge-upstream;dur=341,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="esCkxqox3qaqy-1XKHQZ2TzN8GMzDtIJ7ZlPVe9NSMnIDRAwe97wAg==",cdn-downstream-fbl;dur=393
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -829,10 +917,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 7d27498ef63e76e5a81975299a76fae4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - esCkxqox3qaqy-1XKHQZ2TzN8GMzDtIJ7ZlPVe9NSMnIDRAwe97wAg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 052ade6a94791d5e14e50b23010c3939
+      - f8b3cff3ab482a574b84b3fb89636b90
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -856,61 +952,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16102
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18211
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfSFAulJVXUmuvSulFAJIRxEyu5ONL157a3tJ0jv+e8fe
-        lwBhr4Kqp5O4rMcz88zMM+P55MGqoCL1Yk+BSEFB+pYBT3VP0Bx0TydzyGlPFqCoYVLoHqTM5GBo
-        L5lTkQGXWe8OlEYZpKdQKNAgTH03KbWR+cwavAmDIAwGCv4qQZvpuoATRRPDEvB6HrP+w/0wiPBD
-        A5/h59yYQse+n8IMEpPKj3JADadaMyoGAoyPnoxPC+ZHPtO6BL8xsIA16h9PJ2fTPp6N8MhB0F78
-        ydOIrdQJNZBJta5iSPELNaIg2usHYT8MplEQhwdxGA2G+7vfIe7AgrRODAJ3Zl4J0ur7aM8BrcKu
-        P1LQiWKFTRyeviE6p5z3SMq0YSIxpGCQAJEzspRqMbDaiRTnir8QRSmYLRflN/SOGqr8OwZL38Ha
-        AKxFYbAbjn7U7G/4Iceylzl6tbRAl1OqF7ZW5a2xv+IZ5Rp6XqX4DuNyuj1vzpA4Kpmvj+AOEGtw
-        3/MMQ2YVyBIvFiXG6D2hyW7QJQgbQaHkRwz1lZWotV0dXGWbOtiPB+zZhHsumDFoQHutb0vhX91d
-        LWdmSZUlsmZ5wRkCTp+kBAvl6DccrYajF8L9QsmaSNqCDYMDhBENV9Hw//VS0cKRFB2G+6tw/2s4
-        XDUed6PVbvQ1PNbMv7/fpmPU0HHGVhfVDMQiX11v39xtbtIsU5DhvNlqAsQpeVm1//Ps3+sS7HcJ
-        DjoEUadg1CX4fhtnNTarUzuU3Avhxf2wnpU284olVUifts5sP2BS9VyWPB0zXXC6rrsGj7GE5gLL
-        YzupdkENPkbVEH95z1dPxOZR8Ctzyna0+3koS1sMB/7SHjCRebFRpUWTKMBg7Zh47pEIh3vNI/E0
-        bV2jLGpH2VNBS6pCMamYWb8y4EbdH77srWA5zUD7VkM3RhgecLkc6LtsMxOP5LKZnUNvuzuilvOc
-        3oKdfs80hh0az6Yh7GIoPueYjznVk4IlR0ws3lrJGAq7vYikYZDj1dLJ2hMhxQSXF3rL4RSorlip
-        6l/eydH5z++Ob47eHU6OzyY3k9PT308xPuxSjQnBC9M5kBMc88IQ65cwTaTga4Ijg3FrlBhJ3jNF
-        yYmCHGcGKTXya/Dc6AixnbzgMwuCQh/EXvUmYu0w+ZueejQrsAwZE5Q/vVTvXnV6Hcs5oqu/bV0z
-        Ae3tsrBN28XjKGx5XK1Jr6Repdw+r483m5excUO3n2iywGWzoVxjvPJ1WO9z/wlwsxT6zW4WNduA
-        AEv1RHKpjis0t7yEfqZwYm1WIknGsiq2zAtch4V5nvR77VD4UmGfKrUD43E6/xSbfztTZjjsxOTq
-        Ay2imBxKuWBALpnBGWvIGSSlAvKW0+yzzQ4mh8uE8rnUJh4Fo8CfMZHi2POjg+G1Mzh2ycO4Pkpi
-        aRXvkH/VJN/gn2+d+hkufXYGoRpOixrkuAQyxkDx8De6JmHQI5aMbRCHlxMUXeF//f1w6JDaOiZL
-        GOTMKBhIlflIY2pLy3Axs/T38epgbnLucFd2Lqydc7EQcvkwSSdKpiU+9RORYWPnWCZ/ism3Pl2G
-        EC/5RS77RnZkqagNRNfEJ1ehNuSPkioDimxMdqjCxmfotD+8OSFnCRUd9+3OaZeRNqoHcZyttYFc
-        YxxpIRmSbSd2565CNmM5ZUIzAwPkIyZMz28lVWnXjS374w3PduJ/AAAA///sWV1L3EAU/SuDICiY
-        mN3NursFsYu00AdpUaggwjKZTNzQ3UnIh1Gs/73nzsxOY7qxRYr4IPgQMzP3K/eee+7stZozYdIJ
-        2MsiKRUrZcUam1sVwLE0+ZUgvw5Ys0zFkq0lVyUWudlhJcDfaxVJxoUAusqY3aac1SgYUdzngCfs
-        U0oakuC3LDrDt77RoyUZdLmUivKLcSc3w+QJj2AJuQWyx1KVZMVan2FZQZjNsVoSZAKuf0h1QIZB
-        eFoxw0QYXzX8nlxkOdfW1SUym3HFWgZiblRy5eOLl+Sz89DE4FpREEgbxQgWWAvLjYkksKwRoK2W
-        tnxueX+OWkT3QcjIe5svTdP4WcPLXFcFilDe+fky1xkNJQvIXFjdC16BekU1cmqx9/VyfvHNuzjz
-        0Kh1rToleUapTNWwx+N1qvbZ3v5PJMqqyj4gDf/kOGPX6LtNro/8DMI2AFYFkF2TLaKD3a19pDfo
-        WwgdU+2ecFxDfyTNrLZv7OMeQR87DpxOxJiLJRW4bcDtHt6F+LJerzk1rZ2/4TVFnShoVrywwxEV
-        OUG9Ecn9Eh+P49F0Mo0Gk0COxCwQs/EwmQ2SI+hxm6DhmW2SUmIex9CBLoeWF99/bBkCQCFZz86+
-        plZ8dFG9TcOUnb9CCaLH40EYHk3EdDIezSIRTQKoT7hMpuIkPtZSdkfz3eFn/Jlz3pori6+eZ16V
-        fl16DQLhDX0Cbj+vo1UqKFJeznlJgcJ53UdAE/F4iqLwc0Ux787Rb9/i7iD+9i3uDvJv3WJgVGyG
-        VUsFT5H6YDJJUguR6gIiPDejo0G4K5BBbPxUF1kuD6+APWL5u9LoIgmrrnRJg71X284fwz5cDfuG
-        ytANlYXF93cYebWEeYeR17D4HUa2wEgXBvqYWugImeMrcOfGFOUD3Xjb5wCWZBW3F/ldKX2ULOjD
-        pWC4HeD6boWCXgd6KZvzrHuij8uNehccyZPqNi0yZVieeRXX9lck8++/RO82q/7fbaYR5oRCE8a0
-        75m+69lcqaIEjMkPm0fbX15sgP7F7XAj92Bnze/OZVmvSHDLWX1LU1TzyjhOd8V0k0Ouu/dPDw+f
-        nLYHtLWPj4+/AAAA//8DAJfCg5u0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18211","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18211","key":"NTEST-1858","fields":{"statuscategorychangedate":"2025-04-30T18:26:17.891+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1858/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:17.552+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:17.642+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/274]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/274 (274)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/104]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1858/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18211/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 5a0ccd65-8c92-4104-8881-4c9c86d9a2f4
+      - 9a530b91-276e-4e46-9c2b-96e90fc5d733
       Atl-Traceid:
-      - 5a0ccd658c92410488814c9c86d9a2f4
+      - 9a530b91276e4e469c2b96e90fc5d733
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:13 GMT
+      - Wed, 30 Apr 2025 16:26:18 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -920,7 +999,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=282,atl-edge-internal;dur=17,atl-edge-upstream;dur=266,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=320,atl-edge;dur=287,atl-edge-internal;dur=15,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="MkYHGXGCfpMGskZw5B3efudPqAM_ZQKS74ZgfRj1mHySbgg1udfWdA==",cdn-downstream-fbl;dur=323
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -929,14 +1008,125 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MkYHGXGCfpMGskZw5B3efudPqAM_ZQKS74ZgfRj1mHySbgg1udfWdA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 80142fb2a186dd07bf14dee32c730e4d
+      - ac4760181197a9635886ddaa54dc7eb4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added_empty has occurred.", "title": "Created/Updated
+      0 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/104", "url_api": "http://localhost:8080/api/v2/tests/104/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      104, "url_ui": "http://localhost:8080/test/104", "url_api": "http://localhost:8080/api/v2/tests/104/"},
+      "finding_count": 0, "findings": {"new": [], "reactivated": [], "mitigated":
+      [], "untouched": [{"id": 273, "title": "Zap1: Cookie Without Secure Flag", "severity":
+      "Low", "url_ui": "http://localhost:8080/finding/273", "url_api": "http://localhost:8080/api/v2/findings/273/"},
+      {"id": 274, "title": "Zap2: Cookie Without Secure Flag", "severity": "Low",
+      "url_ui": "http://localhost:8080/finding/274", "url_api": "http://localhost:8080/api/v2/findings/274/"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1321'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added_empty
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1321\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added_empty\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
+        \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
+        \"172.18.0.9:37088\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \ \"data\": \"{\\\"description\\\": \\\"Event scan_added_empty has occurred.\\\",
+        \\\"title\\\": \\\"Created/Updated 0 findings for Security How-to: 1st Quarter
+        Engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/104\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/104/\\\", \\\"product_type\\\":
+        {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 104, \\\"url_ui\\\": \\\"http://localhost:8080/test/104\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/104/\\\"}, \\\"finding_count\\\":
+        0, \\\"findings\\\": {\\\"new\\\": [], \\\"reactivated\\\": [], \\\"mitigated\\\":
+        [], \\\"untouched\\\": [{\\\"id\\\": 273, \\\"title\\\": \\\"Zap1: Cookie
+        Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/273\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/273/\\\"}, {\\\"id\\\":
+        274, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\", \\\"severity\\\":
+        \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/274\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/274/\\\"}]}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added_empty
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        0,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [],\n      \"reactivated\":
+        [],\n      \"untouched\": [\n        {\n          \"id\": 273,\n          \"severity\":
+        \"Low\",\n          \"title\": \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/273/\",\n          \"url_ui\": \"http://localhost:8080/finding/273\"\n
+        \       },\n        {\n          \"id\": 274,\n          \"severity\": \"Low\",\n
+        \         \"title\": \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/274/\",\n          \"url_ui\": \"http://localhost:8080/finding/274\"\n
+        \       }\n      ]\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\":
+        \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
+        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
+        {\n      \"id\": 104,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/104/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/104\"\n    },\n    \"title\":
+        \"Created/Updated 0 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/104/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/104\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:18 GMT
+      Transfer-Encoding:
+      - chunked
     status:
       code: 200
       message: OK

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_push_to_jira_reimport_with_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_push_to_jira_reimport_with_push_to_jira.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2rVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwFWFKfmlfARZMDmU6BTWFaM8SzlWRADXECAQ96FP+BQtd05S6FiwGnBaZrkWfHN
-        yu7GKBvAjOYLKQDnqCRNCxSZUpkCqdgynS9qlWfIcgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAhIgJPCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:19.402+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 4002d7dd-fa7f-47b4-8b1f-370f92bd716c
+      - d0182a28-d055-4c89-84e4-d954b320b701
       Atl-Traceid:
-      - 4002d7ddfa7f47b48b1f370f92bd716c
+      - d0182a28d0554c8984e4d954b320b701
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:13 GMT
+      - Wed, 30 Apr 2025 16:26:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=148,atl-edge-internal;dur=14,atl-edge-upstream;dur=135,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="Y5WV9G-l3GkT2W9LGc_s5Ele-08Tbd7xdFMPC66RxDhdHHe5Ov4baA==",cdn-downstream-fbl;dur=263,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=260,atl-edge;dur=176,atl-edge-internal;dur=13,atl-edge-upstream;dur=164,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 35f3ad5aa26e63a13ffedf420998e698.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Y5WV9G-l3GkT2W9LGc_s5Ele-08Tbd7xdFMPC66RxDhdHHe5Ov4baA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - d5e11e908099c6b9ef1c6baf19b3e0e4
+      - b451f3913836f3383e7adfdff808afad
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - c508178b-8878-44dc-9241-1aa16403b736
+      - ce6bdc98-6d44-4da5-a863-ab7d0b4b1372
       Atl-Traceid:
-      - c508178b887844dc92411aa16403b736
+      - ce6bdc986d444da5a863ab7d0b4b1372
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:14 GMT
+      - Wed, 30 Apr 2025 16:26:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=286,atl-edge-internal;dur=15,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=302,atl-edge;dur=269,atl-edge-internal;dur=14,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="jBXJcJ0UqFkabeWD5Pbucj04ZDQJkLvXOZScPKFUvfG9zWEAwxNRLA==",cdn-downstream-fbl;dur=305
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 aa3674a12327640af71c59263be8ffc6.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - jBXJcJ0UqFkabeWD5Pbucj04ZDQJkLvXOZScPKFUvfG9zWEAwxNRLA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - fa4697ac40d0ca68de59529bf2d473e3
+      - e0afc0879f5d20336790dd0afeaff7d5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/275]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/275 (275)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16103","key":"NTEST-1619","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16103"}'
+      string: '{"id":"18213","key":"NTEST-1859","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213"}'
     headers:
       Atl-Request-Id:
-      - faf08cd4-d4e4-420c-a878-f1402ab9e5b2
+      - b28bfc0a-6d51-49c4-9a84-e83e8beaf024
       Atl-Traceid:
-      - faf08cd4d4e4420ca878f1402ab9e5b2
+      - b28bfc0a6d5149c49a84e83e8beaf024
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:14 GMT
+      - Wed, 30 Apr 2025 16:26:20 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=667,atl-edge-internal;dur=20,atl-edge-upstream;dur=646,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="SG5sPS7XmY8W5WylLsgmNCKpsj4FTsVqk6AJC3OUALtN51TR7JYphA==",cdn-downstream-fbl;dur=708,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=705,atl-edge;dur=618,atl-edge-internal;dur=16,atl-edge-upstream;dur=602,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c8780798b589dc6b55523ca0a9bc3c02.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - SG5sPS7XmY8W5WylLsgmNCKpsj4FTsVqk6AJC3OUALtN51TR7JYphA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - b545bcd32fb1e6c73be6a736e3ad751b
+      - 4f79cf0c96cee0a74183e38dcf0b990e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1619
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8atMk8yCEMFJVbUlo2VKakgDSUoTMzM3EG489tT0kKct/7/U8
-        kiUwu4Kqq0gw9vV9Hx/fBwdWGRWxEzoKRAwK4mMGPNZtQVPQbR3NIaVtmYGihkmh2xAzk4Kh7WhO
-        RQJcJu17UBplEJ9DpkCDMNXZKNdGpjNr8Nb3PN/rKvg7B22m6wzGikaGReC0HWb9+33f28OFBj7D
-        5dyYTIeuG8MMIhPLj7JLDadaMyq6AoyLnoxLM+YGLtM6B7c2sIA16p9NR5NpB/cOcasIQTvhg6Mx
-        tlxH1EAi1brMIcYVagResN/x/I7vTQMv9A9Cv9c9CHo/YNyeDdI6MRh4YeaNQVp9F+15wSbtahGD
-        jhTLbOFw9x3RKeW8TWKmDRORIRmDCIickaVUi67VjqS4UPyVUeSC2XZRfkvvqaHKvWewdIuwtgFW
-        IiynP/hJs3/gxxTbnqfo1cICXU6pXthe5XfGfoUzyjW0nVLxBPMqdNvOnCFwVDRfn8I9YKzeY9sx
-        DJGVIUqcUOSYo7MDkz2vFmRKfsSM3ljwSrsod9HAutx28RlItlldCGYMGtDOxrdF6m/FWS1nZkmV
-        xatmacYZBhzvZI79KFDWG6x6g1eG+4XO1Jls+tLzDjCMoLcKev+vl7L7BRbRod9f+f1v4XBVe9wL
-        VnvBt/BYAfzx8Tkc/SacBk2CvVowY6vLkhwRFtc3CJMkUZAg33z1EuzXAsxM8rzkhZeP9psEBw2C
-        oFEwaBIcPg+npM1y15JS8UI4YcfHJTX4cJSE+/qLW9L5lsDd0pyy17L4PJK5LZxvSfnKbjCROKFR
-        OWD70Ki5xI7by1kGV9iz9hWLyjo+PNuzsaKynsucx0OmM07X1eW2kFCAyVr+eOmR2Ds8rB+J3bJt
-        qGxX0ASqYAOqTDGpmFm/sYi1utt73VvBUpqAdq2Gro0w3OBy2dX3yZYsT+WyJtWe8/zaBJtLwOkd
-        WFq0+N+dCJqg6zch1B/YesypHmUsOmVicWwlQ8js9CKiumdFJ5eFbLMjpBjh8ELvOJwD1SUOVPXl
-        jE8vfjk5uz09ORqdTUa3o/PzP84xP7ylGguCB6ZzIGPkf2GI9UuYJlLwNUEuYdwaJUaS90xRMlaQ
-        IpmQXCNmuy9xCg4loeN9Yp6X6VnolG8i9g6Lv71TT7gC25AwQfnuoWr2qspboJpjdDXdYF8TAZvT
-        eWYvbROOe/1BjeNyTHoj9Erlzbv7dLJ5HRq3cPuZRgscNmvI1cZLX0fVPPefAq6HQreezYJ6TBBg
-        oR5JLtVZGc0dz6GTKOSI7UgkyVCWzZZphuOwMC+Dfr+JFPY3pPCljj8t519i+2tNmeHQCsn1B5r5
-        ITmScsGAXDGDrGbIBKJcATnmNPlkq4PF4TKifC61CQfewHNnTMRIpW5wsH9TGBwWxcO8PkpiYRW2
-        yFc1yXf45/tCfYJDn+UgVEO2qIIc5kCGmA9u/k7XxPfaxIJxk8TR1QhF1/iv0/d7RaS2j9ESuikz
-        CrpSJS7CmNrWMpzYLPxdPNqdm5QXcZd2Lq2dC7EQcvl5kcZKxjnOACOR4MVOsU3uFGtsfRYVwnjJ
-        r3LZMbKhSlllILghLrn2tSF/5lQZUGRrskEVtj79QvvDuzGZRFQ0nLfDKN6jshtPf63JWhtINeYR
-        Z5Ih2FphsV90yFYspUxoZqCLeMSC6fmdpCpuOvHM/nCLs1b4LwAAAP//7Flta9swEP4rolBooXad
-        xGmSQelC2WAfykYLK5RCkGW5MYtl45e6pet/33OSoqVe3I0ySj8U8sGJpLvT+e655y7Xas6ECSdg
-        L4ukVKySNWttbNUAx8rEV4L4OmDtMhVLlkmuKixys8NKwH2vVSQZFwLoKmN2m3LWIGFEeV8AnrBP
-        KWnKsr9h0Rne9Y1uLcmgy6VUFF+MO7k5Ok/cCJbQtcACWaqSvMz0GZaXhNkcqxVBJuD6h1QHZBiE
-        pzUztZ/xVcvv6Yqs4Nq6pkJkM67YhoHoG5Vc+XjjFd3Z3dD44FqRE0gb+QgWWAurtYkksGrgoK2W
-        btx54/bnyEVUH7iMbm/jpW1bP295VeisQBLKO79YFjqioWQBmQure8FrkJ2oQUwt9r5ezi++eRdn
-        Hgq1zlWnpMgplCkb9nicpWqf7e3/RKCs6vwDwvBPjjN2hb5b5PpwbhD2LTjSSwBYl4B8zeyImXW2
-        ho6QdhYCJ6O70Mc1Asc19NvTlGv7xj52HDhjntTsLnLjBXCxpOw3daFqsoxT0dr5G16T14mC5uUL
-        KxxRkRPkGxHnL/HxOB5NJ9NoMAnkSMwCMRsPk9kgOYIetwkantkmKSTmcQwdqHIoefH9xw1DACgk
-        69mm2OSKjyqqt2mYso1ZKEH0eDwIw6OJmE7Go1kkokkA9QmXyVScxMdayu5ovjv8jI8552VcWXz1
-        PPNT5TeV18IR3tAn4PaLJlqlgjzlFZxX5Cic13UENBGPp0gKv1Dk826D/fYt7nbob9/ibof/1i0G
-        FMWmPbRU8BShDyaTJI0QqU4gwnPTjhoguwIZxMZPTZkX8vAKECOWvzONJkxYdalLGuxcbTt/DPtw
-        NexrKsO+SUXosLu0wP+OL68WSe/48hoWv+PLFnzpwoAjZI6/wOobk3sPNAq3zwEU5jW3g/yulF7m
-        1YtLvZRsuB35+qZCQR8HJUDYuhD0cdBR34mRI3lS3aZlrgyRMz/Fjf0XyXz9J+/lmZHwsH60cP8C
-        +N34A+xwLfdgJ+N357JqViR4Q7cempT1vDZ23Ob1/5vUGmFOKHShXfye65nTephKs2Ka5JBKZ8hT
-        a4dPzLUHtHseHx9/AQAA//8DAPl9fVC0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18213","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213","key":"NTEST-1859","fields":{"statuscategorychangedate":"2025-04-30T18:26:20.584+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:20.337+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:20.404+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/275]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/275 (275)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 61223f7f-30f8-4c58-b543-590e04393e48
+      - 497d72d5-03d5-4990-aeaf-845fc59596a9
       Atl-Traceid:
-      - 61223f7f30f84c58b543590e04393e48
+      - 497d72d503d54990aeaf845fc59596a9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:15 GMT
+      - Wed, 30 Apr 2025 16:26:21 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=273,atl-edge-internal;dur=17,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="PX9LxwMnePkQW4VBYj15tPWHOBDE4DRdfnwj7LWgRMV_s0Q6i03YDg==",cdn-downstream-fbl;dur=333,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=331,atl-edge;dur=256,atl-edge-internal;dur=16,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 82e46a17c2e4998f87de230e61a57612.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - PX9LxwMnePkQW4VBYj15tPWHOBDE4DRdfnwj7LWgRMV_s0Q6i03YDg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 8f8c1318e8794bb4f0315e2e61b371f0
+      - 4c2ae3458a70ff6b1a05bb195568147a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16103
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18213
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8atMk8yCEMFJVbUlo2VKakgDSUoTMzM3EG489tT0kKct/7/U8
-        kiUwu4Kqq0gw9vV9Hx/fBwdWGRWxEzoKRAwK4mMGPNZtQVPQbR3NIaVtmYGihkmh2xAzk4Kh7WhO
-        RQJcJu17UBplEJ9DpkCDMNXZKNdGpjNr8Nb3PN/rKvg7B22m6wzGikaGReC0HWb9+33f28OFBj7D
-        5dyYTIeuG8MMIhPLj7JLDadaMyq6AoyLnoxLM+YGLtM6B7c2sIA16p9NR5NpB/cOcasIQTvhg6Mx
-        tlxH1EAi1brMIcYVagResN/x/I7vTQMv9A9Cv9c9CHo/YNyeDdI6MRh4YeaNQVp9F+15wSbtahGD
-        jhTLbOFw9x3RKeW8TWKmDRORIRmDCIickaVUi67VjqS4UPyVUeSC2XZRfkvvqaHKvWewdIuwtgFW
-        IiynP/hJs3/gxxTbnqfo1cICXU6pXthe5XfGfoUzyjW0nVLxBPMqdNvOnCFwVDRfn8I9YKzeY9sx
-        DJGVIUqcUOSYo7MDkz2vFmRKfsSM3ljwSrsod9HAutx28RlItlldCGYMGtDOxrdF6m/FWS1nZkmV
-        xatmacYZBhzvZI79KFDWG6x6g1eG+4XO1Jls+tLzDjCMoLcKev+vl7L7BRbRod9f+f1v4XBVe9wL
-        VnvBt/BYAfzx8Tkc/SacBk2CvVowY6vLkhwRFtc3CJMkUZAg33z1EuzXAsxM8rzkhZeP9psEBw2C
-        oFEwaBIcPg+npM1y15JS8UI4YcfHJTX4cJSE+/qLW9L5lsDd0pyy17L4PJK5LZxvSfnKbjCROKFR
-        OTxWPG2tKRaVVXt4tmcjw6N6LnMeD5nOOF1XVxm3MSxziZix17uqhgJM1vLHS4/E3uFh/Ujslm1D
-        ZbuCJlAFG1BliknFzPqNRazV3d7r3gqW0gS0azV0bYThBpfLrr5PtmR5Kpc1qfac59cm2FwCTu/A
-        0qLF/+5E0ARdvwmh/sDWY071KGPRKROLYysZQmanFxHVXSx6uyxkmx0hxQiHF3rH4RyoLpGhqi9n
-        fHrxy8nZ7enJ0ehsMrodnZ//cY754S3VWBA8MJ0DGSP/C0OsX8I0kYKvCXIJ49YoMZK8Z4qSsYIU
-        yYTkGjHbfYlTcCgJHe8T87xMz0KnfBOxd1j87Z16whXYhoQJyncPVbNXVd4C5xyjq+kG+5oI2JzO
-        M3tpm3Dc6w9qHJdj0huhVypv3t2nk83r0LiF2880WuCwWUOuNl76Oqrmuf8UcD0UuvVsFtRjggAL
-        9Uhyqc7KaO54Dp1EIWtsRyJJhrJstkwzHIeFeRn0+02ksL8hhS91/Gk5/xLbX2vKDIdWSK4/0MwP
-        yZGUCwbkihnkOUMmEOUKyDGnySdbHSwOlxHlc6lNOPAGnjtjIkYqdYOD/ZvC4LAoHub1URILq7BF
-        vqpJvsM/3xfqExz6LAehGrJFFeQwBzLEfHDzd7omvtcmFoybJI6uRii6xn+dvt8rIrV9jJbQTZlR
-        0JUqcRHG1LaW4cRm4e/i0e7cpLyIu7Rzae1ciIWQy8+LNFYyznEGGIkEL3aKbXKnWGPrs6gQxkt+
-        lcuOkQ1VyioDwQ1xybWvDfkzp8qAIluTDaqw9ekX2h/ejckkoqLhvB1G8R6V3Xj6a03W2kCqMY84
-        kwzB1gqL/aJDtmIpZUIzA13EIxZMz+8kVXHTiWf2h1uctcJ/AQAA///sWW1r2zAQ/iuiUGihdp3E
-        aZJB6ULZYB/KRgsrlEJQZLkxi2Xjl7ql63/fc5KiuV7cjTJKPxTywYmku9P57rnnLtdqzoQJJ2Av
-        W0qpWCkr1tjYqgCOpYmvGPF1wJpVIlYslVyVWORmh5WA+16rpWRcCKCrjNhtwlmNhBHFfQ54wj6l
-        pCnUfsuiM7zrG91akkGXK6kovhh3cjN0nrgRLKFrgQWyRMVZkeozLCsIszlWS4JMwPUPqQ7IMAhP
-        KmbYAOPrht/TFVnOtXV1ichmXLGWgegblVz7eOMl3dnd0PjgWpETSBv5CBZYC8uNiSSwrOGgrZa2
-        7ty6/TlyEdUHLqPb23hpmsbPGl7mOiuQhPLOz1e5jmgoWUDmwupe8Ar0Z1kjphZ7Xy/nF9+8izMP
-        hVrnqlOSZxTKlA17PEoTtc/29n8iUNZV9gFh+CfHGbtC3y1yfTg3CNs4VxVAdk3giJJ1tzoa3FkI
-        HSHtLAR9J4I+rhE4rqHfnqZc2zf2sePAGfOkZneRGy+AixVlv6kLZZ2mnIrWzt/wmrxOFDQrXljh
-        iIqcIN+IOH+JjsfRaDqZLgeTQI7ELBCz8TCeDeIj6HGboOGZbZJCYh5F0IEqh5IX3X9sGQJAIVnP
-        NsUmV3xUUb1Nw5RtzEIJosejQRgeTcR0Mh7NlmI5CaA+5jKeipPoWEvZHc13h5/xMee8lCuLr55n
-        fir9uvQaOMIb+gTcfl4v14kgT3k55yU5Cud1HQFNxOMpksLPFfm822C/fYu7Hfrbt7jb4b91i4FR
-        kWkYLRU8ReiDycRxLUSiE4jw3LSjBuGuQAax8VNdZLk8vALEiNXvTKMJE1Zd6pIGO1fbzh/DPlwN
-        +5rKsG9SETrsLizwv+PLq0XSO768hsXv+LIFX7ow4AiZ4y+w+sbk3gONwu1zAIVZxe0gvyull3n1
-        4lIvJRtuR76+qVDQx0EJELYuBO7KnYVR34mRI3lS3SZFpgyRMz9Ftf0XyXz9J+9lqZHwsHm0cP8C
-        +G39AXa4kXuwk/K7c1nWaxLc0q2HJkU1r4wdt1n1/ya1RpgTCl1oF79neua0Ga/SrJgmOaTSGfLU
-        2uETc+0B7Z7Hx8dfAAAA//8DACbrnVO0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18213","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213","key":"NTEST-1859","fields":{"statuscategorychangedate":"2025-04-30T18:26:20.584+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:20.337+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:20.404+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/275]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/275 (275)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 8c5eb28a-b0b3-4a63-ae60-e0e56e6092fd
+      - 140424e1-fd7e-48d2-b9f3-ef96556e5f84
       Atl-Traceid:
-      - 8c5eb28ab0b34a63ae60e0e56e6092fd
+      - 140424e1fd7e48d2b9f3ef96556e5f84
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:15 GMT
+      - Wed, 30 Apr 2025 16:26:21 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=279,atl-edge-internal;dur=15,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="8ewGdEaQYdRxNcJ-YYD1H4qgO3u-3bki-JtreM5utWT8nNe_nAL5WQ==",cdn-downstream-fbl;dur=372,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=369,atl-edge;dur=282,atl-edge-internal;dur=17,atl-edge-upstream;dur=266,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0835ebd52ef8594cd8aa4dac9cfbd9a8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 8ewGdEaQYdRxNcJ-YYD1H4qgO3u-3bki-JtreM5utWT8nNe_nAL5WQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - b74453e1ee67b22e52c511934416e4b4
+      - a9d71e220e6a36e58bfdda7c94969c87
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1q5d3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwGW56fmlfARZMCyKdApLCvGeDrnaRADXECAQ96FP+BQtd05S6FiwGnOaZbkRfHN
-        yu7GKBvAlC4KKQAzVJLOcxSpUqkCqdhynhW1WqTIFgrYmcDraLhtBxFfiEqM2t9ZKWL7QPSpImhe
-        tyU5nh/2ZE2cXN9X5PgJAAD//wMAbwrOYyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:22.001+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 69eb7642-44e7-4712-b352-a4580fb6bc42
+      - dfa7450b-169b-402b-9ea2-b78581bae5e8
       Atl-Traceid:
-      - 69eb764244e74712b352a4580fb6bc42
+      - dfa7450b169b402b9ea2b78581bae5e8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:15 GMT
+      - Wed, 30 Apr 2025 16:26:22 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=18,atl-edge-upstream;dur=144,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=194,atl-edge;dur=161,atl-edge-internal;dur=13,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="5ubgXR5k8Vfrtg4A7wyNSKeLEq64LXBtSk1tIa2xc1bgziQwXwyo3Q==",cdn-downstream-fbl;dur=197
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 5ubgXR5k8Vfrtg4A7wyNSKeLEq64LXBtSk1tIa2xc1bgziQwXwyo3Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - dfa62aadc70c5b7c9499420bafb36560
+      - 63b74fc870fe08ff99b82b274abac5bb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 828f92e3-09a1-41cb-9aa8-6987bcc93d7f
+      - c54211fe-e98b-4225-b5f3-d0ea40da8463
       Atl-Traceid:
-      - 828f92e309a141cb9aa86987bcc93d7f
+      - c54211fee98b4225b5f3d0ea40da8463
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:16 GMT
+      - Wed, 30 Apr 2025 16:26:22 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=332,atl-edge-internal;dur=17,atl-edge-upstream;dur=314,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="CsgOPY1WM1cpKzDIQEcQWAoAi71e69TcBDQY38BduO8bcB1mvBYfrQ==",cdn-downstream-fbl;dur=373,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=371,atl-edge;dur=284,atl-edge-internal;dur=18,atl-edge-upstream;dur=266,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c1388c9ad241eb02cd4ddbe69b1a2d34.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - CsgOPY1WM1cpKzDIQEcQWAoAi71e69TcBDQY38BduO8bcB1mvBYfrQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 8cc522c4e359160e39ca0d090222910a
+      - 153f3b32325e90642aeacd9ec94d274c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/276]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/276 (276)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16104","key":"NTEST-1620","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16104"}'
+      string: '{"id":"18215","key":"NTEST-1860","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18215"}'
     headers:
       Atl-Request-Id:
-      - d7970280-2d31-451e-8d9b-ac87ea67b74e
+      - 60097f2f-6841-4917-aa82-48b28df21d99
       Atl-Traceid:
-      - d79702802d31451e8d9bac87ea67b74e
+      - 60097f2f68414917aa8248b28df21d99
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:17 GMT
+      - Wed, 30 Apr 2025 16:26:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=785,atl-edge-internal;dur=25,atl-edge-upstream;dur=756,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="nedeDjLAVpksPnf-Lfl4ZyKU3Y_c7Ym8L_vw9-OiTZnxZTiAqo5UnA==",cdn-downstream-fbl;dur=847,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=844,atl-edge;dur=769,atl-edge-internal;dur=25,atl-edge-upstream;dur=745,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f6567fa2210130239a3a2c737c9517ac.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - nedeDjLAVpksPnf-Lfl4ZyKU3Y_c7Ym8L_vw9-OiTZnxZTiAqo5UnA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 4e8c811d221ed37df372f4660fd19ff2
+      - 53330ff8f9f08118c1e02b693617d095
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1620
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1860
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxtXihtF2ma7mjZ2BhjUEC6DCGTnKamjp3ZDm3H5b/vOG+F
-        Qu4VTLsCQezj8/748XlwYJVRETuho0DEoCA+YMBj3RE0Bd3R0RxS2pEZKGqYFLoDMTMpGNqJ5lQk
-        wGXSuQelUQbxKWQKNAhTnY1ybWQ6swZvfM/zvZ6Cv3PQZrrO4ETRyLAInI7DrH9/4Ht9XGjgM1zO
-        jcl06LoxzCAysbyTPWo41ZpR0RNgXPRkXJoxN3CZ1jm4tYEFrFH/eDo5m3b9QeDhVhGCdsIHR2Ns
-        uY6ogUSqdZlDjCvUCLxgr+v5Xd+bBl7oD/G35wXBdxi3tVE4MRh4YeadQVp9F+15QZN2tYhBR4pl
-        tnC4+4HolHLeITHThonIkIxBBETOyFKqRc9qR1KcK/7GKHLBbLsov6H31FDl3jNYukVYmwArke/t
-        +qMfNfsHfkix7XmKXi0s0OWU6oXtVX5r7Fc4o1xDxykVDzGvQrfjzBkCR0Xz9RHcA8bqPXYcwxBZ
-        GaLECUWOOTpbMNn1akGm5B1m9M6CV9pFuYsG1uW2iycg2WR1LpgxaEA7jW+L1N+Ks1rOzJIqi1fN
-        0owzDDjeyhz7UaCsP1r1R28M9zOdqTNp+tL3hhhG0F8F/f/XS9n9Aovo0B+s/MHXcLiqPe4Gq93g
-        a3isAP74+BKOfhtOgzbBbi2YsdVFSY4Ii6trhEmSKEiQb754CfZqAWYmeV7ywutHB22CYYsgaBWM
-        2gTfvwynpM1y15JS8UI4YdfHJTX4cJSE+/aLW9L5hsDd0pyy17L43Je5LZxvSfnSbjCROKFROTxW
-        PG2tKRaVVXt4sWcjw6N6LnMej5nOOF1XVxm3MSxzgZix17uqhgJM1vLHy0di0BsM/PqR2C5bQ2Xb
-        gjZQBQ2oMsWkYmb9ziLW6q59Et/wVrCUJqBdq6FrIww3uFz29H2yIcsjuaxJte+8vDZBcwk4vQVL
-        ixb/2xNBG3T9NoT6I1uPOdWTjEVHTCwOrGQMmZ1eRFR3sejtspA1O0KKCQ4v9JbDKVBdIkNVX87J
-        0fnPh8c3R4f7k+Ozyc3k9PSPU8wPb6nGguCB6RzICfK/MMT6JUwTKfiaIJcwbo0SI8mvTFFyoiBF
-        MiG5Rsz2XuMUH6+T431inpdpETrlm4i9w+Jv7tQzrsA2JExQvn2omr2q8hY45xhdTTfY10RAczrP
-        7KVtw/EwGNY4Lsekd0KvVG7e3eeTzdvQuIHbTzRa4LBZQ642Xvrar+a5/xRwPRS69WwW1GOCAAv1
-        SHKpjstobnkO3UQha2xGIknGsmy2TDMch4V5HfR7DSl8rrHbSg1hPC/nX2LzszNlhsNOSK4+0iwI
-        yb6UCwbkkhnkOUPOIMoVkANOk0+2OlgcLiPK51KbcOSNPHfGRIxU6gbDwXVhcFwUD/O6k8TCKtwh
-        X9Qk3+Cfbwv1Mxz6LAehGrJFFeQ4BzLGRHHzd7omvtchFoxNEvuXExRd4b/uwO8Xkdo+Rkvopcwo
-        6EmVuAhjalvLcGKz8HfxaG9uUl7EXdq5sHbOxULI5dMinSgZ5zgDTESCFzvFNrlTLL71WVQI4yW/
-        yGXXyJYqZZWB4Jq45MrXhvyZU2VAkY3JFlXY+PQL7Y8fTshZREXLeTuM4j3aa7J6ksfZWhtINeYR
-        Z5Ih2HbCYr/okK1YSpnQzEAP8YgF0/NbSVXcduKF/fEGZzvhvwAAAP//7Flta9swEP4rolBooXad
-        xGmSQelC2WAfykYLK5RCkGW5MYtl45e6pet/33OSoqVe3I0ySj8U8sGJpLvT+e655y7Xas6ECSdg
-        L4ukVKySNWttbNUAx8rEV4L4OmDtMhVLlkmuKixys8NKwH2vVSQZFwLoKmN2m3LWIGFEeV8AnrBP
-        KWkKtb9h0Rne9Y1uLcmgy6VUFF+MO7k5Ok/cCJbQtcACWaqSvMz0GZaXhNkcqxVBJuD6h1QHZBiE
-        pzUzbIDxVcvv6Yqs4Nq6pkJkM67YhoHoG5Vc+XjjFd3Z3dD44FqRE0gb+QgWWAurtYkksGrgoK2W
-        btx54/bnyEVUH7iMbm/jpW1bP295VeisQBLKO79YFjqioWQBmQure8Fr0J+oQUwt9r5ezi++eRdn
-        Hgq1zlWnpMgplCkb9nicpWqf7e3/RKCs6vwDwvBPjjN2hb5b5PrIzyDsW3Ckl5CxLgH5mtkRV+ts
-        DR0h7SwETkZ3oY9rBI5r6LenKdf2jX3sOHDGPKnZXUjHC+BiSdlv6kLVZBmnorXzN7wmrxMFzcsX
-        VjiiIifINyLOX+LjcTyaTqbRYBLIkZgFYjYeJrNBcgQ9bhM0PLNNUkjM4xg6UOVQ8uL7jxuGAFBI
-        1rNNsckVH1VUb9MwZRuzUILo8XgQhkcTMZ2MR7NIRJMA6hMuk6k4iY+1lN3RfHf4GR9zzsu4svjq
-        eeanym8qr4UjvKFPwO0XTbRKBXnKKzivyFE4r+sIaCIeT5EUfqHI590G++1b3O3Q377F3Q7/rVsM
-        KIpNw2ip4ClCH0wmSRohUp1AhOemHTVAdgUyiI2fmjIv5OEVIEYsf2caTZiw6lKXNNi52nb+GPbh
-        atjXVIZ9k4rQYXdpgf8dX14tkt7x5TUsfseXLfjShQFHyBx/gdU3JvceaBRunwMozGtuB/ldKb3M
-        qxeXeinZcDvy9U2Fgj4OSoCwdSHo46CjvhMjR/Kkuk3LXBkiZ36KG/svkvn6T97LMyPhYf1o4f4F
-        8LvxB9jhWu7BTsbvzmXVrEjwhm49NCnreW3suM3r/zepNcKcUOhCu/g91zOn9XiVZsU0ySGVzpCn
-        1g6fmGsPaPc8Pj7+AgAA//8DAMSj+Uq0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18215","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18215","key":"NTEST-1860","fields":{"statuscategorychangedate":"2025-04-30T18:26:23.348+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1860/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:23.032+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:23.118+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/276]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/276 (276)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1860/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18215/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - e87f2005-f122-4bea-9ae5-80658bfb1f03
+      - 103b2b8a-3a86-4d60-9d3a-f2f62aed9623
       Atl-Traceid:
-      - e87f2005f1224bea9ae580658bfb1f03
+      - 103b2b8a3a864d609d3af2f62aed9623
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:17 GMT
+      - Wed, 30 Apr 2025 16:26:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=283,atl-edge-internal;dur=14,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="uwIdlCdGrb7aWz3BNA-IL0A8jKRXhSgL5K4F55Q22WQdCa-opemuhA==",cdn-downstream-fbl;dur=364,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=361,atl-edge;dur=274,atl-edge-internal;dur=18,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 51e6f466f192ce588105b138cebcc0d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - uwIdlCdGrb7aWz3BNA-IL0A8jKRXhSgL5K4F55Q22WQdCa-opemuhA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 3141def97ab576b0350f4f6936ed11a0
+      - 41ade01989c89e374bbb592b54dd1b3d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16104
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18215
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+0/rNhT+V6z8tLG2eVDaLtI03dGyccdYRwtIlyFkktPU1LEz26HtuPzvO86j
-        BUruBNOuQBA/zvs7n8+DA6uMitgJHQUiBgXxEQMe65agKeiWjuaQ0pbMQFHDpNAtiJlJwdBWNKci
-        AS6T1j0ojWcQn0GmQIMw1d0o10amM6vwxvc83+so+CsHbabrDMaKRoZF4LQcZu37Pd/r4kIDn+Fy
-        bkymQ9eNYQaRieWd7FDDqdaMio4A46Il49KMuYHLtM7BrRUsYI3yp9PRZNr2e4GHW4UL2gkfHI2+
-        5TqiBhKp1mUMMa5QIvCCg7bnt31vGnih38ffjhcE36HfVkdhxKDjhZp3OmnlXdTnBZuwq0UMOlIs
-        s4nD3Q9Ep5TzFomZNkxEhmQMIiByRpZSLTpWOpLiXPE3epELZstF+Q29p4Yq957B0i3c2jpYHfne
-        vj/4UbO/4YcUy56naNXCAk1OqV7YWuW3xn6FM8o1tJxS8BjjKmRbzpwhcFQ0X5/APaCv3mPLMQyR
-        lSFKnFDkGKPzAib7Xn2QKXmHEb0z4ZV0ke6igHW67eIJSLZRnQtmDCrQzsa2ReqvxV0tZ2ZJlcWr
-        ZmnGGTocv4gc61GgrDtYdQdvdPcLlakj2dSl6/XRjaC7Crr/r5Wy+gUW0aDfW/m9r2FwVVvcD1b7
-        wdewWAH88XEXjn4TToP6YMZWFyUHYvWvrndv7tc3aZIoSJBvdpoAA5A8L9v/dXMHTQe9poN+w0HQ
-        eDBoOvh+18+SNstdS0rFC+GEbR+X1ODDURLu2xu3pPMtgbulOmXbsvg8lLlNnG9J+dJuMJE4oVE5
-        PFY8bbUpFpXpfNjZs57hVT2XOY+HTGecrqtWxm10y1wgZmx7V9lQgMFa/th9JHqdXs+vH4mXadtQ
-        2cuDJlAFG1BliknFzPqdSazFXfskvuGtYClNQLtWQtdKGG5wuezo+2RLlidyWZNq19ltm2CDeU5v
-        wdLiK41h2eTVNPhNCPUHNh9zqkcZi06YWBzZkyFkdnoRUV3ForbL4myzI6QY4fBCbzmcAdUlMlT1
-        5YxPzn8+Pr05OT4cnU5GN6Ozs9/PMD7sUo0JwQvTOZAx8r8wxNolTBMp+JoglzBulRIjyUemKBkr
-        SJFMSK4Rs53XOMXHdnK8z8zzMi1Cp3wTsXaY/G1PPeMKLEPCBOUvL1WzV5XeAuccvavWtq6JgM3t
-        PLNN24TjftCvcVyOSe+EXim8eXefTzZvQ+MWbj/RaIHDZg25Wnlp67Ca5/6Tw/VQ6NazWVCPCQIs
-        1CPJpTotvbnlObQThayxHYkkGcqy2DLNcBwW5nXQHzSRwsGGFL5U8efp/FNsf/amzHDYC8nVJ5oF
-        ITmUcsGAXDKDPGfIBKJcATniNPlss4PJ4TKifC61CQfewHNnTMRIpW7Q710XCodF8jCuO0ksrMI9
-        8q+S5Bv8820hPsGhz3IQiiFbVE4OcyBDjAc3f6Nr4nstYsG4CeLwcoRHV/iv3fO7hae2jtESOikz
-        CjpSJS7CmNrSMpzYLPxdvNqZm5QXfpd6Lqyec7EQcvk0SWMl4xxngJFIsLFTLJM7xRxbm0WG0F/y
-        i1y2jWzIUlYpCK6JS658bcgfOVUGFNmqbBCFrU2/kP70YUwmERUN9+0win10sInqSRyTtTaQaowj
-        ziRDsO2FxX5RIZuxlDKhmYEO4hETpue3kqq46caO/uEWZ3vhPwAAAP//7Flta9swEP4rolBooXad
-        xGmSQelC2WAfykYLK5RCkGW5MYtl45e6pet/33OSoqVe3I0ySj8U8sGJpLvT+e655y7Xas6ECSdg
-        L4ukVKySNWttbNUAx8rEV4L4OmDtMhVLlkmuKixys8NKwH2vVSQZFwLoKmN2m3LWIGFEeV8AnrBP
-        KWkKtb9h0Rne9Y1uLcmgy6VUFF+MO7k5Ok/cCJbQtcACWaqSvMz0GZaXhNkcqxVBJuD6h1QHZBiE
-        pzUzbIDxVcvv6Yqs4Nq6pkJkM67YhoHoG5Vc+XjjFd3Z3dD44FqRE0gb+QgWWAurtYkksGrgoK2W
-        btx54/bnyEVUH7iMbm/jpW1bP295VeisQBLKO79YFjqioWQBmQure8Fr0J+oQUwt9r5ezi++eRdn
-        Hgq1zlWnpMgplCkb9nicpWqf7e3/RKCs6vwDwvBPjjN2hb5b5PpwbhD2LTiKSwBYl4B8zeyIq3W2
-        ho6QdhaCPpoc9HGNwHEN/fY05dq+sY8dB86YJzW7i9x4AVwsKftNXaiaLONUtHb+htfkdaKgefnC
-        CkdU5AT5RsT5S3w8jkfTyTQaTAI5ErNAzMbDZDZIjqDHbYKGZ7ZJCol5HEMHqhxKXnz/ccMQAArJ
-        erYpNrnio4rqbRqmbGMWShA9Hg/C8GgippPxaBaJaBJAfcJlMhUn8bGWsjua7w4/42POeRlXFl89
-        z/xU+U3ltXCEN/QJuP2iiVapIE95BecVOQrndR0BTcTjKZLCLxT5vNtgv32Lux3627e42+G/dYsB
-        RbFpGC0VPEXog8kkSSNEqhOI8Ny0owbIrkAGsfFTU+aFPLwCxIjl70yjCRNWXeqSBjtX284fwz5c
-        DfuaytA1ld0Fh92lBf53fHm1SHrHl9ew+B1ftuBLFwYcIXP8BVbfmNx7oFG4fQ6gMK+5HeR3pfQy
-        r15c6qVkw+3I1zcVCvo4KAHC1oWgj4OO+k6MHMmT6jYtc2WInPkpbuy/SObrP3kvz4yEh/WjhfsX
-        wO/GH2CHa7kHOxm/O5dVsyLBG7r10KSs57Wx4zav/9+k1ghzQqEL7eL3XM+c1uNVmhXTJIdUOkOe
-        Wjt8Yq49oN3z+Pj4CwAA//8DAKJCzYy0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18215","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18215","key":"NTEST-1860","fields":{"statuscategorychangedate":"2025-04-30T18:26:23.348+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1860/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:23.032+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:23.118+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/276]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/276 (276)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1860/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18215/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 71c94b49-8471-4569-a089-12bd56a9f85a
+      - 23b3112b-a894-460c-893d-45f735b7101c
       Atl-Traceid:
-      - 71c94b4984714569a08912bd56a9f85a
+      - 23b3112ba894460c893d45f735b7101c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:17 GMT
+      - Wed, 30 Apr 2025 16:26:24 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=310,atl-edge-internal;dur=14,atl-edge-upstream;dur=297,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=276,atl-edge;dur=244,atl-edge-internal;dur=15,atl-edge-upstream;dur=229,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="KBrryJVJHeQMBDWjYc9wPVxcD6dUeiBpoS_IWuj1-W4QVffPwPYEsw==",cdn-downstream-fbl;dur=280
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8139bc666c011a53bdc5037ba6d5931e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - KBrryJVJHeQMBDWjYc9wPVxcD6dUeiBpoS_IWuj1-W4QVffPwPYEsw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3c3f7487d6cdc02dea65bae75be504e0
+      - 92f616ea4049ef7abe3108cad05bf8c5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:36686\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:37096\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:17 GMT
+      - Wed, 30 Apr 2025 16:26:24 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/105", "url_api": "http://localhost:8080/api/v2/tests/105/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      105, "url_ui": "http://localhost:8080/test/105", "url_api": "http://localhost:8080/api/v2/tests/105/"},
+      "finding_count": 2, "findings": {"new": [{"id": 275, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/275",
+      "url_api": "http://localhost:8080/api/v2/findings/275/"}, {"id": 276, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/276",
+      "url_api": "http://localhost:8080/api/v2/findings/276/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:37100\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/105\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/105/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 105, \\\"url_ui\\\": \\\"http://localhost:8080/test/105\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/105/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 275, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/275\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/275/\\\"},
+        {\\\"id\\\": 276, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/276\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/276/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 275,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/275/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/275\"\n        },\n
+        \       {\n          \"id\": 276,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/276/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/276\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        105,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/105/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/105\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/105/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/105\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:24 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -959,26 +1046,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2rVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwFWFKfmlfARZMDmU6BTWFaM8SzlWRADXECAQ96FP+BQtd05S6FiwGnB6SKhaf7N
-        yu7GKBvAjOYLKQDnqCRNCxSZUpkCqdgynS9qlWfIcgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAmMrpOCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:24.781+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 5ab72883-f3e7-410b-99c0-728af749b72f
+      - 45f92200-938f-4d05-a733-c54ff860def8
       Atl-Traceid:
-      - 5ab72883f3e7410b99c0728af749b72f
+      - 45f92200938f4d05a733c54ff860def8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:18 GMT
+      - Wed, 30 Apr 2025 16:26:24 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -988,7 +1071,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=150,atl-edge-internal;dur=15,atl-edge-upstream;dur=135,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=200,atl-edge;dur=167,atl-edge-internal;dur=14,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ZUAdLi1_OiedRMX1PRRlFTIzTskkL0JjkGw8KM4Ghs57xlQkWLqLAQ==",cdn-downstream-fbl;dur=204
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -997,10 +1080,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 edb5724c2fa0963fde9c6c5089b747ce.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ZUAdLi1_OiedRMX1PRRlFTIzTskkL0JjkGw8KM4Ghs57xlQkWLqLAQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4cb24cd61b7c3bcc92ba59864f63c3c5
+      - d3500fc2a9bc86cc2555463ce362872c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1024,61 +1115,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16103
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18213
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaWb7IMQwkpVdSWhpaU0JQGkowiZ3cnGxGtvbS9JyvG/d7yP
-        5HjsVVD1hHSX9Xje33yeBwdWORWJEzkKRAIKkiMGPNGuoBloV8dzyKgrc1DUMCm0CwkzGRjqxnMq
-        UuAyde9BaZRBcga5Ag3C1HfjQhuZzazBm8D3A7+r4K8CtJmucxgrGhsWg+M6zPoP+oG/ix8a+Aw/
-        58bkOvK8BGYQm0TeyS41nGrNqOgKMB56Mh7NmRd6TOsCvMbAAtaofzodTaYdPDvAozIE7UQPjsbY
-        Ch1TA6lU6yqHBL9QI/TDvY4fdAJ/GvpRsB8Fve5+2PsO4/ZtkNaJwcBLM+8M0up7aM8PN2nXHwno
-        WLHcFg5PPxCdUc5dkjBtmIgNyRnEQOSMLKVadK12LMW54m+MohDMtovyG3pPDVXePYOlV4a1DbAW
-        YTmDwQ+a/Q3fZ9j2IkOvFhbockr1wvaquDX2VzSjXIPrVIrHmFep6zpzhsBR8Xx9AveAsfqPrmMY
-        IitHlDiRKDBH5xlMdv1GkCt5hxm9s+C1dlnusoFNue3HZyDZZnUumDFoQDsb3xapv5Z3tZyZJVUW
-        r5plOWcYcPIsc+xHibLeYNUbvDHcL3SmyWTTl56/j2GEvVXY+3+9VN0vsYgOg/4q6H8Nh6vG4264
-        2g2/hsca4I+PL+EYtOE0bBPsNoIZW11U5IiwuLpGmKSpghT55sUQYAKSF9X4v251r03QbxPstwjC
-        VsGgTXDwMs6KNqtTS0rlC+FEncB1sDPmAqtuB6S6UJKLbZJicZXkw4szOzpYfz2XBU+GTOecrusB
-        w+MlNfgYVST+djKonojto+BV5pQd9fLnoSxsMwIb6qU9YCJ1IqMK6ztWgMla/njtkdg9OGgeiedl
-        21DZc0EbqMINqHLFpGJm/c6EG3Wv97a3gmU0Be1ZDd0YYXjA5bKr79MtWZ7IZUOqPefl2ISbIeD0
-        FiwtWvw/3wjaoBu0ITQY2HrMqR7lLD5hYnFkJUPI7fYi4gYvJYqWpWxzIqQY4fJCbzmcAdUVBlX9
-        yxmfnP90fHpzcnw4Op2MbkZnZ7+fYX44pRoLghemcyBj5H9hiPVLmCZS8DVBLmHcGiVGkl+YomSs
-        IEMyIYVGfHVf4xRcSiLH/8R8P9ezyKneROwdFn87U0+4AtuQMkH580v17lWXt0Q5x+gausG+pgI2
-        t4vcDm0bjnv9QYPjak16J/Qq5c27+3SzeRsat3D7kcYLXDYbyDXGK1+H9T73nwJulkKv2c3CZk0Q
-        YKEeSy7VaRXNLS+gkyrkp+1KJMlQVs2WWY7rsDCvg36vjRT2NqTwpY4/LeefYvu3M2WGw05Erj7S
-        PIjIoZQLBuSSGWRUQyYQFwrIEafpJ1sdLA6XMeVzqU008Ae+N2MiQdrzwv2969LgsCwe5nUniYVV
-        tEP+VZN8g/98W6pPcOmzHIRqyBZ1kMMCyBDzwcPf6JoEvkssGDdJHF6OUHSF/3X6Qa+M1PYxXkI3
-        Y0ZBV6rUQxhT21qGG5uFv4dXu3OT8TLuys6FtXMuFkIuPy/SWMmkwB1gJFIc7Azb5E2xxtZnWSGM
-        l/wslx0jW6qU1wbCa+KRq0Ab8kdBlQFFtiZbVGHrMyi1P34Yk0lMRct9u4ziHFXdePq3M1lrA5nG
-        PJJcMgTbTlSelx2yFcsoE5oZ6CIesWB6fiupStpuvLA/3OJsJ/oHAAD//+xZ70sbQRD9VxZBUPDO
-        S3KapCA2SAv9IC0KFUQIm709czS3d9wPT7H+732zu27jNWuLFPGD4IczuzfzdjLz9s3kSs2YMOkE
-        7mULKRWrZcM6m1sNyLE2+ZUiv/ZYt8zEkuWSqxqL3OywFnDeK7WQjAsBdpUJu8k4a1EwororQU/Y
-        p5Q0kiBcQ3SK7/pat5YE6GIpFeUX485ugc4TJwISOhZUIMtUWlS5focVFXE2x2pNlAm6/iHVHgGD
-        8axhRncwvur4HR2RlVyja2tkNuOKrQFE36jkKsQ3XtOZ3QlNDK4UBYG8UYyAwCKsHyGSwbpFgDYi
-        XTvz2unPUIu4fRAyOr3Nl67rwqLjdamrAkUob8NyWeqMhpM5bM6t7zlvILQWLXJqvvP1Ynb+LTg/
-        DXBR61p1TsqCUpmqYYcneaZ22c7uTyTKqik+IA3/1DgH7qLvX3I+nhvEvgUncYkAmwqUr1UYqcLe
-        1tgJ0t5C5JPJkU9rRE5r6G9PS67NG33qOHJgEGMullTgG/R+n8nrNs85XVpbf+NrijpJ0KJ64Q1H
-        UuQY9UYi90tydJCMJuPJYjCO5EhMIzE9GKbTQXoIP24TPDyzTVJKzJIEPnDL4cpL7j6uAQGhkK1n
-        m2JTKyFuUb1N05RtzGIJoceTQRwfjsVkfDCaLsRiHMF9ymU6EcfJkbayPZptDz/jz7wX5FxZfg0C
-        81EdtnXQIRDBMCTiDst2scoERSooOa8pUHhf3yOQiXg8QVGEpaKY9xvst4+436G/fcT9Dv+tIwYV
-        JaY1tVLwBKkPJZOmrRCZLiDic9M6GiK7hBjExk9tVZRy/xIUI5a/K40mTFh1pUse7Fxts36Mfbwa
-        +5rK2DepiB13V5b43/nl1TLpnV9eA/E7v2zglz4NOEHm9ApQX5vau6dRuH2O4LBouB3k9614lZeX
-        l7ySbLiZ+XxTocinQYkQNi5EPg068r0xciJPqpusKpRReeajpLW/Ipl//yl6RW4s3D8+Wrp/Af2u
-        /QC2/2h3byvnt2eybldkeM23HppUzawxOG6K5v9NVY0xZxS+0C5+L/TMyQ1yi0pPcsilA/IU7fAJ
-        XPuCDs/Dw8MvAAAA//8DAPuo3Iy0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18213","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213","key":"NTEST-1859","fields":{"statuscategorychangedate":"2025-04-30T18:26:20.584+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:20.337+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:20.404+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/275]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/275 (275)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 6d41cf1a-8459-46c7-b944-05c6b185602d
+      - 5b68d771-0c02-45d6-bcd8-01e986917cc6
       Atl-Traceid:
-      - 6d41cf1a845946c7b94405c6b185602d
+      - 5b68d7710c0245d6bcd801e986917cc6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:18 GMT
+      - Wed, 30 Apr 2025 16:26:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1088,7 +1162,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=314,atl-edge-internal;dur=17,atl-edge-upstream;dur=299,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="_mbOYnC8-j-4CIpCwWrKC7JuEvT-sRCjpa89ekDxJi-m3AH5U0n5jQ==",cdn-downstream-fbl;dur=358,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=356,atl-edge;dur=268,atl-edge-internal;dur=15,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1097,10 +1171,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 471c951325b4c2c11c6c583a1d28e92a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - _mbOYnC8-j-4CIpCwWrKC7JuEvT-sRCjpa89ekDxJi-m3AH5U0n5jQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 2f1db6288df4f4e0e672cb6bb4f964e2
+      - b1ebfc9cd1966510572c699d63019c22
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1127,26 +1209,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1q1b3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLCiODWvREggAzYbAx3DsmKM51OeRzHABUQ45n38A/aVbs9ZChUDTgtOF9kS8m9W
-        tjdWuQjmdL6QAnCGStJpgSJXKlcgFVtOZ4tazXNkcwXsTBBMMtzqXqQXohKDCXdOitQ+EHOqCNrX
-        bUmO54c9OZsm1/cVOX4CAAD//wMAjKWi6CACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:25.671+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 8aa50442-2a26-4aca-9a65-ad15eb6087f1
+      - 32a1bd99-ac2a-4a1a-8d00-24d3f75fe442
       Atl-Traceid:
-      - 8aa504422a264aca9a65ad15eb6087f1
+      - 32a1bd99ac2a4a1a8d0024d3f75fe442
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:18 GMT
+      - Wed, 30 Apr 2025 16:26:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1156,7 +1234,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=165,atl-edge-internal;dur=13,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="n1OWV0tUBAWjaGlO57bRzrMpOWZvpU5RP-qE7a6G-r8Xp6EhI--z4g==",cdn-downstream-fbl;dur=255,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=252,atl-edge;dur=162,atl-edge-internal;dur=17,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1165,10 +1243,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ed78483d37e5338746e5a4b545e5818e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - n1OWV0tUBAWjaGlO57bRzrMpOWZvpU5RP-qE7a6G-r8Xp6EhI--z4g==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 68c7bf632329db0051dcc5d6422862f9
+      - 739a41760d6b9f2a825c0e28e2c6e2e7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1192,61 +1278,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16103
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18213
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa0/jRhT9KyN/aqkTPwghWKqqLQktW0pTEkBaitBg3zizGc+4M2OSlOW/944f
-        yfLwrqDqKhJ4Hvd97pl778AqpyJxIkeBSEBBcsSAJ9oVNAPt6ngOGXVlDooaJoV2IWEmA0PdeE5F
-        Clym7h0ojWeQnEGuQIMw9d240EZmM6vwJvD9wO8q+LsAbabrHMaKxobF4LgOs/aDfuDv4kIDn+Fy
-        bkyuI89LYAaxSeRH2aWGU60ZFV0BxkNLxqM580KPaV2A1yhYwBrlT6ejybSDewe4Vbqgneje0ehb
-        oWNqIJVqXcWQ4AolQj/c6/hBJ/CnoR8F+1HQ6+6HvR/Qb986aY0YdLxU80YnrbyH+vxwE3a9SEDH
-        iuU2cbj7juiMcu6ShGnDRGxIziAGImdkKdWia6VjKc4Vf6UXhWC2XJTf0DtqqPLuGCy90q2tg/UR
-        pjMY/KTZP/BjhmUvMrRqYYEmp1QvbK2KW2O/ohnlGlynEjzGuEpZ15kzBI6K5+sTuAP01X9wHcMQ
-        WTmixIlEgTE6T2Cy67cdBM1BruRHDPWNlailyzqUlW3qYBefoWcb7rlgxqAC7WxsWwj/Vt7VcmaW
-        VFkga5blnKHDyZOUYKFK+PUGq97gle5+oWRNJJuC9fx9dCPsrcLe/2ulgkUJUjQY9FdB/1sYXDUW
-        d8PVbvgtLNbIf3h4DsewgeOMrS4qDsQiX10/v7nb3KRpqiBFvvlqE+w1BxiA5EXFCy9f7bcd7Lcc
-        hK0Hg7aDg+fuVLRZ7VpSKl8IJ+oENVfazCsWV57fP9uz/YBJ1XNZ8GTIdM7puu4a3MYSmgssj+2k
-        2gQ1+BhVJP76nq+eiO2j4FXqlO3o8vNQFrYYpfOXdoOJ1ImMKqw3sQIM1tLES4/E7sFB80g8TVsb
-        lYUbKnt6sAFVrphUzKzfGHAj7vVe91awjKagPSuhGyUMN7hcdvVduuXEE7lsuLPnPO+OcIN5Tm/B
-        st8LjWFJ48U0BG0IDQY2H3OqRzmLT5hYHNmTIeR2ehFxg6ASV8vybLMjpBjh8EJvOZwB1RUqVf3l
-        jE/Ofzk+vTk5PhydTkY3o7OzP84wPuxSjQnBC9M5kDHSvDDE2iVMEyn4miBlMG6VEiPJe6YoGSvI
-        kDNIoRFf3ZeoA4eSyPE/Md/P9SxyqjcRa4fJ3/bUI67AMqRMUP70Uj171ektUc7Ru3pt65oK2Nwu
-        ctu0bTju9QcNjqsx6Y3Qq4Q3z+vjyeZ1aNzC7WcaL3DYbCDXKK9sHdbz3H9yuBkKvWY2C5tpQICF
-        eiy5VKeVN7e8gE6qkLG2I5EkQ1kVW2Y5jsPCvAz6vTZS2NuQwpcq/jidf4ntb2fKDIediFx9oHkQ
-        kUMpFwzIJTPIsYZMIC4UkCNO0082O5gcLmPK51KbaOAPfG/GRIK054X7e9elwmGZPIzroyQWVtEO
-        +aok+Q7/fF+KT3DosxyEYsgWtZPDAsgQ48HN3+maBL5LLBg3QRxejvDoCv91+kGv9NTWMV5CN2NG
-        QVeq1EMYU1tahoOZhb+HV7tzk/HS70rPhdVzLhZCLj9P0ljJpMCnfiRSbOwMy+RNMcfWZpkh9Jf8
-        KpcdI1uylNcKwmvikatAG/JnQZUBRbYqW0RhazMopT+8G5NJTEXLfTtzYh9V1Xj825mstYFMYxxJ
-        LhmCbScq98sK2YxllAnNDHQRj5gwPb+VVCVtN57pH25xthP9CwAA///sWW1L3EAQ/iuLICiYmLvL
-        eXcFsYe00A/SolBBhGOz2Xihd5uQF6NY/3uf2d3bxvRiixTxg+CHmN2dnZnMPPPM3LWaM2HCCdjL
-        IikVK2XFGhtbFcCxNPGVIL4OWLNMxZKtJVclFrnZYSXA3msVScaFALrKmN2mnNVIGFHc54An7FNK
-        GpLgtzQ6w7e+0a0lKXS5lIrii3EnN0PnCYugCZkFssdSlWTFWp9hWUGYzbFaEmQCrn9IdUCKQXha
-        McNEGF81/J5MZDnX2tUlIptxxVoKom9UcuXji5dks7PQ+OBakRPoNvIRNLAalhsVSWBZw0FbNW3Z
-        3LL+HLmI6gOXkfU2Xpqm8bOGl7nOCiShvPPzZa4jGpcsIHNh717wCtQrqhFTi72vl/OLb97FmYdC
-        rXPVXZJnFMqUDXs8Xqdqn+3t/0SgrKrsA8LwT44zdoW+W+T6cG4QtnGuKoDsmmwRHexudTS4sxA6
-        QtpZCPpOBI5r6I+kmdX2jX3cI+hjx4FTBj7mYkkJbgtwu4Z3kbys12tORWvnb3hNXicKmhUvrHBE
-        RU6Qb0Ryv8TH43g0nUyjwSSQIzELxGw8TGaD5Aj3uE244ZltkkJiHse4A1UOJS++/9hSBIBCsp7t
-        fU2u+KiiepuGKdt/hRJEj8eDMDyaiOlkPJpFIpoEuD7hMpmKk/hYS9kdzXeHn/Fnznlrriy+ep55
-        Vfp16TVwhDf0Cbj9vI5WqSBPeTnnJTkK53UdAU3E4ymSws8V+bzbR799jbuN+NvXuNvIv3WNgVGx
-        aVYtFTxF6IPJJEktRKoTiPDctI4G4a5ABrHxU11kuTy8AvaI5e9Mo0ESVl3q0g12rradP4Z9uBr2
-        NZWhayoLi+/vMPJqAfMOI6+h8TuMbIGRLgz0MbXQETLHV2DOjUnKB5p42+cAmmQVt4P8rpRe5tWL
-        S33jn2C4Hfl6mVmvZb2UzZncWRj1nRg5kifVbVpkyrA88yqu7a9I5t9/8d5tVv2/aaYR5oTiJrRp
-        3zM969mMVJECRuWHzaOtLy9WQP/idriRe7Cz5nfnsqxXJLhlrJ7SFNW8MobTrJgmOWS6e//08PDJ
-        aXtAa/v4+PgLAAD//wMAxHvmNbQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18213","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213","key":"NTEST-1859","fields":{"statuscategorychangedate":"2025-04-30T18:26:20.584+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:20.337+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:20.404+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/275]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/275 (275)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 5dca7c39-7709-496f-9524-8d22cf69e5b6
+      - c1db045a-018a-4a52-92a2-409036a10be7
       Atl-Traceid:
-      - 5dca7c397709496f95248d22cf69e5b6
+      - c1db045a018a4a5292a2409036a10be7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:19 GMT
+      - Wed, 30 Apr 2025 16:26:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1256,7 +1325,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=272,atl-edge-internal;dur=17,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="iB53L0zaz61v386Cfr0sTXZEsZipf2zIfYmrUzUrASOzfqO_-ygzHA==",cdn-downstream-fbl;dur=351,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=349,atl-edge;dur=262,atl-edge-internal;dur=18,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1265,10 +1334,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8f3e5b5af450fbcfb7e821f6aa6b3d76.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - iB53L0zaz61v386Cfr0sTXZEsZipf2zIfYmrUzUrASOzfqO_-ygzHA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 7a7e693542b0afed9c80c6f9aa2b7ae7
+      - bbd41324b28a43c6cbf153dc4b2bf62b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1295,41 +1372,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 704605e8-4841-448e-8d37-40ebd8f811f5
+      - 769ba2bb-f4d6-4883-98e5-1ac0dbd63256
       Atl-Traceid:
-      - 704605e84841448e8d3740ebd8f811f5
+      - 769ba2bbf4d6488398e51ac0dbd63256
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:19 GMT
+      - Wed, 30 Apr 2025 16:26:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1339,7 +1403,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=290,atl-edge-internal;dur=14,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="JWKNix31cL6qf36Vr4X1Xz7tbmw87K9qGalEQkL56ybGNK3uOPbkbw==",cdn-downstream-fbl;dur=377,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=59,cdn-upstream-fbl;dur=374,atl-edge;dur=294,atl-edge-internal;dur=15,atl-edge-upstream;dur=279,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1348,13 +1412,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b6805b08a4af317938604723e3f3424a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JWKNix31cL6qf36Vr4X1Xz7tbmw87K9qGalEQkL56ybGNK3uOPbkbw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - f306d3e4e89304936c45d77e221b6b35
+      - 4051b2ca5365264d3ba543b97db1a80c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1367,7 +1439,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/275]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/275 (275)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1375,7 +1447,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -1387,27 +1459,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1288'
+      - '1308'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16103
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18213
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 76211070-43e4-4db7-b07d-5be79654c6c4
+      - 415f6770-febe-4317-9e6c-f9a706e1dfca
       Atl-Traceid:
-      - 7621107043e44db7b07d5be79654c6c4
+      - 415f6770febe43179e6cf9a706e1dfca
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:19 GMT
+      - Wed, 30 Apr 2025 16:26:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1417,17 +1491,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=290,atl-edge-internal;dur=40,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=297,atl-edge;dur=264,atl-edge-internal;dur=17,atl-edge-upstream;dur=247,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="qqMwi0FKwVJojZpr5SrHRIcFk0FaWX5IKDnRikTyKZXdAANzECdeSQ==",cdn-downstream-fbl;dur=303
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qqMwi0FKwVJojZpr5SrHRIcFk0FaWX5IKDnRikTyKZXdAANzECdeSQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e683966a0f0e4f9c68b80cb1eb43036e
+      - dbeca2f9206da89228a7df283a80777a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1451,61 +1533,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16103
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18213
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+0/rNhT+V6z8tLG2eVBKiTRNd7RsbIx1UEC6DCGTnKamjp3ZDm3H5X/fcV69
-        UHInmHZVCeLHeX/n83l0YJVRETuho0DEoCA+YsBj3RE0Bd3R0RxS2pEZKGqYFLoDMTMpGNqJ5lQk
-        wGXSeQCl8QziM8gUaBCmuhvl2sh0ZhXe+p7nez0Ff+WgzXSdwUTRyLAInI7DrH1/4Hu7uNDAZ7ic
-        G5Pp0HVjmEFkYnkve9RwqjWjoifAuGjJuDRjbuAyrXNwawULWKP86XR8Pu3i3gFuFS5oJ3x0NPqW
-        64gaSKRalzHEuEKJwAv2up7f9b1p4IX+fuj3e/tB/zv027NOWiMGHS/UvNNJK++iPi9owq4WMehI
-        scwmDnc/EJ1SzjskZtowERmSMYiAyBlZSrXoWelIigvF3+hFLpgtF+W39IEaqtwHBku3cGvjYHWE
-        6fSHP2j2N3yfYtnzFK1aWKDJKdULW6v8ztivcEa5ho5TCh5jXIVsx5kzBI6K5usTeAD01XvqOIYh
-        sjJEiROKHGN0XsBk12s78OuDTMl7DPWdlaikizoUla3rYBefoWcT7oVgxqAC7TS2LYR/Le5qOTNL
-        qiyQNUszztDh+EVKsFAF/PrDVX/4Rne/ULI6kqZgfW8f3Qj6q6D//1opYVGAFA36g5U/+BoGV7XF
-        3WC1G3wNixXyn5624RjUcJyx1WXJgVjk65vtm7v1TZokChLkm60mQD8lz8v2fx39e20Hg7aD/ZaD
-        oPVg2HZwsO1nSZvlriWl4oVwwq5fcaXNvGJRGdLj1p7tB0yqnsucxyOmM07XVdfgNpbQXGJ5bCdV
-        JqjBx6gk8bf3fPlEbB4Ft1SnbEcXn4cyt8UonL+yG0wkTmhUbr2JFGCwliZeeyR2Dw7qR+Jl2tqo
-        LGio7OVBA6pMMamYWb8z4Frc7b/trWApTUC7VkLXShhucLns6Ydkw4kncllzZ9/Z7o6gwTynd2DZ
-        75XGsKTxahr8NoT6Q5uPOdXjjEUnTCyO7MkIMju9iKhGUIGrZXHW7Agpxji80DsOZ0B1iUpVfTmT
-        k4ufjk9vT44Px6fn49vx2dnvZxgfdqnGhOCF6RzIBGleGGLtEqaJFHxNkDIYt0qJkeQXpiiZKEiR
-        M0iuEV+916gDh5LQ8T4xz8v0LHTKNxFrh8nf9NQzrsAyJExQ/vJSNXtV6S1QztG7am3rmghobueZ
-        bdo2HPcHwxrH5Zj0TuiVws3z+nyyeRsaN3D7kUYLHDZryNXKS1uH1Tz3nxyuh0K3ns2CehoQYKEe
-        SS7VaenNHc+hmyhkrM1IJMlIlsWWaYbjsDCvg36vIYUvFfalUEMYz9P5p9j8dqbMcNgJyfVHmvkh
-        OZRywYBcMYMca8g5RLkCcsRp8slmB5PDZUT5XGoTDr2h586YiJH23GB/76ZQOCqSh3HdS2JhFe6Q
-        f5Uk3+Cfbwvxcxz6LAehGLJF5eQoBzLCQHHzN7omvtchFoxNEIdXYzy6xn/dgd8vPLV1jJbQS5lR
-        0JMqcRHG1JaW4WBm4e/i1d7cpLzwu9RzafVciIWQy8+TNFEyzvGpH4sEGzvFMrlTTL61WWQI/SU/
-        y2XXyJYsZZWC4Ia45NrXhvyRU2VAkY3KFlHY2PQL6Y8fJuQ8oqLlvp05sY/Kajz/7ZyvtYFUYxxx
-        JhmCbScs9osK2YyllAnNDPQQj5gwPb+TVMVtN7b0jzY42wn/AQAA///sWV1L3EAU/SuDICiYmN3N
-        ursFsYu00AdpUaggwjKZTNzQ3UnIh1Gs/73nzsxOY7qxRYr4IPgQMzP3K/eee+7stZozYdIJ2Msi
-        KRUrZcUam1sVwLE0+ZUgvw5Ys0zFkq0lVyUWudlhJcDfaxVJxoUAusqY3aac1SgYUdzngCfsU0oa
-        kuC3LDrDt77RoyUZdLmUivKLcSc3w+QJj2AJuQWyx1KVZMVan2FZQZjNsVoSZAKuf0h1QIZBeFox
-        w0QYXzX8nlxkOdfW1SUym3HFWgZiblRy5eOLl+Sz89DE4FpREEgbxQgWWAvLjYkksKwRoK2Wtnxu
-        eX+OWkT3QcjIe5svTdP4WcPLXFcFilDe+fky1xkNJQvIXFjdC16BekU1cmqx9/VyfvHNuzjz0Kh1
-        rToleUapTNWwx+N1qvbZ3v5PJMqqyj4gDf/kOGPX6LtNro/8DMI2AFYFkF2TLaKD3a19pDfoWwgd
-        U+2ecFxDfyTNrLZv7OMeQR87DpxOxJiLJRW4bcDtHt6F+LJerzk1rZ2/4TVFnShoVrywwxEVOUG9
-        Ecn9Eh+P49F0Mo0Gk0COxCwQs/EwmQ2SI+hxm6DhmW2SUmIex9CBLoeWF99/bBkCQCFZz86+plZ8
-        dFG9TcOUnb9CCaLH40EYHk3EdDIezSIRTQKoT7hMpuIkPtZSdkfz3eFn/Jlz3pori6+eZ16Vfl16
-        DQLhDX0Cbj+vo1UqKFJeznlJgcJ53UdAE/F4iqLwc0Ux787Rb9/i7iD+9i3uDvJv3WJgVGyGVUsF
-        T5H6YDJJUguR6gIiPDejo0G4K5BBbPxUF1kuD6+APWL5u9LoIgmrrnRJg71X284fwz5cDfuGytAN
-        lYXF93cYebWEeYeR17D4HUa2wEgXBvqYWugImeMrcOfGFOUD3Xjb5wCWZBW3F/ldKX2ULOjDpWC4
-        HeD6boWCXgd6KZvzrHuij8uNehccyZPqNi0yZVieeRXX9lck8++/RO82q/7fbaYR5oRCE8a075m+
-        69lcqaIEjMkPm0fbX15sgP7F7XAj92Bnze/OZVmvSHDLWX1LU1TzyjhOd8V0k0Ouu/dPDw+fnLYH
-        tLWPj4+/AAAA//8DAJMCHpu0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18213","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213","key":"NTEST-1859","fields":{"statuscategorychangedate":"2025-04-30T18:26:20.584+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:20.337+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:20.404+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/275]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/275 (275)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 39a43024-f0b4-44ee-a2f8-ad8f867892de
+      - aef7925f-6618-4aab-abae-e0fc63091fd9
       Atl-Traceid:
-      - 39a43024f0b444eea2f8ad8f867892de
+      - aef7925f66184aababaee0fc63091fd9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:20 GMT
+      - Wed, 30 Apr 2025 16:26:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1515,7 +1580,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=291,atl-edge-internal;dur=16,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="C1NJUp_N1oEdiA6HfFHDnm9XEYQ28kr8wQIj4u0IGYAu1dUdSS4ryg==",cdn-downstream-fbl;dur=356,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=353,atl-edge;dur=260,atl-edge-internal;dur=17,atl-edge-upstream;dur=238,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1524,10 +1589,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 82e46a17c2e4998f87de230e61a57612.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - C1NJUp_N1oEdiA6HfFHDnm9XEYQ28kr8wQIj4u0IGYAu1dUdSS4ryg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - fcfbba5f85fc89a3c25349eeab21f140
+      - a9e58127970ab73475c373dff430e9ad
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1554,26 +1627,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2T9WPLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPARYUZyaV8JHkAHLpkCnsKwY4+mcp0EMcAEBDnkX/oBD1XbnLIWKAacFZ5DkWfbN
-        yu7GKBvAlOYLKQAzVJLOCxSpUqkCqdhyni1qlafIcgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAIirRmyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:27.946+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 9711f816-a732-461b-bd98-e3c00690ee20
+      - 61bc5ec9-4b40-4215-bdb5-e352c098ba63
       Atl-Traceid:
-      - 9711f816a732461bbd98e3c00690ee20
+      - 61bc5ec94b404215bdb5e352c098ba63
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:20 GMT
+      - Wed, 30 Apr 2025 16:26:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1583,7 +1652,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=354,atl-edge-internal;dur=17,atl-edge-upstream;dur=342,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=32,cdn-upstream-fbl;dur=284,atl-edge;dur=155,atl-edge-internal;dur=15,atl-edge-upstream;dur=140,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="XpOJragWubM614xQm4U6HEE2x-qjO5R0w0xDOoCwZFKkiGvw0N4k4g==",cdn-downstream-fbl;dur=289
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1592,10 +1661,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - XpOJragWubM614xQm4U6HEE2x-qjO5R0w0xDOoCwZFKkiGvw0N4k4g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 5ac300da3773645c494da40c622236ad
+      - 45572c5a555e15a412ec4f807c62724a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1619,61 +1696,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16104
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18215
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeRCSdKSq2pLQ0lJKSQBpKUJm5mZi4rGntockZfnvvZ5X
-        ICG7gqorEIx9fd/Hx/fRgWVGReyEjgIRg4L4iAGPdUvQFHRLRzNIaUtmoKhhUugWxMykYGgrmlGR
-        AJdJ6wGURhnE55Ap0CBMdTbKtZHp1Bq89T3P9zoK/s5Bm8kqgzNFI8MicFoOs/79nu91caGBT3E5
-        MybToevGMIXIxPJedqjhVGtGRUeAcdGTcWnG3MBlWufg1gbmsEL908loPGn7vcDDrSIE7YSPjsbY
-        ch1RA4lUqzKHGFeoEXjBQdvz2743CbzQ7+NvxwuC7zBua6NwYjDwwsw7g7T6LtrzgibtahGDjhTL
-        bOFw9wPRKeW8RWKmDRORIRmDCIickoVU847VjqS4UPyNUeSC2XZRfksfqKHKfWCwcIuw1gFWIt/b
-        9wc/avYP/JBi2/MUvVpYoMsJ1XPbq/zO2K9wSrmGllMqHmNehW7LmTEEjopmqxN4AIzVe2o5hiGy
-        MkSJE4occ3Q2YLLv1YJMyXvM6J0Fr7SLchcNrMttF89Ass7qQjBj0IB2Gt8Wqb8VZ7WcmgVVFq+a
-        pRlnGHC8kTn2o0BZd7DsDt4Y7mc6U2fS9KXr9TGMoLsMuv+vl7L7BRbRod9b+r2v4XBZe9wPlvvB
-        1/BYAfzpaRuO/i6cBrVgypaXJQdi969vtk/u1ydpkihIkG++eAkOagFmJnle8sLrR3u7BP0dgmCn
-        YLBL8P12OCVtlruWlIoXwgnbPi6pwYejJNy3X9ySztcE7pbmlL2WxeehzG3hfEvKV3aDicQJjcrh
-        qeJpa02xqKza49aejQyP6pnMeTxkOuN0VV1l3MawzCVixl7vqhoKMFnLH9uPRK/T6/n1I7FZtobK
-        NgW7QBU0oMoUk4qZ1TuLWKu79kl8w1vBUpqAdq2Gro0w3OBy0dEPyZosT+SiJtWus31tggbznN6B
-        pcVXLoZlk1fL4O9CqD+w9ZhRPcpYdMLE/MhKhpDZ6UVEdReL3i4KWbMjpBjh8ELvOJwD1SUyVPXl
-        nJ1c/Hx8entyfDg6HY9uR+fnf5xjfnhLNRYED0xmQM6Q/4Uh1i9hmkjBVwS5hHFrlBhJfmWKkjMF
-        KZIJyTVitvMap/h4nRzvE/O8TIvQKd9E7B0Wf32nXnAFtiFhgvLNQ9XsVZW3wDnH6Kq17WsioDmd
-        Z/bS7sJxP+jXOC7HpHdCr1Ru3t2Xk83b0LiG2080muOwWUOuNl76Oqzmuf8UcD0UuvVsFtRjggAL
-        9UhyqU7LaO54Du1EIWusRyJJhrJstkwzHIeFeR30Bw0pfK6xm0oNYbws519i/bM3YYbDXkiuP9Is
-        CMmhlHMG5IoZ5DlDxhDlCsgRp8knWx0sDpcR5TOpTTjwBp47ZSJGKnWDfu+mMDgsiod53UtiYRXu
-        kS9qkm/wz7eF+hiHPstBqIZsUQU5zIEMMVHc/J2uiO+1iAVjk8Th1QhF1/iv3fO7RaS2j9ECOikz
-        CjpSJS7CmNrWMpzYLPxdPNqZmZQXcZd2Lq2dCzEXcvG8SGdKxjnOACOR4MVOsU3uBItvfRYVwnjJ
-        L3LRNnJHlbLKQHBDXHLta0P+zKkyoMja5A5VWPv0C+2PH87IOKJix3k7jOI9OmiyepbHeKUNpBrz
-        iDPJEGx7YbFfdMhWLKVMaGagg3jEgunZnaQq3nViy/5wjbO98F8AAAD//+xZbUvcQBD+K4sgKJiY
-        u8t5dwWxh7TQD9KiUEGEY7PZeKF3m5AXo1j/e5/Z3dvG9GKLFPGD4IeY3Z2Xzcwzz8xdqzkTJpyA
-        vSySUrFSVqyxsVUBHEsTXwni64A1y1Qs2VpyVWKRmx1WAvy9VpFkXAigq4zZbcpZjYQRxX0OeMI+
-        paQp1H7LojN86xvdWpJBl0upKL4Yd3IzdJ7wCJaQW2CBLFVJVqz1GZYVhNkcqyVBJuD6h1QHZBiE
-        pxUzbIDxVcPvyUWWc21dXSKyGVesZSD6RiVXPr54ST47D80dXCu6BNJGdwQLrIXlxkQSWNa4oK2W
-        tnxueX+OXET1wZWR9zZemqbxs4aXuc4KJKG88/NlriMaShaQubC6F7wC/YlqxNRi7+vl/OKbd3Hm
-        oVDrXHVK8oxCmbJhj8frVO2zvf2fCJRVlX1AGP7Jccau0HeLXB/5GYRtAKwKILsmcETJulsdDe4s
-        BH0LoWOq3ROOa+iPpJnV9o193CPoY8eB0/mkZnchHR+AiyVlv6kLZb1ecypaO3/Da7p1oqBZ8cIK
-        R1TkBPlGxPlLfDyOR9PJNBpMAjkSs0DMxsNkNkiOoMdtgoZntkkKiXkcQweqHEpefP+xZQgAhWQ9
-        2xSbXPFRRfU2DVO2MQsliB6PB2F4NBHTyXg0i0Q0CaA+4TKZipP4WEvZHc13h5/xZ855a64svnqe
-        eVX6dek1uAhv6BNw+3kdrVJBN+XlnJd0UTiv6whoIh5PkRR+rujOuw3227e426G/fYu7Hf5btxgY
-        FZuG0VLBU4Q+mEyS1EKkOoEIz007ahDuCmQQGz/VRZbLwytgj1j+zjSaMGHVpS5psHO17fwx7MPV
-        sK+pDF1TWVh8f4eRVwuYdxh5DYvfYWQLjHRhoI+phY6QOf4Cd25MUj7QKNw+B7Akq7gd5Hel9FGy
-        oA+XguF2gOubCgW9DvRSNudZ90Qflxv1LjiSJ9VtWmTKEDnzKq7tr0jm33+5vdus+n8TUiPMCYUm
-        tGnfMz3r2Yw1kQLG5IfNo60vLzZA/+J2uJF7sLPmd+eyrFckuOWsntIU1bwyjtOsmCY55Lp7//Tw
-        8Mlpe0Bb+/j4+AsAAP//AwDQFWvxtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18215","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18215","key":"NTEST-1860","fields":{"statuscategorychangedate":"2025-04-30T18:26:23.348+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1860/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:23.032+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:23.118+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/276]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/276 (276)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1860/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18215/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f2453750-06bd-4a1d-a969-9e6841dd1a96
+      - 280761d2-a750-4c72-a058-0b80a99fc39d
       Atl-Traceid:
-      - f245375006bd4a1da9699e6841dd1a96
+      - 280761d2a7504c72a0580b80a99fc39d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:21 GMT
+      - Wed, 30 Apr 2025 16:26:28 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1683,7 +1743,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=289,atl-edge-internal;dur=14,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="ptEtbKXz75rhR0WchG2WTgSrYUCx8UlLp1t4Is0Kz8pSHxqZZjTb3w==",cdn-downstream-fbl;dur=353,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=350,atl-edge;dur=272,atl-edge-internal;dur=15,atl-edge-upstream;dur=258,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1692,10 +1752,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 087e16218fcf1ccb7472a2c9f6a4cbe2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ptEtbKXz75rhR0WchG2WTgSrYUCx8UlLp1t4Is0Kz8pSHxqZZjTb3w==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - d71841b1ef166b7fcf626e68e5ff7dc6
+      - 4f79d53299c59607e42582df70119dbf
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1722,41 +1790,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 8ae2bd15-07d4-45e1-8c37-dee70f1de3a4
+      - 79d030cf-b999-4384-ba71-694f453dd756
       Atl-Traceid:
-      - 8ae2bd1507d445e18c37dee70f1de3a4
+      - 79d030cfb9994384ba71694f453dd756
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:21 GMT
+      - Wed, 30 Apr 2025 16:26:28 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1766,7 +1821,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=285,atl-edge-internal;dur=16,atl-edge-upstream;dur=269,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="qclpvC3LofrFSP4lXTERNhmYk1Sld0cKhCB13Uq3yHbAMOgoMidyPw==",cdn-downstream-fbl;dur=371,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=60,cdn-upstream-fbl;dur=369,atl-edge;dur=287,atl-edge-internal;dur=17,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1775,13 +1830,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qclpvC3LofrFSP4lXTERNhmYk1Sld0cKhCB13Uq3yHbAMOgoMidyPw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - d9ff52ef1e5c2c5c55d2f3929dec377d
+      - 4a40190b7c3cc82e30bef8dfc3c5ed03
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1794,7 +1857,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/276]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/276 (276)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1802,7 +1865,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -1814,27 +1877,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1288'
+      - '1308'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16104
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18215
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 361ddcd3-52e4-4a73-a1a0-1ccec701c2e0
+      - e4929aae-e4af-44c4-82d2-98df35a775ef
       Atl-Traceid:
-      - 361ddcd352e44a73a1a01ccec701c2e0
+      - e4929aaee4af44c482d298df35a775ef
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:21 GMT
+      - Wed, 30 Apr 2025 16:26:29 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1844,17 +1909,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=283,atl-edge-internal;dur=14,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=315,atl-edge;dur=282,atl-edge-internal;dur=15,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="5XFS8smFEoJqwhsiSGXmAAF9szaRHBgciLcXyXjZ16yYq1BFw2KZcw==",cdn-downstream-fbl;dur=322
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 5XFS8smFEoJqwhsiSGXmAAF9szaRHBgciLcXyXjZ16yYq1BFw2KZcw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 25b1df9d3838eeff736b3953b627e8c4
+      - 851fe8044d01128c792adaa7c562c8cc
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1878,61 +1951,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16104
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18215
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeRCSdKSq2pLQ0lJKSQBpKUJm5mZi4rGntockZfnvvZ5X
-        ICG7gqorEIx9fd/Hx/fRgWVGReyEjgIRg4L4iAGPdUvQFHRLRzNIaUtmoKhhUugWxMykYGgrmlGR
-        AJdJ6wGURhnE55Ap0CBMdTbKtZHp1Bq89T3P9zoK/s5Bm8kqgzNFI8MicFoOs/79nu91caGBT3E5
-        MybToevGMIXIxPJedqjhVGtGRUeAcdGTcWnG3MBlWufg1gbmsEL908loPGn7vcDDrSIE7YSPjsbY
-        ch1RA4lUqzKHGFeoEXjBQdvz2743CbzQ7+NvxwuC7zBua6NwYjDwwsw7g7T6LtrzgibtahGDjhTL
-        bOFw9wPRKeW8RWKmDRORIRmDCIickoVU847VjqS4UPyNUeSC2XZRfksfqKHKfWCwcIuw1gFWIt/b
-        9wc/avYP/JBi2/MUvVpYoMsJ1XPbq/zO2K9wSrmGllMqHmNehW7LmTEEjopmqxN4AIzVe2o5hiGy
-        MkSJE4occ3Q2YLLv1YJMyXvM6J0Fr7SLchcNrMttF89Ass7qQjBj0IB2Gt8Wqb8VZ7WcmgVVFq+a
-        pRlnGHC8kTn2o0BZd7DsDt4Y7mc6U2fS9KXr9TGMoLsMuv+vl7L7BRbRod9b+r2v4XBZe9wPlvvB
-        1/BYAfzpaRuO/i6cBrVgypaXJQdi969vtk/u1ydpkihIkG++eAkOagFmJnle8sLrR3u7BP0dgmCn
-        YLBL8P12OCVtlruWlIoXwgnbPi6pwYejJNy3X9ySztcE7pbmlL2WxeehzG3hfEvKV3aDicQJjcrh
-        qeJpa02xqKza49aejQyP6pnMeTxkOuN0VV1l3MawzCVixl7vqhoKMFnLH9uPRK/T6/n1I7FZtobK
-        NgW7QBU0oMoUk4qZ1TuLWKu79kl8w1vBUpqAdq2Gro0w3OBy0dEPyZosT+SiJtWus31tggbznN6B
-        pcVXLoZlk1fL4O9CqD+w9ZhRPcpYdMLE/MhKhpDZ6UVEdReL3i4KWbMjpBjh8ELvOJwD1SUyVPXl
-        nJ1c/Hx8entyfDg6HY9uR+fnf5xjfnhLNRYED0xmQM6Q/4Uh1i9hmkjBVwS5hHFrlBhJfmWKkjMF
-        KZIJyTVitvMap/h4nRzvE/O8TIvQKd9E7B0Wf32nXnAFtiFhgvLNQ9XsVZW3wDnH6Kq17WsioDmd
-        Z/bS7sJxP+jXOC7HpHdCr1Ru3t2Xk83b0LiG2080muOwWUOuNl76Oqzmuf8UcD0UuvVsFtRjggAL
-        9UhyqU7LaO54Du1EIWusRyJJhrJstkwzHIeFeR30Bw0pfK6xm0oNYbws519i/bM3YYbDXkiuP9Is
-        CMmhlHMG5IoZ5DlDxhDlCsgRp8knWx0sDpcR5TOpTTjwBp47ZSJGKnWDfu+mMDgsiod53UtiYRXu
-        kS9qkm/wz7eF+hiHPstBqIZsUQU5zIEMMVHc/J2uiO+1iAVjk8Th1QhF1/iv3fO7RaS2j9ECOikz
-        CjpSJS7CmNrWMpzYLPxdPNqZmZQXcZd2Lq2dCzEXcvG8SGdKxjnOACOR4MVOsU3uBItvfRYVwnjJ
-        L3LRNnJHlbLKQHBDXHLta0P+zKkyoMja5A5VWPv0C+2PH87IOKJix3k7jOI9OmiyepbHeKUNpBrz
-        iDPJEGx7YbFfdMhWLKVMaGagg3jEgunZnaQq3nViy/5wjbO98F8AAAD//+xZbUvcQBD+K4sgKJiY
-        u8t5dwWxh7TQD9KiUEGEY7PZeKF3m5AXo1j/e5/Z3dvG9GKLFPGD4IeY3Z2Xzcwzz8xdqzkTJpyA
-        vSySUrFSVqyxsVUBHEsTXwni64A1y1Qs2VpyVWKRmx1WAvy9VpFkXAigq4zZbcpZjYQRxX0OeMI+
-        paQp1H7LojN86xvdWpJBl0upKL4Yd3IzdJ7wCJaQW2CBLFVJVqz1GZYVhNkcqyVBJuD6h1QHZBiE
-        pxUzbIDxVcPvyUWWc21dXSKyGVesZSD6RiVXPr54ST47D80dXCu6BNJGdwQLrIXlxkQSWNa4oK2W
-        tnxueX+OXET1wZWR9zZemqbxs4aXuc4KJKG88/NlriMaShaQubC6F7wC/YlqxNRi7+vl/OKbd3Hm
-        oVDrXHVK8oxCmbJhj8frVO2zvf2fCJRVlX1AGP7Jccau0HeLXB/5GYRtAKwKILsmcETJulsdDe4s
-        BH0LoWOq3ROOa+iPpJnV9o193CPoY8eB0/mkZnchHR+AiyVlv6kLZb1ecypaO3/Da7p1oqBZ8cIK
-        R1TkBPlGxPlLfDyOR9PJNBpMAjkSs0DMxsNkNkiOoMdtgoZntkkKiXkcQweqHEpefP+xZQgAhWQ9
-        2xSbXPFRRfU2DVO2MQsliB6PB2F4NBHTyXg0i0Q0CaA+4TKZipP4WEvZHc13h5/xZ855a64svnqe
-        eVX6dek1uAhv6BNw+3kdrVJBN+XlnJd0UTiv6whoIh5PkRR+rujOuw3227e426G/fYu7Hf5btxgY
-        FZuG0VLBU4Q+mEyS1EKkOoEIz007ahDuCmQQGz/VRZbLwytgj1j+zjSaMGHVpS5psHO17fwx7MPV
-        sK+pDF1TWVh8f4eRVwuYdxh5DYvfYWQLjHRhoI+phY6QOf4Cd25MUj7QKNw+B7Akq7gd5Hel9FGy
-        oA+XguF2gOubCgW9DvRSNudZ90Qflxv1LjiSJ9VtWmTKEDnzKq7tr0jm33+5vdus+n8TUiPMCYUm
-        tGnfMz3r2Yw1kQLG5IfNo60vLzZA/+J2uJF7sLPmd+eyrFckuOWsntIU1bwyjtOsmCY55Lp7//Tw
-        8Mlpe0Bb+/j4+AsAAP//AwDQFWvxtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18215","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18215","key":"NTEST-1860","fields":{"statuscategorychangedate":"2025-04-30T18:26:23.348+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1860/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:23.032+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:23.118+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/276]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/276 (276)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1860/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18215/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - abe54554-90b3-48ad-a15c-741202c5b488
+      - f35fd785-3bb1-4d2c-95a4-760c620e7605
       Atl-Traceid:
-      - abe5455490b348ada15c741202c5b488
+      - f35fd7853bb14d2c95a4760c620e7605
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:22 GMT
+      - Wed, 30 Apr 2025 16:26:29 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1942,7 +1998,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=275,atl-edge-internal;dur=13,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=273,atl-edge;dur=240,atl-edge-internal;dur=16,atl-edge-upstream;dur=224,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="MQkoCru08o3uNmoGpNURLK8goAZgjMHUnIiH2oOPuq8LAed8xlnTRA==",cdn-downstream-fbl;dur=277
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1951,14 +2007,125 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 895116b5366f3f5264f7b6361d3fd564.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MQkoCru08o3uNmoGpNURLK8goAZgjMHUnIiH2oOPuq8LAed8xlnTRA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 98f81979eb9378de8b9d900141da1439
+      - 4db13db0091bd347706d281a949f4045
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added_empty has occurred.", "title": "Created/Updated
+      0 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/105", "url_api": "http://localhost:8080/api/v2/tests/105/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      105, "url_ui": "http://localhost:8080/test/105", "url_api": "http://localhost:8080/api/v2/tests/105/"},
+      "finding_count": 0, "findings": {"new": [], "reactivated": [], "mitigated":
+      [], "untouched": [{"id": 275, "title": "Zap1: Cookie Without Secure Flag", "severity":
+      "Low", "url_ui": "http://localhost:8080/finding/275", "url_api": "http://localhost:8080/api/v2/findings/275/"},
+      {"id": 276, "title": "Zap2: Cookie Without Secure Flag", "severity": "Low",
+      "url_ui": "http://localhost:8080/finding/276", "url_api": "http://localhost:8080/api/v2/findings/276/"}]}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1321'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added_empty
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1321\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added_empty\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
+        \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
+        \"172.18.0.9:60454\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \ \"data\": \"{\\\"description\\\": \\\"Event scan_added_empty has occurred.\\\",
+        \\\"title\\\": \\\"Created/Updated 0 findings for Security How-to: 1st Quarter
+        Engagement: ZAP Scan\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/105\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/105/\\\", \\\"product_type\\\":
+        {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 105, \\\"url_ui\\\": \\\"http://localhost:8080/test/105\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/105/\\\"}, \\\"finding_count\\\":
+        0, \\\"findings\\\": {\\\"new\\\": [], \\\"reactivated\\\": [], \\\"mitigated\\\":
+        [], \\\"untouched\\\": [{\\\"id\\\": 275, \\\"title\\\": \\\"Zap1: Cookie
+        Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/275\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/275/\\\"}, {\\\"id\\\":
+        276, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\", \\\"severity\\\":
+        \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/276\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/276/\\\"}]}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added_empty
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        0,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [],\n      \"reactivated\":
+        [],\n      \"untouched\": [\n        {\n          \"id\": 275,\n          \"severity\":
+        \"Low\",\n          \"title\": \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/275/\",\n          \"url_ui\": \"http://localhost:8080/finding/275\"\n
+        \       },\n        {\n          \"id\": 276,\n          \"severity\": \"Low\",\n
+        \         \"title\": \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/276/\",\n          \"url_ui\": \"http://localhost:8080/finding/276\"\n
+        \       }\n      ]\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\":
+        \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
+        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
+        {\n      \"id\": 105,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/105/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/105\"\n    },\n    \"title\":
+        \"Created/Updated 0 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/105/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/105\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:29 GMT
+      Transfer-Encoding:
+      - chunked
     status:
       code: 200
       message: OK
@@ -1981,26 +2148,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrlrVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCGcAWQopJOXm8rFcP1Q/083Q1rEi/HmEJjCBl+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0XxHCY4AWxal5JcIIUqDzBLIElhWlnM04i2KAC4hwzPv4B+wr3Z6zGVQUeFZwStOcLb9Z
-        2d5Y5SLIsnwhBeAclcxmBQqmFFMgFV3O5ota5QxproCeCYIZDbe6F+MLUYnBhDsnxdg+EHOqCNrX
-        bUmO54c9OTtOru8rcvwEAAD//wMAQ7/unSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:30.155+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - c1598578-f917-4f53-ab10-9fedfe3c2054
+      - 84d244f6-237a-443e-920e-17e5e7171743
       Atl-Traceid:
-      - c1598578f9174f53ab109fedfe3c2054
+      - 84d244f6237a443e920e17e5e7171743
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:22 GMT
+      - Wed, 30 Apr 2025 16:26:30 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2010,7 +2173,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=161,atl-edge-internal;dur=16,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="vdbxpSdNJ4mWzQgeJFtreS5ROhmrVQ0FcCaFBp0eaylA6kXVjnpyOg==",cdn-downstream-fbl;dur=260,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=258,atl-edge;dur=170,atl-edge-internal;dur=15,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2019,10 +2182,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 82e46a17c2e4998f87de230e61a57612.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - vdbxpSdNJ4mWzQgeJFtreS5ROhmrVQ0FcCaFBp0eaylA6kXVjnpyOg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 9e5b7c26fa90453d22dca270a2504b2d
+      - 728ccd4a2b2575d8af9fca57ea366729
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2046,61 +2217,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16103
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18213
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8atMk8yCEMFJVbUlo2VKakgDSUoTMzM3EG489tT0kKct/7/U8
-        kiUwu4Kqq0gw9vV9Hx/fBwdWGRWxEzoKRAwK4mMGPNZtQVPQbR3NIaVtmYGihkmh2xAzk4Kh7WhO
-        RQJcJu17UBplEJ9DpkCDMNXZKNdGpjNr8Nb3PN/rKvg7B22m6wzGikaGReC0HWb9+33f28OFBj7D
-        5dyYTIeuG8MMIhPLj7JLDadaMyq6AoyLnoxLM+YGLtM6B7c2sIA16p9NR5NpB/cOcasIQTvhg6Mx
-        tlxH1EAi1brMIcYVagResN/x/I7vTQMv9A9Cv9c9CHo/YNyeDdI6MRh4YeaNQVp9F+15wSbtahGD
-        jhTLbOFw9x3RKeW8TWKmDRORIRmDCIickaVUi67VjqS4UPyVUeSC2XZRfkvvqaHKvWewdIuwtgFW
-        IiynP/hJs3/gxxTbnqfo1cICXU6pXthe5XfGfoUzyjW0nVLxBPMqdNvOnCFwVDRfn8I9YKzeY9sx
-        DJGVIUqcUOSYo7MDkz2vSeDXgkzJj5jqGztRaRd9KDpb98EuPkPPNt0LwYxBA9rZ+LYQ/q04q+XM
-        LKmyQNYszTjDgOOdkmCjCvj1Bqve4JXhfqFldSabhvW8Awwj6K2C3v/rpYRFAVJ06PdXfv9bOFzV
-        HveC1V7wLTxWyH98fA7HoAmne7VgxlaXJTli969vEA1JoiBBvvnqJdivBZiA5HnJCy8f7TcJDhoE
-        QaNg0CQ4fB5OSZvlriWl4oVwwo6PS2rw4SgJ9/X3s6TzLYG7pTllb1/xeSRzWzjfkvKV3WAicUKj
-        csAuoVFziY21d7AMrrBn7SsWlXV8eLZnY0VlPZc5j4dMZ5yuqztsO68Ak7U08dIjsXd4WD8Su2Vr
-        orJgQ2W7gg2oMsWkYmb9xiLW6m7vdW8FS2kC2rUaujbCcIPLZVffJ1tOPJXLmjt7zvPbEWwuAad3
-        YNnP4n93ImiCrt+EUH9g6zGnepSx6JSJxbGVDCGz04uI6p4VnVwWss2OkGKEwwu943AOVJc4UNWX
-        Mz69+OXk7Pb05Gh0Nhndjs7P/zjH/PCWaiwIHpjOgYyR5oUh1i9hmkjB1wQpg3FrlBhJ3jNFyVhB
-        ipxBco2Y7b5EHTiUhI73iXlepmehU76J2Dss/vZOPeEKbEPCBOW7h6rZqypvgWqO0dV0g31NBGxO
-        55m9tE047vUHNY7LMemN0CuVN8/r08nmdWjcwu1nGi1w2KwhVxsvfR1V89x/CrgeCt16NgvqaUCA
-        hXokuVRnZTR3PIdOopAjtiORJENZNlumGY7DwrwM+v0mUtjfkMKXOv60nH+J7a81ZYZDKyTXH2jm
-        h+RIygUDcsUMspohE4hyBeSY0+STrQ4Wh8uI8rnUJhx4A8+dMREjlbrBwf5NYXBYFA/z+iiJhVXY
-        Il/VJN/hn+8L9QkOfZaDUA3ZogpymAMZYj64+TtdE99rEwvGTRJHVyMUXeO/Tt/vFZHaPkZL6KbM
-        KOhKlbgIY2pby3Aws/B38Wh3blJexF3aubR2LsRCyOXnRRorGef41I9Eghc7xTa5U6yx9VlUCOMl
-        v8plx8iGKmWVgeCGuOTa14b8mVNlQJGtyQZV2Pr0C+0P78ZkElHRcN7OnHiPym48/bUma20g1ZhH
-        nEmGYGuFxX7RIVuxlDKhmYEu4hELpud3kqq46cQz+8MtzlrhvwAAAP//7Flta9swEP4rolBooXad
-        xGmSQelC2WAfykYLK5RCkGW5MYtl45e6pet/33OSoqVe3I0ySj8U8sGJpLvT+e655y7Xas6ECSdg
-        L4ukVKySNWttbNUAx8rEV4L4OmDtMhVLlkmuKixys8NKwH2vVSQZFwLoKmN2m3LWIGFEeV8AnrBP
-        KWnKsr9h0Rne9Y1uLcmgy6VUFF+MO7k5Ok/cCJbQtUD2WKqSvMz0GZaXhNkcqxVBJuD6h1QHZBiE
-        pzUztZ/xVcvv6Yqs4Nq6pkJkM67YhoHoG5Vc+XjjFd3Z3dD44FqRE0gb+QgWWAurtYkksGrgoK2W
-        btx54/bnyEVUH7iMbm/jpW1bP295VeisQBLKO79YFjqioWQBmQure8FrkJ2oQUwt9r5ezi++eRdn
-        Hgq1zlWnpMgplCkb9nicpWqf7e3/RKCs6vwDwvBPjjN2hb5b5PpwbhD2LTjSSwBYl4B8zeyImXW2
-        ho6QdhYCJ6O70Mc1Asc19NvTlGv7xj52HDhjntTsLnLjBXCxpOw3daFqsoxT0dr5G16T14mC5uUL
-        KxxRkRPkGxHnL/HxOB5NJ9NoMAnkSMwCMRsPk9kgOYIetwkantkmKSTmcQwdqHIoefH9xw1DACgk
-        69ne1+SKjyqqt2mYsv1XKEH0eDwIw6OJmE7Go1kkokkA9QmXyVScxMdayu5ovjv8jI8552VcWXz1
-        PPNT5TeV18IR3tAn4PaLJlqlgjzlFZxX5Cic13UENBGPp0gKv1Dk824f/fYt7jbib9/ibiP/1i0G
-        FMWmPbRU8BShDyaTJI0QqU4gwnPTjhoguwIZxMZPTZkX8vAKECOWvzONBklYdalLGuxcbTt/DPtw
-        NexrKsO+SUXosLu0wP+OL68WSe/48hoWv+PLFnzpwoAjZI6/wOobk3sPNPG2zwEU5jW3g/yulF7m
-        1YtLvZRsuB35+qZCQR8HJUDYuhD0cdBR34mRI3lS3aZlrgyRMz/Fjf0XyXz9J+/lmZHwsH60cP8C
-        +N34A+xwLfdgJ+N357JqViR4Q7cempT1vDZ23Ob1/5vUGmFOKHShXfye65nTephKs2Ka5JBKZ8hT
-        a4dPzLUHtHseHx9/AQAA//8DAC6dOrG0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18213","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213","key":"NTEST-1859","fields":{"statuscategorychangedate":"2025-04-30T18:26:20.584+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:20.337+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:20.404+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/275]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/275 (275)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/105]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1859/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18213/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 4ef6ea6a-9d6d-4c44-86e3-09a79b322c1d
+      - 6e4ec227-33ec-4e9e-85d6-b688cb302075
       Atl-Traceid:
-      - 4ef6ea6a9d6d4c4486e309a79b322c1d
+      - 6e4ec22733ec4e9e85d6b688cb302075
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:22 GMT
+      - Wed, 30 Apr 2025 16:26:30 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2110,7 +2264,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=256,atl-edge-internal;dur=12,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="l43kmyOBFzqV_L1kT69a0RoM2BdKSXEivV-STjKz5oAAZR_XZ9Yl6g==",cdn-downstream-fbl;dur=379,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=376,atl-edge;dur=289,atl-edge-internal;dur=15,atl-edge-upstream;dur=274,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2119,10 +2273,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ed78483d37e5338746e5a4b545e5818e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - l43kmyOBFzqV_L1kT69a0RoM2BdKSXEivV-STjKz5oAAZR_XZ9Yl6g==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 9cac753997c906ad1de9f5adde3fdd00
+      - 4e0cd3dac3b817ed9d2c38330759f53c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_twice_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_twice_push_to_jira.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrmq1b3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCGcAWQopJOXm8rFcP1Q/083Q1rEi/HmEJjCBl+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0XxHCY4AWxal5JcIIUqCzBLIElhWlnOWcRTHABUQ45n38A/aVbs/ZDCoKPCs4zdO8YN+s
-        bG+schFk2XwhBeAMlczyAgVTiimQii7z2aJWc4Z0roCeCYIZDbe6F+MLUYnBhDsnxdg+EHOqCNrX
-        bUmO54c9OTtOru8rcvwEAAD//wMAn9fdaiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:31.008+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 932d94de-0a67-4c27-8ce6-69ce4ab8759c
+      - 01530f16-5967-42b4-9911-c8ab83696d6d
       Atl-Traceid:
-      - 932d94de0a674c278ce669ce4ab8759c
+      - 01530f16596742b49911c8ab83696d6d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:23 GMT
+      - Wed, 30 Apr 2025 16:26:31 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=139,atl-edge-internal;dur=16,atl-edge-upstream;dur=125,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=206,atl-edge;dur=173,atl-edge-internal;dur=19,atl-edge-upstream;dur=154,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="33qzOI_AnTvKkWkrT_wcUETwkcWwfMOHZfsUa-8QEpnHhShRxBt7OA==",cdn-downstream-fbl;dur=210
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 895116b5366f3f5264f7b6361d3fd564.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 33qzOI_AnTvKkWkrT_wcUETwkcWwfMOHZfsUa-8QEpnHhShRxBt7OA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ad43e9bad73d064d26fbc34aaf77a202
+      - bba2423e8f618de0d468864f86afcfa0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 4c785b22-4c2c-4c77-bcd4-eb411c05b800
+      - c599a53e-41f7-4e38-bf8e-f34c581a067e
       Atl-Traceid:
-      - 4c785b224c2c4c77bcd4eb411c05b800
+      - c599a53e41f74e38bf8ef34c581a067e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:23 GMT
+      - Wed, 30 Apr 2025 16:26:31 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=307,atl-edge-internal;dur=15,atl-edge-upstream;dur=292,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=323,atl-edge;dur=291,atl-edge-internal;dur=17,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="_3HqYM8EmNdU5hidWX-Kg5JZwzb1vxaUn-VFpPhBIL-GR9-kxDCC9g==",cdn-downstream-fbl;dur=328
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e665d09233240df4d3172e59222e0ba2.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - _3HqYM8EmNdU5hidWX-Kg5JZwzb1vxaUn-VFpPhBIL-GR9-kxDCC9g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e55918fab2885b957f9d2273e25e980d
+      - 0eeff82e0bc4308092e66a1f43511d46
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/277]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/277 (277)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/106]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16105","key":"NTEST-1621","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16105"}'
+      string: '{"id":"18217","key":"NTEST-1861","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18217"}'
     headers:
       Atl-Request-Id:
-      - 118fdd15-3c06-4645-80af-7b8e0d81fc5f
+      - 1d99461d-f272-45d1-8833-3d76882673e7
       Atl-Traceid:
-      - 118fdd153c06464580af7b8e0d81fc5f
+      - 1d99461df27245d188333d76882673e7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:24 GMT
+      - Wed, 30 Apr 2025 16:26:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=676,atl-edge-internal;dur=17,atl-edge-upstream;dur=658,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=714,atl-edge;dur=681,atl-edge-internal;dur=18,atl-edge-upstream;dur=664,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ztTQ-ctg7NCiG_eGRvbVVrLk4Cw1_2Mxt4bWBch9EN6zHCZ5lkcaRg==",cdn-downstream-fbl;dur=719
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ztTQ-ctg7NCiG_eGRvbVVrLk4Cw1_2Mxt4bWBch9EN6zHCZ5lkcaRg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 2da82039cecd6c03851808bb0132578e
+      - 40de517a97ddf8b23a54bf5887295e6f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1621
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1861
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9kEI6UpVdSWh5UophQDSUYTM7mRj4rW3tjePcvzvHe8r
-        QNiroOrpJC7r8by++WY8Dw6sMipiJ3QUiBgUxIcMeKw7gqagOzqaQUo7MgNFDZNCdyBmJgVDO9GM
-        igS4TDoLUBplEJ9BpkCDMNXdKNdGplNr8Nb3PN/rKfgrB20m6wxOFY0Mi8DpOMz69we+t4cfGvgU
-        P2fGZDp03RimEJlY3sseNZxqzajoCTAuejIuzZgbuEzrHNzawBzWqH8yGZ9Puv4g8PGoCEE74YOj
-        MbZcR9RAItW6zCHGL9QIvGCv6/ld35sEXujvh0G/1x8G32Hcng3SOjEYeGHmnUFafRfteUGTdvUR
-        g44UyyxwePqB6JRy3iEx04aJyJCMQQRETslSqnnPakdSXCj+xihywWy5KL+lC2qochcMlm4R1ibA
-        SuR7u/7wR83+hh9SLHueoldLC3Q5oXpua5XfGfsrnFKuoeOUikeYV6HbcWYMiaOi2foYFoCxeo8d
-        xzBkVoYscUKRY47OC5rserUgU/IeM3on4JV2AXdRwBpu+/GEJJusLgQzBg1op/FtmfprcVfLqVlS
-        ZfmqWZpxhgHHLzLHehQs6w9X/eEbw/1CZepMmrr0vX0MI+ivgv7/66WsfsFFdOgPVv7gazhc1R53
-        g9Vu8DU8VgR/fNymo9/G06AWTNnqspyBWP3rm+2bu/VNmiQKEpw3W02ACUiel+3/uru9NsGgTbDf
-        IghaBcM2wffbcZZjszy1Q6l4IZyw61ez0pZEsahM6WHrzDYKoq1nMufxiOmM03XVTni8pAafnnJk
-        v731ywdh8wS4pTllG7v4eSBzC30R6pU9YCJxQqNy6xuNmkvkjG3vCg0FmKydH689Ev7esH4kXsLW
-        jLKXgjZSBQ2pMsWkYmb9Tghqdbf/treCpTQB7VoNXRtheMDlsqcXyWZYHstlPVT7znbbBA3nOb0D
-        OxZfaQw7TV6FwW9jqD+0eMyoHmcsOmZifmglI8js9iKimkEFr5aFrDkRUoxxeaF3HM6A6pKVqvrl
-        nB5f/Hx0cnt8dDA+OR/fjs/Ofj/D/LBLNQKCFyYzIKc4/4Uh1i9hmkjB1wRnCePWKDGSfGSKklMF
-        KQ4TkmtkXO+1meJjOzneZ+Z5mV6ETvkmYu0Q/E1PPZsVWIaECcpfXqp2rwregvcco6u+bV0TAc3t
-        PLNN28bjYLfhcbkmvZN6pXLz7j7fbN7Gxg3dfqLRHJfNmnK18dLXQbXP/aeA66XQrXezoF4TBFiq
-        R5JLdVJGc8dz6CYKJ9ZmJZJkJMtiyzTDdViY10m/1wyFLxX2pVIzMJ7D+afY/NuZMMNhJyTXn2jm
-        h+RAyjkDcsUMzlhDziHKFZBDTpPPFh0Eh8uI8pnUJhx6Q8+dMhHjIHSD/f2bwuCoAA/zupfE0irc
-        If+qSb7BP98W6ue49NkZhGo4LaogRzmQESaKh7/RNfG9DrFkbJI4uBqj6Br/6w78fhGprWO0hF7K
-        jIKeVImLNKa2tAw3Nkt/F6/2ZiblRdylnUtr50LMhVw+BelUyTjHHWAsEmzsFMvkThB867NACOMl
-        v8hl18gWlLLKQHBDXHLta0P+yKkyoMjGZIsqbHz6hfanD6fkPKKi5b5dRrGPBk1WT/I4X2sDqcY8
-        4kwyJNtOWJwXFbKIpZQJzQz0kI8ImJ7dSarithtb9kcbnu2E/wAAAP//7FldSxtBFP0rgyAouOsm
-        2ZikIDZIC32QFoUKIoTJ7KxZmswu++Eq1v/ec2cm07jN2CJFfBB8WHdm7tfee+65k2s1ZcKkE7CX
-        zaVUrJI1a21u1QDHyuRXivw6YO0iEwu2klxVWORmh5UAf6/VXDIuBNBVJuw246xBwYjyvgA8YZ9S
-        0pCEcMOiM3zrGz1akkGXC6kovxh3cnNMnvAIlpBbYIEsU2lervQZlpeE2RyrFUEm4PqHVAdkGIRn
-        NTNMhPFly+/JRVZwbV1TIbMZV2zDQMyNSi5DfPGKfHYemhhcKwoCaaMYwQJrYbU2kQRWDQK01dIN
-        nze8P0ctovsgZOS9zZe2bcO85VWhqwJFKO/CYlHojIaSGWTOrO4Zr0G95g1yarb39XJ68S24OAvQ
-        qHWtOiVFTqlM1bDHk1Wm9tne/k8kyrLOPyAN/+Q4Q9fou03OR356sW/BUVxCxroE5GteRjyxszXy
-        seHYMdXuCcc19EfSzGr7Rh/3iHzsOHI6EWMuFlTgtgFv9vAuxFfNasWpae38Da8p6kRB8/KFHY6o
-        yAnqjWjvl+R4mAzGo/G8N4rkQEwiMRn200kvPYIetwkantkmKSWmSQId6HJoecn9xw1DACgk69mh
-        2NRKiC6qt2mYsoNZLEH0eNKL46ORGI+Gg8lczEcR1KdcpmNxkhxrKbuD6W7/M/7MuWDFlcXXIDCv
-        qrCpghaBCPohAXdYNPNlJihSQcF5RYHCed1HQBPxeIqiCAtFMe8O2G/f4u6E/vYt7k74b91iQFFi
-        hlVLBU+R+mAyadoIkekCIjw3w6QBsiuQQWz81JR5IQ+vgD1i8bvS6IYJq650SYO9V9vOH2Mfrsa+
-        oTJ2Q2Vp8f0dRl4tYd5h5DUsfoeRLTDShQEfU4sdIXN8Be7cmKJ8oKtw+xzBkrzm9iK/K8VHySIf
-        LkX97QDnuxWKvA54KZuPahKEbF0YeBccyZPqNitzZVieeZU09lck8++/RO82r//f/aYR5oRCE8a0
-        77m+61lfqaIEjMkP60fbX15sgP7F7XAt92Bnxe/OZdUsSfCGs/qWpqyntXGc7orpJodcd++fHu4/
-        OW0PaGsfHx9/AQAA//8DAGXHjI60HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18217","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18217","key":"NTEST-1861","fields":{"statuscategorychangedate":"2025-04-30T18:26:32.267+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1861/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:31.972+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:32.056+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/277]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/277 (277)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/106]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1861/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18217/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 6a6a0449-f82d-46f9-806e-b951e55a21cc
+      - 84133189-8b43-411f-8622-4e6e165f1135
       Atl-Traceid:
-      - 6a6a0449f82d46f9806eb951e55a21cc
+      - 841331898b43411f86224e6e165f1135
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:24 GMT
+      - Wed, 30 Apr 2025 16:26:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=266,atl-edge-internal;dur=15,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="wpuoL9b3C_v9Op6yd3lOezGLnbJUuvzqJDaaomnkbkwZiU9SVnAtJA==",cdn-downstream-fbl;dur=359,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=356,atl-edge;dur=283,atl-edge-internal;dur=18,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8dac9acbf37a4821f35529f7cc336eba.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - wpuoL9b3C_v9Op6yd3lOezGLnbJUuvzqJDaaomnkbkwZiU9SVnAtJA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 498ddbe8fd42336ed262334573e3573a
+      - 18ab57502c304664fcf16f8c7f5af2de
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16105
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18217
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9kEI6UpVdSWh5UophQDSUYTM7mRj4rW3tjePcvzvHe8r
-        QNiroOrpJC7r8by++WY8Dw6sMipiJ3QUiBgUxIcMeKw7gqagOzqaQUo7MgNFDZNCdyBmJgVDO9GM
-        igS4TDoLUBplEJ9BpkCDMNXdKNdGplNr8Nb3PN/rKfgrB20m6wxOFY0Mi8DpOMz69we+t4cfGvgU
-        P2fGZDp03RimEJlY3sseNZxqzajoCTAuejIuzZgbuEzrHNzawBzWqH8yGZ9Puv4g8PGoCEE74YOj
-        MbZcR9RAItW6zCHGL9QIvGCv6/ld35sEXujvh0G/1x8G32Hcng3SOjEYeGHmnUFafRfteUGTdvUR
-        g44UyyxwePqB6JRy3iEx04aJyJCMQQRETslSqnnPakdSXCj+xihywWy5KL+lC2qochcMlm4R1ibA
-        SuR7u/7wR83+hh9SLHueoldLC3Q5oXpua5XfGfsrnFKuoeOUikeYV6HbcWYMiaOi2foYFoCxeo8d
-        xzBkVoYscUKRY47OC5rserUgU/IeM3on4JV2AXdRwBpu+/GEJJusLgQzBg1op/FtmfprcVfLqVlS
-        ZfmqWZpxhgHHLzLHehQs6w9X/eEbw/1CZepMmrr0vX0MI+ivgv7/66WsfsFFdOgPVv7gazhc1R53
-        g9Vu8DU8VgR/fNymo9/G06AWTNnqspyBWP3rm+2bu/VNmiQKEpw3W02ACUiel+3/uru9NsGgTbDf
-        IghaBcM2wffbcZZjszy1Q6l4IZyw61ez0pZEsahM6WHrzDYKoq1nMufxiOmM03XVTni8pAafnnJk
-        v731ywdh8wS4pTllG7v4eSBzC30R6pU9YCJxQqNy6xuNmkvkjG3vCg0FmKydH689Ev7esH4kXsLW
-        jLKXgjZSBQ2pMsWkYmb9Tghqdbf/treCpTQB7VoNXRtheMDlsqcXyWZYHstlPVT7znbbBA3nOb0D
-        OxZfaQw7TV6FwW9jqD+0eMyoHmcsOmZifmglI8js9iKimkEFr5aFrDkRUoxxeaF3HM6A6pKVqvrl
-        nB5f/Hx0cnt8dDA+OR/fjs/Ofj/D/LBLNQKCFyYzIKc4/4Uh1i9hmkjB1wRnCePWKDGSfGSKklMF
-        KQ4TkmtkXO+1meJjOzneZ+Z5mV6ETvkmYu0Q/E1PPZsVWIaECcpfXqp2rwregvcco6u+bV0TAc3t
-        PLNN28bjYLfhcbkmvZN6pXLz7j7fbN7Gxg3dfqLRHJfNmnK18dLXQbXP/aeA66XQrXezoF4TBFiq
-        R5JLdVJGc8dz6CYKJ9ZmJZJkJMtiyzTDdViY10m/1wyFLxX2pVIzMJ7D+afY/NuZMMNhJyTXn2jm
-        h+RAyjkDcsUMzlhDziHKFZBDTpPPFh0Eh8uI8pnUJhx6Q8+dMhHjIHSD/f2bwuCoAA/zupfE0irc
-        If+qSb7BP98W6ue49NkZhGo4LaogRzmQESaKh7/RNfG9DrFkbJI4uBqj6Br/6w78fhGprWO0hF7K
-        jIKeVImLNKa2tAw3Nkt/F6/2ZiblRdylnUtr50LMhVw+BelUyTjHHWAsEmzsFMvkThB867NACOMl
-        v8hl18gWlLLKQHBDXHLta0P+yKkyoMjGZIsqbHz6hfanD6fkPKKi5b5dRrGPBk1WT/I4X2sDqcY8
-        4kwyJNtOWJwXFbKIpZQJzQz0kI8ImJ7dSarithtb9kcbnu2E/wAAAP//7FldS9xAFP0rgyAomJjd
-        zbq7BbGLtNAHaVGoIMIymUzc0N1JyIdRrP+9587MTmO6sUWK+CD4EDMz9yv3nnvu7LWaM2HSCdjL
-        IikVK2XFGptbFcCxNPmVIL8OWLNMxZKtJVclFrnZYSXA32sVScaFALrKmN2mnNUoGFHc54An7FNK
-        GpLgtyw6w7e+0aMlGXS5lIryi3EnN8PkCY9gCbkFFshSlWTFWp9hWUGYzbFaEmQCrn9IdUCGQXha
-        McNEGF81/J5cZDnX1tUlMptxxVoGYm5UcuXji5fks/PQxOBaURBIG8UIFlgLy42JJLCsEaCtlrZ8
-        bnl/jlpE90HIyHubL03T+FnDy1xXBYpQ3vn5MtcZDSULyFxY3QtegXpFNXJqsff1cn7xzbs489Co
-        da06JXlGqUzVsMfjdar22d7+TyTKqso+IA3/5Dhj1+i7Ta6P/AzCNgBWBZBd0y+ig92tfaQ36FsI
-        HVPtnnBcQ38kzay2b+zjHkEfOw6cTsSYiyUVuG3A7R7ehfiyXq85Na2dv+E1RZ0oaFa8sMMRFTlB
-        vRHt/RIfj+PRdDKNBpNAjsQsELPxMJkNkiPocZug4ZltklJiHsfQgS6Hlhfff2wZAkAhWc8OxaZW
-        fHRRvU3DlB3MQgmix+NBGB5NxHQyHs0iEU0CqE+4TKbiJD7WUnZH893hZ/yZc96aK4uvnmdelX5d
-        eg0C4Q19Am4/r6NVKihSXs55SYHCed1HQBPxeIqi8HNFMe8O2G/f4u6E/vYt7k74b91iYFRshlVL
-        BU+R+mAySVILkeoCIjw3w6RBuCuQQWz8VBdZLg+vgD1i+bvS6IYJq650SYO9V9vOH8M+XA37hsrQ
-        DZWFxfd3GHm1hHmHkdew+B1GtsBIFwb6mFroCJnjK3DnxhTlA12F2+cAlmQVtxf5XSl9lCzow6Vg
-        uB3g+m6Fgl4Heimb86x7oo/LjXoXHMmT6jYtMmVYnnkV1/ZXJPPvv0TvNqv+3/2mEeaEQhPGtO+Z
-        vuvZXKmiBIzJD5tH219ebID+xe1wI/dgZ83vzmVZr0hwy1l9S1NU88o4TnfFdJNDrrv3Tw8Pn5y2
-        B7S1j4+PvwAAAP//AwCf0eyAtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18217","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18217","key":"NTEST-1861","fields":{"statuscategorychangedate":"2025-04-30T18:26:32.267+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1861/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:31.972+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t3z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:32.056+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/277]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/277 (277)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/106]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1861/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18217/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d9df0fa7-0482-4538-b812-a9d4230a3901
+      - de450034-a500-46cc-a2d7-055f42f07936
       Atl-Traceid:
-      - d9df0fa704824538b812a9d4230a3901
+      - de450034a50046cca2d7055f42f07936
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:25 GMT
+      - Wed, 30 Apr 2025 16:26:33 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=282,atl-edge-internal;dur=21,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="KfN59_JAx_B35F8EMoeq5k5wmLqHGPFGyVUPWd5U7BS6DbPNuE8lOA==",cdn-downstream-fbl;dur=286,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=283,atl-edge;dur=261,atl-edge-internal;dur=21,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f6567fa2210130239a3a2c737c9517ac.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - KfN59_JAx_B35F8EMoeq5k5wmLqHGPFGyVUPWd5U7BS6DbPNuE8lOA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 72963aeb2c013d13e4551b132e3120fc
+      - 36d4da27f5232aa4dedb3f947e6d0d0a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2bfm25oSExEAykdhcQQmnqiEKaVE06aZr230nEBDsCN8t+
-        Xj+WD6ThFrejIoy8OTdYNp+3KFG41rybmDvFre24jjU6MiNtZwfF9//gKxx3ncAW7cca1bBC7XD8
-        65KV0VJNqAX+LrnD0XZGezgBSGKIIao2l4/V+qH+mW6mvvEVYc8BmsEMXrwTB2X2vb+y3g/BtlJm
-        an2omTrVfkUI8wFalqfmFXcBpEDzCJIIljWlLEtZ5sUAF+Bhn7f+DzjWXX/OJlBTYEnJaB7nRfrN
-        iv5GS+PBLCkWggPmKEWSlsgzKTMJQtJlmi8aWWRICwn0TOBUMNx2Iw8vRMkn5e6M4KF9IOpUEdSv
-        24oczw97MjpMru9rcvwEAAD//wMAGKJ1siACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:33.570+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 08d4de91-8ad8-4d39-b718-bb5d0108d477
+      - 89e88d8f-b936-4722-9f9d-30995cb2b229
       Atl-Traceid:
-      - 08d4de918ad84d39b718bb5d0108d477
+      - 89e88d8fb93647229f9d30995cb2b229
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:25 GMT
+      - Wed, 30 Apr 2025 16:26:33 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=172,atl-edge-internal;dur=15,atl-edge-upstream;dur=159,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=192,atl-edge;dur=159,atl-edge-internal;dur=17,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ZEye5TqHaBujlRYovfcnONDWGgDkuEXxaQ6DOaBAxeyvQ75KcNvInA==",cdn-downstream-fbl;dur=196
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 4bbf91f2f9edc22eb68408b6405ae452.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ZEye5TqHaBujlRYovfcnONDWGgDkuEXxaQ6DOaBAxeyvQ75KcNvInA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f02fe41a67ed89d5e3ad89cf4321bc5c
+      - 631f35d0368de06f3f164dbfab48dfd5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 0288758d-f1c4-450c-af93-149229bb48f7
+      - f12eb223-d67b-44d2-a622-2da034785d08
       Atl-Traceid:
-      - 0288758df1c4450caf93149229bb48f7
+      - f12eb223d67b44d2a6222da034785d08
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:25 GMT
+      - Wed, 30 Apr 2025 16:26:34 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=324,atl-edge-internal;dur=13,atl-edge-upstream;dur=311,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=323,atl-edge;dur=290,atl-edge-internal;dur=15,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="elYVO7376cQnKBO2sRlSYyIdLqaoiOchZLNWAYePF499KZSELZqCWw==",cdn-downstream-fbl;dur=327
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ae39d1ac6bb931d0ff3d636fc3e249de.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - elYVO7376cQnKBO2sRlSYyIdLqaoiOchZLNWAYePF499KZSELZqCWw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 834e0edda1e3a7051305c240769dfdab
+      - e034365f0ea717476308a93f67e30270
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/278]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/278 (278)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/106]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16106","key":"NTEST-1622","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16106"}'
+      string: '{"id":"18219","key":"NTEST-1862","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18219"}'
     headers:
       Atl-Request-Id:
-      - 350071fa-b022-4fbb-a2e9-d11bc58a0b34
+      - 5bb727ee-f227-4a8c-b64b-6ac2f7a0bcb2
       Atl-Traceid:
-      - 350071fab0224fbba2e9d11bc58a0b34
+      - 5bb727eef2274a8cb64b6ac2f7a0bcb2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:26 GMT
+      - Wed, 30 Apr 2025 16:26:34 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=876,atl-edge-internal;dur=13,atl-edge-upstream;dur=863,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=628,atl-edge;dur=595,atl-edge-internal;dur=16,atl-edge-upstream;dur=579,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="mRBxxC4DR9yZ7HVnqHIu9aGL5DDR9dxM6OjjZ6q3Oup1-z0J03aldw==",cdn-downstream-fbl;dur=633
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 60b2b330807c6611e06e3923c8e315cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - mRBxxC4DR9yZ7HVnqHIu9aGL5DDR9dxM6OjjZ6q3Oup1-z0J03aldw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7796bad402a764322d70c1819ddb69f8
+      - 5687439c7982709dcd0aea6f8887026a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1622
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1862
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfUkI6UpVdSWhpaU0JQGkowiZ3cnGxGtvbS9JyvHfO96X
-        BAJ7J6h6OonLejzvzzyeBwdWGRWxEzoKRAwK4iMGPNYtQVPQLR3NIaUtmYGihkmhWxAzk4KhrWhO
-        RQJcJq17UBplEJ9BpkCDMNXdKNdGpjNr8Mb3PN/rKPg7B22m6wzGikaGReC0HGb9+33f6+OHBj7D
-        z7kxmQ5dN4YZRCaWd7JDDadaMyo6AoyLnoxLM+YGLtM6B7c2sIA16p9OR5Np2+8HAR4VIWgnfHA0
-        xpbriBpIpFqXOcT4hRqBF+y3Pb/te9PAC/2DMOh3Bv3gO4zbs0FaJwYDL8y8M0ir76I9z0ZVpl19
-        xKAjxTJbODz9QHRKOW+RmGnDRGRIxiACImdkKdWiY7UjKc4Vf2MUuWC2XZTf0HtqqHLvGSzdIqxt
-        gJXI97r+4EfN/oEfUmx7nqJXCwt0OaV6YXuV3xr7K5xRrqHllIrHmFeh23LmDIGjovn6BO4BY/Ue
-        W45hiKwMUeKEIsccnR2YdL1akCl5hxm9s+CVdlHuooF1ue3HE5BsszoXzBg0oJ2Nb4vU34q7Ws7M
-        kiqLV83SjDMMON7JHPtRoKw3WPUGbwz3M52pM9n0pecdYBhBbxX0/l8vZfcLLKJDv7/y+1/D4ar2
-        2A1W3eBreKwA/vj4Eo5+E06DJkG3FszY6qIkR4TF1TXCJEkUJMg3XxyC/VqAmUmel7zw+tV+k+Cg
-        QRA0CgZNgu9fhlPSZnlqSal4IZyw7eMnNfhwlIT79sEt6XxL4G5pTtmxLH4eytwWzrekfGkPmEic
-        0KgcsH1o1Fxgx+1wlsEV9qx9xaKyjg8vzmysqKznMufxkOmM03U13BYSCjBZyx+vPRK9rlc/Ertl
-        21DZrqAJVMEGVJliUjGzfmcRa3W397a3gqU0Ae1aDV0bYXjA5bKj75MtWZ7IZU2qPefl2ASbIeD0
-        FiwtWvzvbgRN0PWbEOoPbD3mVI8yFp0wsTiykiFkdnsRUd2zopPLQrY5EVKMcHmhtxzOgOoSB6r6
-        5YxPzn8+Pr05OT4cnU5GN6Ozsz/OMD+cUo0FwQvTOZAx8r8wxPolTBMp+JoglzBujRIjya9MUTJW
-        kCKZkFwjZjuvcYqP4+R4n5jnZaYbOuWbiL3D4m9n6hlXYBsSJijfvVTtXlV5C1RzjK6mG+xrImBz
-        O8/s0DbheL/XrXFcrknvhF6pvHl3n282b0PjFm4/0WiBy2YNudp46euw2uf+U8D1UujWu1lQrwkC
-        LNQjyaU6LaO55Tm0E4UcsV2JJBnKstkyzXAdFuZ10O83kcL+hhQ+1/Hn5fxLbP/tTZnhsBeSq480
-        C0JyKOWCAblkBlnNkAlEuQJyxGnyyVYHi8NlRPlcahMOvIHnzpiIkUrd4GBwXRgcFsXDvO4ksbAK
-        98gXNck3+OfbQn2CS5/lIFRDtqiCHOZAhpgPHv5O18T3WsSCcZPE4eUIRVf4X7vv94pIbR+jJXRS
-        ZhR0pEpchDG1rWW4sVn4u3i1MzcpL+Iu7VxYO+diIeTyaZHGSsY57gAjkeBgp9gmd4o1tj6LCmG8
-        5Be5bBvZUKWsMhBcE5dc+dqQP3OqDCiyNdmgCluffqH98cOYTCIqGu7bZRTnqL/J6kkek7U2kGrM
-        I84kQ7DthcV50SFbsZQyoZmBDuIRC6bnt5KquOnGC/vDLc72wn8BAAD//+xZbWvbMBD+K6JQaKF2
-        ncRZkkHpQtlgH8pGCyuUQpBluTGLZeOXuqXrf+9zkqKlXtyNMko/FPLBiaS70/nuuecuV2rOhAkn
-        YC+LpFSskjVrbWzVAMfKxFeC+Dpg7TIVS5ZJrioscrPDSsB9r1QkGRcC6CpjdpNy1iBhRHlXAJ6w
-        TylpyrK/YdEp3vW1bi3JoIulVBRfjDu5OTpP3AiW0LXAAlmqkrzM9BmWl4TZHKsVQSbg+qdUB2QY
-        hKc1M7Wf8VXL7+iKrODauqZCZDOu2IaB6BuVXPl44xXd2d3Q+OBKkRNIG/kIFlgLq7WJJLBq4KCt
-        lm7ceeP2Z8hFVB+4jG5v46VtWz9veVXorEASylu/WBY6oqFkAZkLq3vBa5CdqEFMLfa+XczPv3vn
-        px4Ktc5Vp6TIKZQpG/Z4nKVqn+3t/0KgrOr8I8LwT44zdoW+W+T6cG4Q9i040ksAWJeAfM3siJl1
-        toaOkHYWAieju9DHNQLHNfTb05Rr+8Y+dhw4Y57U7C5y4wVwsaTsN3WharKMU9Ha+Rtek9eJgubl
-        CyscUZFj5BsR56/x0TgeTSfTaDAJ5EjMAjEbD5PZIKHpidsEDc9skxQS8ziGDlQ5lLz47tOGIQAU
-        kvVsU2xyxUcV1ds0TNnGLJQgejwehOGHiZhOxqNZJKJJAPUJl8lUHMdHWsruaL47/IKPOedlXFl8
-        9TzzU+U3ldfCEd7QJ+D2iyZapYI85RWcV+QonNd1BDQRjydICr9Q5PNug/32Le526G/f4m6H/9Yt
-        BhTFpj20VPAEoQ8mkySNEKlOIMJz044aILsEGcTGz02ZF/LwEhAjlr8zjSZMWHWpSxrsXG07fwz7
-        cDXsayrDvklF6LC7tMD/ji+vFknv+PIaFr/jyxZ86cKAI2SOv8Dqa5N79zQKt88BFOY1t4P8rpRe
-        5tWLS72UbLgd+fqmQkEfByVA2LoQ9HHQUd+JkSN5Ut2kZa4MkTM/xY39F8l8/Sfv5ZmRcL9+tHD/
-        Avjd+APscC33YCfjt2eyalYkeEO3HpqU9bw2dtzk9f+b1BphTih0oV38keuZ03qYSrNimuSQSmfI
-        U2uHT8y1B7R7Hh4eHgEAAP//AwCMrkLttBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18219","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18219","key":"NTEST-1862","fields":{"statuscategorychangedate":"2025-04-30T18:26:34.670+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1862/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:34.415+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t47:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:34.499+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/278]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/278 (278)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/106]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1862/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18219/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 9760891e-cf35-4a1d-b30e-93d9a497caa2
+      - 389ad2e6-cca9-4178-93f1-383df24e9097
       Atl-Traceid:
-      - 9760891ecf354a1db30e93d9a497caa2
+      - 389ad2e6cca9417893f1383df24e9097
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:27 GMT
+      - Wed, 30 Apr 2025 16:26:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=315,atl-edge-internal;dur=14,atl-edge-upstream;dur=302,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=286,atl-edge;dur=253,atl-edge-internal;dur=15,atl-edge-upstream;dur=237,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="MtVyPeMXLFanpCAcJNMSQ0ib2JFImsm5t0oeI86anDRzD5OIB09Omw==",cdn-downstream-fbl;dur=293
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MtVyPeMXLFanpCAcJNMSQ0ib2JFImsm5t0oeI86anDRzD5OIB09Omw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 606fbb6f2f0a29fd8d74918826f82bf8
+      - 172000e178bd9eb2bfb144798a201a3b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16106
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18219
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfUkI6UpVdSWhpaU0JQGkowiZ3cnGxGtvbS9JyvHfO96X
-        BAJ7J6h6OonLejzvzzyeBwdWGRWxEzoKRAwK4iMGPNYtQVPQLR3NIaUtmYGihkmhWxAzk4KhrWhO
-        RQJcJq17UBplEJ9BpkCDMNXdKNdGpjNr8Mb3PN/rKPg7B22m6wzGikaGReC0HGb9+33f6+OHBj7D
-        z7kxmQ5dN4YZRCaWd7JDDadaMyo6AoyLnoxLM+YGLtM6B7c2sIA16p9OR5Np2+8HAR4VIWgnfHA0
-        xpbriBpIpFqXOcT4hRqBF+y3Pb/te9PAC/2DMOh3Bv3gO4zbs0FaJwYDL8y8M0ir76I9z0ZVpl19
-        xKAjxTJbODz9QHRKOW+RmGnDRGRIxiACImdkKdWiY7UjKc4Vf2MUuWC2XZTf0HtqqHLvGSzdIqxt
-        gJXI97r+4EfN/oEfUmx7nqJXCwt0OaV6YXuV3xr7K5xRrqHllIrHmFeh23LmDIGjovn6BO4BY/Ue
-        W45hiKwMUeKEIsccnR2YdL1akCl5hxm9s+CVdlHuooF1ue3HE5BsszoXzBg0oJ2Nb4vU34q7Ws7M
-        kiqLV83SjDMMON7JHPtRoKw3WPUGbwz3M52pM9n0pecdYBhBbxX0/l8vZfcLLKJDv7/y+1/D4ar2
-        2A1W3eBreKwA/vj4Eo5+E06DJkG3FszY6qIkR4TF1TXCJEkUJMg3XxyC/VqAmUmel7zw+tV+k+Cg
-        QRA0CgZNgu9fhlPSZnlqSal4IZyw7eMnNfhwlIT79sEt6XxL4G5pTtmxLH4eytwWzrekfGkPmEic
-        0KgcsH1o1Fxgx+1wlsEV9qx9xaKyjg8vzmysqKznMufxkOmM03U13BYSCjBZyx+vPRK9rlc/Ertl
-        21DZrqAJVMEGVJliUjGzfmcRa3W397a3gqU0Ae1aDV0bYXjA5bKj75MtWZ7IZU2qPefl2ASbIeD0
-        FiwtWvzvbgRN0PWbEOoPbD3mVI8yFp0wsTiykiFkdnsRUd2zopPLQrY5EVKMcHmhtxzOgOoSB6r6
-        5YxPzn8+Pr05OT4cnU5GN6Ozsz/OMD+cUo0FwQvTOZAx8r8wxPolTBMp+JoglzBujRIjya9MUTJW
-        kCKZkFwjZjuvcYqP4+R4n5jnZaYbOuWbiL3D4m9n6hlXYBsSJijfvVTtXlV5C1RzjK6mG+xrImBz
-        O8/s0DbheL/XrXFcrknvhF6pvHl3n282b0PjFm4/0WiBy2YNudp46euw2uf+U8D1UujWu1lQrwkC
-        LNQjyaU6LaO55Tm0E4UcsV2JJBnKstkyzXAdFuZ10O83kcL+hhQ+1/Hn5fxLbP/tTZnhsBeSq480
-        C0JyKOWCAblkBlnNkAlEuQJyxGnyyVYHi8NlRPlcahMOvIHnzpiIkUrd4GBwXRgcFsXDvO4ksbAK
-        98gXNck3+OfbQn2CS5/lIFRDtqiCHOZAhpgPHv5O18T3WsSCcZPE4eUIRVf4X7vv94pIbR+jJXRS
-        ZhR0pEpchDG1rWW4sVn4u3i1MzcpL+Iu7VxYO+diIeTyaZHGSsY57gAjkeBgp9gmd4o1tj6LCmG8
-        5Be5bBvZUKWsMhBcE5dc+dqQP3OqDCiyNdmgCluffqH98cOYTCIqGu7bZRTnqL/J6kkek7U2kGrM
-        I84kQ7DthcV50SFbsZQyoZmBDuIRC6bnt5KquOnGC/vDLc72wn8BAAD//+xZbWvbMBD+K6JQaKF2
-        ncRZkkHpQtlgH8pGCyuUQpBluTGLZeOXuqXrf+9zkqKlXtyNMko/FPLBiaS70/nuuecuV2rOhAkn
-        YC+LpFSskjVrbWzVAMfKxFeC+Dpg7TIVS5ZJrioscrPDSsB9r1QkGRcC6CpjdpNy1iBhRHlXAJ6w
-        TylpyrK/YdEp3vW1bi3JoIulVBRfjDu5OTpP3AiW0LXAAlmqkrzM9BmWl4TZHKsVQSbg+qdUB2QY
-        hKc1M7Wf8VXL7+iKrODauqZCZDOu2IaB6BuVXPl44xXd2d3Q+OBKkRNIG/kIFlgLq7WJJLBq4KCt
-        lm7ceeP2Z8hFVB+4jG5v46VtWz9veVXorEASylu/WBY6oqFkAZkLq3vBa5CdqEFMLfa+XczPv3vn
-        px4Ktc5Vp6TIKZQpG/Z4nKVqn+3t/0KgrOr8I8LwT44zdoW+W+T6cG4Q9i040ksAWJeAfM3siJl1
-        toaOkHYWAieju9DHNQLHNfTb05Rr+8Y+dhw4Y57U7C5y4wVwsaTsN3WharKMU9Ha+Rtek9eJgubl
-        CyscUZFj5BsR56/x0TgeTSfTaDAJ5EjMAjEbD5PZIKHpidsEDc9skxQS8ziGDlQ5lLz47tOGIQAU
-        kvVsU2xyxUcV1ds0TNnGLJQgejwehOGHiZhOxqNZJKJJAPUJl8lUHMdHWsruaL47/IKPOedlXFl8
-        9TzzU+U3ldfCEd7QJ+D2iyZapYI85RWcV+QonNd1BDQRjydICr9Q5PNug/32Le526G/f4m6H/9Yt
-        BhTFpj20VPAEoQ8mkySNEKlOIMJz044aILsEGcTGz02ZF/LwEhAjlr8zjSZMWHWpSxrsXG07fwz7
-        cDXsayrDvklF6LC7tMD/ji+vFknv+PIaFr/jyxZ86cKAI2SOv8Dqa5N79zQKt88BFOY1t4P8rpRe
-        5tWLS72UbLgd+fqmQkEfByVA2LoQ9HHQUd+JkSN5Ut2kZa4MkTM/xY39F8l8/Sfv5ZmRcL9+tHD/
-        Avjd+APscC33YCfjt2eyalYkeEO3HpqU9bw2dtzk9f+b1BphTih0oV38keuZ03qYSrNimuSQSmfI
-        U2uHT8y1B7R7Hh4eHgEAAP//AwCMrkLttBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18219","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18219","key":"NTEST-1862","fields":{"statuscategorychangedate":"2025-04-30T18:26:34.670+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1862/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:34.415+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t47:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:34.499+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/278]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/278 (278)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/106]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1862/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18219/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 083d9fed-3aef-4ee1-9447-8d794ca0e759
+      - cd9c821a-4c2c-4291-b726-c82096678682
       Atl-Traceid:
-      - 083d9fed3aef4ee194478d794ca0e759
+      - cd9c821a4c2c4291b726c82096678682
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:27 GMT
+      - Wed, 30 Apr 2025 16:26:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=254,atl-edge-internal;dur=12,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="83Mx9edUaVHqalPIxMrDC_rmjL-AOv-gSNdnLk8Q_BGlyQrg5Cec9w==",cdn-downstream-fbl;dur=358,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=355,atl-edge;dur=281,atl-edge-internal;dur=18,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f266ac47d4aee3a84c8fc38a6ef92022.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 83Mx9edUaVHqalPIxMrDC_rmjL-AOv-gSNdnLk8Q_BGlyQrg5Cec9w==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - b22c281a98c0d664799304adaf39f4f6
+      - 6d2d77f637ca8dfce41b778eeeb086d5
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:44518\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:60460\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,300 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:27 GMT
+      - Wed, 30 Apr 2025 16:26:35 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/106", "url_api": "http://localhost:8080/api/v2/tests/106/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      106, "url_ui": "http://localhost:8080/test/106", "url_api": "http://localhost:8080/api/v2/tests/106/"},
+      "finding_count": 2, "findings": {"new": [{"id": 277, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/277",
+      "url_api": "http://localhost:8080/api/v2/findings/277/"}, {"id": 278, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/278",
+      "url_api": "http://localhost:8080/api/v2/findings/278/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:60464\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/106\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/106/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 106, \\\"url_ui\\\": \\\"http://localhost:8080/test/106\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/106/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 277, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/277\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/277/\\\"},
+        {\\\"id\\\": 278, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/278\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/278/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 277,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/277/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/277\"\n        },\n
+        \       {\n          \"id\": 278,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/278/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/278\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        106,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/106/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/106\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/106/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/106\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:35 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event test_added has occurred.", "title": "Test created
+      for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null, "url_ui":
+      "http://localhost:8080/test/107", "url_api": "http://localhost:8080/api/v2/tests/107/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      107, "url_ui": "http://localhost:8080/test/107", "url_api": "http://localhost:8080/api/v2/tests/107/"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '843'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - test_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:60474\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
+        Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
+        \\\"url_ui\\\": \\\"http://localhost:8080/test/107\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/107/\\\",
+        \\\"product_type\\\": {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\":
+        \\\"http://localhost:8080/product/type/2\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"},
+        \\\"product\\\": {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\":
+        \\\"http://localhost:8080/product/2\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"},
+        \\\"engagement\\\": {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\":
+        1, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/engagements/1/\\\"}, \\\"test\\\": {\\\"title\\\":
+        null, \\\"id\\\": 107, \\\"url_ui\\\": \\\"http://localhost:8080/test/107\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/107/\\\"}}\",\n  \"files\":
+        {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event test_added
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        107,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/107/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/107\"\n    },\n    \"title\":
+        \"Test created for Security How-to: 1st Quarter Engagement: ZAP Scan\",\n
+        \   \"url_api\": \"http://localhost:8080/api/v2/tests/107/\",\n    \"url_ui\":
+        \"http://localhost:8080/test/107\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:35 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/107", "url_api": "http://localhost:8080/api/v2/tests/107/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      107, "url_ui": "http://localhost:8080/test/107", "url_api": "http://localhost:8080/api/v2/tests/107/"},
+      "finding_count": 2, "findings": {"new": [{"id": 279, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/279",
+      "url_api": "http://localhost:8080/api/v2/findings/279/"}, {"id": 280, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/280",
+      "url_api": "http://localhost:8080/api/v2/findings/280/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:60484\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/107\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/107/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 107, \\\"url_ui\\\": \\\"http://localhost:8080/test/107\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/107/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 279, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/279\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/279/\\\"},
+        {\\\"id\\\": 280, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/280\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/280/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 279,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/279/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/279\"\n        },\n
+        \       {\n          \"id\": 280,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/280/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/280\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        107,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/107/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/107\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/107/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/107\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:35 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_twice_push_to_jira_push_all_issues.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_twice_push_to_jira_push_all_issues.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bprmrVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDZrUKEMjXt3iQhGeK+FTSwGMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCKcAaQIJTMvN5WO5fqh+ppuhrWNF+PMITWACL9GJnXH7Nl5Z7bvRtjJu
-        aGKoHrRpviKExwAtilPzSoQRpEDnU0insKwo5SzjLIoBLiDCMe/jH7CvdHvOplBR4GnB6SLJWP7N
-        yvbGKhdBluYLKQDnqGSaFSiYUkyBVHSZzRe1yhnSXAE9EwQzGm51L8YXohKDCXdOirF9IOZUEbSv
-        25Iczw97cnacXN9X5PgJAAD//wMAHn2r7iACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:36.261+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 132f1352-49ae-4da4-97f1-4ab3b3e9c367
+      - 7a0551b6-946d-419c-bc65-2b9c9a2c9bfd
       Atl-Traceid:
-      - 132f135249ae4da497f14ab3b3e9c367
+      - 7a0551b6946d419cbc652b9c9a2c9bfd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:28 GMT
+      - Wed, 30 Apr 2025 16:26:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=235,atl-edge-internal;dur=23,atl-edge-upstream;dur=212,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="vYYiJTj2v2iBq_5ZsWzy835YSJzIJZv9yefMPHfWDG0jcZ00zBMVjg==",cdn-downstream-fbl;dur=259,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=53,cdn-upstream-fbl;dur=257,atl-edge;dur=183,atl-edge-internal;dur=16,atl-edge-upstream;dur=169,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b1383a69c949c8987c982636bd26b4f2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - vYYiJTj2v2iBq_5ZsWzy835YSJzIJZv9yefMPHfWDG0jcZ00zBMVjg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - fe281dc5c9c9a0bb7035bfe11ac20973
+      - e3d2bcfd30939b8ac27ac28e2a9c4703
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 4bf490fd-aaec-45ca-b9fa-50b243c18ec5
+      - 02ccaae6-ccd6-4b6f-a10d-0fe93b9f529e
       Atl-Traceid:
-      - 4bf490fdaaec45cab9fa50b243c18ec5
+      - 02ccaae6ccd64b6fa10d0fe93b9f529e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:28 GMT
+      - Wed, 30 Apr 2025 16:26:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=323,atl-edge-internal;dur=23,atl-edge-upstream;dur=300,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="UCx60FwDcmhvomLKzoYubCsj0qLcsT2WsZB8TiJgBqwRGmI2v6Dggw==",cdn-downstream-fbl;dur=419,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=417,atl-edge;dur=331,atl-edge-internal;dur=15,atl-edge-upstream;dur=316,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2bdfafaaaec33c116889588ecd9de280.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - UCx60FwDcmhvomLKzoYubCsj0qLcsT2WsZB8TiJgBqwRGmI2v6Dggw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 17cb3aa1d614344d25f3250e9d25a2e9
+      - ae0c2dc70feab6914d452a5712631abe
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/281]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/281 (281)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/108]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16107","key":"NTEST-1623","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16107"}'
+      string: '{"id":"18221","key":"NTEST-1863","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18221"}'
     headers:
       Atl-Request-Id:
-      - bdee3be4-2ea4-4e0e-b317-44c01b44a3bd
+      - fe47709d-2bda-49a6-aa45-3c49c693fb96
       Atl-Traceid:
-      - bdee3be42ea44e0eb31744c01b44a3bd
+      - fe47709d2bda49a6aa453c49c693fb96
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:29 GMT
+      - Wed, 30 Apr 2025 16:26:37 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=714,atl-edge-internal;dur=15,atl-edge-upstream;dur=697,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="cY4gya-nhS2Tlemszuepji_Ofj2dzDLMHJai2vctN8-2MGRXiKllZw==",cdn-downstream-fbl;dur=718,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=716,atl-edge;dur=629,atl-edge-internal;dur=17,atl-edge-upstream;dur=611,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 595c26368a4c8eede29e4b5da7206efc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - cY4gya-nhS2Tlemszuepji_Ofj2dzDLMHJai2vctN8-2MGRXiKllZw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 276fa64a9cb9db5f4d0b57949e287f29
+      - 2dedd0b19f34365bbfb2f597a0aea9ed
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1623
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1863
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvdhxHQHD0MXuli3LssRJgGZFQEtnmTVFaiQV22vz33ek
-        JLt1og7JsKJAavF47889vA8erAsqUi/2FIgUFKRvGPBUdwTNQXd0soCcdmQBihomhe5AykwOhnaS
-        BRUZcJl17kFplEF6AYUCDcLUd5NSG5nPrcG7MAjCoKfgrxK0mW4KOFc0MSwBr+Mx6z8chsEr/NDA
-        5/i5MKbQse+nMIfEpPK97FHDqdaMip4A46Mn49OC+ZHPtC7BbwwsYYP6Z9PJ5bQbDqM+HrkQtBd/
-        8DTGVuqEGsik2lQ5pPiFGlEQHXaDsBsG0yiIw1dxdNQbHPW/w7gDG6R1YjBwZ+aFQVp9H+0F0Tbt
-        +iMFnShW2MLh6Wuic8p5h6RMGyYSQwoGCRA5Jyuplj2rnUhxpfgzoygFs+2i/I7eU0OVf89g5buw
-        dgHWojDoh6MfNPsbvs+x7WWOXi0s0OWU6qXtVTkz9lc8p1xDx6sUTzAvp9vxFgyBo5LF5hTuAWMN
-        HjqeYYisAlHixaLEHL09mPSDRlAo+R4zemHBa21XbtfAptz24xOQ7LK6EswYNKC9rW+L1F/dXS3n
-        ZkWVxatmecEZBpzuZY79cCgbjNaD0TPD/UJnmky2fRk4oEeDdTT4f71U3XdYRIfhcB0Ov4bDdeOx
-        H6370dfwWAP84eExHMM2nEZtgn4jmLP1dUWOCIvbdwiTLFOQId88GgJMQPKyGv+nrR62CYZtglct
-        gqhVMGoTHD2Os6LN6tSSknshvLgb1lxpW6JYUqX04dGZHRSstl7IkqdjpgtON/U44fGKGnx6Ksp+
-        /uhXD8LuCfArc8oOtvt5LEtbehfqjT1gIvNio0rrG42aa8SMHe+6GgowWcsfTz0S4SBoHon9sm2p
-        bF/QBqpoC6pCMamY2bywBI26P3jeW8FymoH2rYZujDA84HLV0/fZjixP5aoh1YH3eGyi7RBwOgNL
-        ixb/+xtBG3TDNoSGI1uPBdWTgiWnTCzfWMkYCru9iKRBkMPVysm2J0KKCS4vdMbhAqiuUKnqX975
-        6dVPJ2d3pyfHk7PLyd3k4uL3C8wPp1RjQfDCdAHkHPlfGGL9EqaJFHxDkEsYt0aJkeQXpig5V5Aj
-        mZBSI+J6T3FKiOPkBR9ZEBRmFnvVm4i9w+LvZuozrsA2ZExQvn+p3r3q8jrcc4yuoRvsayZge7ss
-        7NC24TiKhg2OqzXphdCrlLfv7uebzfPQuIPbjzRZ4rLZQK4xXvk6rve5/xRwsxT6zW4WNWuCAAv1
-        RHKpzqpoZryEbqaQsXYrkSRjWTVb5gWuw8I8DfrDNlI43JLClzr+eTn/FLt/B1NmOBzE5PYtLcKY
-        HEu5ZEBumEGONeQSklIBecNp9tFWB4vDZUL5QmoTj4JR4M+ZSJEI/WgUvnMGx654mNd7SSys4gPy
-        r5rkG/zzrVO/xKXPchCqIVvUQY5LIGPMBw9/oxsSBh1iwbhN4vhmgqJb/K87DAcuUtvHZAW9nBkF
-        PakyH2FMbWsZbmwW/j5e7S1Mzl3clZ1ra+dKLIVcfVqkcyXTEneAichwsHNskz/FGlufrkIYL/lZ
-        rrpGtlSpqA1E74hPbkNtyB8lVQYU2ZlsUYWdz9Bpv319Ti4TKlru22UU52i0zeqTPC432kCuMY+0
-        kAzBdhC7c9chW7GcMqGZgR7iEQumFzNJVdp245H98Q5nB/E/AAAA///sWe9LG0EQ/VcWQVDwzkty
-        mqQgNkgL/SAtChVECJu9PXM0t3fcD0+x/u99s7tu4zVrixTxg+CHM7s383Yy8/bN5ErNmDDpBO5l
-        CykVq2XDOptbDcixNvmVIr/2WLfMxJLlkqsai9zssBZw3iu1kIwLAXaVCbvJOGtRMKK6K0FP2KeU
-        NCIhXEN0iu/6WreWBOhiKRXlF+POboHOEycCEjoWVCDLVFpUuX6HFRVxNsdqTZQJuv4h1R4Bg/Gs
-        YUaJML7q+B0dkZVco2trZDbjiq0BRN+o5CrEN17Tmd0JTQyuFAWBvFGMgMAirB8hksG6RYA2Il07
-        89rpz1CLuH0QMjq9zZeu68Ki43WpqwJFKG/DclnqjIaTOWzOre85byC9Fi1yar7z9WJ2/i04Pw1w
-        UetadU7KglKZqmGHJ3mmdtnO7k8kyqopPiAN/9Q4B+6i719yPp4bxL4FJ3GJAJsKlK91GenE3tbY
-        CdLeQuSTyZFPa0ROa+hvT0uuzRt96jhyYBBjLpZU4Bv0fp/J6zbPOV1aW3/ja4o6SdCieuENR1Lk
-        GPVGsvdLcnSQjCbjyWIwjuRITCMxPRim00F6CD9uEzw8s01SSsySBD5wy+HKS+4+rgEBoZCtZ5ti
-        UyshblG9TdOUbcxiCaHHk0EcH47FZHwwmi7EYhzBfcplOhHHyZG2sj2abQ8/48+8F+RcWX4NAvNR
-        HbZ10CEQwTAk4g7LdrHKBEUqKDmvKVB4X98jkIl4PEFRhKWimPcb7LePuN+hv33E/Q7/rSMGFSWm
-        WbVS8ASpDyWTpq0QmS4g4nPTTBoiu4QYxMZPbVWUcv8SFCOWvyuNJkxYdaVLHuxcbbN+jH28Gvua
-        ytg3qYgdd1eW+N/55dUy6Z1fXgPxO79s4Jc+DThB5vQKUF+b2runUbh9juCwaLgd5PeteJWXl5e8
-        kmy4mfl8U6HIp0GJEDYuRD4NOvK9MXIiT6qbrCqUUXnmo6S1vyKZf/8pekVuLNw/Plq6fwH9rv0A
-        tv9od28r57dnsm5XZHjNtx6aVM2sMThuiub/zVmNMWcUvtAufi/0zMmNdotKT3LIpQPyFO3wCVz7
-        gg7Pw8PDLwAAAP//AwAfKO4utBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18221","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18221","key":"NTEST-1863","fields":{"statuscategorychangedate":"2025-04-30T18:26:37.720+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1863/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:37.431+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t4f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:37.515+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/281]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/281 (281)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/108]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1863/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18221/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - dd10fd82-f917-4b5d-8bc8-17a623633551
+      - ec07c594-3cc6-478b-b3f3-3ce1ec9ad3e9
       Atl-Traceid:
-      - dd10fd82f9174b5d8bc817a623633551
+      - ec07c5943cc6478bb3f33ce1ec9ad3e9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:29 GMT
+      - Wed, 30 Apr 2025 16:26:38 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=302,atl-edge-internal;dur=18,atl-edge-upstream;dur=285,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="w6FmFiJclnnXzqdccqtX4NUr_AFt-SUjEtXwT5acJ-degIWmucjFXw==",cdn-downstream-fbl;dur=349,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=347,atl-edge;dur=264,atl-edge-internal;dur=18,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9b5b156d64ffeaa3e7df806f8b45cd5c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - w6FmFiJclnnXzqdccqtX4NUr_AFt-SUjEtXwT5acJ-degIWmucjFXw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - e0ad2310a4de7237b4c4bc0406b28220
+      - c833a461c21627f26e0e3b931ff4c497
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16107
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18221
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSGU9CyI5UVVsSWraUUgggLV0hM3MzMfHYU9tDkrL8917P
-        K7tAdgVVV0hh/Ljvc4/vvQernMnEizwNMgENyQEHkZiOZBmYjonnkLGOykEzy5U0HUi4zcCyTjxn
-        MgWh0s4daINnkJxCrsGAtPXduDBWZTOn8JoGAQ16Gv4uwNjpOocTzWLLY/A6Hnf26ZAGe7gwIGa4
-        nFubm8j3E5hBbBN1q3rMCmYMZ7Inwfpoyfos537oc2MK8BsFC1ij/PF0cjbt0mHYx63SBeNF955B
-        3woTMwup0usqhgRXKBEG4W43oF0aTMMgontR+KY3eNP/Af0OnJPOiEXHSzWvdNLJ+6gvCNuw60UC
-        JtY8d4nD3bfEZEyIDkm4sVzGluQcYiBqRpZKL3pOOlbyXIsXelFI7srFxDW7Y5Zp/47D0i/d2jhY
-        H9GgT0c/Gf4P/Jhh2YsMrTpYoMkpMwtXq+LGuq9oxoSBjlcJHmJcpWzHm3MEjo7n6yO4A/Q1eOh4
-        liOyckSJF8kCY/QewaQfNAe5VrcY0SsTXkuX6S4L2KTbLT4BySaqc8mtRQXGa207pP5W3jVqZpdM
-        O7wanuWCo8PJo8ixHiXKBqPVYPRCd79QmSaSti6DEujhYBUO/l8rVfVLLKJBOlzR4bcwuGos9sNV
-        P/wWFmuAPzw8hSPdhtOwOZjx1UXFgVj9qw9Pb/abmyxNNaTIN19tgt3mACNToqh44fmrw20He1sO
-        wq0Ho20Hb566U9FmtetIqXwhvKhLccksPhwV4b68cSs63xC4X6nTri3Lz31VuMRRR8qXboPL1Ius
-        LuCh5mmnTfO4ytr9kz3nGV41c1WIZMxNLti6bmXcRrfsBWLGtXedDQ0YrOOP5x4JOgiaR+Jx2loq
-        e3ywDVRhC6pcc6W5Xb8yiY24P3jZW8EzloLxnYRplHDcEGrZM3fphiyP1LIh1YH3tG3CFvOC3YCj
-        xWcaw7HJs2mg2xBKRy4fc2YmOY+PuFwcuJMx5G56kXFTxbK2y/Ks3ZFKTnB4YTcCToGZChm6/vJO
-        js5/OTy+PjrcnxyfTa4np6d/nGJ82KUGE4IXpnMgJ8j/0hJnl3BDlBRrglzChVNKrCLvuGbkREOG
-        ZEIKg5jtPccpFNvJCz7yIMjtTeRVbyLWDpO/6anPuALLkHLJxONL9exVp7fEuUDv6rWrayqhvV3k
-        rmm34TgMhw2OqzHpldCrhNt39/PJ5mVo3MDtZxYvcNhsINcor2zt1/Pcf3K4GQr9ZjYLmzFBgoN6
-        rITSx5U3N6KAbqqRNTYjkSJjVRVbZTmOw9I+D/rdlhS+VNjHQi1hfJ7Ov+Tmb2fKrYCdiFy9ZzmN
-        yL5SCw7kklvkOUvOIC40kAPB0o8uO5gcoWIm5srYaBSMAn/GZYJU6ocj+qFUOC6Th3HdKuJgFe2Q
-        r0qS7/Dn+1L8DIc+x0EohmxROzkugIwxUNz8na0JDTrEgbENYv9ygkdX+K87pIPSU1fHeAm9jFsN
-        PaVTH2HMXGk5TmwO/j5e7c1tJkq/Kz0XTs+5XEi1/DRJJ1olBc4AE5liY2dYJn+KyXc2ywyhv+RX
-        texatSVLea0g/EB8ckWNJX8WTFvQZKNyiyhsbNJS+v3bE3IWM7nlvhtGsY9GbVSfxHG2NhYyg3Ek
-        ueIItp2o3C8r5DKWMS4Nt9BDPGLCzPxGMZ1su/FE/3iDs53oXwAAAP//7FltS9xAEP4riyAomJi7
-        y3l3BbGHtNAP0qJQQYRjs9l4oXebkBejWP97n9nd28b0YosU8YPgh5jdnZfNzDPPzF2rORMmnIC9
-        LJJSsVJWrLGxVQEcSxNfCeLrgDXLVCzZWnJVYpGbHVYC/L1WkWRcCKCrjNltylmNhBHFfQ54wj6l
-        pCnUfsuiM3zrG91akkGXS6kovhh3cjN0nvAIlpBbYIEsVUlWrPUZlhWE2RyrJUEm4PqHVAdkGISn
-        FTNsgPFVw+/JRZZzbV1dIrIZV6xlIPpGJVc+vnhJPjsPzR1cK7oE0kZ3BAusheXGRBJY1rigrZa2
-        fG55f45cRPXBlZH3Nl6apvGzhpe5zgokobzz82WuIxpKFpC5sLoXvAL9iWrE1GLv6+X84pt3ceah
-        UOtcdUryjEKZsmGPx+tU7bO9/Z8IlFWVfUAY/slxxq7Qd4tcH/kZhG0ArAoguyZwRMm6Wx0N7iwE
-        fQuhY6rdE45r6I+kmdX2jX3cI+hjx4HT+aRmdyEdH4CLJWW/qQtlvV5zKlo7f8NrunWioFnxwgpH
-        VOQE+UbE+Ut8PI5H08k0GkwCORKzQMzGw2Q2SI6gx22Chme2SQqJeRxDB6ocSl58/7FlCACFZD3b
-        FJtc8VFF9TYNU7YxCyWIHo8HYXg0EdPJeDSLRDQJoD7hMpmKk/hYS9kdzXeHn/Fnznlrriy+ep55
-        Vfp16TW4CG/oE3D7eR2tUkE35eWcl3RROK/rCGgiHk+RFH6u6M67Dfbbt7jbob99i7sd/lu3GBgV
-        m4bRUsFThD6YTJLUQqQ6gQjPTTtqEO4KZBAbP9VFlsvDK2CPWP7ONJowYdWlLmmwc7Xt/DHsw9Ww
-        r6kMXVNZWHx/h5FXC5h3GHkNi99hZAuMdGGgj6mFjpA5/gJ3bkxSPtAo3D4HsCSruB3kd6X0UbKg
-        D5eC4XaA65sKBb0O9FI251n3RB+XG/UuOJIn1W1aZMoQOfMqru2vSObff7m926z6fxNSI8wJhSa0
-        ad8zPevZjDWRAsbkh82jrS8vNkD/4na4kXuws+Z357KsVyS45aye0hTVvDKO06yYJjnkunv/9PDw
-        yWl7QFv7+Pj4CwAA//8DAHH7lzC0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18221","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18221","key":"NTEST-1863","fields":{"statuscategorychangedate":"2025-04-30T18:26:37.720+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1863/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:37.431+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t4f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:37.515+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/281]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/281 (281)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/108]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1863/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18221/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 18cbb99d-2b25-418c-9701-f21d818be520
+      - 30d20b08-1a84-4e37-af83-7b2775c001a2
       Atl-Traceid:
-      - 18cbb99d2b25418c9701f21d818be520
+      - 30d20b081a844e37af837b2775c001a2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:30 GMT
+      - Wed, 30 Apr 2025 16:26:38 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=290,atl-edge-internal;dur=13,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=331,atl-edge;dur=299,atl-edge-internal;dur=20,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="6zYF3imx1buvbI85y13rw9LousClOoMgm5qSKyjPQq0o4PiKm3pbxg==",cdn-downstream-fbl;dur=336
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 6zYF3imx1buvbI85y13rw9LousClOoMgm5qSKyjPQq0o4PiKm3pbxg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f37fe7d6c664e9e352b35182c3fff069
+      - c6a38510ba83e01a601aeb8e48a2a3ad
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2bfm25oSExEAykdhcQQmnqiEKaVE06aZr230nEBDsCN8t+
-        Xj+WD6ThFrejIoy8OTdYNp+3KFG41rybmDvFre24jjU6MiNtZwfF9//gKxx3ncAW7cca1bBC7XD8
-        65KV0VJNqAX+LrnD0XZGezgBSGKIIao2l4/V+qH+mW6mvvEVYc8BmsEMXrwTB2X2vb+y3g/BtlJm
-        an2omTrVfkUI8wFalqfmFXcBpEDzCJIIljWlLEtZ5sUAF+Bhn7f+DzjWXX/OJlBTYEnJUogLyL9Z
-        0d9oaTyYJcVCcMAcpUjSEnkmZSZBSLpM80UjiwxpIYGeCZwKhttu5OGFKPmk3J0RPLQPRJ0qgvp1
-        W5Hj+WFPRofJ9X1Njp8AAAD//wMAGaaVdyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:39.200+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - bdb53704-007f-47ed-ba0e-bc4b257c5040
+      - c2d1b790-867a-4c9c-bce1-b14f1e53e7c7
       Atl-Traceid:
-      - bdb53704007f47edba0ebc4b257c5040
+      - c2d1b790867a4c9cbce1b14f1e53e7c7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:30 GMT
+      - Wed, 30 Apr 2025 16:26:39 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=154,atl-edge-internal;dur=20,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=178,atl-edge;dur=145,atl-edge-internal;dur=14,atl-edge-upstream;dur=131,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="gHL1hHUbJ9ysarCOpaQiAQpQ8UKLio1qc3v9cyHI2SoA_ULO-EyMvQ==",cdn-downstream-fbl;dur=183
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 535c2b5354e6ba6798fd64420ee97a2c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - gHL1hHUbJ9ysarCOpaQiAQpQ8UKLio1qc3v9cyHI2SoA_ULO-EyMvQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - b08684d8cf682414994247ebc6595824
+      - 3db0f1a086cfb11553296433a741d0f1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 3eb252cd-2671-419d-9ec2-487fb7cfca18
+      - 9dde5443-3904-4131-8999-e7259c99ecd3
       Atl-Traceid:
-      - 3eb252cd2671419d9ec2487fb7cfca18
+      - 9dde5443390441318999e7259c99ecd3
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:31 GMT
+      - Wed, 30 Apr 2025 16:26:39 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=299,atl-edge-internal;dur=19,atl-edge-upstream;dur=279,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=374,atl-edge;dur=354,atl-edge-internal;dur=21,atl-edge-upstream;dur=331,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="El-iy0EFUV9OIjbP0T1wEMwbiuoQvxchpWi6c2B1MlbOvjQIL5AM0A==",cdn-downstream-fbl;dur=378
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 72fcd81c14e3eb0facf41fedad65e9e4.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - El-iy0EFUV9OIjbP0T1wEMwbiuoQvxchpWi6c2B1MlbOvjQIL5AM0A==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 35d7e6c1ad7312896ce82d8967d4736d
+      - aa4c84e2d033d0661d82802aecea0267
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/282]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/282 (282)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/108]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16108","key":"NTEST-1624","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16108"}'
+      string: '{"id":"18223","key":"NTEST-1864","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18223"}'
     headers:
       Atl-Request-Id:
-      - acc1fbd3-3538-4d25-8014-110522bfd218
+      - 66421ff2-8ba1-4525-8ba2-fc6981f2a2bc
       Atl-Traceid:
-      - acc1fbd335384d258014110522bfd218
+      - 66421ff28ba145258ba2fc6981f2a2bc
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:31 GMT
+      - Wed, 30 Apr 2025 16:26:40 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=784,atl-edge-internal;dur=13,atl-edge-upstream;dur=772,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=788,atl-edge;dur=755,atl-edge-internal;dur=16,atl-edge-upstream;dur=740,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="TI6a47YR-Yy8bFomgjYsICCEPzF74ZXWKFQlq8QlcmlF-iQQfL4WAw==",cdn-downstream-fbl;dur=791
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - TI6a47YR-Yy8bFomgjYsICCEPzF74ZXWKFQlq8QlcmlF-iQQfL4WAw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 276c03832910d096c9397d32b7969e8c
+      - 2f72bcd936caec23a32a97b006dec65a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1624
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1864
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+U8jNxT+V6z5qaVJ5shBOlJVbUloaSmlEEBaipCZeZmYeOyp7SFJWf73Ps8V
-        rtkVVF0hhfHx7u99fvcOrDMqYid0FIgYFMT7DHisO4KmoDs6WkBKOzIDRQ2TQncgZiYFQzvRgooE
-        uEw6d6A0nkF8ApkCDcJUd6NcG5nOrcJr3/N8r6fg7xy0mW0yOFY0MiwCp+Mwa98f+d4YFxr4HJcL
-        YzIdum4Mc4hMLG9ljxpOtWZU9AQYFy0Zl2bMDVymdQ5urWAJG5Q/mk1PZ11/FAxwq3BBO+G9o9G3
-        XEfUQCLVpowhxhVKBF4w7Hp+1/dmgRf6u2Hf7+2O+9+h35510hox6Hih5p1OWnkX9XlBE3a1iEFH
-        imU2cbj7geiUct4hMdOGiciQjEEERM7JSqplz0pHUpwp/kYvcsFsuSi/pnfUUOXeMVi5hVtbB6sj
-        3+v74x81+wd+SLHseYpWLSzQ5Izqpa1VfmPsVzinXEPHKQUPMK5CtuMsGAJHRYvNIdwB+uo9dBzD
-        EFkZosQJRY4xOs9g0vfqg0zJW4zonQmvpIt0FwWs020Xj0CyjepMMGNQgXYa2xapvxV3tZybFVUW
-        r5qlGWfocPwscqxHgbLBeD0Yv9Hdz1SmjqSpy8DbRTeCwRrR/b9aKatfYBEN+qO1P/oaBte1xX6w
-        7gdfw2IF8IeHl3D023Aa1Adztj4vORCrf3n18ma/vkmTREGCfPPFJhjWBxiZ5HnJC69fHbUd7LYc
-        BK0H47aD71+6U9JmuWtJqXghnLDr45IafDhKwn1745Z0viVwt1SnbFsWn3syt4nzLSlf2A0mEic0
-        KoeHiqetNsWiMmv3L/asZ3hVL2TO4wnTGaebqpVxG90y54gZ295VNhRgsJY/XnskBuNh/Ug8T1tD
-        Zc8P2kAVNKDKFJOKmc07k1iLu/b9e8NbwVKagHathK6VMNzgctXTd8mWLA/lqibVgfOybYIG85ze
-        gKXFVxrDssmrafDbEOqPbT4WVE8zFh0ysdy3JxPI7PQiorqKRW1XxVmzI6SY4vBCbzicANUlMlT1
-        5Rwfnv18cHR9eLA3PTqdXk9PTv44wfiwSzUmBC/MFkCOkf+FIdYuYZpIwTcEuYRxq5QYSX5lipJj
-        BSmSCck1Yrb3Gqf42E6O94l5XmZuQ6d8E7F2mPxtTz3hCixDwgTlzy9Vs1eV3gLnHL2r1rauiYDm
-        dp7Zpm3D8XDo1zgux6R3Qq8Ubt7dp5PN29C4hdtPNFrisFlDrlZe2tqr5rn/5HA9FLr1bBbUY4IA
-        C/VIcqmOSm9ueA7dRCFrbEciSSayLLZMMxyHhXkd9MOGFD5X2OdCDWE8TedfYvu3M2OGw05ILj/S
-        LAjJnpRLBuSCGeQ5Q04hyhWQfU6TTzY7mBwuI8oXUptw7I09d85EjFTqBuPgqlA4KZKHcd1KYmEV
-        7pAvSpJv8OfbQvwUhz7LQSiGbFE5OcmBTDBQ3PydbojvdYgFYxPE3sUUjy7xX3fkDwpPbR2jFfRS
-        ZhT0pEpchDG1pWU4sVn4u3i1tzApL/wu9ZxbPWdiKeTqcZKOlYxznAGmIsHGTrFM7gyTb20WGUJ/
-        yS9y1TWyJUtZpSC4Ii659LUhf+ZUGVBkq7JFFLY2/UL644djchpR0XLfDqPYR+MmqkdxnG60gVRj
-        HHEmGYJtJyz2iwrZjKWUCc0M9BCPmDC9uJFUxW03XuifbHG2E/4LAAD//+xZbUvcQBD+K4sgKJiY
-        u8t5dwWxh7TQD9KiUEGEY7PZeKF3m5AXo1j/e5/Z3dvG9GKLFPGD4IeY3Z2Xzcwzz8xdqzkTJpyA
-        vSySUrFSVqyxsVUBHEsTXwni64A1y1Qs2VpyVWKRmx1WAvy9VpFkXAigq4zZbcpZjYQRxX0OeMI+
-        paQp1H7LojN86xvdWpJBl0upKL4Yd3IzdJ7wCJaQW2CBLFVJVqz1GZYVhNkcqyVBJuD6h1QHZBiE
-        pxUzbIDxVcPvyUWWc21dXSKyGVesZSD6RiVXPr54ST47D80dXCu6BNJGdwQLrIXlxkQSWNa4oK2W
-        tnxueX+OXET1wZWR9zZemqbxs4aXuc4KJKG88/NlriMaShaQubC6F7wC/YlqxNRi7+vl/OKbd3Hm
-        oVDrXHVK8oxCmbJhj8frVO2zvf2fCJRVlX1AGP7Jccau0HeLXB/5GYRtAKwKILsmcETJulsdDe4s
-        BH0LoWOq3ROOa+iPpJnV9o193CPoY8eB0/mkZnchHR+AiyVlv6kLZb1ecypaO3/Da7p1oqBZ8cIK
-        R1TkBPlGxPlLfDyOR9PJNBpMAjkSs0DMxsNkNkiOoMdtgoZntkkKiXkcQweqHEpefP+xZQgAhWQ9
-        2xSbXPFRRfU2DVO2MQsliB6PB2F4NBHTyXg0i0Q0CaA+4TKZipP4WEvZHc13h5/xZ855a64svnqe
-        eVX6dek1uAhv6BNw+3kdrVJBN+XlnJd0UTiv6whoIh5PkRR+rujOuw3227e426G/fYu7Hf5btxgY
-        FZuG0VLBU4Q+mEyS1EKkOoEIz007ahDuCmQQGz/VRZbLwytgj1j+zjSaMGHVpS5psHO17fwx7MPV
-        sK+pDF1TWVh8f4eRVwuYdxh5DYvfYWQLjHRhoI+phY6QOf4Cd25MUj7QKNw+B7Akq7gd5Hel9FGy
-        oA+XguF2gOubCgW9DvRSNudZ90Qflxv1LjiSJ9VtWmTKEDnzKq7tr0jm33+5vdus+n8TUiPMCYUm
-        tGnfMz3r2Yw1kQLG5IfNo60vLzZA/+J2uJF7sLPmd+eyrFckuOWsntIU1bwyjtOsmCY55Lp7//Tw
-        8Mlpe0Bb+/j4+AsAAP//AwBUdpSrtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18223","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18223","key":"NTEST-1864","fields":{"statuscategorychangedate":"2025-04-30T18:26:40.598+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1864/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:40.293+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t4n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:40.377+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/282]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/282 (282)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/108]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1864/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18223/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - ad319825-e9a9-4504-81d7-056a2831a9f7
+      - b4f8a795-d4e2-4ab6-84c0-ec837029d18e
       Atl-Traceid:
-      - ad319825e9a9450481d7056a2831a9f7
+      - b4f8a795d4e24ab684c0ec837029d18e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:32 GMT
+      - Wed, 30 Apr 2025 16:26:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=269,atl-edge-internal;dur=14,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=328,atl-edge;dur=295,atl-edge-internal;dur=18,atl-edge-upstream;dur=278,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="iNCQmVDavsBJa344XwhxrKLdzCyPcHK_9hvrW2K0G-o8t9T7010pVQ==",cdn-downstream-fbl;dur=333
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 aa3674a12327640af71c59263be8ffc6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - iNCQmVDavsBJa344XwhxrKLdzCyPcHK_9hvrW2K0G-o8t9T7010pVQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 95144d5f99c098a1909c08503a57295d
+      - 803a2f5cbb1923051b32986a90ce9bb6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16108
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18223
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfUkC6UpVdSWh5UophQDSUYTM7mRj4rW3tpck5fjvHe9b
-        gLBXQdXTSVzW43l75pnxPDiwyqiIndBRIGJQEB8w4LHuCJqC7uhoDintyAwUNUwK3YGYmRQM7URz
-        KhLgMuncg9Iog/gUMgUahKnuRrk2Mp1Zgze+5/leT8FfOWgzXWdwomhkWAROx2HWv7/reyP80MBn
-        +Dk3JtOh68Ywg8jE8k72qOFUa0ZFT4Bx0ZNxacbcwGVa5+DWBhawRv3j6eRs2vV3gwEeFSFoJ3xw
-        NMaW64gaSKRalznE+IUagRcMu57f9b1p4IX+Xtj3e3uj/ncYt2eDtE4MBl6YeWeQVt9Fe17QpF19
-        xKAjxTILHJ5+IDqlnHdIzLRhIjIkYxABkTOylGrRs9qRFOeKvzGKXDBbLspv6D01VLn3DJZuEdYm
-        wErke31/9KNmf8MPKZY9T9GrpQW6nFK9sLXKb439Fc4o19BxSsVDzKvQ7ThzhsRR0Xx9BPeAsXqP
-        HccwZFaGLHFCkWOOzgua9L1akCl5hxm9E/BKu4C7KGANt/14QpJNVueCGYMGtNP4tkz9tbir5cws
-        qbJ81SzNOMOA4xeZYz0Klg1Gq8HojeF+oTJ1Jk1dBt4ehhEMVsju/9VLWf2Ci+jQ3135u1/D4ar2
-        2A9W/eBreKwI/vi4TUe/jadBLZix1UU5A7H6V9fbN/v1TZokChKcN1tNgAlInpft/7q7YZtgt02w
-        1yIIWgWjNsH323GWY7M8tUOpeCGcsOtXs9KWRLGoTOlh68w2CqKt5zLn8ZjpjNN11U54vKQGn55y
-        ZL+99csHYfMEuKU5ZRu7+Lkvcwt9EeqlPWAicUKjcusbjZoL5Ixt7woNBZisnR+vPRKD0bB+JF7C
-        1oyyl4I2UgUNqTLFpGJm/U4IanXXvn9veCtYShPQrtXQtRGGB1wue/o+2QzLI7msh+rA2W6boOE8
-        p7dgx+IrjWGnyasw+G0M9UcWjznVk4xFR0wsDqxkDJndXkRUM6jg1bKQNSdCigkuL/SWwylQXbJS
-        Vb+ck6Pznw+Pb44O9yfHZ5Obyenp76eYH3apRkDwwnQO5ATnvzDE+iVMEyn4muAsYdwaJUaSj0xR
-        cqIgxWFCco2M6702U3xsJ8f7zDwvM3ehU76JWDsEf9NTz2YFliFhgvKXl6rdq4K34D3H6KpvW9dE
-        QHM7z2zTtvF4OPRrHpdr0jupVyo37+7zzeZtbNzQ7ScaLXDZrClXGy997Vf73H8KuF4K3Xo3C+o1
-        QYCleiS5VMdlNLc8h26icGJtViJJxrIstkwzXIeFeZ30w2YofKmwL5WagfEczj/F5t/OlBkOOyG5
-        +kSzICT7Ui4YkEtmcMYacgZRroAccJp8tuggOFxGlM+lNuHIG3nujIkYB6EbjILrwuC4AA/zupPE
-        0ircIf+qSb7BP98W6me49NkZhGo4LaogxzmQMSaKh7/RNfG9DrFkbJLYv5yg6Ar/6+76gyJSW8do
-        Cb2UGQU9qRIXaUxtaRlubJb+Ll7tzU3Ki7hLOxfWzrlYCLl8CtKJknGOO8BEJNjYKZbJnSL41meB
-        EMZLfpHLrpEtKGWVgeCauOTK14b8kVNlQJGNyRZV2Pj0C+1PH07IWURFy327jGIfjZqsnuRxttYG
-        Uo15xJlkSLadsDgvKmQRSykTmhnoIR8RMD2/lVTFbTe27I83PNsJ/wEAAP//7FldS9xAFP0rgyAo
-        mJjdzbq7BbGLtNAHaVGoIMIymUzc0N1JyIdRrP+9587MTmO6sUWK+CD4EDMz9yv3nnvu7LWaM2HS
-        CdjLIikVK2XFGptbFcCxNPmVIL8OWLNMxZKtJVclFrnZYSXA32sVScaFALrKmN2mnNUoGFHc54An
-        7FNKGpLgtyw6w7e+0aMlGXS5lIryi3EnN8PkCY9gCbkFFshSlWTFWp9hWUGYzbFaEmQCrn9IdUCG
-        QXhaMcNEGF81/J5cZDnX1tUlMptxxVoGYm5UcuXji5fks/PQxOBaURBIG8UIFlgLy42JJLCsEaCt
-        lrZ8bnl/jlpE90HIyHubL03T+FnDy1xXBYpQ3vn5MtcZDSULyFxY3QtegXpFNXJqsff1cn7xzbs4
-        89Coda06JXlGqUzVsMfjdar22d7+TyTKqso+IA3/5Dhj1+i7Ta6P/AzCNgBWBZBd0y+ig92tfaQ3
-        6FsIHVPtnnBcQ38kzay2b+zjHkEfOw6cTsSYiyUVuG3A7R7ehfiyXq85Na2dv+E1RZ0oaFa8sMMR
-        FTlBvRHt/RIfj+PRdDKNBpNAjsQsELPxMJkNkiPocZug4ZltklJiHsfQgS6Hlhfff2wZAkAhWc8O
-        xaZWfHRRvU3DlB3MQgmix+NBGB5NxHQyHs0iEU0CqE+4TKbiJD7WUnZH893hZ/yZc96aK4uvnmde
-        lX5deg0C4Q19Am4/r6NVKihSXs55SYHCed1HQBPxeIqi8HNFMe8O2G/f4u6E/vYt7k74b91iYFRs
-        hlVLBU+R+mAySVILkeoCIjw3w6RBuCuQQWz8VBdZLg+vgD1i+bvS6IYJq650SYO9V9vOH8M+XA37
-        hsrQDZWFxfd3GHm1hHmHkdew+B1GtsBIFwb6mFroCJnjK3DnxhTlA12F2+cAlmQVtxf5XSl9lCzo
-        w6VguB3g+m6Fgl4Heimb86x7oo/LjXoXHMmT6jYtMmVYnnkV1/ZXJPPvv0TvNqv+3/2mEeaEQhPG
-        tO+ZvuvZXKmiBIzJD5tH219ebID+xe1wI/dgZ83vzmVZr0hwy1l9S1NU88o4TnfFdJNDrrv3Tw8P
-        n5y2B7S1j4+PvwAAAP//AwB2k0SVtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18223","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18223","key":"NTEST-1864","fields":{"statuscategorychangedate":"2025-04-30T18:26:40.598+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1864/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:40.293+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t4n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:40.377+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/282]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/282 (282)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/108]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1864/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18223/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f959b78c-6b7c-48d9-a49c-00e7f1900de9
+      - 9abcd38b-8a84-4bf1-8aa7-541af38c4da1
       Atl-Traceid:
-      - f959b78c6b7c48d9a49c00e7f1900de9
+      - 9abcd38b8a844bf18aa7541af38c4da1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:32 GMT
+      - Wed, 30 Apr 2025 16:26:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=253,atl-edge-internal;dur=14,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=20,cdn-upstream-fbl;dur=361,atl-edge;dur=278,atl-edge-internal;dur=16,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="-xtaCxf9PZ0Pz_OeDCJMKp00xUY1wY75h0VCNvMF6Mg4_MCSaAJ0AQ==",cdn-downstream-fbl;dur=365
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd759629cc514da7a59a47ab24885b18.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -xtaCxf9PZ0Pz_OeDCJMKp00xUY1wY75h0VCNvMF6Mg4_MCSaAJ0AQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - bb1bee180d12ad94458029ff1b1de937
+      - 259b87fc594a106b067554d8f29dbb5b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:42770\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:50656\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,300 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:32 GMT
+      - Wed, 30 Apr 2025 16:26:41 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/108", "url_api": "http://localhost:8080/api/v2/tests/108/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      108, "url_ui": "http://localhost:8080/test/108", "url_api": "http://localhost:8080/api/v2/tests/108/"},
+      "finding_count": 2, "findings": {"new": [{"id": 281, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/281",
+      "url_api": "http://localhost:8080/api/v2/findings/281/"}, {"id": 282, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/282",
+      "url_api": "http://localhost:8080/api/v2/findings/282/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:50660\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/108\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/108/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 108, \\\"url_ui\\\": \\\"http://localhost:8080/test/108\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/108/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 281, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/281\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/281/\\\"},
+        {\\\"id\\\": 282, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/282\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/282/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 281,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/281/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/281\"\n        },\n
+        \       {\n          \"id\": 282,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/282/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/282\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        108,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/108/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/108\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/108/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/108\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:41 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event test_added has occurred.", "title": "Test created
+      for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null, "url_ui":
+      "http://localhost:8080/test/109", "url_api": "http://localhost:8080/api/v2/tests/109/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      109, "url_ui": "http://localhost:8080/test/109", "url_api": "http://localhost:8080/api/v2/tests/109/"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '843'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - test_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:50672\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
+        Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
+        \\\"url_ui\\\": \\\"http://localhost:8080/test/109\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/109/\\\",
+        \\\"product_type\\\": {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\":
+        \\\"http://localhost:8080/product/type/2\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"},
+        \\\"product\\\": {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\":
+        \\\"http://localhost:8080/product/2\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"},
+        \\\"engagement\\\": {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\":
+        1, \\\"url_ui\\\": \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/engagements/1/\\\"}, \\\"test\\\": {\\\"title\\\":
+        null, \\\"id\\\": 109, \\\"url_ui\\\": \\\"http://localhost:8080/test/109\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/109/\\\"}}\",\n  \"files\":
+        {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event test_added
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        109,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/109/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/109\"\n    },\n    \"title\":
+        \"Test created for Security How-to: 1st Quarter Engagement: ZAP Scan\",\n
+        \   \"url_api\": \"http://localhost:8080/api/v2/tests/109/\",\n    \"url_ui\":
+        \"http://localhost:8080/test/109\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:41 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/109", "url_api": "http://localhost:8080/api/v2/tests/109/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      109, "url_ui": "http://localhost:8080/test/109", "url_api": "http://localhost:8080/api/v2/tests/109/"},
+      "finding_count": 2, "findings": {"new": [{"id": 283, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/283",
+      "url_api": "http://localhost:8080/api/v2/findings/283/"}, {"id": 284, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/284",
+      "url_api": "http://localhost:8080/api/v2/findings/284/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:50674\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/109\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/109/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 109, \\\"url_ui\\\": \\\"http://localhost:8080/test/109\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/109/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 283, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/283\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/283/\\\"},
+        {\\\"id\\\": 284, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/284\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/284/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 283,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/283/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/283\"\n        },\n
+        \       {\n          \"id\": 284,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/284/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/284\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        109,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/109/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/109\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/109/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/109\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:26:42 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_no_push_to_jira_but_push_all.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_no_push_to_jira_but_push_all.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwFWFKfmlfARZMDyKdApLCvGeJbyLIgBLiDAIe/CH3Co2u6cpVAx4LTgaZqkkH+z
-        srsxygYwo/OFFIA5KknTAkWmVKZAKrZM80Wt5hmyuQJ2JvA6Gm7bQcQXohKj9ndWitg+EH2qCJrX
-        bUmO54c9WRMn1/cVOX4CAAD//wMA1D31ziACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:42.486+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - f0babe04-5068-4f3f-a1b5-d7d4c4d881c3
+      - b25bccb7-36cf-4d2a-9e66-23c7693aba88
       Atl-Traceid:
-      - f0babe0450684f3fa1b5d7d4c4d881c3
+      - b25bccb736cf4d2a9e6623c7693aba88
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:33 GMT
+      - Wed, 30 Apr 2025 16:26:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=163,atl-edge-internal;dur=18,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="TkJp2Y0f9boUhfwZcV4AnK5cQh_3vIV1OkeTonvpD38oWFHWVW61xQ==",cdn-downstream-fbl;dur=272,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=269,atl-edge;dur=183,atl-edge-internal;dur=14,atl-edge-upstream;dur=169,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 87441111f0e4d414e651812e90f76e78.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - TkJp2Y0f9boUhfwZcV4AnK5cQh_3vIV1OkeTonvpD38oWFHWVW61xQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 25f8a4c0d341ad057cfcf8ed8b1e8da0
+      - b668596ee6731e7d630a50354870fe6b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 9c9dda6d-8120-4b0a-8793-7882e328d44b
+      - 19d9a556-903c-49ed-90cc-9f3b5207fc8b
       Atl-Traceid:
-      - 9c9dda6d81204b0a87937882e328d44b
+      - 19d9a556903c49ed90cc9f3b5207fc8b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:33 GMT
+      - Wed, 30 Apr 2025 16:26:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=243,atl-edge-internal;dur=16,atl-edge-upstream;dur=228,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=381,atl-edge;dur=349,atl-edge-internal;dur=14,atl-edge-upstream;dur=335,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0K3uMKnmCqsMqTY3k0MBKVcHgW7Kb6ZUwWLxKdGxi_qhLUT47Kmrkw==",cdn-downstream-fbl;dur=385
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8139bc666c011a53bdc5037ba6d5931e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0K3uMKnmCqsMqTY3k0MBKVcHgW7Kb6ZUwWLxKdGxi_qhLUT47Kmrkw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ff94c860d5ec39a8b5da210e2a8d0df1
+      - 5bc0b4d5c3efebf93e9347db77e28a54
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -157,7 +156,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/97]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/7]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -166,28 +165,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/285]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/286]\n*Defect Dojo link:* http://localhost:8080/finding/286
-      (286)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (286)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/285]\n*Defect
       Dojo link:* http://localhost:8080/finding/285 (285)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -201,7 +200,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3358'
+      - '3333'
       Content-Type:
       - application/json
       User-Agent:
@@ -210,18 +209,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16109","key":"NTEST-1625","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16109"}'
+      string: '{"id":"18225","key":"NTEST-1865","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18225"}'
     headers:
       Atl-Request-Id:
-      - 5d08805b-655f-45e2-b05b-72e78082591e
+      - 6ab328be-1a5c-4bfd-b856-68512e385d88
       Atl-Traceid:
-      - 5d08805b655f45e2b05b72e78082591e
+      - 6ab328be1a5c4bfdb85668512e385d88
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:34 GMT
+      - Wed, 30 Apr 2025 16:26:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -231,7 +232,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=785,atl-edge-internal;dur=15,atl-edge-upstream;dur=770,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="MHU7karM5JehWeF-Cb47fINYo1uRLQ8i-2I6zn-j_ZF5tcrL0gTt5w==",cdn-downstream-fbl;dur=720,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=716,atl-edge;dur=629,atl-edge-internal;dur=31,atl-edge-upstream;dur=597,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -240,10 +241,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9d71affbaf22baf23eab459f3d2ee77a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MHU7karM5JehWeF-Cb47fINYo1uRLQ8i-2I6zn-j_ZF5tcrL0gTt5w==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 6de2e7bd35ce97a790d7915a0584a3c8
+      - f542f18ccb5f2156b3a19717809663c9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -267,66 +276,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1625
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1865
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+thIvybbCmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxvnv3eWl
-        +FCmdqexH4hrD+x++2H12YF1yWXiRI4GmYCG5LWAPDEDyQswAxNnUPCBKkFzK5Q0A0iELcDyQZxx
-        mUKu0sEStME9SGZQajAgbXs2roxVxYIUXge+H/iuhr8qMHa+KeFc89iKGJyBI8h+sB/4r3BiIF/g
-        NLO2NJHnJbCA2Cbqk3K5zbkxgktXgvXQkvV4KbzQE8ZU4HUKbmGD8mfz6cV8GOyHe7hUu2Cc6LNj
-        0LfKxNxCqvSmuUOCM5QI/XBv6AfDwJ+HfhQcRKOxOz4Y/4h+++QkGbHoeK3mhU6SvIf6/LC/djtJ
-        wMRalBQ4XD1kpuB5PmCJMFbI2LJSQAxMLdhK6VuXpGMl3+n8mV5UUlC6eH7Nl9xy7S0FrLzara2D
-        7Vbgj4LJz0b8DT8VmPaqQKsECzQ55+aWclXdWBpFC54bGDiN4Aneq5YdOJlA4Og425zCEtBX/8vA
-        sQKRVSJKnEhWeEfnAUxG/q6NoNsotfqEV31hJlrpOg91Zrs80OQr9Gyv+04Ka1GBcXrbBOHf6rNG
-        LeyKawKyEUWZC3Q4eRASTFQNv/FkPZ48091vpKy7SZ+wsX+AboTjdTj+f600sKhBigaD/XWw/z0M
-        rjuLo3A9Cr+HxRb5X748hmPYwXEh1u8bDsQkX149PjnqTvI01ZAi3zwqAvRT5VVT/k+jf2/Xxv6u
-        jYMdG+HOjcmujVeP/Wxos1klUqpfCCcaBi1XUuS1iJsrfX60RvWAQTWZqvLkWJgy55u2anAZU2jf
-        Y3qokloT3OJj1JD482u+eSK2j4LXqNNU0fXwSFWUjNr5D7QgZOpEVlfkTawBL0s08dQj4Y/7R+Jh
-        2HZRWdhT2cONHlSlFkoLu3nhhTtxr35p/v1bIQqegvFIwnRKBC5kIs1cs0y3pPgWVzr2DJ3H9RH2
-        qM/5DRD/PVEaRBtPBiLYhdFgQhHJuJmWIj4V8vY17RxDSf2LjDsM1cha1Xv9ilRyiu0Lv8lhBtw0
-        uNTtyDk/fffm5Oz69ORoenYxvZ7OZn/M8H5YpwZDggfmGbBzJHppGdllwjAl8w1D0hA5KWVWsV+F
-        5uxcQ4GswSqDCHOfIo8AC8rx74Tvl1ZHTvMqYvYw/NuquscWmIhUSJ4/PNR2X214a5zn6F07p8ym
-        EvrTVUlluwvJweigQ3LTKL0QfI1w/8De722eh8ct3n7h8S22mx3kOuWNraO2o/tPDndtYVMzaCTs
-        +gEJK6pulSt91nhzk1cwTDVy1rYpUuxYNclWRYkNsbRPg36vp4VvJfahUE8Z98P5UX79f8hSraqS
-        GsXXQiZIYoZhrbAbAMnKymSQ1Cg9mR3S9waYkEuyTDBLGP4UYPiaQRKRsix02RtS91H+UH9/iNhl
-        r1bIiEmMlxXcKh357p47uqOgY8xzFfM8U8ZGE3/ie4tG5rr2zXt1cIXC7PIC4oooir1Vq6FVO2Tx
-        aU4qfJrDK+axy8BY9mfFtQXNpjLFwiwwzDtEoT/gBbX02fnv7LBCCmAXMZc7pKjR84LAv2oienfH
-        LrB5rR3F8dH7af350Hy6RNOk7QFoOBcW6YBEa2DhCBUxYkx2xy5RxzBECsDaG4VB7QYBVS4TV2K/
-        76Zq6S2rXCJ0LVKLd//8FakY+X4vF6/ALYTV4CqdeljfnDAvsGclXvDwqJvZIie5bb5wUmeMlIX4
-        N4O0yjkGdU2/4ep7HIMUPCcoXfwDAAD//+xZbW/aMBD+K9akVYBIGiDhrao6VFap0qimTduH7gvG
-        cSATkCgvVJP24/ec44SXEuioWnXSBAJi++zz+e4534OMVijVmMEqd8UMdXY2Ty4uMU3btKolxtQn
-        f97stmn9AVL/StbJVOqazPbZpY19Oq3ek+2ixyu72E+3i33ULi9uE6fMJgi43On6NWUfamO1YSrZ
-        EJGKxhs5MVmvzgjH2TYI5K9ZwyxQQD23zFc7bOxgqIAXmPgzYJSSoPRROVbBR3Xf9g9tntUQj2j+
-        gS/jpNDAivAmNcXzgnP7BGpfgzSCLW/8uQR4yszeZ9Pkggshw0T9XDvfhuBwDfI1gHGhRgD017hp
-        +sE5d1d+jAwiKdt2gP8e2RxOlF8L6ETH6xXGDBcYRvqjMNdXlkh7g9aOvMEtvCHW3sCTBPk3rrOH
-        mS9mDLf46RQYnAL+WMix1nLKOENJIyCIS5GIuEd6jAdqo8YnvpymQOMxm0nuQnLFkUHNbLfs+1qh
-        EeB+LjdTy3Z/Xmn1Nz0SQz6rC72b96N7mnc3tmfAyBnE0QgfV8HeP34whPh9+iD/wiNtK8YsYTqZ
-        +0If2shXiVSf2Td11yIL68PIlGEAmTk6Ir15yN0uQi4SkrkLmK8eGPLeynelu+VOXxBSuIBi6b9x
-        Ci0aBpQ2yccr3F34yyqrVH8v4MNJ0C/8di9mvDheOCfihUN44TwPL05KGY/w4tSktXm8r40X7f94
-        8Qp4Yf9beNEuRI/gxWO6wykq/t1qt4wHadiblVASwWUU70LM0O7QMv7LKuuwC9JqV6IgHXIrlA0s
-        IyGsMqLMKtZUATCj4kNX4pvF/G6tF6eLBafq9d3B8opMTlRUEJ1Y5xIhcQWPJbLr1r103Fa30500
-        OpZsiZ4lek7T6zW8NtYpBmGFA8Mk+cPAdSkaMFIE7q8PG4qgEKa5DnLg6gykiVpaDSOZnIe1pdXo
-        crdh2+2O6HaAlxMx6VhY3uPS64or91LN8r41eN+8wTuTMxZ8qQs/w8iaYjONjQcYwmiaVFGaWRyS
-        pYyQ85gMBXmF9Hwe4+f1yLDMcEl8wy6f/vY13iXk377Gu4T+W9cYAOVmpLUmhK7h+mzEPS8VwlcB
-        RGVdRiFn8HYfLGngxzQKQnl+D+ARRKDqSKM/lNBbhC6toP9f288i2WWgapeRy3ZBLkca3J8KI38A
-        AAD//xotRihOMIOyGAEAAAD//yLg4tFihNYupksxgl4M4GqmmcBbY/DGCtA76ZBMWQ2a+YayDYAu
-        yS9JhE7oo5uCqz1mgKtcMjDCXsDhmhsywOkBnO01uM/QdeBqyBnjlIC38FLzyjKL8vMgTTyIUEop
-        dDUJhEtM6JXll1BvVhNiGNxQoE0ZicVh+eAZH9jUKjALQJxcDWNC6xeyHQBeeaMPM1dHKTexIii1
-        uDQHZDCSZ8FzNUUljiUQj4PmjEHzOSCvw8VRNRuh6IZqALu2trYWAAAA//8DAF9lO6y8JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18225","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18225","key":"NTEST-1865","fields":{"statuscategorychangedate":"2025-04-30T18:26:43.885+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1865/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:43.644+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t4v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:43.718+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/7]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/286]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/285]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/286]\n*Defect Dojo link:* http://localhost:8080/finding/286
+        (286)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/285]\n*Defect
+        Dojo link:* http://localhost:8080/finding/285 (285)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1865/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18225/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 05a103f8-a38a-4252-b545-dfdd10945aa7
+      - 0e19b551-5639-427b-9c3f-e73a7a474bb5
       Atl-Traceid:
-      - 05a103f8a38a4252b545dfdd10945aa7
+      - 0e19b5515639427b9c3fe73a7a474bb5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:34 GMT
+      - Wed, 30 Apr 2025 16:26:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -336,7 +346,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=322,atl-edge-internal;dur=13,atl-edge-upstream;dur=309,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=300,atl-edge;dur=267,atl-edge-internal;dur=15,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ryfpQf2j48Ls6bkUDbOQp8MfTRaTlOwrAUHBFXdurdqhwOaETKSDKg==",cdn-downstream-fbl;dur=305
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -345,10 +355,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9fe7d47ea2a815113a41181f1d63f69e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ryfpQf2j48Ls6bkUDbOQp8MfTRaTlOwrAUHBFXdurdqhwOaETKSDKg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e3116682b4ff31b7041ee26baa9b9dba
+      - 11b0fb4c0cdaae0e0a6e63d1edd2305d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,67 +390,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16109
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18225
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWVPcRhD+K1N6dBZdu8BaVakUgbVNQghZ1vYDpqhB6pXGSDPKzGiPgP97uqWV
-        1hxyAqkYHjRXH9P99Te9tw6sSi4TJ3I0yAQ0JG8E5IkZSF6AGZg4g4IPVAmaW6GkGUAibAGWD+KM
-        yxRylQ4WoA3uQTKFUoMBaTdn48pYVcxJ4VXg+4HvavizAmNn6xLONI+tiMEZOILsB3uB/xonBvI5
-        TjNrSxN5XgJziG2iPiuX25wbI7h0JVgPLVmPl8ILPWFMBV6r4AbWKH86m5zPdoK9cBeXaheME906
-        Bn2rTMwtpEqvmzskOEOJ0A93d/xgJ/BnoR8F+9Fw5I72Rz+g3z45SUYsOl6reaGTJO+hPj/srr2Z
-        JGBiLUoKHK4eMFPwPB+wRBgrZGxZKSAGpuZsqfSNS9Kxku91/kwvKikoXTy/4gtuufYWApZe7dbW
-        wc1W4A+D8U9G/AU/Fpj2qkCrBAs0OePmhnJVXVsaRXOeGxg4jeAx3quWHTiZQODoOFufwALQV//L
-        wLECkVUiSpxIVnhH5wFMhn7fRtBulFp9xqu+MBMb6ToPdWbbPNDkK/Rsr/teCmtRgXE62wThX+uz
-        Rs3tkmsCshFFmQt0OHkQEkxUDb/ReDUaP9Pdb6SsvUmXsJG/j26Eo1U4+n+tNLCoQYoGg71VsPc9
-        DK5ai8NwNQy/h8UN8r98eQzHsA+nw3ZjLlYfGnLE7F9cIhrSVEOKfPOPRbDbbuAFVF41vPD00b2+
-        jf2ejbB3Y9y38fqxOw1tNqtESvUL4UQ7AU65xYejIdzn12dD51sC9xp1mqqvHh6qigIXECl/pAUh
-        UyeyugLMEiq1HzCxVIONc7U+0q9F3MTx9tEa+YrCJlNVnhwJU+Z8valhyrwGvCzRxFOPhD/qHomH
-        YeujsrCjsocbHahKLZQWdv3CILbiXv3S/Pu3QhQ8BeORhGmVCFzIRJq5ZpFuSfEdrrTsGTqP6yPs
-        yiDn10D8RxXwsCfoA2/Qh9FgTBHJuJmUIj4R8uYN7RxBSf2LjNus1blc1nvdilRygu0Lv85hCtw0
-        SNCbkXN28v7t8enVyfHh5PR8cjWZTn+f4v2wTg2GBA/MMmBnSPTSMrLLhGFK5muGpCFyUsqsYr8I
-        zdmZhgJZg1UGUes+RR4BFpTj3wnfL62OnOZVxOxh+LdVdY8tMBGpkDx/eGjTfW3CW+M6R+9awsHM
-        phK601VJZduH5GC43yK5aZReCL5GuHtg7/c2z8PjFm8/8/gG280Wcq3yxtbhpqP7Tw63bWFTM2gk
-        bPsBCUuqbpUrfdp4c51XsJNqZIltU6TYkWqSrYoSG2Jpnwb9bh8t7Ha08K2M3w/nJ/n1/wFLtapK
-        ahTfCJkgMRqGtcKuASQrK5NBUqP0eHpA32tgQi7IAMEsYfhTgOGjBUlEyrLQZW9J3Sf5qv6+ithF
-        p1bIiEmMlxXcKh357q47vKOgY8xzFfM8U8ZGY3/se/NG5qr2zXu9f4nC7OIc4oooir1Tyx2remTx
-        aU4qfJrDS+axi8BY9kfFtQXNJjLFwiwwzD2i0B3wglr69Ow3dlAhBbDzmMseKWr0vCDwL5uI3t2x
-        c2xea0dxfPhhUn8+Np820TTZPPU0nAmLdECiNbBwhIoYMSa7YxeoYydECsDaG4ZB7QYBVS4SV2K/
-        76Zq4S2qXCJ0LVKLd//8JakY+n4nFy/BLYTV4CqdeljfnDAvsGclXvDwqJvZIie5bb5wUmeMlIX4
-        N4W0yjkGdUW/4ep7HIEUPCconf8NAAD//+xZbW/aMBD+K9akVYBIGiDhrao6VFap0qimTduH7gvG
-        cSATEJQXqkn78XvOcQKkBDqqVp00tQJi++zz+e453xMZrlGqMYNV7vIZ6uxsHl9cYpq2aVVLjKlP
-        /rzZbdP6AyTbtayTqdQ1me2zSxv7dFq9J9tFj1d2sZ9uF/uoXV7cJk6ZTRBwmdP1a8o+1MZqw0Sy
-        ISIVjTdyYrJenRGOs10QyP5mDTNHAfXcMl/tsLGDoQJeYOLPgFFKgtJH5VgFH9V92z+0eVZDPKL5
-        B76Mk0IDK8Kb1BTPC87dE6h9DZIQtrzx5xLgKVN7n03jCy6EXMXq58b5tgSHG5CvAYxzNQKgv8ZN
-        0w/Oubv2IyQKSdm2A/z3yOZwouxaQCc63qwwZrjAMNIfhbm+soTaG7R25A1u7g2R9gYex8i/UZ09
-        zHwxY7g3T6fA4ATwx1Ycay2njDOUNAKCuBSJkHukx3igNmp84stpAjQes5nkLiTXHBnUTHfLvm8U
-        GgHu53I7tez2ZwVVf9sjMeSzKhLcrB/d06y7sTsDRs4gjkb4uAr2/vGDIcTv0wf5Fx5pWxFmWSWT
-        uS/0oY18lUj1mX1Tdy2ysD6MVBkGkJmjI9Sbh9ztYsVFTDJ3AfPVA0PeW/uudHfc6QtCChdQLP03
-        TqFFVwGlTfLxCncX/rLKKtXfC/hwHPRzv92LGS+OF86JeOEQXjjPw4uTUsYjvDg1aW0f72vjRfs/
-        XrwCXtj/Fl60c9EjePGY7nDyir9Y7ZYVPA27rCPnv6gSikP4kiJ5iKQpDLVzbqrQYeVzFDvKSAcr
-        Jx0y85QNLCPKrFyZneK9WMKp6JhRZZIWiFGyWHCqXt8dLK/I5ERFBeGJdS4RElfwWCLQbt1Lx211
-        O91Jo2PJluhZouc0vV7Da2OdfBBWODBMkj8MXJeiASNF4P76sKUICmGa6yAHrkwtTdTSahjJZDys
-        La1Gl7sN2253RLcDvJyIScfC8h6XXldcuZdqlvetwfvmDf5TOWPBl7rwM4y0KTKTyHiAIYymSRWl
-        mcYhWcpYcR6RoSCvkJ7PI/y8HhmWuVoS31Dk09++xkVC/u1rXCT037rGwCE3pYk1IXQN12cj7nmJ
-        EL4KICrrUlo6RbH7YEkDPyZhsJLn98AXQQSqjjR6oYTePHRpBf1+bT+LZJeBql1GLttlbyzsHLhD
-        jfoFfPkDAAD//xotX2iXkgayfAEAAAD//yLXxaPlC61dTJfyBb0YgLfG4I0XoKvTIXmvGjTzDWUb
-        AC3ML0mETuijm4Kz2YWzXMLZHjPCXvLhmhsywNUABRUIWCUMcDVAjXHpMIa38FLzyjKL8vMgrTiI
-        UEopdDUJhEtU6OXnQkyohjGhxT0ZxS/SQhh9mLk6SrmJFUGpxaU5IIOR7AZPnRSVOJZA3FGWX0K9
-        GVuIYXBDgXZlJBaH5YNnnmCTqqA5Y9B8DshKuENQXWuE4lyoBnDw1NbWAgAAAP//AwD2UFh6vCQA
-        AA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18225","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18225","key":"NTEST-1865","fields":{"statuscategorychangedate":"2025-04-30T18:26:43.885+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1865/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:43.644+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t4v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:43.718+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/7]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/286]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/285]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/286]\n*Defect Dojo link:* http://localhost:8080/finding/286
+        (286)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/285]\n*Defect
+        Dojo link:* http://localhost:8080/finding/285 (285)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1865/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18225/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 9e244b84-3122-47cf-818c-89a135b7dd3d
+      - c31feb70-7ff7-4209-a47b-edc1bb80ad52
       Atl-Traceid:
-      - 9e244b84312247cf818c89a135b7dd3d
+      - c31feb707ff74209a47bedc1bb80ad52
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:35 GMT
+      - Wed, 30 Apr 2025 16:26:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -442,7 +460,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=14,atl-edge-upstream;dur=279,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=32,cdn-upstream-fbl;dur=395,atl-edge;dur=266,atl-edge-internal;dur=14,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="C8ykt-W4pXsZrUVXMB0Izdd6LsoNO1KbU4GakjtzCnhLtZVZuSxYhw==",cdn-downstream-fbl;dur=399
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -451,10 +469,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 d45e064f8c3e1035d136019303749e0e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - C8ykt-W4pXsZrUVXMB0Izdd6LsoNO1KbU4GakjtzCnhLtZVZuSxYhw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - bbce9ccdeef81c193cee63b082894a98
+      - 13967563a0bb5b0dc38e5100798fc798
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -481,26 +507,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwFWFKfmlfARZMDyKdApLCvGeJbyLIgBLiDAIe/CH3Co2u6cpVAx4LTgaZ7kafrN
-        yu7GKBvAjM4XUgDmqCRNCxSZUpkCqdgyzRe1mmfI5grYmcDraLhtBxFfiEqM2t9ZKWL7QPSpImhe
-        tyU5nh/2ZE2cXN9X5PgJAAD//wMAIy4xXiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:45.252+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 05c6479b-d6f7-4f23-9a84-e3274f7f12af
+      - b47667a0-5ef4-4b7c-8a5b-6faec63d26a0
       Atl-Traceid:
-      - 05c6479bd6f74f239a84e3274f7f12af
+      - b47667a05ef44b7c8a5b6faec63d26a0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:35 GMT
+      - Wed, 30 Apr 2025 16:26:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -510,7 +532,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=143,atl-edge-internal;dur=15,atl-edge-upstream;dur=128,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="Z5JBkqA1bQv_nPxXSl4dEhppf-NpWjhyKtHwBNFFh-jpTAX0ia76RA==",cdn-downstream-fbl;dur=232,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=59,cdn-upstream-fbl;dur=230,atl-edge;dur=150,atl-edge-internal;dur=14,atl-edge-upstream;dur=137,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -519,10 +541,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b1383a69c949c8987c982636bd26b4f2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Z5JBkqA1bQv_nPxXSl4dEhppf-NpWjhyKtHwBNFFh-jpTAX0ia76RA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - b167a62c39bd39aac4442705d9b0c517
+      - 289e030b14caae8281842772238fb772
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -549,41 +579,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 7eb329cd-dd45-4d45-9a01-685e46301b7c
+      - efa8ef66-c25a-4558-bb57-e20b60d4d070
       Atl-Traceid:
-      - 7eb329cddd454d459a01685e46301b7c
+      - efa8ef66c25a4558bb57e20b60d4d070
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:35 GMT
+      - Wed, 30 Apr 2025 16:26:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -593,7 +610,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=313,atl-edge-internal;dur=15,atl-edge-upstream;dur=299,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=17,cdn-upstream-fbl;dur=427,atl-edge;dur=353,atl-edge-internal;dur=18,atl-edge-upstream;dur=335,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="LxRGOkgdYFPJMEHzwPdU_Yahl6o8c15QQ3BUAH6W7MjjWi9dHQAjVA==",cdn-downstream-fbl;dur=430
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -602,13 +619,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 41e9e91568ab5e34cd26bd32ceb4035e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - LxRGOkgdYFPJMEHzwPdU_Yahl6o8c15QQ3BUAH6W7MjjWi9dHQAjVA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 9d0468f4c2cec1441226ad7f018de1e3
+      - 756aa88ddaddf56fd3857cfe7b948878
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -620,28 +645,27 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/98] in [Security
-      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
-      / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n|| Severity || CVE ||
-      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
-      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
-      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
-      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
-      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
-      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/289] | Active,
-      Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/8] in [Security How-to|http://localhost:8080/product/2]
+      / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n||
+      Severity || CVE || CWE || Component || Version || Title || Status ||\n| High
+      | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082] | [94|https://cwe.mitre.org/data/definitions/94.html]
+      | pg | 5.1.0 | [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/289]
+      | Active, Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
       | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
       Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/287] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/289]\n*Defect
       Dojo link:* http://localhost:8080/finding/289 (289)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -650,31 +674,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/287]\n*Defect Dojo link:* http://localhost:8080/finding/287
-      (287)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (287)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -683,25 +705,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
     headers:
       Accept:
@@ -713,7 +733,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7140'
+      - '6803'
       Content-Type:
       - application/json
       User-Agent:
@@ -722,18 +742,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16110","key":"NTEST-1626","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16110"}'
+      string: '{"id":"18227","key":"NTEST-1866","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18227"}'
     headers:
       Atl-Request-Id:
-      - 4f199dc8-9955-4a15-8cd8-0f1a9549ed3d
+      - f0f39464-53b1-4832-bf14-61d9b1fafde6
       Atl-Traceid:
-      - 4f199dc899554a158cd80f1a9549ed3d
+      - f0f3946453b14832bf1461d9b1fafde6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:36 GMT
+      - Wed, 30 Apr 2025 16:26:46 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -743,7 +765,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=786,atl-edge-internal;dur=15,atl-edge-upstream;dur=771,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="0K5gZ7afVnDWvqDoi2uK0xvBqYL5AvkZof6pSWW9RAkgUGhuNy9JBg==",cdn-downstream-fbl;dur=802,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=799,atl-edge;dur=723,atl-edge-internal;dur=16,atl-edge-upstream;dur=707,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -752,10 +774,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 595c26368a4c8eede29e4b5da7206efc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0K5gZ7afVnDWvqDoi2uK0xvBqYL5AvkZof6pSWW9RAkgUGhuNy9JBg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 5349ff2abf0b0b813ff6882be6819c3a
+      - 73b9abb0a92f788ad3dc48fe3110ac99
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -779,78 +809,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1626
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1866
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX6VPbRhT/V3b0IdNJbV02xiiT6VDiJLSUUuMkHwjDLNKztEHaVXZXPhLyv/ft
-        6nAxOFPoNDCD9nr37x18dWBVUp44kSOBJyAhec0gT1SP0wJUT8UZFLQnSpBUM8FVDxKmC9C0F2eU
-        p5CLtLcAqfAOkimUEhRw3byNK6VFMTcMrwLfD3xXwucKlJ6tSziTNNYsBqfnMCM/GAWBjxsF+Ry3
-        mdalijwvgTnEOhGfhEt1TpVilLsctIeStEdL5oUeU6oCr2VwA2ukP51Nzmf9YBSO8MiqoJzoq6NQ
-        t0rFVEMq5Lq2IcEdUoR+uNf3g37gz0I/CvajwcjdPwh/Rr0NWytEo+KWzROVNPQe8vPDzuxmk4CK
-        JSuN4/D0kKiC5nmPJExpxmNNSgYxEDEnSyFvXEMdC/5O5o/UouLMhIvmV3RBNZXegsHSs2ptFGyu
-        An8QjH9R7Au8LDDsVYFSDSxQ5IyqGxOr6lqbVTSnuYKeUxMeo12WtudkDIEj42x9AgtAXf1vPUcz
-        RFaJKHEiXqGNzhZMBn57UUrxCS16osMbautuG8DW3Vsg2Vj1jjOtkYFyOtkGqb/bt0rM9ZJKg1fF
-        ijJnqHCyZTnGw6JsOF4Nx49U9zuRaS3p4jL091GNcLgKh/+vlDr6FosoMBitgtGPELhqJQ7C1SD8
-        ERIbgH/7dh+OwS6chu3FnK3e1zUQo39xef/loH1J01RCivXmXhKgASKv6vR/WNzerovRrov9HRfh
-        zovxrouD+3rWZbM+NUXJdggn6gdNrTQhkSyuTfp678wkCnpbZaLKk1dMlTldN+mEx0uqsfXUJfvx
-        qV83hE0L8Gp20iS2XR6JyrjeqvrBHDCeOpGWlZGNTPV7xIxJ78YbEtBYUz8eahKDTZPYdltXyrYv
-        doEq7EBVSiYk0+snuqAl92yn+fe9ghU0BeUZCtUyYXiQsTRz1SLdVMu3eNKW1dC5nzhhh/qcXoMp
-        jA+khqknDzoi2IXRYGw8klE1KVl8wvjNa3PzCkozv/C4xZBF1tLedSdc8AmOL/Q6hylQVeNSNivn
-        7OTdm+PTq5Pjo8np+eRqMp3+OUX7ME8VugQfzDIgZ9gBuCZGLmGKCJ6vCVYTlhumRAvyG5OUnEko
-        sJyQSiHm3IeqSoAJ5fi3zPdL/SVy6q6I0UP3b7LqTrXAQKSM03z7UTN9Ne61yM9Ru2ZvIpty6F5X
-        pUnbXUgejkctkutB6Yngq4m7znt3tnkcHjd4+5XGNzhutpBrmdeyjpqJ7j8p3I6Fdc6gkLAdFDgs
-        TXaLXMjTWpvrvIJ+KrFmbYYiQV6JOtiiKHEg5vph0O91ZeF7gd0m6krGXXd+5P/8PSSpFFVpBsXX
-        jCdY1hTBXCHXAJyUlcogsSg9nh6a7zUQxhdGsoFZQvBfAYLdDJLIMMtCl7wx7D7y5/b7PCIXHVvG
-        I1Km0Z4buP6tcTb6OhcxzTOhdDT2x743r99eWZ28g/ElEpGLc4grU5rIW7Hsa7GDFnt1UmGvDi+J
-        Ry4CpclfFZUaJJnwFBOyQPfuIIXugRdY6tOzP8hhhalPzmPKd1CZyc/DfyEua0/e3pJzHFqtorg+
-        ej+xnw/1pw2w2TS93yxnTGMZMKQWULhCRsRUSnJLLpBHP8TUx57kj0OrhgEoXyQuxznfTcXCW1Q5
-        R8hqLCne3feXhsXBsCOLl+AWTEtwhUw9TGtqoM5whjXlwDsYupkuckNVpvjHxsmwCPFnCoXQgGYk
-        QCYrjIehIX3y01naI89y/YKEbhC4ISHPUv3iJfkbAAD//+xYUW/bNhD+KwcEKGTNoRfZjhYPeQiS
-        DhiwFsPS7mUeYEVmam2y5IhSmqLrf993JEVRsdWi6faWJHDkOx55/O5491FT8T2MtWIqUCeoVcw6
-        xUzMRdzK5518LjBXKz/t5Pw47+TsnZWfiNNOHnXyyB8/7eRTMe3ks04+6zYQd+vyoyd36/JjNBpI
-        DpvJk+iHM0b0AhTmXo459PoeQIfiHH9lnO34/yrOzzF+cozjoRijELZFYRHqeLOMwqtG0hUqKIQ/
-        yRtBZ2Pi/kr94tz+bk6Eq876+1Q8H8tvDNkZynZ4pVs9uvBfJTEJQji+aEcBPkaHAvu5sFKITgDx
-        H/h3/ITDivVw6vUE39YU+pkVXpdNlUpkVy5Dbs/HaKPbTEmGdffOG3jVkYgQzd4ti9RTtj+LrJwk
-        6/tMgaHgBjCPIvCLW0YYh6Glncw0Vrt3KwKlg38FJVSZLE45i6XLYt6DrJKbLOeOWm+SmsoUCyl6
-        vwE3qUGurSGjdpMoSWVFd7gzfiDclFM+gwqzp1Vyyw6AjDXbgph7CX3OQM8rSeDnVL8vW5OUVCqL
-        BPcYJixYKks3BB4A7p5nf0uw91usksDt3S7PUv3i0hKj1uFcAh+cWKb//iizNfjUFCq5RaFgtn+s
-        Gh4C/9RdbpezyCjaJjDOSvACz3kllkW0PzuMCiCt2Bm4h+tqBT6IeR06zNWcD4lFqpJ1UxVIbTyp
-        Jq8ZXc8HjDvohGAAj45wcSkRT/xdlkUqd/WyWK1Wy4IvgzV9pEvsDJznE50Tv8nNKhm8OHqIYqSW
-        +T9qx6Zm5DmBOVuzgJX6SdjNsaQ1YLjOaXX98peXl2/ohC6u6cVdU9Y/LvFjJp+ERoJDeEgdTpY4
-        l9/xVlWZS4G7QoDsT3F/E7K4H/3J3oBAw6SYTIz1SjtgnNIABvBjTIGsqjEjOKJzPjn0ETPbPWGu
-        NTv+aWTBod9dotArcFbkC/FR8+Xt66FFr4qDJw7UcWiGKrkz2qvlTrNXzT3No3ruaR5VdE/zqKZ7
-        mkdV3Wn26rqn6Vd24PSrfjmzbkFa2JEWJIsK5vPgYowsJryQDxdjZEGxqhYuxsiB4mnajtei0lMx
-        SA6VnoZBcqj0NAySQ6WnYZAcKp7GgORQ6WkMSF4yAa8NMolT8tjQvcV+oeebyoI/0J3w7SLlc4DE
-        bG5w/G0PeJXpe59tAaG7yETiQTws6K1+V8AFyBb7NiSomDk0lfCNpkNGJloHbWZDNiaMB23mQzYm
-        wAdtTodsTEScDQX0mjuQ7k6uw+kkGJuIj3XZNSHmVpPkqqSdSWBBTCPcovHQojqkn1/UJgS61N4C
-        NnY/b3dJWnPcXpeU6S+EFLjP1nLdtXkM/A2cqJKo5upr+rw13ZV842aaEiTrbVaMKBj9swUNqcuF
-        ox4H6ewzlfUOsF/wvkxl4ydS2ZipbPy/UNl/AQAA//8iqSlLbr8XOdnSuilrONqUBakCAAAA///s
-        mtFqgzAUhl9lDHoZFzVOvShdGRvsoi/Qu/REtzHUopXRt985xgabNR0MCl4EeiH1xBMO5ueX//NW
-        1ltZb2UvqfqZNTvT9TNrNlV2b2VP8/JW1lvZeVjZ0Cz9w8r+Du8Tk1/b2a0r1Q/FNNc7tBK+Bq6A
-        OAe71EVzcNcNYRAMe4WJ0E9TcBW6InXuwj646SkPBwkfFKmNufI0mraTy66vKklZ7P3FsJBGTUBF
-        0/4zrSV3spIABHG8qWWi4izNdmHKixhyDnkSlXlYEvhnirDDlbKC3oO1Utijw0q0e8enyUagIfTt
-        OuI1zL4I3ltdRmtOmJEoeJhJFQrxmEKWJnG+g13KsX0pizKDlVoOT1nE60X0ij+9jlWyHmNMxvRf
-        XdB37BsHwaKA8tFAayBNiu2l7GhQuH7w6Hja8PJ5w3iwryk1t3Gx+e/Y5s3mv2ObV5v7jlGYlEav
-        RqwBv9ePdxtZlj3A53CAKATTaJSWtW1TU+FL3zb74mGLggOEAY0njXhJvGuOLnUYKdHLLIRwialw
-        IVLCIFLtKOpeRm71wvwAAAD//8JIMKPFCD1cPFqMYClG0IsBXM0zE3grDN5IAXonHZIpq0ELu6Fs
-        A6BL8ksSocvS0U3B1Q4zwFUuGRhhL+BwrXA0wOkBnO00uM/QdeBqwBnjlIC37FLzyjKL8vMgTTuI
-        UEopdE8EhEtM6JUBm/3krhbEWK0LMQxuKNCmjMTisHzwukXYAmFgFoA4uRrGhNYvZDsAvH9EH2au
-        jlJuYkUQZOAJxbPgFYdFJY4lEI+DVj6DViWCvA4XR9VshKIbqgHs2traWgAAAAD//wMAfZTioIIz
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18227","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18227","key":"NTEST-1866","fields":{"statuscategorychangedate":"2025-04-30T18:26:46.761+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1866/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:46.492+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t53:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:46.575+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/8]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/289] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/287] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/289]\n*Defect
+        Dojo link:* http://localhost:8080/finding/289 (289)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/287]\n*Defect Dojo link:*
+        http://localhost:8080/finding/287 (287)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1866/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18227/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 6ff4d5d9-2bc7-4194-9b92-6a3d3f5157db
+      - 4d240e61-213f-44ab-9e02-f58ec04c7957
       Atl-Traceid:
-      - 6ff4d5d92bc741949b926a3d3f5157db
+      - 4d240e61213f44ab9e02f58ec04c7957
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:37 GMT
+      - Wed, 30 Apr 2025 16:26:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -860,7 +925,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=248,atl-edge-internal;dur=16,atl-edge-upstream;dur=233,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=330,atl-edge;dur=296,atl-edge-internal;dur=14,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="f_fZOvoer-AD0yhWUxfUPniCfHxRx0aobWsQknO66MZlZrATp9-m0Q==",cdn-downstream-fbl;dur=333
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -869,10 +934,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 771067dca4682f83a6c9963c412d66cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - f_fZOvoer-AD0yhWUxfUPniCfHxRx0aobWsQknO66MZlZrATp9-m0Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ff6c77e3ec486a78ab7c1c9168e4a8c7
+      - b640cf4964e3fe0b8ee5a2a8daed7820
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -896,78 +969,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16110
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18227
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+FENn682O46gohix122xZljlu+yENAkY6S2woUiMpv7Tpf99R
-        suTFibolw5oAkcTjvfDuuYeXLw6sCioSJ3IUiAQUJK8Z8ET3BM1B93ScQU57sgBFDZNC9yBhJgdD
-        e3FGRQpcpr0FKI0ySKZQKNAgzGZvXGoj87k1eBX4fuC7Cv4sQZvZuoAzRWPDYnB6DrP+g1EQ+Pih
-        gc/xMzOm0JHnJTCH2CTyk3Sp4VRrRoUrwHjoyXi0YF7oMa1L8BoDN7BG/dPZ5HzWD0bhCJeqELQT
-        fXE0xlbqmBpIpVrXZ0jwCzVCP9zr+0E/8GehHwX70WDk7h+EP2Lc1mzlxGDglZknBmn1PbTnh+2x
-        Nx8J6FixwiYOVw+JzinnPZIwbZiIDSkYxEDknCylunGtdizFO8UfGUUpmC0X5Vd0QQ1V3oLB0qvC
-        2ga4EQX+IBj/pNlneJlj2cscvVpYoMsZ1Te2VuW1sW/RnHINPadWPMZzVbo9J2MIHBVn6xNYAMbq
-        f+05hiGyCkSJE4kSz+jswGTgdwmCRlAo+QmP+sRKbLSrOlSVbeqwg57tcd8JZgwa0E7r20L412qv
-        lnOzpMoCWbO84AwDTnZSgoWq4Dccr4bjR4b7jZI1J2kLNvT3MYxwuAqH/6+XGhYVSNFhMFoFo+/h
-        cNV4HISrQfg9PG6Q//XrfTiGXTgdNII5W72vyRGrf3GJaEhTBSnyzT82wV4jwANIXta88PDWUZdg
-        v0MQdgrGXYKD++HUtFmvWlKqbggn6gf4SQ1eHDXhPr4/azrfErhXm1O2+6rXI1naxAWWlD/YBSZS
-        JzKqBKwSGjXvsbC2B+vgKnvWvmJxnccv99ZsrKisM1ny5BXTBafrTQ/byivAw1qaeOiSGGwvid20
-        dVFZ2FLZrqAFVaGYVMysn5jERt2rbpp/f1ewnKagPauhGyMMFzKWZq5epFtSfIsrDXuGzv3+CNs2
-        4PQaLP/ZDtidCbrAG3RhNBjbjGRUTwoWnzBx89pKXkFh5xcRN1WrarmsZO2KkGKC4wu95jAFqmsk
-        qM2bc3by7s3x6dXJ8dHk9HxyNZlOf5/i+bBPNaYEN8wyIGdI9MIQ65cwTaTga4Kkwbg1SowkvzBF
-        yZmCHFmDlBpR6z5EHgE2lOPfMt8vzOfIqW9FrB6mf9tVd9gCC5EyQfnups30tUlvhWuO0TWEg5VN
-        BbS7y8K2bReSh+NRg+R6UHoi+Grl9oK9O9s8Do9bvP1M4xscNxvINcZrX0ebie4/BdyMhXXPoJOw
-        mQcELG13Sy7VaR3NNS+hnypkie1QJMkrWRdb5gUOxMI8DPq9LlrYa2nhWxW/m86P4u+/hyRVsizs
-        oPiaiQSJURPsFXINIEhR6gySCqXH00P7vAbCxMI6sDBLCP4rQPDSgiSyxrLQJW+suY/iefV8HpGL
-        1iwTESnSaM8NXP/WJhtzzWVMeSa1icb+2Pfm9d6rKibvYHyJSuTiHOLSUhN5K5d9Izt08UpOSryS
-        w0vikYtAG/JHSZUBRSYixYbMMb0dqtBu8IJK+/TsN3JYYuuT85iKDi074Hn4L8RlncnbW3KOQ2sV
-        KL4fvZ9Ujw/1oymw/dhc8fZ1xgzSgFWtAIVvaIhYpiS35AJt9ENsfbzV/HFYhWEBKhaJK3DOd1O5
-        8BYlFwhZg5Ti3d1/aU0cDFu1eAluzowCV6rUw7amFuoMR1VLB97B0M1Mzq1WkeKfqk7WRIg/U8il
-        ATxGAmSywnpYHdInP5ylPfKMmxckdIPADQl5lpoXL8lfAAAA///sWFFv2zYQ/isHBChkzaEX2Y4W
-        D3kIkg4YsBbD0u5lHmBFZmptsuSIUpqi63/fdyRFUbHVoun2liRw5DseefzuePdRU/E9jLViKlAn
-        qFXMOsVMzEXcyuedfC4wVys/7eT8OO/k7J2Vn4jTTh518sgfP+3kUzHt5LNOPus2EHfr8qMnd+vy
-        YzQaSA6byZPohzNG9AKk4V6OOfSa7tOhOMdfGWc7/r+K83OMnxzjeCjGKIRtUViEOt4so/CqkXSF
-        CgrhT/JG0NmYuL9Svzi3v5sT4aqz/j4Vz8fyG0N2hrIdXulWjy78V0lMghCOL9pRgI/RocB+LqwU
-        ohNA/Af+HT/hsGI9nHo9wbc1hX5mhddlU6US2ZXLkNvzMdroNlOSYd298wZedSQiRLN3yyL1lO3P
-        Iisnyfo+UyAiuAHMowj84pYRxmFoaSczjdXu3YpA6eBfQQlVJotTzmLpspj3IKvkJsu5o9abpKYy
-        xUKK3m/ATWqQa2vIqN0kSlJZ0R1uaR8IN+WUz6DC7GmV3LIDIGPNtiDmXkKfM9DzShL4OdXvy9Yk
-        JZXKIsE9hgkLlsrSDYEHgLvn2d8S7P0WqyRwe7fLs1S/uLTEqHU4l8AHJ5bpvz/KbA0+NYVKblEo
-        mO0fq4aHwD91l9vlLDKKtgmMsxK8wHNeiWUR7c8OowJIK3YG7uHCW4ErYl6HDnM150Nikapk3VQF
-        UhtPqslrRtfzAeMOOiEYwKMjXFxKxBN/l2WRyl29LFar1bLgy2BNH+kSOwPn+UTnxG9ys0oGL44e
-        ohipZf6P2rGpGXlOYM7WLGClfhJ2cyxpDRiuc1pdv/zl5eUbOqGLa3px15T1j0v8mMknoZHgEB5S
-        h5MlzuV3vFVV5lLgrhAg+1Pc34Qs7kd/sjcg0DApJhNjvdIOGKc0gAH8GFMgq2rMCI7onE8OfcTM
-        dk+Ya82OfxpZcOh3lyj0CpwV+UJ81Hx5+xZo0avi4IkDdRyaoUrujPZqudPsVXNP86iee5pHFd3T
-        PKrpnuZRVXeavbruafqVHTj9ql/vrFuQFnakBcmigvk8uBgjiwkv5MPFGFlQrKqFizFyoHiatuO1
-        qPRUDJJDpadhkBwqPQ2D5FDpaRgkh4qnMSA5VHoaA5KXTMBrg0zilDw2dG+xX+j5prLgD3QnfLtI
-        +RwgMZsbHH/bA15l+t5nW0DoLjKReBAPC3qr3xVwAbLFvg0JKmYOTSV8o+mQkYnWQZvZkI0J40Gb
-        +ZCNCfBBm9MhGxMRZ0MBveYOpLuT63A6CcYm4mNddk2IudUkuSppZxJYENMIt2g8tKgO6ecXtQmB
-        LrW3gI3dz9tdktYct9clZfoLIQXus7Vcd20eA38DJ6okqrn6mj5vTXcl37iZpgTJepsVIwpG/2xB
-        Q+py4ajHQTr7TGW9A+wXvC9T2fiJVDZmKhv/L1T2XwAAAP//IqkpS26/FznZ0ropazjalAWpAgAA
-        AP//7JrRaoMwFIZfZQx6GRdrnHpRujI22EVfoHfxRLcxrEUro2+/c4yGmjUdrDdeBHpRmhNzOJif
-        v/yft7Leynore0nVJ9ZsousTa3au7N7KjvPyVtZb2XlY2dBs/cPK/g7vY5Nf29mtK74LhWvB0ByU
-        6x0bCV89skDIgVUqDGlhLXDzDHvBFaFzE6GP43EVurAPbpqZRNF2ICmPRwkflLfpuLPtqkpSFnt/
-        MSykURNQUTf/TGvJnawlAGEgb2oVqyhN0jxMeBFBxiGLl2UWlgT+mSI84UpZQe/BRik8o8VKtHun
-        p7NGoCb07TrJ1Y+4CN4bXUZ7RppIFDxMpQqFeEwgTeIoyyFPOB5fyqJMYa1W/VMW0WaxfMWP3scq
-        uR9iTMb0T23QtewbB8GWAeWjgdZAmhQ7SNnSoHB/79HxtuHX5y3jwWFPqblNhc2/Yxsrm3/HNpY2
-        945Rf5SGnQasAf+vn+62siw7gM/+AlEIpuEqrV67ek+FL11TH4qHHeoKEAY03DTCInHVXF06YaBE
-        L7MQwiWmwoVICRd3J4xgN4Pae3258U36AQAA//8iPiWNli/0cPFo+YKlfEEvBuCtMHijBejqdEje
-        qwat34ayDYAW5pckQpelo5uCs7mFs1zC2Q4zwl7y4VrhaICr4QkqELBKGOBqeBrj0mEMb9ml5pVl
-        FuXnQVpvEKGUUuieCAiXqNDLz4WYUA1jQot7MopfpO0c+jBzdZRyEyuCIONAKHaDFwAWlTiWQNxR
-        Bux+kLtqEWPdMcQwuKFAuzISi8PywesnYUuDQSufQasSQVbCHYLqWiMU50I1gIOntrYWAAAA//8D
-        AG5saKGCMwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18227","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18227","key":"NTEST-1866","fields":{"statuscategorychangedate":"2025-04-30T18:26:46.761+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1866/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:46.492+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t53:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:46.575+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/8]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/289] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/287] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/289]\n*Defect
+        Dojo link:* http://localhost:8080/finding/289 (289)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/287]\n*Defect Dojo link:*
+        http://localhost:8080/finding/287 (287)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1866/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18227/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 68d5ca50-ed31-4a12-b75a-cdddbfeb180b
+      - 003adfae-7d52-4335-b61a-8fc8f8cce0ce
       Atl-Traceid:
-      - 68d5ca50ed314a12b75acdddbfeb180b
+      - 003adfae7d524335b61a8fc8f8cce0ce
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:37 GMT
+      - Wed, 30 Apr 2025 16:26:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -977,7 +1085,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=240,atl-edge-internal;dur=17,atl-edge-upstream;dur=223,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=284,atl-edge;dur=252,atl-edge-internal;dur=16,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="BuHb_09d1NoZOmiaSCy4NhSKdJ5afZHPrjC-8IV2POuZu1Qk8zLH_A==",cdn-downstream-fbl;dur=288
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -986,10 +1094,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 73e04d645babcbb9ee8f20cc865b009c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - BuHb_09d1NoZOmiaSCy4NhSKdJ5afZHPrjC-8IV2POuZu1Qk8zLH_A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d2abb1f7072e4cf7869d30a9756e5bcb
+      - 61a2c5526145c1bd6ef80871aa7a1a22
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1016,26 +1132,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL2q1b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmCzBGgCy4oxnmc8D2KACwhwyLvwBxyqtjtnKVQMOC14VqTFIvtm
-        ZXdjlA1gTucLKQBnqCTNChS5UrkCqdgymy1qNc+RzRWwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMADsN38CACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:48.093+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 0e3a3f1e-9a8b-49c5-bcfb-f293beca70b3
+      - 27f91074-4d00-4610-9d40-046e962bb111
       Atl-Traceid:
-      - 0e3a3f1e9a8b49c5bcfbf293beca70b3
+      - 27f910744d0046109d40046e962bb111
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:37 GMT
+      - Wed, 30 Apr 2025 16:26:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1045,7 +1157,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=172,atl-edge-internal;dur=18,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=192,atl-edge;dur=160,atl-edge-internal;dur=17,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="QFk8_neCK1m5X1vDIX-T1iPj_AznFMLaGVFSAV81ZpV8lQN3PNSzJA==",cdn-downstream-fbl;dur=195
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1054,10 +1166,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QFk8_neCK1m5X1vDIX-T1iPj_AznFMLaGVFSAV81ZpV8lQN3PNSzJA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c86b6a758cb0c0de1f7579a05983f250
+      - 6b8c2621cac7a27ba0bef7de0ffe3a22
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1084,41 +1204,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 0efb9d31-0caa-44f0-8cb4-1bc7f47c7eca
+      - 511d1057-6a6e-48d1-a9e8-e62e280f2b56
       Atl-Traceid:
-      - 0efb9d310caa44f08cb41bc7f47c7eca
+      - 511d10576a6e48d1a9e8e62e280f2b56
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:38 GMT
+      - Wed, 30 Apr 2025 16:26:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1128,7 +1235,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=278,atl-edge-internal;dur=14,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=344,atl-edge;dur=311,atl-edge-internal;dur=23,atl-edge-upstream;dur=288,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="cmVRQvAC9SprsNdEFXJIaIjD9ojcG4gxfw8CskKGVQCtpU09l5dHBg==",cdn-downstream-fbl;dur=348
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1137,13 +1244,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - cmVRQvAC9SprsNdEFXJIaIjD9ojcG4gxfw8CskKGVQCtpU09l5dHBg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 93580e00fa3ff61f1f8bdf62c31d3671
+      - 2ddb8bd94541e062d993cf118da5ddaa
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1155,22 +1270,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/99] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/9] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/288]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/288]\n*Defect
       Dojo link:* http://localhost:8080/finding/288 (288)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -1184,7 +1298,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1972'
+      - '1944'
       Content-Type:
       - application/json
       User-Agent:
@@ -1193,18 +1307,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16111","key":"NTEST-1627","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16111"}'
+      string: '{"id":"18229","key":"NTEST-1867","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18229"}'
     headers:
       Atl-Request-Id:
-      - 16027b59-8f1c-4bc5-86b3-df5f3d8a2795
+      - baff02ed-6f43-4156-924f-ba9ff28f749c
       Atl-Traceid:
-      - 16027b598f1c4bc586b3df5f3d8a2795
+      - baff02ed6f434156924fba9ff28f749c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:38 GMT
+      - Wed, 30 Apr 2025 16:26:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1214,7 +1330,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=644,atl-edge-internal;dur=14,atl-edge-upstream;dur=631,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="JWa5sCLe4ikb15CyNrOmESvBgr47B23RUEORdnzMUPKyUTJC7OEXdA==",cdn-downstream-fbl;dur=854,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=851,atl-edge;dur=765,atl-edge-internal;dur=13,atl-edge-upstream;dur=752,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1223,10 +1339,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 05df0d22c8cc3d4b946b6f2dc43d6b9c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JWa5sCLe4ikb15CyNrOmESvBgr47B23RUEORdnzMUPKyUTJC7OEXdA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - e0d1176c7aa28835c0fc33866a947267
+      - fbceda30b7b9a71f82bc0f29ae2583aa
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1250,64 +1374,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1627
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1867
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/6lwTv4VA8EynQyFcaSmlIXf3gWMYYW9sHbbkSnJeevDfu2vH
-        yfHia6HTm3ywrdW+aPfZR5vPDixLLhMncjTIBDQkxwLyxPQkL8D0TJxBwXuqBM2tUNL0IBG2AMt7
-        ccZlCrlKe3PQBmWQTKDUYEDa9d64MlYVMzJ4Hfh+4Lsa/qzA2OmqhHPNYyticHqOIP/BbhAE+GEg
-        n+FnZm1pIs9LYAaxTdQn5XKbc2MEl64E66En6/FSeKEnjKnAaw3cwgr1z6bji2k/2A33cKkOwTjR
-        Z8dgbJWJuYVU6VVzhgS/UCP0w2HfD/qBPw39KNiLBiN3NNz/HuP2KUhyYjHw2swrgyR9D+354ebY
-        648ETKxFSYnD1QNmCp7nPZYIY4WMLSsFxMDUjC2UvnVJO1bync5fGEUlBZWL59d8zi3X3lzAwqvD
-        2ga4FgX+IBj9aMRf8EOBZa8K9EqwQJdTbm6pVtWNpbdoxnMDPadRPMFz1bo9JxMIHB1nq1OYA8bq
-        3/ccKxBZJaLEiWSFZ3QewWTgt4JSq094olcmfK1dp7suYJtu+vgCJNtTvZPCWjRgnI1vQuqv9V6j
-        ZnbBNeHViKLMBQacPDo51qNG2c5ouTN6YbhfqUx7kk1ddnxCdbizDHf+Xy9N9WssosNgdxnsfguH
-        y9bjIFwOwm/hcQ3w+/uncAy6cBp2CQatYCaW7xtyRFhcXiFM0lRDinzzj00wbAV4MpVXDS88v3W3
-        S7DXIQg7BaMuwf7TcBrabFaJlOobwon6AX5yixdHQ7gvb9yGzrcE7jXmNLVl/XqoKkpcQKT8gRaE
-        TJ3I6gru1zxN1rSIm6x9frJGkeFWk6kqT46EKXO+WrcyLmNY9j1ihtp7nQ0NeFjij+cuieFg2F4S
-        j9O2obLHgi5QhRtQlVooLezqlUls1b36pvn3d4UoeArGIw3TGhG4kIk0c8083bLlz7jS0mroPG2c
-        cNMGOb8BIkbqgMczQRd4gy6MBiPKSMbNuBTxqZC3xyQ5gpLmFxm3dayru6hlmxWp5BjHF36TwwS4
-        abCh12/O+em7tydn16cnh+Ozi/H1eDL5fYLnwz41mBLcMM2AneMNIC0jv0wYpmS+YsgmIiejzCr2
-        i9CcnWsokE5YZRC17nOsEmBDOf6d8P2y2ouc5lbE6mH6t131gC2wEKmQPH+8aT19rdNbIz3H6FrC
-        wcqmEja7q5LatgvJu6HfIrkZlF4JvkZ5c/M+nG1ehsct3n7i8S2Omy3kWuONr8P1RPefAm7HwqZn
-        0EnYDgoSFtTdKlf6rInmJq+gn2rkje1QpNiRaoqtihIHYmmfB/2wixaGG1r4WsUfpvOj/PJ3wFKt
-        qpIGxWMhEyRGw7BX2A2AZGVlMkhqlJ5MDuh5A0zIOTkgmCUM/wowvLQgichYFrrsLZn7KN/UzzcR
-        u9yYFTJiM8xhFvnuwPXvKN+Y7lzFPM+UsdHIH/nerNl+XYfl7e9foR67vIC4InZiP6tF36oOXbyu
-        kwqv6/CKeewyMJb9UXFtQbOxTLEnC8xwhypsNnhBrX12/hs7qLD72UXMZYcWDX9eEPhXTTLv7tgF
-        zq11oPh++H5cPz40j7bG9LG+5el1KiwyAanWmMI3NMSILNkdu0Qb/RDJrU//VvbrMAijcp64Ekd9
-        N1Vzb17lElFrkVW8h/uvyMSO3+Sa9OIFuIWwGlylUw9bmxPcBc6xRAkebnUzW+SkV5cKn3WxyM4E
-        0irnmMsl/Wurwz8CKXhO4LkAPcc/Z6zPvjtG6d8AAAD//+xZbW/aMBD+K9akVgWRNEAoL1XVoXaV
-        +oFp2rR96L7U2E7JBASFhGpqf/yes40LKe62Tqv6oQJB4vNb7s7PPXeZNNj+tDjG4E7Yqnm0Z019
-        2Or1aMEhQu1KNUg3miuze9Jpfa3RQV0rhdpY/bxU7BweiMYLNQ5Zv8EIn9i2c68/k2bovFvft8P/
-        /DjY97mGEZzwHxkjgMVWfzuOHeCntuuhn3pkVoeLofk7/oJnWRsrwnH0FP/mb9t6r3/JyhxavEin
-        ClCgjKb3b4pj7VwbHc8fIKoOKHHLZsAue/TDNDvkcpUuAXPgF53WEdArIR3DVdZBjWx3rSe/Zoi8
-        jLaKjNLG2tya3G6ETC6dyZfW5LcTQj6O+eY3DJRbQI6gLXKe0EoUogFJi7IIoflvD/OPgD1TZSFu
-        W7Tm9IMNL0KPT5qmyrUYUmjmxIk3JkDPCUajER6pD+SgqszGRsMS1MYjyFcqoOCViscdjTThKwq3
-        G1YiBBvQDzkXbodCYL4BwsN4mgprwVGqY4I14FdNG0jn1jLmqViWsykEeegsfzlbcFHQmI8ZS/UN
-        A46vUqnkli99xnkCl8LSf+MhdugiozBADn7A5Syd19hB7X4GBy6yAZz2MRPvODJaJWK+WNyMfQKX
-        mlGQLnLQEp1/UEZR6Rq7tKkiiNwcVYGPD0eOD6/V4+voy+Eit5ktXlllF7wouJhQ5DTcZVnOZpyI
-        1Ttf5CdtU4KU5c9kX3QGT7kQlNZdypOObPe6vXGzG6m26Eei32kl/WZyhHVcJ6zwRDdFrjCUks4J
-        eopM/ny/sRHQM5rryZKN1rIKwfB0NxqzLhvECkkIl804PuqKXrfT7o/FuBth+YSrpCdO5YmeZa89
-        3Gtd4GvGBTM+t5wkCEzTMiyXwS0UEbRCIjuhOYKkqWDB+ZIUhfEa4ZHC4PJsFEThYk4suFr+ef07
-        rtaPXv+Oq/Wn175jQJA05QybppzB9dmIJ0kpRKoPEJEyUywxAHYFEouOH8o8W6jDK0CLoLTenjSq
-        f0Lqji6tYKu+u3Ob2Iensa/kEfvqaLHD7NwC/hu+vJgnveHLS+z4DV924EsVBhwRc7wFu74xZ++O
-        XtTY6wgLZgW3r5mqs3gZlxeXvFSstRv5fBXLyMc9CRB2CiIf92z7RrQduVPzVZpnc0PgTJMs7TtO
-        c/tH2stmZoY7ffkLAAD//0IMZZFR/CJNz+rDzNVRyk2sCEotLs0BGYxkN3hAr6jEsQTijrL8EurN
-        I0AMgxsKtCsjsTgsHzweChv8B81kgEYZQVbCHYLqWiMU50I1gIOntrYWAAAA//8DAH28w1VSHwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18229","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18229","key":"NTEST-1867","fields":{"statuscategorychangedate":"2025-04-30T18:26:49.520+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1867/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:49.226+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:49.317+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/9]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/288]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/288]\n*Defect
+        Dojo link:* http://localhost:8080/finding/288 (288)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1867/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18229/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - fa657d12-ebaf-43c7-96de-1051d0891df8
+      - ffd93483-3dc3-492a-87cb-6ea014583946
       Atl-Traceid:
-      - fa657d12ebaf43c796de1051d0891df8
+      - ffd934833dc3492a87cb6ea014583946
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:39 GMT
+      - Wed, 30 Apr 2025 16:26:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1317,7 +1428,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=316,atl-edge-internal;dur=17,atl-edge-upstream;dur=298,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=296,atl-edge;dur=263,atl-edge-internal;dur=14,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="V9CO9wtovpJV5FxOzm5YCX2X919qykgNDDRvmoo88V2tXYBkdeosDA==",cdn-downstream-fbl;dur=299
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1326,10 +1437,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 de5b26aba33b480d2b740b96a34fe916.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - V9CO9wtovpJV5FxOzm5YCX2X919qykgNDDRvmoo88V2tXYBkdeosDA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 98e1eaad86770677c71c2cf6d411e692
+      - a6ba10c0a0a049923191a8d03d7dad48
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1353,65 +1472,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16111
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18229
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJl3zInOl0XFtOnLquKyvJg+PxwOSKREwCLADqqO3/3l0e
-        Unword1pRg/EtQd2v/2wunVgUXKZOJGjQSagITkSkCemJ3kBpmfiDAreUyVoboWSpgeJsAVY3osz
-        LlPIVdqbgTa4B8kYSg0GpG3PxpWxqpiSwqvA9wPf1fBnBcZOliWcaR5bEYPTcwTZD3aCIMCJgXyK
-        08za0kSel8AUYpuoL8rlNufGCC5dCdZDS9bjpfBCTxhTgdcpuIElyp9ORueTfrAT7uJS7YJxolvH
-        oG+VibmFVOllc4cEZygR+uF23w/6gT8J/SjYjQZDd7i99yP67ZOTZMSi47WaVzpJ8h7q88PVtdtJ
-        AibWoqTA4eo+MwXP8x5LhLFCxpaVAmJgasrmSt+4JB0r+UHnL/SikoLSxfMrPuOWa28mYO7Vbq0d
-        bLcCfxAMfzbiL/ipwLRXBVolWKDJCTc3lKvq2tIomvLcQM9pBI/xXrVsz8kEAkfH2fIEZoC++vc9
-        xwpEVokocSJZ4R2dRzAZ+Js2gm6j1OoLXvWVmWil6zzUme3yQJOv0LO+7gcprEUFxlnZJgj/Wp81
-        amrnXBOQjSjKXKDDyaOQYKJq+G0NF1vDF7r7jZR1N1klbMsnuIdbi3Dr/7XSwKIGKRoMdhbBzvcw
-        uOgsDsLFIPweFlvk398/hWPYwXEqFh8bDsQkX1w+PTnoTvI01ZAi3/xjEWx3G3gBlVcNLzx/dGfT
-        xu6GjXDjxnDTxt5TdxrabFaJlOoXwon6AU65xYejIdyX12dD52sC9xp1mqqvHh6oigIXECl/ogUh
-        UyeyuoL7lqdJmxZxE7XbJ2vkGR41mary5FCYMufLtmJxGd2yHxEaVMVtNDTgZYkmnnsktgfb3SPx
-        OGybqCxcUdnjjRWoSi2UFnb5yiB24l790vz7t0IUPAXjkYTplAhcyESauWaWrknxHa507Bk6T+sj
-        XKE+59dA/PdMaRBtPBuIYBNGgyFFJONmVIr4RMibI9o5hJL6Fxl3eayzO6/3VitSyRG2L/w6hzFw
-        02BDtyPn7OTD2+PTq5Pjg9Hp+ehqNB7/Psb7YZ0aDAkemGTAzpDopWVklwnDlMyXDElD5KSUWcXe
-        C83ZmYYCWYNVBlHrPkceARaU498J3y+r3chpXkXMHoZ/XVUP2AITkQrJ88eH2u6rDW+N9By9a+eU
-        2VTC6nRVUtluQvJO6HdIbhqlV4KvEV49sA97m5fhcY23X3h8g+1mB7lOeWProO3o/pPDXVvY1Awa
-        Cbt+QMKcqlvlSp823lznFfRTjbyxbooUO1RNslVRYkMs7fOg317RwrcS+1hoRRkPw/lZfv3bZ6lW
-        VUmN4pGQCRKjYVgr7BpAsrIyGSQ1So/H+/S9BibkjCwTzBKGfwUYvmaQRKQsC132ltR9lm/q75uI
-        XazUChmxKcYwi3x34Pp3FG8Md65inmfK2GjoD31v2hy/qt3y9vYuUY5dnENcETuxd2ret2qDLL7K
-        SYWvcnjJPHYRGMv+qLi2oNlIpliTBUZ4gyisDnhBLX169hvbr7D62XnM5QYp6vG8IPAvm2De3bFz
-        7FtrR3F88HFUfz41ny7HNGmffxpOhEUmINEaUzhCRYzIkt2xC9TRD5Hc+vRvZa92gzAqZ4krsdV3
-        UzXzZlUuEbUWWcV7eP6SVGz5TaxJLp6DWwirwVU69bC0OcFdYLtKlODhUTezRU5ydarwWyeL9Iwh
-        rXKOsVzQv7ba/UOQgucEnnPQM/xzxvrshyPc/RsAAP//7Fltb9owEP4r1qRVBZE0QCgvVdWhskr9
-        wDRt2j50X2psp2QCgkJCNa0/fs85jhtS3G2dVvVD1QqIz6935+eeu8xb7GCRnWBwz+80HNozpj7q
-        DAa04BihdqtapBtNidkd6bRZanTU1EqhNtac5IpN4IFovFAznw1bjPCJ7Tp3+Tdv+9a79XPX/8/H
-        wb4nGkZww78njAAWW/3tOHaIj8a+Qz92ZNaEi6H5G768J1kbK8Jx9BT/5m+7em9+TvIUWryIFwpQ
-        oApNH9xkJ9q5Kh0n9xDVBJTYZRNgl7n6fpwccbmNN8A/8Ite5xjoFZGO4SplUCPbXevJrxkiL6Ot
-        IqM0sTY1JjcbIZNLa/KNMfntnJCPY77VDQPlFpAjaIuUR7QShWhA0jrPfGj+6/38U2DPQhmI2xWV
-        ZH9U8SL0+KhpqizFkEIzp1ZcmQA95xiNRnikvpCjujJblYYNqI1DkG6VR8ErFg87FtKIbyncVqxE
-        CDaiD3IuPI6FwHwjhIfZIhbGgtNYxwRjwC+aNpDOjWWKU7EkZQsIUt9a/nK55iKjMR8SFusHBhzf
-        xlLJHV/6hPsELoWl/8ZDzNB1QmGAHPyQy2W8arDDxt0SDpwlIzjtQybes2S0TsRcFL0dVoN0loJ9
-        6DSDEod6V5us1QSBSxDafKo+wvLhUguuji5+HLhyuMCuucMr67SDZxkXc4qcBXfZ5MslJ2L1xhX5
-        SduUICXpE9kX3cEzLgSldZfytCe7g/5g1u4HqiuGgRj2OtGwHR1jHdsJKzzSTZErjKWke4KeIpE/
-        3lU2AnpGcz1amdHqVz4Ynu5GY8rqQKiQhHDZDsPjvhj0e93hTMz6AZaPuIoG4kye6lnedsdvOxf4
-        L8Z5S74ynMTziqaNn2+8WyjC6/hEdvziCpKmvDXnG1IUxmuERwqDn+dTL/DXK2LB9SrPy99xvUz0
-        8ndcLzO99B0Dm2RRzjBpyjlcn015FOVCxPoCESkriiUFsl2BxKLj+zxN1uroCpgjKK03N43KnJDa
-        q0srmKrv/twmdOFp6Cp5hLbkkRpcf4WRZ3OYVxh5jh2/wsgeGKnDgIuhhZaIWd6C49wUl/InvY8x
-        vwPsJMm4ec1Un8VFxQIXLgWd/QDnqlgGzgM4qZo9WX2Ei8N1nQJL7tRqG6fJqiBwRZPMzTvO4vFP
-        tLdNsmr9/hcAAAD//yKpHMYYv4cYBjcUaFNGYnFYPngcEjboDswCECdXw5jQ+oVsB4Dng/Vh5uoo
-        5SZWBKUWl+aADEbyLHgEsajEsQTicdBMBmiUEeR1uDiqZiMU3VANYNfW1tYCAAAA//8DABVAJj1S
-        HwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18229","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18229","key":"NTEST-1867","fields":{"statuscategorychangedate":"2025-04-30T18:26:49.520+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1867/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:49.226+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:49.317+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/9]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/110]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/288]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/288]\n*Defect
+        Dojo link:* http://localhost:8080/finding/288 (288)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1867/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18229/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d1695b1a-dc82-4c74-87cf-7da9d571bce3
+      - aa452825-a361-4ac1-9667-7cb5a80001b7
       Atl-Traceid:
-      - d1695b1adc824c7487cf7da9d571bce3
+      - aa452825a3614ac196677cb5a80001b7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:39 GMT
+      - Wed, 30 Apr 2025 16:26:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1421,7 +1526,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=287,atl-edge-internal;dur=15,atl-edge-upstream;dur=274,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=288,atl-edge;dur=251,atl-edge-internal;dur=18,atl-edge-upstream;dur=237,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="48C7puP3TSybxz4xSUc2ykfOg0fzL5IGQ2_QaDsGoFALaX_UqRYFkg==",cdn-downstream-fbl;dur=292
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1430,10 +1535,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 895116b5366f3f5264f7b6361d3fd564.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 48C7puP3TSybxz4xSUc2ykfOg0fzL5IGQ2_QaDsGoFALaX_UqRYFkg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ca5a86d4025323cd3ae82694540784c7
+      - d564a7698b9872461584231fb6b74383
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1466,7 +1579,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1480,9 +1593,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"849\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33912\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:41416\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -1518,7 +1631,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:39 GMT
+      - Wed, 30 Apr 2025 16:26:50 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1536,25 +1649,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       110, "url_ui": "http://localhost:8080/test/110", "url_api": "http://localhost:8080/api/v2/tests/110/"},
       "finding_count": 5, "findings": {"new": [{"id": 285, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/285", "url_api": "http://localhost:8080/api/v2/findings/285/"},
-      {"id": 286, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/286",
-      "url_api": "http://localhost:8080/api/v2/findings/286/"}, {"id": 287, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/287", "url_api": "http://localhost:8080/api/v2/findings/287/"},
-      {"id": 288, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/288", "url_api":
-      "http://localhost:8080/api/v2/findings/288/"}, {"id": 289, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/289", "url_api": "http://localhost:8080/api/v2/findings/289/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/285",
+      "url_api": "http://localhost:8080/api/v2/findings/285/"}, {"id": 286, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/286", "url_api": "http://localhost:8080/api/v2/findings/286/"},
+      {"id": 287, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/287",
+      "url_api": "http://localhost:8080/api/v2/findings/287/"}, {"id": 288, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/288", "url_api": "http://localhost:8080/api/v2/findings/288/"},
+      {"id": 289, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/289",
+      "url_api": "http://localhost:8080/api/v2/findings/289/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -1565,11 +1676,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2507'
+      - '2372'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -1581,11 +1692,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2507\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2372\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33926\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:41420\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -1600,63 +1711,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 110, \\\"url_ui\\\": \\\"http://localhost:8080/test/110\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/110/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 285, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/285\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/285/\\\"}, {\\\"id\\\": 286, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/286\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/286/\\\"}, {\\\"id\\\":
-        287, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/287\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/287/\\\"}, {\\\"id\\\":
-        288, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/288\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/288/\\\"}, {\\\"id\\\":
-        289, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/289\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/289/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        287, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/287\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/287/\\\"}, {\\\"id\\\": 288, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/288\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/288/\\\"}, {\\\"id\\\": 289, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/289\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/289/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 285,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/285/\",\n          \"url_ui\": \"http://localhost:8080/finding/285\"\n
         \       },\n        {\n          \"id\": 286,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/286/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/286/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/286\"\n        },\n
         \       {\n          \"id\": 287,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/287/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/287\"\n        },\n        {\n          \"id\":
-        288,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/288/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/288\"\n        },\n
-        \       {\n          \"id\": 289,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/289/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/289\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 110,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/110/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/287/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/287\"\n        },\n
+        \       {\n          \"id\": 288,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/288/\",\n          \"url_ui\": \"http://localhost:8080/finding/288\"\n
+        \       },\n        {\n          \"id\": 289,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/289/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/289\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        110,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/110/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/110\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/110/\",\n
@@ -1670,7 +1779,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:39 GMT
+      - Wed, 30 Apr 2025 16:26:50 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_no_push_to_jira_reimport_no_push_to_jira_but_push_all_issues.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_no_push_to_jira_reimport_no_push_to_jira_but_push_all_issues.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bprlq1b3mSCU3QK7V4UkTS9YDRNSpMOxth3N8HB9qi+HXe/
-        //2OO5BaeNz2hnDyEULn+WTSoEIZGvfpMhGM8F4Lm1kMZEQa7Tsj9v/gS+x3WmKD/muNpluhDdj/
-        dcnKWWUGtBJ/l9xh77WzEc4B8gwyGJeb6+dy/VSdp5uhrWNF+GuCRjCCt+jEzrh9G6+s9l2yrYwb
-        mhiqB22anwjhMUCL4tS8ESGBFOhsDPkYlhWlnE05i2KAK4hwzPv4B+wr3V6yOVQUeF5wBhktzqxs
-        76xyEWT5fCEF4AyVzKcFCqYUUyAVXU5ni1rNGdK5AnohCCYZ7nUv0gtRicGEBydFah+IOVUE7fu2
-        JMfLw16cTZPbx4ocvwEAAP//AwBlHVUwIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:50.960+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - d7c5608b-63a0-4568-8e41-fdfa0a4752b2
+      - 30f30667-aa5b-4d4a-83d6-3b6281216889
       Atl-Traceid:
-      - d7c5608b63a045688e41fdfa0a4752b2
+      - 30f30667aa5b4d4a83d63b6281216889
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:40 GMT
+      - Wed, 30 Apr 2025 16:26:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=147,atl-edge-internal;dur=13,atl-edge-upstream;dur=135,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=205,atl-edge;dur=172,atl-edge-internal;dur=15,atl-edge-upstream;dur=158,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="e0g0UddCObiuG_1r4yMIK9UdiAjil9fJuiSi20oK65tKSiNqE5nt8w==",cdn-downstream-fbl;dur=209
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a183b6545fea485604515ba7931cb9b8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - e0g0UddCObiuG_1r4yMIK9UdiAjil9fJuiSi20oK65tKSiNqE5nt8w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a188392f9004309fdd991a73f044d9fc
+      - 0a114e6d7192d9c34fd5e196288bf8c6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 59e00701-4c1d-4388-9e9d-64154f48be54
+      - 019a5a58-353c-49e1-8bf6-386ad094bf89
       Atl-Traceid:
-      - 59e007014c1d43889e9d64154f48be54
+      - 019a5a58353c49e18bf6386ad094bf89
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:40 GMT
+      - Wed, 30 Apr 2025 16:26:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=300,atl-edge-internal;dur=12,atl-edge-upstream;dur=288,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="ZXOfEejCCoIMqn-8BjdH8hMOxhT1mnNUv6MlKbrgIG9qMnnohVqxKg==",cdn-downstream-fbl;dur=295,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=293,atl-edge;dur=271,atl-edge-internal;dur=14,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ZXOfEejCCoIMqn-8BjdH8hMOxhT1mnNUv6MlKbrgIG9qMnnohVqxKg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 40576561defded02953f623f57485d7c
+      - 4a0effc2440b640650272b24d68b4cb0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -157,7 +156,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/100]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/10]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -166,28 +165,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/291]\n*Defect Dojo link:* http://localhost:8080/finding/291
-      (291)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (291)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]\n*Defect
       Dojo link:* http://localhost:8080/finding/290 (290)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -201,7 +200,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3359'
+      - '3334'
       Content-Type:
       - application/json
       User-Agent:
@@ -210,18 +209,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16112","key":"NTEST-1628","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16112"}'
+      string: '{"id":"18231","key":"NTEST-1868","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18231"}'
     headers:
       Atl-Request-Id:
-      - 7ca7f300-d868-40d4-8f9e-87e1bb418514
+      - 76f32db4-4157-4c40-9024-da1d55bbf27e
       Atl-Traceid:
-      - 7ca7f300d86840d48f9e87e1bb418514
+      - 76f32db441574c409024da1d55bbf27e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:41 GMT
+      - Wed, 30 Apr 2025 16:26:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -231,7 +232,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=716,atl-edge-internal;dur=13,atl-edge-upstream;dur=704,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=758,atl-edge;dur=725,atl-edge-internal;dur=19,atl-edge-upstream;dur=705,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="h3QQfyEaeTHdCguIiLUKKXyEG3MlTox3E8KY_u2TxHF-8E0Iu8fznQ==",cdn-downstream-fbl;dur=764
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -240,10 +241,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - h3QQfyEaeTHdCguIiLUKKXyEG3MlTox3E8KY_u2TxHF-8E0Iu8fznQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - b348d9dccfb7bfeb9d4d4e07465830e9
+      - 1958b8b0b8fe6b84c236690dc6401033
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -267,66 +276,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1628
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1868
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX6VPbRhT/V3b0sbV12YCjmU6HgpPQUkqNk3wgDLNIz9IGaVfdXfloyP/e93Q5
-        HM4UOg180F7v/r3Dnx1Yl1wmTuRokAloSF4LyBMzkLwAMzBxBgUfqBI0t0JJM4BE2AIsH8QZlynk
-        Kh0sQRu8g2QGpQYD0rZv48pYVSyI4XXg+4HvavirAmPnmxLONY+tiMEZOILkB/tBEOLGQL7AbWZt
-        aSLPS2ABsU3UJ+Vym3NjBJeuBOuhJOvxUnihJ4ypwOsY3MIG6c/m04v5MNgPJ3hUq2Cc6LNjULfK
-        xNxCqvSmsSHBHVKEfrg39INh4M9DPwoOonHgjscHP6LePilJQiwqXrN5oZJE7yE/nxRtzG43CZhY
-        i5Ich6eHzBQ8zwcsEcYKGVtWCoiBqQVbKX3rEnWs5DudP1OLSgoKF8+v+ZJbrr2lgJVXq7VVsL0K
-        /FEw+dmIv+GnAsNeFSiVYIEi59zcUqyqG0uraMFzAwOnITxBu2ragZMJBI6Os80pLAF19b8MHCsQ
-        WSWixIlkhTY6D2Ay8ruLUqtPaNELHd5S1+6uA9i5mzZfgWRr1TsprEUGxullE1J/q98atbArrgmv
-        RhRlLlDh5IHlGI8aZePJejx5prrfiExnSR+XsX+AaoTjdTj+f6U00a+xiAKD/XWw/z0ErjuJo3A9
-        Cr+HxBbgX748hmOwC6dhd7EQ6/dNDcToX149fjnqXvI01ZBivXmUBGiAyqsm/Z8Wt7frYn/XxcGO
-        i3DnxWTXxavHejZlszmlolR3CCcaBm2tpJBoETcmfX50RomC3jaZqvLkWJgy55s2nfAYY2vfY9wo
-        xVoR3GIzaor484tB0yK2TcFr2GlK9Xp5pCoKRq38BzoQMnUiqyvSJtaAxlL9eKpJ+K8mXZN46La+
-        lD282AWqsAdVqYXSwm5eaHBH7tWd5t/3ClHwFIxHFKZjIvAgE2nmmmW6rZZv8aQrq6HzOHHCHvU5
-        vwEqjE+kBtWTJx0R7MJoMCGPZNxMSxGfCnn7mm6OoaT5RcYdhmpkreq7/kQqOcXxhd/kMANuGlzq
-        duWcn757c3J2fXpyND27mF5PZ7M/Zmgf5qlBl+CDeQbsHDuAtIzkMmGYkvmGYTUROTFlVrFfhebs
-        XEOB5YRVBhHmPlVVAkwox78Tvl9Wi8hpuiJGD92/zap71QIDkQrJ84eP2umrdW+N8xy1a/cU2VRC
-        /7oqKW13ITl4FXRIbgalF4KvIe477/3Z5nl43OLtFx7f4rjZQa5j3sg6aie6/6RwNxY2OYNCwm5Q
-        kLCi7Fa50meNNjd5BcNUY83aDkWKHasm2KoocSCW9mnQ7/Vl4VuBfUjUl4z77vwov/4/ZKlWVUmD
-        4mshEyxihmGusBsAycrKZJDUKD2ZHdL3BpiQS5JMMEsY/hRg2M0giYhZFrrsDbH7KH+ovz9E7LJn
-        K2TEJPrLCm6Vjnx3zx3dkdPR57mKeZ4pY6OJP/G9RUNzXetGsLhCanZ5AXFFNYq9VauhVTuIsWkn
-        FTbt8Ip57DIwlv1ZcW1Bs6lMMTML9PMOUugfeEFNfXb+OzussAawi5jLHVQ0AnpBEFw1Lr27Yxc4
-        vdaK4vro/bT+fGg+XaRp0w4BtJwLi/WASGtk4QoZMSqZ7I5dIo9hiDUAk28UBrUahFS5TFyJA7+b
-        qqW3rHKJ2LVYW7z776+Ixcj3e7p4BW4hrAZX6dTDBOcEeoHTLBUGD5+6mS1yotsGDDd1yIhZiH8z
-        SKuco1PX9COutuMYpOA5YekfAAAA///sWW1v2jAQ/ivWpFaASBogvFZVh8oqVRrVtGr70H3BOA5k
-        AhLlhWrSfvyec5zwUgKMqlUnTSAgts8+n++e8z08yHCJWo0ZrHSfz1Bl57P48grTtEyrXGBMffQX
-        9a7Su4/cv5RVMpW6QLNddmlhn81G92i76PHKLvbxdrEP2uXVbWIV2QQRlzldr6LsQ22sMkgkGyBU
-        0XgrxybrVhkBOdtEgew1rZk5DKjnhvlmh40dDBTyAhR/+oxyEpQ+KMdK+Cjv2v6+zbMK4hHNP/Bl
-        nBQaWBHepKZ4WXBunkDlwU9C2PLWm0mgp0ztfT6JL7kQMojVz5XzrQkOVihfARrnaviAf42bpudf
-        cGfpRUghktJtGwnAJZvDibJ7AZ3oaLXCiOEGw0h/VOb6zhJqb9DakTc4uTdE2ht4HCMBR1X2NPXE
-        lOEaP5kAgxPAHws41lpMGGeoaQQEcSsSIXdJj1FfbdT4zBeTBGg8YlPJHUguOVKome6WfV8pNATc
-        z+R6btnsz0qt3rpHYsgXdaN3sn50T7Lu2uYMGDmFOBrh4yrYe4cPhhC/Rx/kX3ikbUWYJUjGM0/o
-        Qxt6KpPqM/umLltkYX0YqTIMIDNDR6g3D7m7ecBFTDL3PvPUA0PeW3qOdDbc6StCCjdQLP03TqFF
-        A5/SJvl4iTtzb1FmpfLvOXw49nu53+7EjFfHC+tEvLAIL6yX4cVJKeMZXpyatNaP963xovUfL94A
-        L+x/Cy9auegBvHjOdzTzkn+73C0iQmp2UUdOd1GNFIfwJcXIEGe0NdQqYsbsnLXalshZh8wKRQOL
-        WAiriCmz8jVVAEyp+NCl+Ho1v13sRcl8zql8/bC3viKTExflhycWusRIXMNjie26c66aTqPT7oxr
-        bUs2RNcS3Wbd7dbcFtbJB2GFPcMk+UPfcSgaMFL4zq+Pa4qgEqa59rLj6gykiWJaDSOZjKG1pVXr
-        cKdm26226LSBl2MxbltY3uXS7Yhr50rNctbon9Vv8U7ljDlf6MLPMNKmyEwi4wmGMOomVZRmGodk
-        KSPgPCJDQV4hPZ9F+HkzNCwzWBDhsM20v3+Nt6n696/xNtX/3jUGDjkpa60ZoRu4Phty102E8FQA
-        UVmXcsgpij36Cxr4KQn9QF48AngEMag60uivJvTmoUsr6D/YdtNIdhGo2kXssp2zy6EG9yNh5A8A
-        AAD//xotRihPMIOxGAEAAAD//yLk4tFihNYupksxgl4M4GqmmcBbY/DGCtA76ZBMWQ2aE4eyDYAu
-        yS9JhM7oo5uCqz1mgKtcMjDCXsDhmhwywOkBnO01XO1MUBGCVcIYpwS8hZeaV5ZZlJ8HaeJBhFJK
-        octJIFxiQq8sv4R605oQw+CGAm3KSCwOywdP+cDmVoFZAOLkahgTWr+Q7QDw0ht9mLk6SrmJFUGp
-        xaU5IIORPAuerCkqcSyBeBw0aQya0AF5HS6OqtkIRTdUA9i1tbW1AAAAAP//AwAEO1K6vSQAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18231","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18231","key":"NTEST-1868","fields":{"statuscategorychangedate":"2025-04-30T18:26:52.169+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1868/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:51.853+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:51.942+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/10]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/291]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/291]\n*Defect Dojo link:* http://localhost:8080/finding/291
+        (291)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]\n*Defect
+        Dojo link:* http://localhost:8080/finding/290 (290)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1868/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18231/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 9168a4bc-f965-42fa-8fe0-51a17fb494fc
+      - 08802491-7bfc-40c8-9601-ead622f267e5
       Atl-Traceid:
-      - 9168a4bcf96542fa8fe051a17fb494fc
+      - 088024917bfc40c89601ead622f267e5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:41 GMT
+      - Wed, 30 Apr 2025 16:26:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -336,7 +346,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=15,atl-edge-upstream;dur=279,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=327,atl-edge;dur=295,atl-edge-internal;dur=16,atl-edge-upstream;dur=279,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ls4WmsH8w0IQcynOSvgsMMoO9bgSpkKULOMHu0KGIIdvfjELW9HSVw==",cdn-downstream-fbl;dur=331
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -345,10 +355,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a65725dd05dc27eea7ae75a2e122228e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ls4WmsH8w0IQcynOSvgsMMoO9bgSpkKULOMHu0KGIIdvfjELW9HSVw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - bfe5f93b20f3dda358a3f31eae451ee7
+      - 6d326ac6ffbab1485092c70f5aaa9165
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,67 +390,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16112
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18231
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX23LbNhD9FQwfW4kkKNlWONPpuLaSuHVdV1aSB8fjgckViZgEWADUpXH+vbuk
-        KMUXZWp3GvuBuO0Fu2cPVp89WFZCpV7sGVApGEhfSyhS21OiBNuzSQ6l6OkKjHBSK9uDVLoSnOgl
-        uVAZFDrrzcFY3IN0ApUBC8qtzya1dbqckcJrHoY89A38VYN101UF50YkTibg9TxJ9vk+5xFOLBQz
-        nObOVTYOghRmkLhUf9K+cIWwVgrlK3ABWnKBqGQQBdLaGoJOwS2sUP5sOr6Y9vl+NMKlxgXrxZ89
-        i77VNhEOMm1W7R1SnKFEFEZ7/ZD3eTiNwpgfxEPuD4cHP6LfITlJRhw63qh5oZMkH6C+kBxtr72e
-        pGATIysKHK4eMluKouixVFonVeJYJSEBpmdsoc2tT9KJVu9M8UwvaiUpXaK4FnPhhAnmEhZB49bW
-        wfUWDwd89LOVf8NPJaa9LtEqwQJNToW9pVzVN45G8UwUFnpeK3iC92pke14uETgmyVenMAf0NfzS
-        85xEZFWIEi9WNd7RewCTQdhtVEZ/whu9MOBr6SbcTQK7cNPkK5Bsb/VOSedQgfU2tgmpvzVnrZ65
-        hTCEVyvLqpDocPrg5piPBmXD0XI4eqa738hMd5NNXobhAboRDZfR8P+10ma/wSIa5PtLvv89DC47
-        i4NoOYi+h8U1wL98eQxHvgunUbcxk8v3LQdi9i+vHp8cdCdFlhnIkG8eFQFeQBd1W/5Pm9vbtbG/
-        a+Ngx0a0c2O0a+PVYz9b2mxXiZSaF8KL+xynwuHD0RLu8wu3pfMtgQetOkNl2QyPdE2B40TKH2hB
-        qsyLnakB04dK3XvMOBVn61yjj/QbmbQB/vxojXxFYZvrukiPpa0KsVoXN0HCAF6W+OOpRyJ8Neoe
-        iYdh21DZw41doIo2oKqM1Ea61QuD2IkHzUvz798KWYoMbEAStlMicSGXWe7bebZly7e40tFq5D0u
-        nGiD+kLcABHjE6VBfPJkIPgujPIRRSQXdlzJ5FSq29e0cwwV9S8q6bLW5HLR7G1WlFZjbF/ETQET
-        ELZFglmPvPPTd29Ozq5PT47GZxfj6/Fk8scE74d1ajEkeGCaAzvHF0A5RnaZtEyrYsWQTWRBSpnT
-        7FdpBDs3UCKdsNoiav2nWIVjQXnhnQzDqp7FXvsqYvYw/NuquscWmIhMKlE8PLTuvtbhbXBdoHfr
-        OWU2U7A5XVdUtruQzF/xDslto/RC8LXCm5f3fm/zPDxu8faLSG6x3ewg1ylvbR2tO7r/5HDXFrY1
-        g0airlFQsKDq1oU2Z603N0UN/cwgS2ybIs2OdZtsXVbYECv3NOj3dtHC3oYWvpXx++H8qL7+P2SZ
-        0XVFjeJrqVIkRsuwVtgNgGJVbXNIG5SeTA7pewNMqjkZIJilDH8KMHzNII1JWR757A2p+6h+aL4/
-        xOxyo1aqmCmMl5PCaROH/p4/uKOgY8wLnYgi19bFo3AUBrNW5rrxjWBxhdLs8gKSmjiKvdWLvtM7
-        hPHRTmt8tKMrFrBLbh37sxbGgWFjlWFllhjnHaKwORDwRvrs/Hd2WCMHsItEqB1S1AIGnPOrNqR3
-        d+wCu9fGURwfvR83nw/tp8s0TdZNAA2n0iEfkGiDLByhIkaUye7YJeroR8gBWHyDiDduEFLVPPUV
-        Nvx+pufBvC4UYtchtwT3z1+RikEYbuSSBfildAZ8bbIAC1wQ6CV2s0QMAR71c1cWJLdNGE6alJGy
-        CP8mkNWFwKAu6Udcc49jUFIUhKV/AAAA///sWW1v2jAQ/ivWpFaASBogvFZVh9pVqjSqadX2ofuC
-        cRzIBCTKC9Wk/fg95zgBUgIdVatOmkBAbJ99Pt8953u4l+EKtRozWOUun6HOTufx+QWm6ZhWtcSY
-        +ujPmn2l9xDZdiXrZCp1gWa77NLBPtut/rPtoscru9jPt4t90C6vbhOrzCaIuMzpBjVlH2pjtetE
-        smuEKhpv5MRk/TojIGfbKJC9Zg0zhwH13DLf7LCxg2uFvADFnz6jnASlD8qxCj6qu7a/b/OshnhE
-        8w98GUeFBlaEN6kpXhac2ydQu/eTELa88eYS6ClTe59O43MuhAxi9XPtfBuC12uUrwGNczV8wL/G
-        TdPzz7iz8iJkCknptosE4JLN4UTZvYBOdLxeYcxwg2GkPypzfWcJtTdo7cgbnNwbIu0NPI6RgKM6
-        e5x5YsZwcZ5OgcEJ4I8FHGstp4wz1DQCgrgViZC7pMd4qDZqfObLaQI0HrOZ5A4kVxwp1Ex3y76v
-        FRoB7udyM7ds92el1mDTIzHki6oSnKwf3dOsu7E9A0bOII5G+LgK9sHhgyHEH9AH+RceaVsRZgmS
-        ydwT+tBGnsqk+sy+qcsWWVgfRqoMA8jM0RHqzUPudhFwEZPMnc889cCQ91aeI50td/qKkMINFEv/
-        jVNo0cCntEk+XuHOwltWWaX6ewEfjv1B7rc7MePV8cI6Ei8swgvrZXhxVMp4ghfHJq3N431rvOj8
-        x4s3wAv738KLTi56AC+e8h3tvOQvlrtlFU/DLuvI6S4qheIQvqRYHmJpCkPtnJwqdFhllJlVxjpY
-        OeuQmadsYBlTZuXKbFXvxRpORceMKpO0QoySxYJT+fphb31FJicuyg+PLHSJkbiExxKDdutctJ1W
-        r9ubNLqWbIm+JfrtpttvuB2skw/CCnuGSfKHoeNQNGCk8J1fHzcUQSVMc+1lx5WppYliWg0jmYyh
-        taXV6HGnYdudruh1gZcTMelaWN7l0u2JS+dCzXLSGp40b/BO5YwFX+rCzzDSpshMIuMRhjCaJlWU
-        ZhqHZCkj4DwiQ0FeIT2fR/h5NTIsM1gS4VBk2t+/xkWq/v1rXKT637vGwCEn5Yk1I3QF12cj7rqJ
-        EJ4KICrrUl46RbEHf0kDPyWhH8izB+CLIAZVRxr91YTePHRpBf0H224ayS4DVbuMXbZzdrnYkQN3
-        qFF/G1/+AAAA//8aLV9omJIGsHwBAAAA//8i28Wj5QutXUyX8gW9GIC3xuCNF6Cr0yF5rxo0Jw5l
-        GwAtzC9JhM7oo5uCs9mFs1zC2R4zwl7y4ZocMsDVAAUVCFglDHA1QI1x6TCGt/BS88oyi/LzIK04
-        iFBKKXQ5CYRLVOjl50JMqIYxocU9GcUv0koYfZi5Okq5iRVBqcWlOSCDkewGz50UlTiWQNxRll9C
-        vSlbiGFwQ4F2ZSQWh+WDp55gs6qgSWPQhA7ISrhDUF1rhOJcqAZw8NTW1gIAAAD//wMARpHfSb0k
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18231","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18231","key":"NTEST-1868","fields":{"statuscategorychangedate":"2025-04-30T18:26:52.169+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1868/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:51.853+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:51.942+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/10]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/291]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/291]\n*Defect Dojo link:* http://localhost:8080/finding/291
+        (291)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]\n*Defect
+        Dojo link:* http://localhost:8080/finding/290 (290)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1868/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18231/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - cbc0bd61-0d90-40d9-928b-a38cb37167e8
+      - d10b2f9c-a56f-4201-a950-23d0e3a76ae5
       Atl-Traceid:
-      - cbc0bd610d9040d9928ba38cb37167e8
+      - d10b2f9ca56f4201a95023d0e3a76ae5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:42 GMT
+      - Wed, 30 Apr 2025 16:26:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -442,7 +460,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=290,atl-edge-internal;dur=13,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="crtBDB2K21UDp9VCrpa9bktdC4m-7AkpFZNRJOKQWWiDHFNxVm20RA==",cdn-downstream-fbl;dur=363,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=360,atl-edge;dur=276,atl-edge-internal;dur=14,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -451,10 +469,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a63f854fb49823d899d920c07df1bcae.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - crtBDB2K21UDp9VCrpa9bktdC4m-7AkpFZNRJOKQWWiDHFNxVm20RA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 1382d1c3eea0c4f8328654f52b706b82
+      - 21ae98f06880744b1b9fa19b702a39a8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -481,26 +507,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrlq5b3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCGcAWQopJOXm8rFcP1Q/083Q1rEi/HmEJjCBl+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0XxHCY4AWxal5JcIIUqB5AlkCy4pSzmacRTHABUQ45n38A/aVbs/ZDCoKPCs4o2kOy29W
-        tjdWuQiybL6QAjBHJbNZgYIpxRRIRZezfFGrOUM6V0DPBMGMhlvdi/GFqMRgwp2TYmwfiDlVBO3r
-        tiTH88OenB0n1/cVOX4CAAD//wMApx7pJCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:53.604+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 4783d337-3d5f-4abc-bfdf-08515e026571
+      - 3138cd0c-d946-4275-9675-b2ad05645cfd
       Atl-Traceid:
-      - 4783d3373d5f4abcbfdf08515e026571
+      - 3138cd0cd94642759675b2ad05645cfd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:42 GMT
+      - Wed, 30 Apr 2025 16:26:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -510,7 +532,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=146,atl-edge-internal;dur=13,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=19,cdn-upstream-fbl;dur=242,atl-edge;dur=162,atl-edge-internal;dur=14,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="IsFK6-_NC16qWWFuq61PPjRsTTC4immNtM8d34RfUUkbswqdN0c0Sg==",cdn-downstream-fbl;dur=245
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -519,10 +541,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9b5b156d64ffeaa3e7df806f8b45cd5c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - IsFK6-_NC16qWWFuq61PPjRsTTC4immNtM8d34RfUUkbswqdN0c0Sg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 71185434ab7d0ce8b9435594c1c34e52
+      - 7444e39f5058f61fe76a32d181401f86
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -549,41 +579,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 9c8af681-b135-430e-a6ce-456ed111f08a
+      - 31792ba6-be7a-41dc-888b-d5ef156bf6a7
       Atl-Traceid:
-      - 9c8af681b135430ea6ce456ed111f08a
+      - 31792ba6be7a41dc888bd5ef156bf6a7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:42 GMT
+      - Wed, 30 Apr 2025 16:26:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -593,7 +610,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=257,atl-edge-internal;dur=16,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=338,atl-edge;dur=306,atl-edge-internal;dur=14,atl-edge-upstream;dur=292,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="pKk7qYe7jnfNTpz2V-XR5YpNYqZeFK1ehK8umqAnA3soUE1sS6eR3A==",cdn-downstream-fbl;dur=342
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -602,13 +619,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - pKk7qYe7jnfNTpz2V-XR5YpNYqZeFK1ehK8umqAnA3soUE1sS6eR3A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 1626b9891cff1307704d4fcb4c7396ff
+      - 9e669e4bec27faa5a11a78523b2d2664
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -620,7 +645,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/101] in [Security
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/11] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
@@ -635,13 +660,13 @@ interactions:
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294]\n*Defect
       Dojo link:* http://localhost:8080/finding/294 (294)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -650,31 +675,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/292]\n*Defect Dojo link:* http://localhost:8080/finding/292
-      (292)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (292)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -683,25 +706,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
     headers:
       Accept:
@@ -713,7 +734,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7141'
+      - '6804'
       Content-Type:
       - application/json
       User-Agent:
@@ -722,18 +743,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16113","key":"NTEST-1629","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16113"}'
+      string: '{"id":"18233","key":"NTEST-1869","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18233"}'
     headers:
       Atl-Request-Id:
-      - 1c97155a-4f9e-440e-98e8-97673ffd08be
+      - 7bb8de3d-0b2d-44ed-b9e2-c74d93f9ba45
       Atl-Traceid:
-      - 1c97155a4f9e440e98e897673ffd08be
+      - 7bb8de3d0b2d44edb9e2c74d93f9ba45
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:43 GMT
+      - Wed, 30 Apr 2025 16:26:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -743,7 +766,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=752,atl-edge-internal;dur=15,atl-edge-upstream;dur=738,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=853,atl-edge;dur=723,atl-edge-internal;dur=17,atl-edge-upstream;dur=706,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="a-V7dlKDFRK4qq8HADXC-UUSRii7GoiJBZinMMFCudf8NX_aVZr_pA==",cdn-downstream-fbl;dur=858
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -752,10 +775,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9fe7d47ea2a815113a41181f1d63f69e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - a-V7dlKDFRK4qq8HADXC-UUSRii7GoiJBZinMMFCudf8NX_aVZr_pA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 2eb6c56fa5ded5ef3ebc5969683e195a
+      - a26009c7249d9f52ff1451de7ff192b6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -779,78 +810,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1629
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1869
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+FENnS6LsJI6KYshSt82WZZnjth/SIGCks8xGIlWS8sua/vfd
-        SZbdvLhYMqwJEPHtXnj33MPLFw8WpVCpF3sGVAoG0tcS8tR2lCjAdmwyhUJ0dAlGOKmV7UAqXQFO
-        dJKpUBnkOuvMwFjcg3QEpQELyq3OJpV1upiQwksehjz0DXyuwLrxsoRTIxInE/A6niT7fJfzHk4s
-        5BOcTp0rbRwEKUwgcan+pH3hcmGtFMpX4AK05AJRyiAKpLUVBK2Ca1ii/Ml4eDbu8t1oH5dqF6wX
-        f/Es+lbZRDjItFk2d0hxhhJRGO10Q97l4TgKY74X93v+7h7/Gf0OyUky4tDxWs0TnST5APWF0fra
-        q0kKNjGypMDh6gGzhcjzDkuldVIljpUSEmB6wubaXPsknWj1zuSP9KJSktIl8ksxE06YYCZhHtRu
-        bRxcbfGwxwe/WPk3vCww7VWBVgkWaHIs7DXlqrpyNIonIrfQ8RrBI7xXLdvxphKBY5Lp8hhmgL6G
-        Xzuek4isElHixarCO3p3YNIL243S6E94oycGfCVdh7tOYBtumnwDks2t3inpHCqw3to2IfX3+qzV
-        EzcXhvBqZVHmEh1O79wc81GjrD9Y9AePdPc7mWlvss5LP9xDN6L+Iur/v1aa7NdYRIN8d8F3f4TB
-        RWuxFy160Y+wuAL416/34ci34TRqNyZy8b7hQMz++cX9k732pMgyAxnyzb0iwAvovGrK/2FzO9s2
-        drdt7G3ZiLZuDLZt7N/3s6HNZpVIqX4hvLjLcSocPhwN4T6+cBs63xB40KgzVJb18FBXFDhOpPyB
-        FqTKvNiZCjB9qNS9x4xTcTbO1fpIv5FJE+Av99bIVxS2U13l6Stpy1wsV8VNkDCAlyX+eOiRiPYH
-        7SNxN2xrKru7sQ1U0RpUpZHaSLd8YhBb8aB+af79WyELkYENSMK2SiQuTGU29e0s27DlW1xpaTXy
-        7hdOtEZ9Lq6AiPGB0iA+eTAQfBtG+YAiMhV2WMrkWKrr17TzCkrqX1TSZq3O5bzeW68orYbYvoir
-        HEYgbIMEsxp5p8fv3hydXB4fHQ5PzoaXw9HozxHeD+vUYkjwwHgK7BRfAOUY2WXSMq3yJUM2kTkp
-        ZU6z36QR7NRAgXTCKouo9R9iFY4F5YU3MgzLSsVe8ypi9jD8m6q6xRaYiEwqkd89tOq+VuGtcZ2j
-        d6s5ZTZTsD5dlVS225Dc2w9bJDeN0hPB1wivX97bvc3j8LjB268iucZ2s4Vcq7yxdbjq6P6Tw21b
-        2NQMGonaRkHBnKpb59qcNN5c5RV0M4MssWmKNHulm2TrosSGWLmHQb+zjRZ21rTwvYzfDudH9e3v
-        AcuMrkpqFF9LlSIxWoa1wq4AFCsrO4W0RunR6IC+V8CkmpEBglnK8F8Bhq8ZpDEpm0Y+e0PqPqrn
-        9fd5zM7XaqWKWZnFOz73wxsKNsY614nIp9q6eBAOwmDSnL2sfUI48AuUYudnkFTETeytnned3iKM
-        j3Va4WMdXbCAnXPr2F+VMA4MG6oMK7LA+G4RhfWBgNfSJ6d/sIMKa5+dJUJtkaLWL+CcXzShvLlh
-        Z9i11o7i+PD9sP58aD5thmmyevxpOJYOeYBEa0ThCBUxokp2w85RRzfC2sdnLRxEtRuEUDVLfYWN
-        vp/pWTCrcoWYdcgpwe3zF6Riv78WS+bgF9IZ8LXJAqxrQViX2MQSHwT7fX/qipykygz/1IkiFRH+
-        jKDQDvAaKbDhAvNBMqzLfjrNOuxZ7l6wyOfcjxh7lrkXL/8BAAD//+xYUU/bSBD+KyMhVY4bNsUk
-        RM2JBwStVKmtqqN3L5eTYpylcevYwWsDVa//vd/srtdr4oBKr28ACs7Mzu7sN7Mz35oOxQsYawVu
-        RWJMjWLcKsZiIqaNfNLKJwJzNfKjVs6Pk1bO3ln5gThq5VErj/zxh60clauVj1v5uN3AtF2XHz25
-        W5cfo8GO5LCpPIpejhnRE7CGaznk0OuLAPXFefqTcbbj/684P8X40THWMeiLMSphUxRmoY43yyg8
-        qyWdoYRC+FpeCHo5JG6w1K3Oze/qQLjyrL8fiqdj+YshG6Nsh2e616MNfy6IWRDC8aAdBfgY9AX2
-        vrBSiE4A8T/4t/+Iw4r1cOr1BL/WFLqZFZ4XdZlIZFcmQ+7P+2ij61RJhnXzyRt41rKIEN3eLYvU
-        U7Y/i7QYxcvrVIGJ4AowiSIQjEtGGIeh4Z1MNRabTwsCp4N/OcVUmixOOIuly2LegyzjizTjjlqt
-        4oqKBAspulmBnFRg19aQUbuIlaSipCtc074SrsoJn0GF2ZMyvmQHwMbqdU5MvoQ+Z+DnpSQQdKpu
-        isYkIZXIPMZFhhkLlkqTFYEHgLxn6RcJ+n6JVWK4vdlkaaLfXFpm1DicSeCDE8v83x9ltgaf6lzF
-        lygUTPf3Vc1D4J+6yuxyFhlF6xjGaQFe4DmvxDyPtmeHUQ6kFTsD93DjLUEWMa9Dh8ma8yG2SJWy
-        qsscqY0nVWcVo+v5gHG9TggGcG8PN5cC8cTfaZEnclPN88ViMc/5NljRNzrFzsB5vtMx8avctJTB
-        s73baIrUMv8HzdjEjDwmUGdrFrBSPwm7OZY0BgzXMS3OX719dfqRDujknJ5d1UX1xxw/ZvJRaCQ4
-        hH3qcDTHuXzOW1VFJgUuCwGyP8EFTsj8evAvewMGDZN8NDLWC+2AcUoDGMCPIQWyLIeM4ICO+eTQ
-        N8xs94S5luz494EFh/52iULvwFmRL8RHzZc374dmnSoOnrijjkOzq5I7o61a7jRb1dzT3KnnnuZO
-        Rfc0d2q6p7lT1Z1mq657mm5lB04f9PudZQPSzI60IFlUMJ8HF2NkMeGFfLgYIwuKVTVwMUYOFE/T
-        dLwGlY6KQXKodDQMkkOlo2GQHCodDYPkUPE0BiSHSkdjQPKSCXitkEmckvuG7s22Cz3fVGb8ge6E
-        bycJnwMkZn2B4297wLtUX/xsCwjdRSYSt+J2Rn/plwVcgGyxb0KCiplBUwrf6HCXkYlWr814l40J
-        Y6/NZJeNCXCvzdEuGxMRZ0MBvecOpLuT63A6CYYm4kNddk2IudXEmSpoYxJYENMIt+h016I6pPcv
-        ahMCXWprARu7N+tNnFQct/cFpfoLIQWu06Vctm0eA/8EJyolqrn6mT5vTTcF37iZpgTxcp3mAwoG
-        /61BQ6pi5qhHL519orLeAfYL3sNUlkndY6hsxFQ2+h1U9gcAAAD//yKtKUtuvxc52dK6KWs42pQF
-        qgIAAAD//+ya0WqDMBSGX2UMehkXNVa9KF0ZG+yiL9C79ES3MdSildG33znGhpo1HWw3XgR6Ic1J
-        TziYn7/8n7ey3sp6K3tV1SfWbKLrE2t2qezeyp7n5a2st7LzsLKh2fqLlf2Z3icmwLbDW1d+FwrX
-        goE3KNg7thI+B2aBmAOrVBjUwlrgLgCEuzJ0bjL083hchS7ug5vDTLJoO5GUx6OEd8rbdN7Z9VUl
-        KYy9v5oW0qiJqGjaP8a15E7WEoA4kFe1SlScpdk+THkRQ84hT6IyD8sl9jFF2OFGWUHvwUYp7NFh
-        Jdq90+PFQaAh9u024zWMuAjeWl1Ge86ckSh4mEkVCrFMIUuTON/DPuXYvpRFmcFarYZfWcSbRfSC
-        H72PVbIeY0zG9Fdd0HfsCwfBooDy0UBrIE2KHaTsaFC4f/DoeNvw8WnLeHCoKTa3ebH5n9gGzuZ/
-        YhtYm/uJUX+Upp1GrgH/r5/utrIse4CP4QJRCKbpKq1eu6amwue+bQ7Fww51BYgDGm8aAZO4aq4u
-        dRgx0eswhHCJqXAxUsIwUvaCEex2VHuvL/97k74BAAD//yIhJY2WL/Rw8Wj5gqV8QS8G4K0weKMF
-        6Op0SN6rBq3shrINgBbmlyRC16Wjm4KzuYWzXMLZDjPCXvLhWuJogKvhCSoQsEoY4Gp4GuPSYQxv
-        2aXmlWUW5edBWm8QoZRS6KYICJeo0MvPhZhQDWNCi3syil+k/Rz6MHN1lHITK4Ig40AodoNXABaV
-        OJZA3FEG7H6Qu2wRY+ExxDC4oUC7MhKLw/LBCyhha4NBS59ByxJBVsIdgupaIxTnQjWAg6e2thYA
-        AAD//wMAftJ2fYMzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18233","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18233","key":"NTEST-1869","fields":{"statuscategorychangedate":"2025-04-30T18:26:55.036+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1869/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:54.718+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:54.818+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/11]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294]\n*Defect
+        Dojo link:* http://localhost:8080/finding/294 (294)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292]\n*Defect Dojo link:*
+        http://localhost:8080/finding/292 (292)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1869/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18233/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 07963c4e-1135-4cfc-871a-e7c06a84c22a
+      - 91ec06aa-3307-4119-8c08-499efb338e37
       Atl-Traceid:
-      - 07963c4e11354cfc871ae7c06a84c22a
+      - 91ec06aa330741198c08499efb338e37
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:44 GMT
+      - Wed, 30 Apr 2025 16:26:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -860,7 +926,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=292,atl-edge-internal;dur=13,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="B43gulen5h1NTO2DY5wVxxjxK5_ikIF5UiJyYGS0Gsb2z-k4lQ8fpw==",cdn-downstream-fbl;dur=374,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=371,atl-edge;dur=286,atl-edge-internal;dur=16,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -869,10 +935,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 087e16218fcf1ccb7472a2c9f6a4cbe2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - B43gulen5h1NTO2DY5wVxxjxK5_ikIF5UiJyYGS0Gsb2z-k4lQ8fpw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 95c1fc365cc58e47d16db8a9ae5d7f52
+      - 5622d9de1def9a0745c4eee758af0067
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -896,78 +970,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16113
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18233
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+FENnS6LsJI6KYshSt82WZZnjth/SIGCks8SGIjWS8sua/vcd
-        9WI3L+6WDGsCRBLJe+Hdc89dPnuwLJlMvdjTIFPQkL7mIFLTk6wA0zNJDgXrqRI0s1xJ04OU2wIs
-        6yU5kxkIlfXmoA3uQTqBUoMBaduzSWWsKmZO4SUNQxr6Gv6swNjpqoRTzRLLE/B6Hnf26S6lA/ww
-        IGb4mVtbmjgIUphBYlP1SfnMCmYMZ9KXYAO0ZANW8iAKuDEVBJ2Ca1ih/Ml0fDbt091oH5dqF4wX
-        f/YM+laZhFnIlF41d0jxCyWiMNrph7RPw2kUxnQvHg783T36I/odOiedEYuO12qe6KSTD1BfGK2v
-        3X6kYBLNSxc4XD0gpmBC9EjKjeUysaTkkABRM7JQ+tp30omS77R4pBeV5C5dTFyyObNMB3MOi6B2
-        a+Ngu0XDAR39ZPhf8LLAtFcFWnWwQJNTZq5drqor697iGRMGel4jeIT3qmV7Xs4RODrJV8cwB/Q1
-        /NLzLEdklYgSL5YV3tG7A5NBuG2DdhulVp/wqk/MRCtd56HObJcH9/EVejbXfSe5tajAeGvbDsK/
-        1meNmtkF0w7Ihhel4OhweickmKgafsPRcjh6pLvfSFl3k3XChuEeuhENl9Hw/7XSwKIGKRqku0u6
-        +z0MLjuLg2g5iL6HxRb5X77ch2PUwXHGl+8bDsQkn1/cPznoTrIs05Ah3/xjEex0G3gBJaqGFx4+
-        urttY2/LRrR1Y7RtY/++Ow1tNquOlOoO4cV92nKli7zmSeP553trrh4wqCZXlUhfcVMKtmqrBpcx
-        hfY9psdVUmuCWWxGDYk/vuabFrFpCkGjTruKrl8PVeWSUTv/wS1wmXmx1ZXzJtGAl3U08VCTiPZH
-        XZO4G7ZtVBatqezuxhpUpeZKc7t64oU78aDuNP++V/CCZWACJ2E6JRwXcp7lvplnG1J8iysde0be
-        /fqI1qgX7Aoc/z1QGo42HgwE3YZROnIRyZkZlzw55vL6tdt5BaWbX2TSYahG1qLeW69IJcc4vrAr
-        ARNgpsGlbt+80+N3b45OLo+PDscnZ+PL8WTy+wTvh3VqMCR4YJoDOUWil5Y4u4QboqRYESQNLpxS
-        YhX5hWtGTjUUyBqkMogw/yHyoFhQXnjDw7CsZOw1XRGzh+HfVNUttsBEZFwycfdQO3214a1xLtC7
-        9ttlNpOwPl2Vrmy3IXmwH3ZIbgalJ4KvEV432NuzzePwuMHbzyy5xnGzg1ynvLF12E50/8nhbixs
-        agaNRN08IGHhqlsJpU8ab65EBf1MI2dthiJFXqkm2aoocSCW9mHQ72yjhZ01LXwr47fD+VF+/XtA
-        Mq2q0g2Kr7lMkcQMwVohVwCSlJXJIa1RejQ5cM8rIFzOnQEHs5TgvwIEuxmksVOWRz5549R9lM/r
-        5/OYnK/VchmTMot3fOqHNy7YGGuhEiZyZWw8CkdhMGvOXtY+IRzoBUqR8zNIKsdN5K1a9K3aIow9
-        Oa2wJ0cXJCDn1FjyR8W0BU3GMsOKLDC+W0RhfSCgtfTJ6W/koMLaJ2cJk1uk3IQXUEovmlDe3JAz
-        nFprR/H98P24fnxoHl2G3Ufb/N3rlFvkASdaIwrfUBFxVEluyDnq6EdY+9iCwlFUu+EQKuepL3HQ
-        9zM1D+aVkIhZi5wS3D5/4VTsD9diyQL8glsNvtJZgHXNHNY5zqqOD4L9oZ/bQjipMsM/daKcigh/
-        JlAoC3iNFMh4iflwMqRPfjjNeuSZsC9I5FPqR4Q8y+yLl38DAAD//+xYUU/bSBD+KyMhVY4bNsUk
-        RM2JBwStVKmtqqN3L5eTYpylcevYwWsDVa//vd/srtdr4oBKr28ACs7Mzu7sN7Mz35oOxQsYawVu
-        RWJMjWLcKsZiIqaNfNLKJwJzNfKjVs6Pk1bO3ln5gThq5VErj/zxh60clauVj1v5uN3AtF2XHz25
-        W5cfo8GO5LCpPIpejhnRE3CYaznk0Gu+T31xnv5knO34/yvOTzF+dIx1DPpijErYFIVZqOPNMgrP
-        aklnKKEQvpYXgl4OiRssdatz87s6EK486++H4ulY/mLIxijb4Znu9WjDnwtiFoRwPGhHAT4GfYG9
-        L6wUohNA/A/+7T/isGI9nHo9wa81hW5mhedFXSYS2ZXJkPvzPtroOlWSYd188gaetSwiRLd3yyL1
-        lO3PIi1G8fI6VWAiuAJMoggE45IRxmFoeCdTjcXm04LA6eBfTjGVJosTzmLpspj3IMv4Is24o1ar
-        uKIiwUKKblYgJxXYtTVk1C5iJako6QqXxq+Eq3LCZ1Bh9qSML9kBsLF6nROTL6HPGfh5KQkEnaqb
-        ojFJSCUyj3GRYcaCpdJkReABIO9Z+kWCvl9ilRhubzZZmug3l5YZNQ5nEvjgxDL/90eZrcGnOlfx
-        JQoF0/19VfMQ+KeuMrucRUbROoZxWoAXeM4rMc+j7dlhlANpxc7APdxOS5BFzOvQYbLmfIgtUqWs
-        6jJHauNJ1VnF6Ho+YFyvE4IB3NvDzaVAPPF3WuSJ3FTzfLFYzHO+DVb0jU6xM3Ce73RM/Co3LWXw
-        bO82miK1zP9BMzYxI48J1NmaBazUT8JujiWNAcN1TIvzV29fnX6kAzo5p2dXdVH9McePmXwUGgkO
-        YZ86HM1xLp/zVlWRSYHLQoDsT3CBEzK/HvzL3oBBwyQfjYz1QjtgnNIABvBjSIEsyyEjOKBjPjn0
-        DTPbPWGuJTv+fWDBob9dotA7cFbkC/FR8+XN+6FZp4qDJ+6o49DsquTOaKuWO81WNfc0d+q5p7lT
-        0T3NnZruae5UdafZquueplvZgdMH/S5m2YA0syMtSBYVzOfBxRhZTHghHy7GyIJiVQ1cjJEDxdM0
-        Ha9BpaNikBwqHQ2D5FDpaBgkh0pHwyA5VDyNAcmh0tEYkLxkAl4rZBKn5L6he7PtQs83lRl/oDvh
-        20nC5wCJWV/g+Nse8C7VFz/bAkJ3kYnErbid0V/6ZQEXIFvsm5CgYmbQlMI3OtxlZKLVazPeZWPC
-        2Gsz2WVjAtxrc7TLxkTE2VBA77kD6e7kOpxOgqGJ+FCXXRNibjVxpgramAQWxDTCLTrdtagO6f2L
-        2oRAl9pawMbuzXoTJxXH7X1Bqf5CSIHrdCmXbZvHwD/BiUqJaq5+ps9b003BN26mKUG8XKf5gILB
-        f2vQkKqYOerRS2efqKx3gP2C9zCVZVL3GCobMZWNfgeV/QEAAP//Iq0pS26/FznZ0ropazjalAWq
-        AgAAAP//7JrPasMwDMZfZQx6dOY0TpMcSlfGBjv0BXpz5WQbI03IH0bfflKcmtSrOxgMcjD0EGqp
-        EiIWX/l+Xsp6Keul7NWtfiHNLvb6hTSbbnYvZc/z8lLWS9l5SNnQpP4iZX+697ExsG3z1uXfhWLq
-        33WNhM8BIyDQwQ41gId1IAxqYR1wVwY3Hvp5Cq5Al6fOXdwHN83IrpPwTpbaaCxPvWnboWz7spRk
-        xt5fdQtp1ERUVM0f7VpSJxsJQMzGq1rHKkqT9BAmPI8g45DFyyILixXWMUFY4UZYTu/BVims0WIk
-        yr3T46QRqIh9u41yDbPPg7dGh1HOGScSOQ9TqUIhVgmkSRxlBzgkHMsXMi9S2Kj18CuLaLtYvuBH
-        57FSHkcbkzH9VRv0LfvCQbBlQP5ooHcgTYrVUrY0KMwfNDreNnx82jEe1EeyzW0sbP4d21zZ/Du2
-        ubS5d4yLSWn2auQa8P/66W4ni6IH+BguEJlgmoTSa21fHSnwuW+qOn/Y48IB4oDGm0ZcJJ6aq0sV
-        Rkz0OgwhXMtUuBgpYRipZlzqfo380wvzDQAA///CTDCjxQg9XDxajGApRtCLAVzNMxN4KwzeSAF6
-        Jx2SKatBC7ihbAOgS/JLEqHr0tFNwdncwlku4VrLaGCEveTD2RzD6TOc7TS4l9EkjHHpMIa37FLz
-        yjKL8vMgTTuIUEopdFMEhEtM6JUBm/3kLhfEWJwLMQxuKNCmjMTisHzwwkXYCmFgFoA4uRrGhNYv
-        ZDsAvIFEH2aujlJuYkUQZOAJxbPgJYdFJY4lEI+Dlj6DliWCvA4XR9VshKIbqgHs2traWgAAAAD/
-        /wMA27QLpYMzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18233","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18233","key":"NTEST-1869","fields":{"statuscategorychangedate":"2025-04-30T18:26:55.036+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1869/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:54.718+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:54.818+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/11]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294]\n*Defect
+        Dojo link:* http://localhost:8080/finding/294 (294)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292]\n*Defect Dojo link:*
+        http://localhost:8080/finding/292 (292)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1869/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18233/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 5804ceca-17ee-4cf3-b7b0-13e920969d62
+      - 416672ed-5ad5-43b3-b658-8484462b9f84
       Atl-Traceid:
-      - 5804ceca17ee4cf3b7b013e920969d62
+      - 416672ed5ad543b3b6588484462b9f84
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:44 GMT
+      - Wed, 30 Apr 2025 16:26:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -977,7 +1086,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=261,atl-edge-internal;dur=15,atl-edge-upstream;dur=247,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=20,cdn-upstream-fbl;dur=334,atl-edge;dur=250,atl-edge-internal;dur=18,atl-edge-upstream;dur=231,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="Yd-6SukFS7n-tyLqsKSxuLYhTk8pDH6zjt7Tzye78f28ydB4eNcWCQ==",cdn-downstream-fbl;dur=338
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -986,10 +1095,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ed78483d37e5338746e5a4b545e5818e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Yd-6SukFS7n-tyLqsKSxuLYhTk8pDH6zjt7Tzye78f28ydB4eNcWCQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 92a16d878c33e584b29b9254def28cc1
+      - 517e460054f3e493e6cb4c1cd96f4a92
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1016,26 +1133,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpLlq1b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUglPW57QwR5C6HzYjKpUaMKtXt3mQxGet9Im1kMZETqxndG7v/BF9jvGoU1+o81mm6FNmD/
-        1yUrZ7UZ0Cr8XXKHvW+cjTAFoBlkMC42l4/F+qH8mW6GtooVEc8JGsEIXqITO+P2bbyy3HfJtjJu
-        qGOoGhpTf0WIiAGW56fmlQwJZMBmY6BjWJaMCT4VPIoBLiDCMe/jH7Avm/acpVAyEDQXnGc5sG9W
-        tTdWuwhyOl8oCThDreg0R8m15hqUZsvpbFHpOUc218DOBMEkw23Ty/RC1HIw4c4pmdoHYk4VQfu6
-        Lcjx/LAnZ9Pk+r4kx08AAAD//wMAJr4+MiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:56.550+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 96307c59-e554-4707-886f-3bd2dcb5f4f4
+      - 2c5563c8-7b34-4a62-a943-5682321ec600
       Atl-Traceid:
-      - 96307c59e5544707886f3bd2dcb5f4f4
+      - 2c5563c87b344a62a9435682321ec600
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:44 GMT
+      - Wed, 30 Apr 2025 16:26:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1045,7 +1158,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=142,atl-edge-internal;dur=14,atl-edge-upstream;dur=128,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="HAl6L9_oSNwFpE1TCX6rm--FteRzwRg6Sh5f25QTiMOFkuSkTX-P1g==",cdn-downstream-fbl;dur=228,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=53,cdn-upstream-fbl;dur=226,atl-edge;dur=154,atl-edge-internal;dur=15,atl-edge-upstream;dur=140,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1054,10 +1167,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0730d54c3f7ca2a2e0c1b4cda1ebc0aa.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - HAl6L9_oSNwFpE1TCX6rm--FteRzwRg6Sh5f25QTiMOFkuSkTX-P1g==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - f46444601af0c8973abf0275ec217317
+      - a1efb9b6cb9435afee136690b53e95e1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1084,41 +1205,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 8b13f1be-9ef7-4095-99ea-12e2ec1500c4
+      - ab7a0d5a-b97e-4bae-8a18-7a53cf02ada5
       Atl-Traceid:
-      - 8b13f1be9ef7409599ea12e2ec1500c4
+      - ab7a0d5ab97e4bae8a187a53cf02ada5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:45 GMT
+      - Wed, 30 Apr 2025 16:26:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1128,7 +1236,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=299,atl-edge-internal;dur=17,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=306,atl-edge;dur=274,atl-edge-internal;dur=15,atl-edge-upstream;dur=258,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="b2daBsH_ObgdlQznwH3XtXALGoj8auhy_YXDccXPt51yjHjYi6bRBg==",cdn-downstream-fbl;dur=310
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1137,13 +1245,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - b2daBsH_ObgdlQznwH3XtXALGoj8auhy_YXDccXPt51yjHjYi6bRBg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ec14510d43aced8e057b0038f33b491d
+      - 43f326895bf56d8ebd223646a03e22e1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1155,22 +1271,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/102] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/12] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]\n*Defect
       Dojo link:* http://localhost:8080/finding/293 (293)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -1184,7 +1299,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1973'
+      - '1945'
       Content-Type:
       - application/json
       User-Agent:
@@ -1193,18 +1308,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16114","key":"NTEST-1630","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16114"}'
+      string: '{"id":"18235","key":"NTEST-1870","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18235"}'
     headers:
       Atl-Request-Id:
-      - a7b38451-8801-40db-bf0b-e4c24cf680f7
+      - 8869a4da-b5c1-47c1-bd14-138dfdf65694
       Atl-Traceid:
-      - a7b38451880140dbbf0be4c24cf680f7
+      - 8869a4dab5c147c1bd14138dfdf65694
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:45 GMT
+      - Wed, 30 Apr 2025 16:26:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1214,7 +1331,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=723,atl-edge-internal;dur=14,atl-edge-upstream;dur=710,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=786,atl-edge;dur=752,atl-edge-internal;dur=16,atl-edge-upstream;dur=737,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="mRVnhZsH1GuBrSOQ_nr7yVWO6LK5ZST2NyxkGUt6FSL31L3c01pkPw==",cdn-downstream-fbl;dur=790
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1223,10 +1340,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 895116b5366f3f5264f7b6361d3fd564.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - mRVnhZsH1GuBrSOQ_nr7yVWO6LK5ZST2NyxkGUt6FSL31L3c01pkPw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c806d9d8f0769d2749bd28d8b327786e
+      - e441a8883568ccaf1d20096e6a765423
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1250,65 +1375,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1630
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1870
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX23LbNhD9FQyfOqnEm2Vb4Uyn49py4tZ1XVlJHhyPByZXJGIKYAFQl8b59+6C
-        pBRflKndaUYPJAHsBbtnz64+e7CsuMy8xNMgM9CQHQsoM9OTfAamZ9ICZrynKtDcCiVNDzJhZ2B5
-        Ly24zKFUeW8O2uAeZGOoNBiQtj2b1saq2ZQUXkdhGIW+hr9qMHayquBc89SKFLyeJ8h+tBdFA/ww
-        UE7xs7C2MkkQZDCF1Gbqk/K5Lbkxgktfgg3Qkg14JYI4EMbUEHQKbmGF8meT0cWkH+3thLjkXDBe
-        8tkz6FttUm4hV3rV3CHDL5SIw3i3H0b9KJzEYRLtJ4Ndfzgc/oh+kw5nxKLjTs0LnST5APWF8fra
-        7UcGJtWiosDh6gEzM16WPZYJY4VMLasEpMDUlC2UvvVJOlXynS6f6UUtBaWLl9d8zi3XwVzAInBu
-        bRxst6JwJxr+bMTf8NMM017P0CrBAk1OuLmlXNU3lt6SKS8N9LxG8ATv5WR7XiEQODotVqcwB/Q1
-        /NLzrEBkVYgSL5E13tF7ABPMWLtRafUJb/TCgLfSLtwugV246eMrkGxu9U4Ka1GB8da2Cam/ubNG
-        Te2Ca8KrEbOqFOhw9uDmmA+HssFwORg+091vZKa7yTovg3Af3YgHy3jw/1ppsu+wiAajvWW09z0M
-        LjuLO/FyJ/4eFluAf/nyGI7RNpzG3cZULN83HIjZv7x6fHKnO8nzXEOOfPOoCPACqqyb8n/a3O62
-        jb1tG/tbNuKtG8NtG68f+9nQZrNKpOQ6hJf0o5YrKSVapM2VPj9ao0LBaJtC1WV2JExV8lVbTriM
-        ubXvMW9UYq0JbrEZNST+fDJoWsSmKQSNOk2l7l4PVU3JcM5/oAUhcy+xuiZvUg14WeKPp5rE7iDq
-        msTDsK2p7OHGNlDFa1BVWigt7OqFF+7EA9dp/n2vEDOegwlIwnRKBC4UIi98M883bPkWVzpajb3H
-        hROvUV/yGyBifKI0iE+eDES0DaPRkCJScDOqRHoq5O0x7RxBRfOLTDsMOWQt3N56RSo5wvGF35Qw
-        Bm4aXOr2zTs/fffm5Oz69ORwdHYxuh6Nx3+M8X5YpwZDggcmBbBz7ADSMrLLhGFKliuGbCJKUsqs
-        Yr8Kzdm5hhnSCasNIsx/ilUiLCgvvBNhWNXzxGu6ImYPw7+pqntsgYnIheTlw0Pt9NWG1+G8RO/a
-        b8psLmF9uq6obLchGQujQ3IzKL0QfI3wuvPen22eh8cN3n7h6S2Omx3kOuWNrcN2ovtPDndjYVMz
-        aCTuBgUJC6puVSp91nhzU9bQzzVy1mYoUuxINclWswoHYmmfBv3umha+ldiHQmvKuB/Oj/Lr3wHL
-        taorGhSPhcyQxAzDWmE3AJJVtSkgcyg9GR/Q8waYkHOyTDDLGP4VYNjNIEtIWRH77A2p+yhfueer
-        hF2u1QqZsCnGsEhCf8cP7yjeGO5SpbwslLHJMByGwbQ5fu3cQkTEVyjILi8grYme2Fu16Fu1RRj7
-        dVZjv0ahgF1GxrI/a64taDaSORblDEO8RRTWB4LISZ+d/84Oaix/dpFyuUWKpr8giqKrJpp3d+wC
-        B1fnKL4fvh+5x4fm0SWZPtr+T68TYZEKSNSBCt9QESO2ZHfsEnX0Y2S3Pv1dee3cIJDKeeZLnPX9
-        XM2DeV1KhK1FWgnun78iFYOwCTbJpQvwZ8Jq8JXOA6xtTngXOMgSJwR41C/srCQ5lyt8umyRnjHk
-        dckxlkv62+bcPwIpeEnouQA9x39nrM9+ONbwDwAAAP//7FnbTttAEP2VVaUiEsXGSRxyQYhGpEg8
-        pKpatQ/0hc3umrhK4siXoKp8fM+sN4tjsrSlKuIBgZJ4Z68zs2fOjLN5ix0s8hMM7vmdhkN7xtZH
-        nWGXFhwjzm9Ui3SjyTK7I502txodNbVSqI01J4ViE7ggGi/UzGfDFiOAYrvevf2bt33r3vq56//n
-        42DfE40juOLfE0YIi63+dhw7xEdj36EfOzJrwsXQ/A1f3pOsjRXhOHqKf/O3Xb03PydFCi1exAsF
-        LFClpg9u8hPtXJWOk3uMagJL7LIJwMtcfT9OjrjcxBkAEASj1zkGfEWkY7jKNqqR7a715NcMoZfR
-        VpFSmmCbGpObjZDJpTV5Zkx+Oyfo45hvdcPAuQXkiNoi5RGtRDEakLQuch+a/3o//xTYs1AG43ZF
-        W7Y/qngRenzUnFJuxZBCM6dWXJkAPecYjUZ4pL6Qo7oyW5WGDNzGIUg3yqPoFYuHHUtpxDcUbytW
-        IgQb0Qc5Fx7HQmC+EeLDbBELY8FprIOCMeAXzRtI58Yy5alYkrIFBKlvLX+5XHOR05gPCYv1AwOO
-        b2Kp5I4vfcJ9ApnC0n/jIWboOqEwQA5+yOUyXjXYYeNuCQfOkxGc9iEV71k2WmdiLo7eDl0Cm4lR
-        +M5T8BKdLFA6U+sauJK20CZU9RGWEG+14OroIsiBK4kL7Jo8z7mYU3A0LLFKNOs8JCuWS07M6o0r
-        9JO2KUNK0ifSL7qDZ1wIysEu5WlPdgf9wazdD1RXDAMx7HWiYTs6xjq2E1Z4pJsiVxhLSfcEPUUi
-        f7yrbAT8jOZ6tGaj1a98UDzdjcZs6wahQhbCZTsMj/ti0O91hzMx6wdYPuIqGogzeapnedsdv+1c
-        4L8c5y35ynASzyubMr/IvFsowuv4RHb88gqSprw15xkpCuM1wiOHwc/zqRf46xXR4Hr95+XvuF5A
-        evk7rhegXvqOAUGyrKWYPOUcrs+mPIoKIWJ9gYiUlZWNEsCuQGLR8X2RJmt1dAXMEZTXm5tGBVBI
-        7dWlFUzZd39yE7rwNHTVPEJb80gNrr/CyLM5zCuMPMeOX2FkD4zUYcDF0EJLxCxPwXFuykv5k97U
-        mN8BdpLk3Lxnqs/iomKBC5eCzn6Ac5UsA+cBnFTNRTEJQvYKuk6BJXdqtYnTZFWyu7JJFuYlZ/n4
-        J9rbJHml2P4LAAD//yKtHMYYbIcYBjcUaFNGYnFYPnggEjbiD8wCECdXw5jQ+oVsB4AnhPVh5uoo
-        5SZWBKUWl+aADEbyLHgIsajEsQTicdBUBmiYEeR1uDiqZiMU3VANYNfW1tYCAAAA//8DALcKVjNT
-        HwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18235","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18235","key":"NTEST-1870","fields":{"statuscategorychangedate":"2025-04-30T18:26:57.815+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1870/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:57.491+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:57.583+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/12]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]\n*Defect
+        Dojo link:* http://localhost:8080/finding/293 (293)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1870/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18235/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 58a497fc-74c4-4a5c-83ca-a5b8ea6e9394
+      - 876a613b-ab50-46bb-b734-1489df50e16a
       Atl-Traceid:
-      - 58a497fc74c44a5c83caa5b8ea6e9394
+      - 876a613bab5046bbb7341489df50e16a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:46 GMT
+      - Wed, 30 Apr 2025 16:26:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1318,7 +1429,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=264,atl-edge-internal;dur=18,atl-edge-upstream;dur=247,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=291,atl-edge;dur=258,atl-edge-internal;dur=16,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="uTe3UZTZVvSAFfWTenJoxizniIkt9tua2_7PwG2fmeEbrPNgCa4Qow==",cdn-downstream-fbl;dur=295
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1327,10 +1438,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b3ac893abff0a2c3dda216fe4cd9157a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - uTe3UZTZVvSAFfWTenJoxizniIkt9tua2_7PwG2fmeEbrPNgCa4Qow==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 9d9a7b69895d1dd2aea51b100a33293b
+      - c45952d3f82ad5439693dd9df3cfd177
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1354,65 +1473,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16114
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18235
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX23LbNhD9FQyfOqnEm2VH4Uyn49py4tR1XVlJHhyPByZXJGIKYAFQl8b59+6C
-        pBRflNbuNKMHkgD2gt2zZ1efPVhWXGZe4mmQGWjIjgSUmelJPgPTM2kBM95TFWhuhZKmB5mwM7C8
-        lxZc5lCqvDcHbXAPsjFUGgxI255Na2PVbEoKr6IwjEJfw581GDtZVXCmeWpFCl7PE2Q/2ouiAX4Y
-        KKf4WVhbmSQIMphCajP1SfncltwYwaUvwQZoyQa8EkEcCGNqCDoFN7BC+dPJ6HzSj/Z2QlxyLhgv
-        +ewZ9K02KbeQK71q7pDhF0rEYbzbD6N+FE7iMIleJoNdfzgc/oh+kw5nxKLjTs0znST5APWF8fra
-        7UcGJtWiosDh6j4zM16WPZYJY4VMLasEpMDUlC2UvvFJOlXynS6f6EUtBaWLl1d8zi3XwVzAInBu
-        bRxst6JwJxr+bMRf8NMM017P0CrBAk1OuLmhXNXXlt6SKS8N9LxG8Bjv5WR7XiEQODotVicwB/Q1
-        /NLzrEBkVYgSL5E13tG7BxPMWLtRafUJb/TMgLfSLtwugV246eMrkGxu9U4Ka1GB8da2Cam/urNG
-        Te2Ca8KrEbOqFOhwdu/mmA+HssFwORg+0d1vZKa7yTovg/AluhEPlvHg/7XSZN9hEQ1Ge8to73sY
-        XHYWd+LlTvw9LLYA//LlIRyjbTiNu42pWL5vOBCzf3H58OROd5LnuYYc+eYfi2C328CbqbJueOHx
-        o3vbNl5u2Yi3bgy3bbx66E5Dm80qkZLrEF7Sj1qupJRokTaef36wRoWC0TaFqsvsUJiq5Ku2nHB5
-        wS22noayn176TUPYtICgUaepsN3rgaop9M7VD7QgZO4lVtdkG5Xa94gZKu82GhrwssQfjzWJ3UHU
-        NYn7YVtT2f2NbaCK16CqtFBa2NUzQ9CJB67T/PteIWY8BxOQhOmUCFwoRF74Zp5v2PINrnS0GnsP
-        Cydeo77k10DE+EhpEJ88GohoG0ajIUWk4GZUifREyJsj2jmEiuYXmXYYcshauL31ilRyhOMLvy5h
-        DNw0uNTtm3d28u718enVyfHB6PR8dDUaj38f4/2wTg2GBA9MCmBn2AGkZWSXCcOULFcM2USUpJRZ
-        xd4KzdmZhhnSCasNYs5/jFUiLCgvvBVhWNXzxGu6ImYPw7+pqjtsgYnIheTl/UPt9NWG1yG/RO/a
-        b8psLmF9uq6obLchGUulQ3IzKD0TfI3wuvPenW2ehscN3n7h6Q2Omx3kOuWNrYN2ovtPDndjYVMz
-        aCTuBgUJC6puVSp92nhzXdbQzzVy1mYoUuxQNclWswoHYmkfB/3uNlrYXdPCtzJ+N5wf5de/fZZr
-        VVc0KB4JmSGtGYa1wq4BJKtqU0DmUHo83qfnNTAh52SAYJYx/CvAsJtBlpCyIvbZa1L3Ub5wzxcJ
-        u1irFTJhU4xhkYT+jh/eUrwx3KVKeVkoY5NhOAyDaXP8yrmFiIgvUZBdnENaEz2xN2rRt2qLMPbr
-        rMZ+jUIBu4iMZX/UXFvQbCRzLMoZhniLKKwPBJGTPj37je3XWP7sPOVyixRNf0EURZdNNG9v2TkO
-        rs5RfD94P3KPD82jSzJ9tP2fXifCIhWQqAMVvqEiRmzJbtkF6ujHyG59+rvyyrlBIJXzzJc46/u5
-        mgfzupQIW4u0Etw9f0kqBmETbJJLF+DPhNXgK50HWNuc8C5wkCVOCPCoX9hZSXIuV/h02SI9Y8jr
-        kmMsl/S3zbl/CFLwktBzDnqO/85Yn/1wpOFvAAAA///sWdtO20AQ/ZVVpSISxcaJHXJBiEakSDyk
-        qlq1D/SFzXpNXCVx5EtQVT6+Z9brxTFZ2lIV8YBASbyz15nZM2fG2aLDDpb5CQb33V7Loj1t66Pe
-        yKcFJ4jzW9kh3SiyzO5Ip+1Ko+O2Ugq1sfa0kGwKF0TjhZy7bNRhBFBs17urv0XXNe6tnn33Px8H
-        +54qHMEV/54wQlhs9bfj2CE+WvsO/diRWRsuhuZv+HKeZG2sCMdRU/ybv+3qvf05KVJo8SJeSmCB
-        LDV9cJOfKOeqdZzeY1QbWGKWTQBe+uq7cXLEw22cAedAMPq9Y8BXRDqGq1RRjWx3rSa/Zgi9jLaK
-        lFIH21SbXG+ETB4ak2fa5LcLgj6O+dY3DJxbQI6oLVIe0UoUowFJmyJ3ofmv9/PPgD1LqTFuV1Sx
-        /XHNi9Djo2KZYSWGFJo5NeLaBOi5wGg0wiPVhRw3ldmpNWTgNhZBupUORa9YPOxYSiO+pXhbsxIh
-        2Jg+yLnwOBEC840RH+bLWGgLzmIVFLQBvyjeQDrXlilPxZKULSFIXWP5y9WGi5zGfEhYrB4YcHwb
-        hzLc8aVPuE8gU1j6bzxED90kFAbIwQ95uIrXLXbYulvBgfNkDKd9SMX7ho02mZgtGHeDejDOU9AP
-        lSVQ1tLsarK1hiAweVND4NlGeIYQV1qwdbQRZM+WxHlmMzzPuVhQcNQssU40m3QjK1YrTszqjS30
-        k7YpQ0rSJ9IvuoNnXAjKyi7D037oDwfDeXfgSV+MPDHq96JRNzrGOqYTVnikmyRXmIQh3RP0FEn4
-        411tI+BnNNejNRulfumC4qluNKaqGwQSWQgPu0FwPBDDQd8fzcV84GH5iMtoKM7CUzXLW3/ytneB
-        /3Kcs+JrzUkcp2zK3CJzbqEIp+cS2XHLK0iacjacZ6QojFcIjxwGP89njudu1kSDm/Wfl7/jZgHp
-        5e+4WYB66TsGNoVlLUXnKedwfTbjUVQIEasLRKSsrHWUyHYFEouO74s02cijK2COoLxe3zQqgEJq
-        ri6toMu++5ObwIanga3mEZiaR6px/RVGns1hXmHkOXb8CiN7YKQJAzaGFhgiZngKjnNTXsqf9KZG
-        //awkyTn+j1TcxYr47Likq026fX2I5+VkVlPZqVq5sgNgW8b4RtyJ9fbOE3WJbsrm8JCv+QsH/9E
-        e9skr5XffwEAAP//Iq0cxhh+hxgGNxRoU0ZicVg+eCASNuIPzAIQJ1fDmND6hWwHgCeE9WHm6ijl
-        JlYEpRaX5oAMRvIseAixqMSxBOJx0FQGaJgR5HW4OKpmIxTdUA1g19bW1gIAAAD//wMAzrg6vVMf
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18235","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18235","key":"NTEST-1870","fields":{"statuscategorychangedate":"2025-04-30T18:26:57.815+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1870/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:57.491+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:57.583+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/12]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]\n*Defect
+        Dojo link:* http://localhost:8080/finding/293 (293)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1870/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18235/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f8d93af1-0131-45fe-ab03-75e75a021c81
+      - c7a57874-b23a-4ca5-b93d-d0ee9bc6ec05
       Atl-Traceid:
-      - f8d93af1013145feab0375e75a021c81
+      - c7a57874b23a4ca5b93dd0ee9bc6ec05
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:46 GMT
+      - Wed, 30 Apr 2025 16:26:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1422,7 +1527,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=256,atl-edge-internal;dur=13,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="F3Kar6h3x3orWn1GwBt396WJysXpmjllN_x1_GU6ZtsT8KloC3nutQ==",cdn-downstream-fbl;dur=370,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=366,atl-edge;dur=283,atl-edge-internal;dur=20,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1431,10 +1536,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2bdfafaaaec33c116889588ecd9de280.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - F3Kar6h3x3orWn1GwBt396WJysXpmjllN_x1_GU6ZtsT8KloC3nutQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 29f48312175119cdbd47b407d3a92442
+      - 36710155ee546fdcde17e753646c3c01
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1467,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1481,9 +1594,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"849\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33930\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:56602\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -1519,7 +1632,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:46 GMT
+      - Wed, 30 Apr 2025 16:26:58 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1537,25 +1650,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       111, "url_ui": "http://localhost:8080/test/111", "url_api": "http://localhost:8080/api/v2/tests/111/"},
       "finding_count": 5, "findings": {"new": [{"id": 290, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/290", "url_api": "http://localhost:8080/api/v2/findings/290/"},
-      {"id": 291, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/291",
-      "url_api": "http://localhost:8080/api/v2/findings/291/"}, {"id": 292, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/292", "url_api": "http://localhost:8080/api/v2/findings/292/"},
-      {"id": 293, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/293", "url_api":
-      "http://localhost:8080/api/v2/findings/293/"}, {"id": 294, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/294", "url_api": "http://localhost:8080/api/v2/findings/294/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/290",
+      "url_api": "http://localhost:8080/api/v2/findings/290/"}, {"id": 291, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/291", "url_api": "http://localhost:8080/api/v2/findings/291/"},
+      {"id": 292, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/292",
+      "url_api": "http://localhost:8080/api/v2/findings/292/"}, {"id": 293, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/293", "url_api": "http://localhost:8080/api/v2/findings/293/"},
+      {"id": 294, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/294",
+      "url_api": "http://localhost:8080/api/v2/findings/294/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -1566,11 +1677,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2507'
+      - '2372'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -1582,11 +1693,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2507\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2372\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33932\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:56610\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -1601,63 +1712,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 111, \\\"url_ui\\\": \\\"http://localhost:8080/test/111\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/111/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 290, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/290\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/290/\\\"}, {\\\"id\\\": 291, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/291\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/291/\\\"}, {\\\"id\\\":
-        292, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/292\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/292/\\\"}, {\\\"id\\\":
-        293, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/293\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/293/\\\"}, {\\\"id\\\":
-        294, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/294\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/294/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        292, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/292\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/292/\\\"}, {\\\"id\\\": 293, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/293\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/293/\\\"}, {\\\"id\\\": 294, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/294\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/294/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 290,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/290/\",\n          \"url_ui\": \"http://localhost:8080/finding/290\"\n
         \       },\n        {\n          \"id\": 291,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/291/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/291/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/291\"\n        },\n
         \       {\n          \"id\": 292,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/292/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/292\"\n        },\n        {\n          \"id\":
-        293,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/293/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/293\"\n        },\n
-        \       {\n          \"id\": 294,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/294/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/294\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 111,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/111/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/292/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/292\"\n        },\n
+        \       {\n          \"id\": 293,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/293/\",\n          \"url_ui\": \"http://localhost:8080/finding/293\"\n
+        \       },\n        {\n          \"id\": 294,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/294/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/294\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        111,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/111/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/111\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/111/\",\n
@@ -1671,7 +1780,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:46 GMT
+      - Wed, 30 Apr 2025 16:26:58 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1696,26 +1805,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpLlq1b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUglPW57QwR5C6HzYjKpUaMKtXt3mQxGet9Im1kMZETqxndG7v/BF9jvGoU1+o81mm6FNmD/
-        1yUrZ7UZ0Cr8XXKHvW+cjTAFoBlkMC42l4/F+qH8mW6GtooVEc8JGsEIXqITO+P2bbyy3HfJtjJu
-        qGOoGhpTf0WIiAGW56fmlQwJZMBmY6BjWJaMCT4VPIoBLiDCMe/jH7Avm/acpVAyEDQXPM8o59+s
-        am+sdhHkdL5QEnCGWtFpjpJrzTUozZbT2aLSc45sroGdCYJJhtuml+mFqOVgwp1TMrUPxJwqgvZ1
-        W5Dj+WFPzqbJ9X1Jjp8AAAD//wMAl4QvjyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:26:59.291+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - ec11a179-4089-4980-8308-e71dc9d67bc0
+      - 3f9f02ab-d01e-44a0-ab71-bf10c8114a20
       Atl-Traceid:
-      - ec11a179408949808308e71dc9d67bc0
+      - 3f9f02abd01e44a0ab71bf10c8114a20
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:47 GMT
+      - Wed, 30 Apr 2025 16:26:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1725,7 +1830,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=180,atl-edge-internal;dur=23,atl-edge-upstream;dur=161,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=180,atl-edge;dur=148,atl-edge-internal;dur=14,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="WH7UpNR2eSGGPjl0IyJ5pJmsUuOeRKFB8dCzHZvVrlOl9wPfX5uJQQ==",cdn-downstream-fbl;dur=184
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1734,10 +1839,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a65725dd05dc27eea7ae75a2e122228e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - WH7UpNR2eSGGPjl0IyJ5pJmsUuOeRKFB8dCzHZvVrlOl9wPfX5uJQQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 1c0e64b6399ffc0018dd0c205ce0f2b7
+      - c0eb58bbc83ee452cb10f39a6d2c27d9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1761,66 +1874,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16112
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18231
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+thIvybbCmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxvnv3eUh
-        xQcztTuN/UASwB7Y/fbb1WcH1iWXiRM5GmQCGpLXAvLEDCQvwAxMnEHBB6oEza1Q0gwgEbYAywdx
-        xmUKuUoHS9AG9yCZQanBgLTt2bgyVhULUngd+H7guxr+qsDY+aaEc81jK2JwBo4g+8F+EIT4YSBf
-        4GdmbWkiz0tgAbFN1CflcptzYwSXrgTroSXr8VJ4oSeMqcDrFNzCBuXP5tOL+TDYDye4VLtgnOiz
-        Y9C3ysTcQqr0prlDgl8oEfrh3tAPhoE/D/0oOIjGgTseH/yIfvvkJBmx6Hit5oVOkryH+nxytLl2
-        +5GAibUoKXC4eshMwfN8wBJhrJCxZaWAGJhasJXSty5Jx0q+0/kzvaikoHTx/JovueXaWwpYebVb
-        OwfbrcAfBZOfjfgbfiow7VWBVgkWaHLOzS3lqrqx9BYteG5g4DSCJ3ivWnbgZAKBo+NscwpLQF/9
-        LwPHCkRWiShxIlnhHZ0HMBn53Uap1Se80QsD3krX4a4T2IWbPr4Cye5W76SwFhUYZ2ubkPpbfdao
-        hV1xTXg1oihzgQ4nD26O+ahRNp6sx5NnuvuNzHQ32eZl7B+gG+F4HY7/XytN9mssosFgfx3sfw+D
-        687iKFyPwu9hsQX4ly+P4Rj04TTs2xh1Gwuxft+QI8Li8gphkqYaUuSbR0WAF1B51ZT/01r3+jb2
-        +zYOejbC3o1J38arx342tNmsEinVHcKJhkHLlZQSLeLmSp8frVGhYLRNpqo8ORamzPmmLSdcXnGL
-        raeh7OeXftMQdi3Aa9RpKuz69UhVFPra1Q+0IGTqRFZXZBuV2veIGSrvNhoa8LLEH081Cf/VpGsS
-        D8O2pbKHG32gCregKrVQWtjNC0PQiXt1p/n3vUIUPAXjkYTplAhcyESauWaZ7tjyLa50tBo6jwsn
-        3JZBzm+AiJEq4OFM0AfeoA+jwYQiknEzLUV8KuTta9o5hpLmFxl3GKqRtar3titSySmOL/wmhxlw
-        0+BSt2/O+em7Nydn16cnR9Ozi+n1dDb7Y4b3wzo1GBI8MM+AnWMHkJaRXSYMUzLfMGQTkZNSZhX7
-        VWjOzjUUSCesMog59ylWCbCgHP9O+H5ZLSKn6YqYPQz/rqrusQUmIhWS5w8PtdNXG94a+Tl61xEO
-        ZjaVsD1dlVS2fUgOXgUdkptB6YXga4S3nff+bPM8PO7w9guPb3Hc7CDXKW9sHbUT3X9yuBsLm5pB
-        I2E3KEhYUXWrXOmzxpubvIJhqpGzdkORYseqSbYqShyIpX0a9Ht9tLC3pYVvZfx+OD/Kr/8PWapV
-        VdKg+FrIBGnNMKwVdgMgWVmZDJIapSezQ3reABNySQYIZgnDnwIMmxYkESnLQpe9IXUf5Q/184eI
-        XW7VChkxifGyglulI9/dc0d3FHSMea5inmfK2GjiT3xv0chc174RLK5Qml1eQFwRR7G3ajW0qkcY
-        m3ZSYdMOr5jHLgNj2Z8V1xY0m8oUK7PAOPeIwvaAF9TSZ+e/s8MKOYBdxFz2SNEI6AVBcNWE9O6O
-        XeD0WjuK70fvp/XjQ/PoMk0fba+n17mwyAckWiML31ARI8pkd+wSdQxD5AAsvlEY1G4QUuUycSUO
-        /G6qlt6yyiVi1yK3ePfPX5GKke9v5eIVuIWwGlylUw8LnBPoBU6zRAweHnUzW+Qkt0sYftQpI2Uh
-        /s0grXKOQV3Tj7j6HscgBc8JS/8AAAD//+xZbW/aMBD+K9akVoBIGiC8VlWHyipVGtW0avvQfcE4
-        DmQCEuWFatJ+/J5znPBSAh1VUSdNrYDYPvt8vnvO9+RBhkvUasxgpft8hio7n8WXV5imZVrlAmPq
-        o7+od5XefeT+paySqdQFmu2ySwv7bDa6L7aLHq/sYr/cLvZBu7y5TawimyDiMqfrVZR9qI1VBolk
-        A4QqGm/l2GTdKiMgZ5sokP1Na2YOA+q5YZ7ssLGDgUJegOJPn1FOgtIH5VgJH+Vd29+3eVZBPKL5
-        B76Mo0IDK8Kb1BSvC87NE6g8+EkIW956Mwn0lKm9zyfxJRdCBrH6uXK+NcHBCuUrQONcDR/wr3HT
-        9PwL7iy9CJlCUrptIwG4ZHM4UXYvoBMdrVYYMdxgGOmPylzfWULtDVo78gYn94ZIewOPYyTgqMqe
-        pp6YMlzjJxNgcAL4YwHHWosJ4ww1jYAgbkUi5C7pMeqrjRqf+WKSAI1HbCq5A8klRwo1092y7yuF
-        hoD7mVzPLZv9WUXVW/dIDPmi7vhO1o/uSdZd25wBI6cQRyN8XAV77/DBEOL36IP8C4+0rQizBMl4
-        5gl9aENPZVJ9Zt/UZYssrA8jVYYBZGboCPXmIXc3D7iISebeZ556YMh7S8+RzoY7fUVI4QaKpf/G
-        KbRo4FPaJB8vcWfuLcqsVP49hw/Hfi/3252Y8eZ4YR2JFxbhhfU6vDgqZTzDi2OT1vrxnhovWv/x
-        4gR4Yf9beNHKRQ/gxXO+o5mX/NvlblHFU7OLOnK6i0qhOIQvKY6GOKOtoXZOTm11WEWUmVXEOlg5
-        65CZp2hgEVNm5cqoAJhS8bGD+9uu6aJkPudUvn7YW1+RyYmL8sMjC11iJK7hscR/3TlXTafRaXfG
-        tbYlG6JriW6z7nZrbgvr5IOwwp5hkvyh7zgUDRgpfOfXxzVFUAnTXHvZcWVqaaKYVsNIJmNobWnV
-        Otyp2XarLTpt4OVYjNsWlne5dDvi2rlSs5w1+mf1W/yncsacL3ThZxhpU2QmkfEEQxh1kypKM41D
-        spQRcB6RoSCvkJ7PIvy8GRqWGSyIcNhm2t+/xttU/fvXeJvqf+8aA4eclLXWjNANXJ8NuesmQngq
-        gKisS1nlFMUe/QUN/JSEfiAvHoEvghhUHWn0qgm9eejSCvoF224ayS4CVbuIXbaLXlnYOXCHGvU3
-        8eUPAAAA//8aLV9omJIGsHwBAAAA//8i28Wj5QutXUyX8gW9GIC3xuCNFaCr0yF5rxo0Jw5lGwAt
-        zC9JhM7oo5uCs9mFs1zC2R4zwl7y4ZocMsDVAAUVCFglDHA1QI1x6TCGt/BS88oyi/LzIE08iFBK
-        KXQ5CYRLVOjl50JMqIYxocU9GcUv0koYfZi5Okq5iRVBqcWlOSCDkewGz50UlTiWQNxRll9CvQlX
-        iGFwQ4F2ZSQWh+WDp57gc7z5ReAJHZCVcIegutYIxblQDeDgqa2tBQAAAP//AwCcGEz7vSQAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18231","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18231","key":"NTEST-1868","fields":{"statuscategorychangedate":"2025-04-30T18:26:52.169+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1868/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:51.853+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:51.942+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/10]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/291]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/291]\n*Defect Dojo link:* http://localhost:8080/finding/291
+        (291)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]\n*Defect
+        Dojo link:* http://localhost:8080/finding/290 (290)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1868/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18231/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - eae48a3b-fdca-4750-9ab1-cf055db625a7
+      - fdee71ce-8dca-4a50-8316-fc11e5307af0
       Atl-Traceid:
-      - eae48a3bfdca47509ab1cf055db625a7
+      - fdee71ce8dca4a508316fc11e5307af0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:47 GMT
+      - Wed, 30 Apr 2025 16:26:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1830,7 +1944,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=22,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=302,atl-edge;dur=270,atl-edge-internal;dur=16,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0oqdZQiynyZ9V13A12_LmFdJwwu8mh0ukhlZ8WY12X_7FlJ0I3_gJQ==",cdn-downstream-fbl;dur=305
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1839,10 +1953,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 535c2b5354e6ba6798fd64420ee97a2c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0oqdZQiynyZ9V13A12_LmFdJwwu8mh0ukhlZ8WY12X_7FlJ0I3_gJQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d816ee23097fbfbab4271a5218c7f95e
+      - 384fede8a9cb56b14f707b55eea655c8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1869,41 +1991,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 37f9626f-0afe-41c0-ba89-2f922c732d53
+      - 94294542-d510-4900-9601-5121ac38aa2e
       Atl-Traceid:
-      - 37f9626f0afe41c0ba892f922c732d53
+      - 94294542d510490096015121ac38aa2e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:47 GMT
+      - Wed, 30 Apr 2025 16:27:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1913,7 +2022,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=317,atl-edge-internal;dur=15,atl-edge-upstream;dur=302,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=420,atl-edge;dur=293,atl-edge-internal;dur=17,atl-edge-upstream;dur=276,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="lhb8ajaPGdlDZRhJ81VY945Ui35q41pQX_OohaTOIyn9p5ugGKKwew==",cdn-downstream-fbl;dur=424
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1922,13 +2031,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - lhb8ajaPGdlDZRhJ81VY945Ui35q41pQX_OohaTOIyn9p5ugGKKwew==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - bd63c2ed0dbdcf4c91bc4a935810ac9b
+      - 92272351b9d413f138b3fe32200379d9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1940,7 +2057,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/100]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/10]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -1949,28 +2066,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/291]\n*Defect Dojo link:* http://localhost:8080/finding/291
-      (291)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (291)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]\n*Defect
       Dojo link:* http://localhost:8080/finding/290 (290)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -1984,27 +2101,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3343'
+      - '3318'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16112
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18231
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 4e06ffed-12e5-40d5-b2d9-42fd382cf30b
+      - d108beba-fb1e-433b-b83a-0c5344c27dc2
       Atl-Traceid:
-      - 4e06ffed12e540d5b2d942fd382cf30b
+      - d108bebafb1e433bb83a0c5344c27dc2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:48 GMT
+      - Wed, 30 Apr 2025 16:27:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2014,17 +2133,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=267,atl-edge-internal;dur=13,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=334,atl-edge;dur=300,atl-edge-internal;dur=16,atl-edge-upstream;dur=285,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="NZe4VPwDN-XJfJRtTz1ZwoOPF4BWhqW4P8EDaxBPEot8GbO0bU3xHw==",cdn-downstream-fbl;dur=340
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - NZe4VPwDN-XJfJRtTz1ZwoOPF4BWhqW4P8EDaxBPEot8GbO0bU3xHw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 305c094c86bbe7f03886ea6512bccaa3
+      - f0e6fd2eee9c4bda4c683cdc7ba9e626
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2048,66 +2175,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16112
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18231
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWVPjRhD+K1N63Ni6bMCrqlSKgHeXhBBiDPvAUtQgtaVZpBllZuQjsP893Trs
-        5fAmkMrCg+bqY7q//qZ958Cy5DJxIkeDTEBD8k5Anpie5AWYnokzKHhPlaC5FUqaHiTCFmB5L864
-        TCFXaW8O2uAeJBMoNRiQtj0bV8aqYkYKrwPfD3xXw58VGDtdlXCqeWxFDE7PEWQ/2A2CECcG8hlO
-        M2tLE3leAjOIbaI+K5fbnBsjuHQlWA8tWY+Xwgs9YUwFXqfgFlYofzIdn037wW44wqXaBeNEd45B
-        3yoTcwup0qvmDgnOUCL0w52+H/QDfxr6UbAXDQN3ONz7Af32yUkyYtHxWs0rnSR5D/X55Ghz7XaS
-        gIm1KClwuLrPTMHzvMcSYayQsWWlgBiYmrGF0rcuScdKnuv8hV5UUlC6eH7N59xy7c0FLLzarY2D
-        7VbgD4LRT0b8BT8WmPaqQKsECzQ55eaWclXdWBpFM54b6DmN4BHeq5btOZlA4Og4Wx3DHNBX/0vP
-        sQKRVSJKnEhWeEfnEUwG/raNoNsotfqMV31lJlrpOg91Zrs80OQr9Gyuey6FtajAOGvbBOFf67NG
-        zeyCawKyEUWZC3Q4eRQSTFQNv+FoORy90N1vpKy7yTphQ38P3QiHy3D4/1ppYFGDFA0Gu8tg93sY
-        XHYWB+FyEH4Piy3yv3x5Csewg+NMLC8aDsQkX149PTnoTvI01ZAi3/xjEex0G3gBlVcNLzx/dHfb
-        xt6WjXDrxmjbxtun7jS02awSKdUvhBP1g5YrKfJaxI3nd0/WqB4wqCZTVZ4cClPmfNVWDS5jCu0F
-        pocqqTXBLT5GDYm/vOabJ2LzKHiNOk0VXQ8PVEXJqJ3/SAtCpk5kdUXexBrwskQTzz0S/ttR90g8
-        Dts2KgvXVPZ4Yw2qUgulhV298sKduFe/NP/+rRAFT8F4JGE6JQIXMpFmrpmnG1L8gCsde4bO0/oI
-        16jP+Q0Q/z1TGkQbzwYi2IbRYEQRybgZlyI+FvL2He0cQkn9i4w7DNXIWtR76xWp5BjbF36TwwS4
-        aXCp25Fzenz+/ujk+vjoYHxyNr4eTya/T/B+WKcGQ4IHphmwUyR6aRnZZcIwJfMVQ9IQOSllVrFf
-        hObsVEOBrMEqgwhznyOPAAvK8e+F75fVLHKaVxGzh+HfVNUDtsBEpELy/PGhtvtqw1vjPEfv2jll
-        NpWwPl2VVLbbkBy8DTokN43SK8HXCK8f2Ie9zcvwuMHbzzy+xXazg1ynvLF10HZ0/8nhri1sagaN
-        hF0/IGFB1a1ypU8ab27yCvqpRs7aNEWKHaom2aoosSGW9nnQ72yjhZ01LXwr4w/D+Ul+/b/PUq2q
-        khrFd0ImSGKGYa2wGwDJyspkkNQoPZrs0/cGmJBzMkAwSxj+FGD4mkESkbIsdNl7UvdJvqm/byJ2
-        uVYrZMQkxssKbpWOfHfHHdxT0DHmuYp5niljo5E/8r1ZI3Nd+0awuEJpdnkGcUUcxT6oRd+qLcL4
-        NicVvs3hFfPYZWAs+6Pi2oJmY5liZRYY5y2isD7gBbX0yelvbL9CDmBnMZdbpKjT84IguGpCen/P
-        zrB7rR3F8cHFuP58bD5dpmnSNgE0nAqLfECiNbJwhIoYUSa7Z5eoox8iB2DxDcKgdoOQKueJK7Hh
-        d1M19+ZVLhG7FrnFe3j+ilQMfH8tFy/ALYTV4CqdeljgnEAvsGklYvDwqJvZIie5TcJwUqeMlIX4
-        N4G0yjkGdUk/4up7HIIUPCcs/Q0AAP//7Fltb9owEP4r1qRWgEgaILxWVYfaVao0qmnV9qH7gnEc
-        yAQkygvVpP34Pec4AVICHVWrTppAQGyffT7fPed7uJfhCrUaM1jlLp+hzk7n8fkFpumYVrXEmPro
-        z5p9pfcQuX8l62QqdU9mu+zSwT7brf6z7aLHK7vYz7eLfdAur24Tq8wmiLjM6QY1ZR9qY7XrRLJr
-        hCoab+TEZP06IyBn2yiQvWYNM4cB9dwy3+ywsYNrhbwAxZ8+o5wEpQ/KsQo+qru2v2/zrIZ4RPMP
-        fBlHhQZWhDepKV4WnNsnULv3kxC2vPHmEugpU3ufTuNzLoQMYvVz7XwbgtdrlK8BjXM1fMC/xk3T
-        88+4s/IiZApJ6baLBOCSzeFE2b2ATnS8XmHMcINhpD8qc31nCbU3aO3IG5zcGyLtDTyOkYCjOnuc
-        eWLGcI2fToHBCeCPBRxrLaeMM9Q0AoK4FYmQu6THeKg2anzmy2kCNB6zmeQOJFccKdRMd8u+rxUa
-        Ae7ncjO3bPdnpdZg0yMx5Iu60TtZP7qnWXdjewaMnEEcjfBxFeyDwwdDiD+gD/IvPNK2IswSJJO5
-        J/ShjTyVSfWZfVOXLbKwPoxUGQaQmaMj1JuH3O0i4CImmTufeeqBIe+tPEc6W+70FSGFGyiW/hun
-        0KKBT2mTfLzCnYW3rLJK9fcCPhz7g9xvd2LGq+OFdSReWIQX1svw4qiU8QQvjk1am8f71njR+Y8X
-        b4AX9r+FF51c9ABePOU72nnJXyx3yyqehr1Z8cQhXEYRL0QNFYfmlFihw87JqUKHVSZh5axDZoWy
-        gWUshFXGlFm5MioAZlR86FJ8s5ov1nRRslhwKl8/7K2vyOTERfnhkYUuMRKX8Fhiu26di7bT6nV7
-        k0bXki3Rt0S/3XT7DbeDdfJBWGHPMEn+MHQcigaMFL7z6+OGIqiEaa69JLg6A2mimFbDSCYjYm1p
-        NXrcadh2pyt6XeDlREy6FpZ3uXR74tK5ULOctIYnzRu8UzljwZe68DOMtCkyk8h4hCGMpkkVpZnG
-        IVnKCDiPyFCQV0jP5xF+Xo0MywyWRDgUCfX3r3GRkX//GhcZ/feuMQDKSVlrzQhdwfXZiLtuIoSn
-        AojKupRDTuHtwV/SwE9J6Afy7AHAI4hB1ZFG/yihNw9dWkH/wbabRrLLQNUuY5ftnF0ONbg/E0b+
-        AAAA//8aLUYoTzCDsRgBAAAA//8i5OLRYoTWLqZLMYJeDOBqppnAW2PwxgrQO+mQTFkNmvqGsg2A
-        LskvSYTO6KObgrPZhbNcwjULZGCEveTD2SzD6TOc7TW4l9EkjHHpMIa38FLzyjKL8vMgTTyIUEop
-        dDkJhEtM6JXll1BvWhNiGNxQoE0ZicVh+eApH9jcKjALQJxcDWNC6xeyHQBeeqMPM1dHKTexIii1
-        uDQHZDCSZ8GTNUUljiUQj4MmjUETOiCvw8VRNRuh6IZqALu2trYWAAAA//8DAH2TMfK9JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18231","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18231","key":"NTEST-1868","fields":{"statuscategorychangedate":"2025-04-30T18:26:52.169+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1868/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:51.853+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:51.942+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/10]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/291]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/291]\n*Defect Dojo link:* http://localhost:8080/finding/291
+        (291)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/290]\n*Defect
+        Dojo link:* http://localhost:8080/finding/290 (290)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1868/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18231/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d38cd713-f78f-4485-a996-bda1a5b2a0cf
+      - 4f75e7be-8278-4d1a-9496-e69ba7b5a9b8
       Atl-Traceid:
-      - d38cd713f78f4485a996bda1a5b2a0cf
+      - 4f75e7be82784d1a9496e69ba7b5a9b8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:48 GMT
+      - Wed, 30 Apr 2025 16:27:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2117,7 +2245,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=285,atl-edge-internal;dur=13,atl-edge-upstream;dur=272,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=294,atl-edge;dur=261,atl-edge-internal;dur=16,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="l5SmI3Ctnx4pUWTZ3kOvYLwMNcaz34bo2se6QkB1biW6MpRNd0navw==",cdn-downstream-fbl;dur=299
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2126,10 +2254,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 60b2b330807c6611e06e3923c8e315cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - l5SmI3Ctnx4pUWTZ3kOvYLwMNcaz34bo2se6QkB1biW6MpRNd0navw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 5f3c0dc8aeba5d0414994387ef32dfd7
+      - d2d7090c0bc1b0042927d8d9bf2a7859
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2156,26 +2292,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrmq1b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCXAGkKWQQlJuLh/L9UP1M92MXR0qwp8jNIEJvAQn9truu3Blte+jbaXt
-        2IRQPba6+YoQHgK0KE7NK+EjSIHOEsgSWFaUcpZzFsQAFxDgkHfhDzhUbXfOZlBR4FnB2SJd5uyb
-        ld2NUTaALJsvpACcoZJZXqBgSjEFUtFlPlvUas6QzhXQM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAeWRw0CACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:01.728+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 90e94878-76f9-4dbb-a00e-8be939b4b4c4
+      - 0831a300-9dcf-4459-bf1e-025a4f587929
       Atl-Traceid:
-      - 90e9487876f94dbba00e8be939b4b4c4
+      - 0831a3009dcf4459bf1e025a4f587929
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:48 GMT
+      - Wed, 30 Apr 2025 16:27:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2185,7 +2317,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=171,atl-edge-internal;dur=22,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="OrrvYD6X_9M3_CQ13b-gN8_NY_rBbTZExtcrrXDypjRdAEgFaoPlFA==",cdn-downstream-fbl;dur=188,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=185,atl-edge;dur=164,atl-edge-internal;dur=14,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2194,10 +2326,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 48f2e5da4dd7651bfa3bfd0054610cf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - OrrvYD6X_9M3_CQ13b-gN8_NY_rBbTZExtcrrXDypjRdAEgFaoPlFA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 41668f2de253a6dd484016ff7768dc2f
+      - 9af5ef74b8a8cbfa9fc1d5518ec3fe06
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2221,78 +2361,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16113
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18233
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61PcNhD/VzT+kOmkd7blO+BwJtOh5JLQUkqPg3wgDCPsPVvBllxJvkeB/70r
-        vy48Li10GpjBeu1Du7/9ablxYFkwETuho0DEoCB+zyGLdU+wHHRPRynkrCcLUMxwKXQPYm5yMKwX
-        pUwkkMmkNwelcQ/iCRQKNAjTnI1KbWQ+swovqe9T31XwZwnaTFcFHCsWGR6B03O4tU+3KR3gREM2
-        w2lqTKFDz4thBpGJ5RfpMpMxrTkTrgDjoSXjsYJ7gce1LsFrFVzDCuWPpuOTaZ9uB7u4VLmgnfDG
-        0ehbqSNmIJFqVd8hxhlKBH6w1fdpn/rTwA/pTjgcuNs79Ef027dOWiMGHa/UvNBJK++hPj/ort1M
-        YtCR4oUNHK7uEZ2zLOuRmGvDRWRIwSECImdkIdW1a6UjKU5V9kwvSsFtulh2yebMMOXNOSy8yq21
-        g80W9Qd09JPmf8HbHNNe5mjVwgJNTpm+trkqr4wdhTOWaeg5teAB3quS7TkpR+CoKF0dwhzQV/+u
-        5xiOyCoQJU4oSryj8wAmA3/TBm03CiW/4FVfmIlGuspDldk2D3byFXrW1z0V3BhUoJ3OtoXwr9VZ
-        LWdmwZQFsuZ5kXF0OH4QEkxUBb/haDkcPdPdb6SsvUmXsKG/g24Ew2Uw/H+t1LCoQIoG6faSbn8P
-        g8vW4iBYDoLvYbFB/t3dYzgGLRxnfHlWcyAm+fzi8clBe5IliYIE+eYfi2Cr3cALyKyseeHpo9ub
-        NnY2bAQbN0abNnYfu1PTZr1qSal6IZywT3HKDD4cNeE+vz5rOl8TuFerU7b6quG+LG3gqCXlT3aB
-        i8QJjSrhruFpq03xqI7azaM16xke1akss/gd10XGVk3F4jK6Zc4QGraKm2gowMtamnjqkQh2R+0j
-        8TBsm6gs6Kjs4UYHqkJxqbhZvTCIrbhXvTT//q3gOUtAe1ZCt0o4LqQ8SV09T9ak+BFXWvYMnMf1
-        EXSoz9gVWP57ojQsbTwZCLoJo3RkI5IyPS54dMjF9Xu78w4K27+IqM1jld1FtdetCCnG2L6wqwwm
-        wHSNDdWMnOPD0w8HR5eHB/vjo5Px5Xgy+X2C98M61RgSPDBNgRwj0QtDrF3CNZEiWxEkDZ5ZpcRI
-        8gtXjBwryJE1SKkRte5T5EGxoBz/lvt+UYrQqV9FzB6Gf11V99gCE5FwwbKHh5ruqwlvhfQMvWvm
-        NrOJgO50Wdiy3YTkwa7fIrlulF4Ivlq4e2Dv9zbPw+Mabz+z6BrbzRZyrfLa1n7T0f0nh9u2sK4Z
-        NBK0/YCAha1umUl1VHtzlZXQTxTyxropkuSdrJMt8wIbYmGeBv1WRwvfSuxDoY4y7ofzs/j6d48k
-        SpaFbRTfcxEjMWqCtUKuAAQpSp1CXKH0YLJnv1dAuJhbyxZmMcF/BQi+ZhCHVlkauOSDVfdZvK6+
-        r0Ny3qnlIiRFEm651PVvbbAx1pmMWJZKbcKRP/K9WX32svIJ4UAvUIqcn0BUWm4iH+Wib+QGYXyT
-        4xLf5OCCeOScakP+KJkyoMhYJFiROcZ3gyh0BzxaSR8d/0b2Sqx9chIxsUHKdngepfSiDuXtLTnB
-        rrVyFMf7Z+Pq86n+tBm2k+bxt8MpN8gDVrRCFI5QEbFUSW7JOeroB1j7+Kz5o6BywyJUzGNXYKPv
-        JnLuzctMIGYNcop3//yFVbE77MSiBbg5NwpcqRIP65pZrHPsVS0feLtDNzV5ZqWKBP9UibIqAvyZ
-        QC4N4DViIOMl5sPKkD754TjpkVeZeUMCl1I3IORVYt68/RsAAP//7FhRT9tIEP4rIyFVjhs2xSRE
-        zYkHBK1Uqa2qo3cvl5NinKVx69jBawNVr/+93+yu12vigEqvbwAKzszO7uw3szPfmg7FCxhrBW5F
-        YkyNYtwqxmIipo180sonAnM18qNWzo+TVs7eWfmBOGrlUSuP/PGHrRyVq5WPW/m43cC0XZcfPblb
-        lx+jwY7ksKk8il6OGdET8IhrOeTQa75PfXGe/mSc7fj/K85PMX50jHUM+mKMStgUhVmo480yCs9q
-        SWcooRC+lheCXg6JGyx1q3PzuzoQrjzr74fi6Vj+YsjGKNvhme71aMOfC2IWhHA8aEcBPgZ9gb0v
-        rBSiE0D8D/7tP+KwYj2cej3BrzWFbmaF50VdJhLZlcmQ+/M+2ug6VZJh3XzyBp61LCJEt3fLIvWU
-        7c8iLUbx8jpVoCi4AkyiCATjkhHGYWh4J1ONxebTgsDp4F9OMZUmixPOYumymPcgy/gizbijVqu4
-        oiLBQopuViAnFdi1NWTULmIlqSjpChe3r4SrcsJnUGH2pIwv2QGwsXqdE5Mvoc8Z+HkpCQSdqpui
-        MUlIJTKPcZFhxoKl0mRF4AEg71n6RYK+X2KVGG5vNlma6DeXlhk1DmcS+ODEMv/3R5mtwac6V/El
-        CgXT/X1V8xD4p64yu5xFRtE6hnFagBd4zisxz6Pt2WGUA2nFzsA93HhLEELM69BhsuZ8iC1Spazq
-        Mkdq40nVWcXoej5gXK8TggHc28PNpUA88Xda5IncVPN8sVjMc74NVvSNTrEzcJ7vdEz8KjctZfBs
-        7zaaIrXM/0EzNjEjjwnU2ZoFrNRPwm6OJY0Bw3VMi/NXb1+dfqQDOjmnZ1d1Uf0xx4+ZfBQaCQ5h
-        nzoczXEun/NWVZFJgctCgOxPcIETMr8e/MvegEHDJB+NjPVCO2Cc0gAG8GNIgSzLISM4oGM+OfQN
-        M9s9Ya4lO/59YMGhv12i0DtwVuQL8VHz5c37oVmnioMn7qjj0Oyq5M5oq5Y7zVY19zR36rmnuVPR
-        Pc2dmu5p7lR1p9mq656mW9mB0wf9fmfZgDSzIy1IFhXM58HFGFlMeCEfLsbIgmJVDVyMkQPF0zQd
-        r0Glo2KQHCodDYPkUOloGCSHSkfDIDlUPI0ByaHS0RiQvGQCXitkEqfkvqF7s+1CzzeVGX+gO+Hb
-        ScLnAIlZX+D42x7wLtUXP9sCQneRicStuJ3RX/plARcgW+ybkKBiZtCUwjc63GVkotVrM95lY8LY
-        azPZZWMC3GtztMvGRMTZUEDvuQPp7uQ6nE6CoYn4UJddE2JuNXGmCtqYBBbENMItOt21qA7p/Yva
-        hECX2lrAxu7NehMnFcftfUGp/kJIget0KZdtm8fAP8GJSolqrn6mz1vTTcE3bqYpQbxcp/mAgsF/
-        a9CQqpg56tFLZ5+orHeA/YL3MJVlUvcYKhsxlY1+B5X9AQAA//8irSlLbr8XOdnSuilrONqUBaoC
-        AAAA///smk1qwzAQha9SClnKlWM5thchDaWFLnKB7JSR3Zbi2PiHktt3xnJErEYpFApeCLIw0Sgj
-        Buvxwvu8lfVW1lvZq6o+sWYTXZ9Ys0tl91b2PC9vZb2VnYeVDc3WX6zsz/Q+NgG2Hd66Yv1QXAZ7
-        XSPhc0ATCDawSw3gYS1w14IwDIa9w2To5ym4Cl2ZOndxH9z0nGTRdlQpu07CO+VtOu9s+7KUFMbe
-        X00LadREVFTNH+NacicbCUAcyKtaxypKk/QQJjyPIOOQxcsiC4sV9jFF2OFGWU7vwVYp7NFiJdq9
-        0+PFQaAi9u02yjXMPg/eGl1Ge844kch5mEoVCrFKIE3iKDvAIeHYvpB5kcJGrYdfWUTbxfIFP3of
-        K+VxjDEZ01+1Qd+yLxwEWwaUjwZaA2lSrJaypUHh/sGj423Dx6cd40F9pNjcxsLmf2KbK5v/iW0u
-        be4nRmFSmn8auQb8v36628mi6AE+hgtEIZimq7Ss7asjFT73TVXnD3sUHCAOaLxpxEXiqrm61GHE
-        RK/DEMIlpsLFSAnDSDWjqHsZ+acX5hsAAP//wkwwo8UIPVw8WoxgKUbQiwFczTMTeCsM3mgBeicd
-        kimrQQu4oWwDoEvySxKh69LRTcHVDjPAVS4ZGGEv4HAtcTTA6QGc7TS4z9B14GrAGeOUgLfsUvPK
-        Movy8yCtN4hQSil0UwSES0zolQGb/eQuF8RY8AsxDG4o0KaMxOKwfPDCRdgqXWAWgDi5GsaE1i9k
-        OwC8gUQfZq6OUm5iRRBk4AnFs+Alh0UljiUQj4OWPoOWJYK8DhdH1WyEohuqAeza2tpaAAAAAP//
-        AwB0uze4gzMAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18233","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18233","key":"NTEST-1869","fields":{"statuscategorychangedate":"2025-04-30T18:26:55.036+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1869/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:54.718+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:54.818+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/11]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294]\n*Defect
+        Dojo link:* http://localhost:8080/finding/294 (294)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292]\n*Defect Dojo link:*
+        http://localhost:8080/finding/292 (292)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1869/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18233/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3200d36d-1a69-4c9e-835c-c4a6adf8e6ac
+      - 8457dd67-3cef-4484-9a15-4628f892a5f6
       Atl-Traceid:
-      - 3200d36d1a694c9e835cc4a6adf8e6ac
+      - 8457dd673cef44849a154628f892a5f6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:49 GMT
+      - Wed, 30 Apr 2025 16:27:02 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2302,7 +2477,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=287,atl-edge-internal;dur=13,atl-edge-upstream;dur=274,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=32,cdn-upstream-fbl;dur=528,atl-edge;dur=398,atl-edge-internal;dur=18,atl-edge-upstream;dur=381,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="rO7XI72LIuV8CZqiC6HiLPO48cnK1JPcMocVAQBQDZNlEKE3sCxD_Q==",cdn-downstream-fbl;dur=532
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2311,10 +2486,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 d45e064f8c3e1035d136019303749e0e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - rO7XI72LIuV8CZqiC6HiLPO48cnK1JPcMocVAQBQDZNlEKE3sCxD_Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d72746a19e19d426aa974b96d759c832
+      - 39123c580c643d1b2f053685af26154f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2341,41 +2524,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 1380b892-d98a-42c2-8bd2-db4effff8a9c
+      - b1a07c3b-b8cb-4a22-a77e-e5d68bbde541
       Atl-Traceid:
-      - 1380b892d98a42c28bd2db4effff8a9c
+      - b1a07c3bb8cb4a22a77ee5d68bbde541
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:49 GMT
+      - Wed, 30 Apr 2025 16:27:02 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2385,7 +2555,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=286,atl-edge-internal;dur=13,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=292,atl-edge;dur=259,atl-edge-internal;dur=15,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="oJm3zALDk0oBbsJVQFV4WLOGfRDzt1OU54yC8g2AGBNTvHx9BzdxlQ==",cdn-downstream-fbl;dur=297
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2394,13 +2564,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - oJm3zALDk0oBbsJVQFV4WLOGfRDzt1OU54yC8g2AGBNTvHx9BzdxlQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3a3b267b271b6903f88119ea45c12318
+      - 3010d698ed8c99de508fba4a00d3e819
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2412,7 +2590,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/101] in [Security
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/11] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
@@ -2427,13 +2605,13 @@ interactions:
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294]\n*Defect
       Dojo link:* http://localhost:8080/finding/294 (294)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -2442,31 +2620,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/292]\n*Defect Dojo link:* http://localhost:8080/finding/292
-      (292)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (292)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -2475,25 +2651,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -2505,27 +2679,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7125'
+      - '6788'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16113
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18233
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 70fe36c8-ca09-4212-8724-8ce43d6c4fab
+      - e259a943-3bac-41db-be78-c6fe37662862
       Atl-Traceid:
-      - 70fe36c8ca09421287248ce43d6c4fab
+      - e259a9433bac41dbbe78c6fe37662862
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:50 GMT
+      - Wed, 30 Apr 2025 16:27:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2535,17 +2711,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=301,atl-edge-internal;dur=14,atl-edge-upstream;dur=288,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="-Q5c0h6c93vb2Hv6735ol-5dmawXvNqg4DIF54AHYX84By1233oxLQ==",cdn-downstream-fbl;dur=427,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=98,cdn-upstream-fbl;dur=422,atl-edge;dur=290,atl-edge-internal;dur=17,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5538280951642fc71308aa997730220e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -Q5c0h6c93vb2Hv6735ol-5dmawXvNqg4DIF54AHYX84By1233oxLQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 94f16b461c7f697a256ac89710197e92
+      - 8bb33cc9b291db78712dda6ed2ac6fa8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2569,78 +2753,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16113
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18233
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+FENnS6LsJI6KYshSt82WZZnjth/SIGCks8xGIlWS8sua/vfd
-        SZbdvLhYMqwJEPHtXnj33MPLFw8WpVCpF3sGVAoG0tcS8tR2lCjAdmwyhUJ0dAlGOKmV7UAqXQFO
-        dJKpUBnkOuvMwFjcg3QEpQELyq3OJpV1upiQwksehjz0DXyuwLrxsoRTIxInE/A6niT7fJfzHk4s
-        5BOcTp0rbRwEKUwgcan+pH3hcmGtFMpX4AK05AJRyiAKpLUVBK2Ca1ii/Ml4eDbu8t1oH5dqF6wX
-        f/Es+lbZRDjItFk2d0hxhhJRGO10Q97l4TgKY74X93v+7h7/Gf0OyUky4tDxWs0TnST5APWF0fra
-        q0kKNjGypMDh6gGzhcjzDkuldVIljpUSEmB6wubaXPsknWj1zuSP9KJSktIl8ksxE06YYCZhHtRu
-        bRxcbfGwxwe/WPk3vCww7VWBVgkWaHIs7DXlqrpyNIonIrfQ8RrBI7xXLdvxphKBY5Lp8hhmgL6G
-        Xzuek4isElHixarCO3p3YNIL243S6E94oycGfCVdh7tOYBtumnwDks2t3inpHCqw3to2IfX3+qzV
-        EzcXhvBqZVHmEh1O79wc81GjrD9Y9AePdPc7mWlvss5LP9xDN6L+Iur/v1aa7NdYRIN8d8F3f4TB
-        RWuxFy160Y+wuAL416/34ci34TRqNyZy8b7hQMz++cX9k732pMgyAxnyzb0iwAvovGrK/2FzO9s2
-        drdt7G3ZiLZuDLZt7N/3s6HNZpVIqX4hvLjLcSocPhwN4T6+cBs63xB40KgzVJb18FBXFDhOpPyB
-        FqTKvNiZCjB9qNS9x4xTcTbO1fpIv5FJE+Av99bIVxS2U13l6Stpy1wsV8VNkDCAlyX+eOiRiPYH
-        7SNxN2xrKru7sQ1U0RpUpZHaSLd8YhBb8aB+af79WyELkYENSMK2SiQuTGU29e0s27DlW1xpaTXy
-        7hdOtEZ9Lq6AiPGB0iA+eTAQfBtG+YAiMhV2WMrkWKrr17TzCkrqX1TSZq3O5bzeW68orYbYvoir
-        HEYgbIMEsxp5p8fv3hydXB4fHQ5PzoaXw9HozxHeD+vUYkjwwHgK7BRfAOUY2WXSMq3yJUM2kTkp
-        ZU6z36QR7NRAgXTCKouo9R9iFY4F5YU3MgzLSsVe8ypi9jD8m6q6xRaYiEwqkd89tOq+VuGtcZ2j
-        d6s5ZTZTsD5dlVS225Dc2w9bJDeN0hPB1wivX97bvc3j8LjB268iucZ2s4Vcq7yxdbjq6P6Tw21b
-        2NQMGonaRkHBnKpb59qcNN5c5RV0M4MssWmKNHulm2TrosSGWLmHQb+zjRZ21rTwvYzfDudH9e3v
-        AcuMrkpqFF9LlSIxWoa1wq4AFCsrO4W0RunR6IC+V8CkmpEBglnK8F8Bhq8ZpDEpm0Y+e0PqPqrn
-        9fd5zM7XaqWKWZnFOz73wxsKNsY614nIp9q6eBAOwmDSnL2sfUI48AuUYudnkFTETeytnned3iKM
-        j3Va4WMdXbCAnXPr2F+VMA4MG6oMK7LA+G4RhfWBgNfSJ6d/sIMKa5+dJUJtkaLWL+CcXzShvLlh
-        Z9i11o7i+PD9sP58aD5thmmyevxpOJYOeYBEa0ThCBUxokp2w85RRzfC2sdnLRxEtRuEUDVLfYWN
-        vp/pWTCrcoWYdcgpwe3zF6Riv78WS+bgF9IZ8LXJAqxrQViX2MQSHwT7fX/qipykygz/1IkiFRH+
-        jKDQDvAaKbDhAvNBMqzLfjrNOuxZ7l6wyOfcjxh7lrkXL/8BAAD//+xYUU/bSBD+KyMhVY4bNsUk
-        RM2JBwStVKmtqqN3L5eTYpylcevYwWsDVa//vd/srtdr4oBKr28ACs7Mzu7sN7Mz35oOxQsYawVu
-        RWJMjWLcKsZiIqaNfNLKJwJzNfKjVs6Pk1bO3ln5gThq5VErj/zxh60clauVj1v5uN3AtF2XHz25
-        W5cfo8GO5LCpPIpejhnRE7CGaznk0OuLAPXFefqTcbbj/684P8X40THWMeiLMSphUxRmoY43yyg8
-        qyWdoYRC+FpeCHo5JG6w1K3Oze/qQLjyrL8fiqdj+YshG6Nsh2e616MNfy6IWRDC8aAdBfgY9AX2
-        vrBSiE4A8T/4t/+Iw4r1cOr1BL/WFLqZFZ4XdZlIZFcmQ+7P+2ij61RJhnXzyRt41rKIEN3eLYvU
-        U7Y/i7QYxcvrVIGJ4AowiSIQjEtGGIeh4Z1MNRabTwsCp4N/OcVUmixOOIuly2LegyzjizTjjlqt
-        4oqKBAspulmBnFRg19aQUbuIlaSipCtc074SrsoJn0GF2ZMyvmQHwMbqdU5MvoQ+Z+DnpSQQdKpu
-        isYkIZXIPMZFhhkLlkqTFYEHgLxn6RcJ+n6JVWK4vdlkaaLfXFpm1DicSeCDE8v83x9ltgaf6lzF
-        lygUTPf3Vc1D4J+6yuxyFhlF6xjGaQFe4DmvxDyPtmeHUQ6kFTsD93DjLUEWMa9Dh8ma8yG2SJWy
-        qsscqY0nVWcVo+v5gHG9TggGcG8PN5cC8cTfaZEnclPN88ViMc/5NljRNzrFzsB5vtMx8avctJTB
-        s73baIrUMv8HzdjEjDwmUGdrFrBSPwm7OZY0BgzXMS3OX719dfqRDujknJ5d1UX1xxw/ZvJRaCQ4
-        hH3qcDTHuXzOW1VFJgUuCwGyP8EFTsj8evAvewMGDZN8NDLWC+2AcUoDGMCPIQWyLIeM4ICO+eTQ
-        N8xs94S5luz494EFh/52iULvwFmRL8RHzZc374dmnSoOnrijjkOzq5I7o61a7jRb1dzT3KnnnuZO
-        Rfc0d2q6p7lT1Z1mq657mm5lB04f9PudZQPSzI60IFlUMJ8HF2NkMeGFfLgYIwuKVTVwMUYOFE/T
-        dLwGlY6KQXKodDQMkkOlo2GQHCodDYPkUPE0BiSHSkdjQPKSCXitkEmckvuG7s22Cz3fVGb8ge6E
-        bycJnwMkZn2B4297wLtUX/xsCwjdRSYSt+J2Rn/plwVcgGyxb0KCiplBUwrf6HCXkYlWr814l40J
-        Y6/NZJeNCXCvzdEuGxMRZ0MBvecOpLuT63A6CYYm4kNddk2IudXEmSpoYxJYENMIt+h016I6pPcv
-        ahMCXWprARu7N+tNnFQct/cFpfoLIQWu06Vctm0eA/8EJyolqrn6mT5vTTcF37iZpgTxcp3mAwoG
-        /61BQ6pi5qhHL519orLeAfYL3sNUlkndY6hsxFQ2+h1U9gcAAAD//yKtKUtuvxc52dK6KWs42pQF
-        qgIAAAD//+ya0WqDMBSGX2UMehkXNVa9KF0ZG+yiL9C79ES3MdSildG33znGhpo1HWw3XgR6Ic1J
-        TziYn7/8n7ey3sp6K3tV1SfWbKLrE2t2qezeyp7n5a2st7LzsLKh2fqLlf2Z3icmwLbDW1d+FwrX
-        goE3KNg7thI+B2aBmAOrVBjUwlrgLgCEuzJ0bjL083hchS7ug5vDTLJoO5GUx6OEd8rbdN7Z9VUl
-        KYy9v5oW0qiJqGjaP8a15E7WEoA4kFe1SlScpdk+THkRQ84hT6IyD8sl9jFF2OFGWUHvwUYp7NFh
-        Jdq90+PFQaAh9u024zWMuAjeWl1Ge86ckSh4mEkVCrFMIUuTON/DPuXYvpRFmcFarYZfWcSbRfSC
-        H72PVbIeY0zG9Fdd0HfsCwfBooDy0UBrIE2KHaTsaFC4f/DoeNvw8WnLeHCoKTa3ebH5n9gGzuZ/
-        YhtYm/uJUX+Upp1GrgH/r5/utrIse4CP4QJRCKbpKq1eu6amwue+bQ7Fww51BYgDGm8aAZO4aq4u
-        dRgx0eswhHCJqXAxUsIwUvaCEex2VHuvL/97k74BAAD//yIhJY2WL/Rw8Wj5gqV8QS8G4K0weKMF
-        6Op0SN6rBq3shrINgBbmlyRC16Wjm4KzuYWzXMLZDjPCXvLhWuJogKvhCSoQsEoY4Gp4GuPSYQxv
-        2aXmlWUW5edBWm8QoZRS6KYICJeo0MvPhZhQDWNCi3syil+k/Rz6MHN1lHITK4Ig40AodoNXABaV
-        OJZA3FEG7H6Qu2wRY+ExxDC4oUC7MhKLw/LBCyhha4NBS59ByxJBVsIdgupaIxTnQjWAg6e2thYA
-        AAD//wMAftJ2fYMzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18233","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18233","key":"NTEST-1869","fields":{"statuscategorychangedate":"2025-04-30T18:26:55.036+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1869/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:54.718+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:54.818+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/11]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/294]\n*Defect
+        Dojo link:* http://localhost:8080/finding/294 (294)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/292]\n*Defect Dojo link:*
+        http://localhost:8080/finding/292 (292)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1869/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18233/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 2a939e98-2d2b-430f-ae60-623913097d4c
+      - 249894a4-edd0-416e-96d6-4fdd71cf3289
       Atl-Traceid:
-      - 2a939e982d2b430fae60623913097d4c
+      - 249894a4edd0416e96d64fdd71cf3289
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:50 GMT
+      - Wed, 30 Apr 2025 16:27:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2650,7 +2869,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=259,atl-edge-internal;dur=14,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=302,atl-edge;dur=269,atl-edge-internal;dur=15,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="4yiioaqfnVo7dRJuNKRTLpL5ogBNvaYG-H8yE6hKYreTKoIur0jA0Q==",cdn-downstream-fbl;dur=305
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2659,10 +2878,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 4yiioaqfnVo7dRJuNKRTLpL5ogBNvaYG-H8yE6hKYreTKoIur0jA0Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 416b08e3bbab4be959dae06c36681a20
+      - bf00ffea46b639eb059ebce523c1a3b8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2689,26 +2916,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2T9WPLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPARYUZyaV8JHkAHLpkCnsKwY4+mcp0EMcAEBDnkX/oBD1XbnLIWKAacFzyDJi+U3
-        K7sbo2wAU5ovpADMUEk6L1CkSqUKpGLLebaoVZ4iyxWwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMA9pDPWCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:04.132+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - bce2883c-ec18-4791-af8b-427b35960b2c
+      - bc7df2f7-e28f-452f-af7c-62b352b034c8
       Atl-Traceid:
-      - bce2883cec184791af8b427b35960b2c
+      - bc7df2f7e28f452faf7c62b352b034c8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:50 GMT
+      - Wed, 30 Apr 2025 16:27:04 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2718,7 +2941,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=155,atl-edge-internal;dur=17,atl-edge-upstream;dur=139,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=232,atl-edge;dur=146,atl-edge-internal;dur=17,atl-edge-upstream;dur=129,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="3X4twFu-PIo5KhX5C1zqvtXaa1y34OPR_wQ3orcXR0m7lESyQQO5Yw==",cdn-downstream-fbl;dur=236
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2727,10 +2950,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 3699bc5ea5aacbe1d32ebe3e874f0c68.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 3X4twFu-PIo5KhX5C1zqvtXaa1y34OPR_wQ3orcXR0m7lESyQQO5Yw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 8a931d88566419be9102f49311298e0c
+      - 6d924dcc9c4e18df5555210422b8d179
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2754,65 +2985,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16114
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18235
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX23LbNhD9FQyfOqnEm2Vb4Uyn49py4tZ1XVlJHhyPByZXJGIKYAFQl8b59+6C
-        pBRflKndaUYPJAHsBbtnz64+e7CsuMy8xNMgM9CQHQsoM9OTfAamZ9ICZrynKtDcCiVNDzJhZ2B5
-        Ly24zKFUeW8O2uAeZGOoNBiQtj2b1saq2ZQUXkdhGIW+hr9qMHayquBc89SKFLyeJ8h+tBdFA/ww
-        UE7xs7C2MkkQZDCF1Gbqk/K5Lbkxgktfgg3Qkg14JYI4EMbUEHQKbmGF8meT0cWkH+3thLjkXDBe
-        8tkz6FttUm4hV3rV3CHDL5SIw3i3H0b9KJzEYRLtJ4Ndfzgc/oh+kw5nxKLjTs0LnST5APWF8fra
-        7UcGJtWiosDh6gEzM16WPZYJY4VMLasEpMDUlC2UvvVJOlXynS6f6UUtBaWLl9d8zi3XwVzAInBu
-        bRxst6JwJxr+bMTf8NMM017P0CrBAk1OuLmlXNU3lt6SKS8N9LxG8ATv5WR7XiEQODotVqcwB/Q1
-        /NLzrEBkVYgSL5E13tF7ABPMWLtRafUJb/TCgLfSLtwugV246eMrkGxu9U4Ka1GB8da2Cam/ubNG
-        Te2Ca8KrEbOqFOhw9uDmmA+HssFwORg+091vZKa7yTovg3Af3YgHy3jw/1ppsu+wiAajvWW09z0M
-        LjuLO/FyJ/4eFluAf/nyGI7RNpzG3cZULN83HIjZv7x6fHKnO8nzXEOOfPOoCPACqqyb8n/a3O62
-        jb1tG/tbNuKtG8NtG68f+9nQZrNKpOQ6hJf0o5YrKSVapM2VPj9ao0LBaJtC1WV2JExV8lVbTri8
-        4BZbT0PZzy/9piFsWkDQqNNU2O71UNUUeufqB1oQMvcSq2uyjUrte8QMlXcbDQ14WeKPp5rE7iDq
-        msTDsK2p7OHGNlDFa1BVWigt7OqFIejEA9dp/n2vEDOegwlIwnRKBC4UIi98M883bPkWVzpajb3H
-        hROvUV/yGyBifKI0iE+eDES0DaPRkCJScDOqRHoq5O0x7RxBRfOLTDsMOWQt3N56RSo5wvGF35Qw
-        Bm4aXOr2zTs/fffm5Oz69ORwdHYxuh6Nx3+M8X5YpwZDggcmBbBz7ADSMrLLhGFKliuGbCJKUsqs
-        Yr8Kzdm5hhnSCasNYs5/ilUiLCgvvBNhWNXzxGu6ImYPw7+pqntsgYnIheTlw0Pt9NWG1yG/RO/a
-        b8psLmF9uq6obLchGUulQ3IzKL0QfI3wuvPen22eh8cN3n7h6S2Omx3kOuWNrcN2ovtPDndjYVMz
-        aCTuBgUJC6puVSp91nhzU9bQzzVy1mYoUuxINclWswoHYmmfBv3umha+ldiHQmvKuB/Oj/Lr3wHL
-        taorGhSPhcyQ1gzDWmE3AJJVtSkgcyg9GR/Q8waYkHOyTDDLGP4VYNjNIEtIWRH77A2p+yhfueer
-        hF2u1QqZsCnGsEhCf8cP7yjeGO5SpbwslLHJMByGwbQ5fu3cQkTEVyjILi8grYme2Fu16Fu1RRj7
-        dVZjv0ahgF1GxrI/a64taDaSORblDEO8RRTWB4LISZ+d/84Oaix/dpFyuUWKpr8giqKrJpp3d+wC
-        B1fnKL4fvh+5x4fm0SWZPtr+T68TYZEKSNSBCt9QESO2ZHfsEnX0Y2S3Pv1dee3cIJDKeeZLnPX9
-        XM2DeV1KhK1FWgnun78iFYOwCTbJpQvwZ8Jq8JXOA6xtTngXOMgSJwR41C/srCQ5lyt8umyRnjHk
-        dckxlkv62+bcPwIpeEnouQA9x39nrM9+ONbwDwAAAP//7FnbTttAEP2VVaUiEsXGSRxyQYhGpEg8
-        pKpatQ/0hc3umrhK4siXoKp8fM+sN4tjsrSlKuIBgZJ4Z68zs2fOjLN5ix0s8hMM7vmdhkN7xtZH
-        nWGXFhwjzm9Ui3SjyTK7I502txodNbVSqI01J4ViE7ggGi/UzGfDFiOAYrvevf2bt33r3vq56//n
-        42DfE40juOLfE0YIi63+dhw7xEdj36EfOzJrwsXQ/A1f3pOsjRXhOHqKf/O3Xb03PydFCi1exAsF
-        LFClpg9u8hPtXJWOk3uMagJL7LIJwMtcfT9OjrjcxBkAEASj1zkGfEWkY7jKNqqR7a715NcMoZfR
-        VpFSmmCbGpObjZDJpTV5Zkx+Oyfo45hvdcPAuQXkiNoi5RGtRDEakLQuch+a/3o//xTYs1AG43ZF
-        W7Y/qngRenzULFNuxZBCM6dWXJkAPecYjUZ4pL6Qo7oyW5WGDNzGIUg3yqPoFYuHHUtpxDcUbytW
-        IgQb0Qc5Fx7HQmC+EeLDbBELY8FprIOCMeAXzRtI58Yy5alYkrIFBKlvLX+5XHOR05gPCYv1AwOO
-        b2Kp5I4vfcJ9ApnC0n/jIWboOqEwQA5+yOUyXjXYYeNuCQfOkxGc9iEV71k2WmdiLo7eDqtROk9B
-        P3SWQFlLvasrNwtcgtAmVPURlhBvteDq6CLIgSuJC+yaPM+5mFNwNCyxSjTrPCQrlktOzOqNK/ST
-        tilDStIn0i+6g2dcCMrKLuVpT3YH/cGs3Q9UVwwDMex1omE7OsY6thNWeKSbIlcYS0n3BD1FIn+8
-        q2wE/IzmerRmo9WvfFA83Y3GbOsGoUIWwmU7DI/7YtDvdYczMesHWD7iKhqIM3mqZ3nbHb/tXOC/
-        HOct+cpwEs8rmzK/yLxbKMLr+ER2/PIKkqa8NecZKQrjNcIjh8HP86kX+OsV0eB6/efl77heQHr5
-        O64XoF76joFNsqylmDzlHK7PpjyKCiFifYGIlJW1jhLZrkBi0fF9kSZrdXQFzBGU15ubRgVQSO3V
-        pRVM2Xd/chO68DR01TxCW/NIDa6/wsizOcwrjDzHjl9hZA+M1GHAxdBCS8QsT8FxbspL+ZPe1Jjf
-        AXaS5Ny8Z6rP4qJigQuXgs5+gHOVLAPnAZxUzZ6sPsLF4bpOgSV3arWJ02RVsruySRbmJWf5+Cfa
-        2yR5pfz+CwAA//8irRzGGH6HGAY3FGhTRmJxWD54IBI24g/MAhAnV8OY0PqFbAeAJ4T1YebqKOUm
-        VgSlFpfmgAxG8ix4CLGoxLEE4nHQVAZomBHkdbg4qmYjFN1QDWDX1tbWAgAAAP//AwBLCv8fUx8A
-        AA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18235","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18235","key":"NTEST-1870","fields":{"statuscategorychangedate":"2025-04-30T18:26:57.815+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1870/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:57.491+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:57.583+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/12]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]\n*Defect
+        Dojo link:* http://localhost:8080/finding/293 (293)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1870/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18235/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d66a8636-1542-4ca9-a324-e9c224240c41
+      - 73255519-4bf9-470f-b6a1-653656f3dc0c
       Atl-Traceid:
-      - d66a863615424ca9a324e9c224240c41
+      - 732555194bf9470fb6a1653656f3dc0c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:51 GMT
+      - Wed, 30 Apr 2025 16:27:04 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2822,7 +3039,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=257,atl-edge-internal;dur=18,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="vFA3gfuw6Zr-_KroMQ5KEmep0lmCattOdtjkH7exFtv39n6y0bYobQ==",cdn-downstream-fbl;dur=354,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=351,atl-edge;dur=277,atl-edge-internal;dur=19,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2831,10 +3048,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8913ce09707cf3a865704b4fbd2875de.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - vFA3gfuw6Zr-_KroMQ5KEmep0lmCattOdtjkH7exFtv39n6y0bYobQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 50f621ff01cf8985e69b113a2cab9566
+      - 4d9edb669a32849b70e0253307d95109
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2861,41 +3086,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - e6b4777a-5f8e-463d-a6cb-7c1b6a53c361
+      - 32f79301-afa6-47da-9c3e-925527eb3c3c
       Atl-Traceid:
-      - e6b4777a5f8e463da6cb7c1b6a53c361
+      - 32f79301afa647da9c3e925527eb3c3c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:51 GMT
+      - Wed, 30 Apr 2025 16:27:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2905,7 +3117,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=282,atl-edge-internal;dur=17,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=303,atl-edge;dur=270,atl-edge-internal;dur=16,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="noDRAKAb6UkLXzUhEBs9cDhw8ACrHX5WSl8qQxmNmUjCFcbztu-bWQ==",cdn-downstream-fbl;dur=306
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2914,13 +3126,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 848ee9f48eafd6caa6bf5371a2f79f28.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - noDRAKAb6UkLXzUhEBs9cDhw8ACrHX5WSl8qQxmNmUjCFcbztu-bWQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - fe43eb61a7e219fbd3ab6b2708e1ae57
+      - c84562387471e565c041a9848a1afd53
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2932,22 +3152,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/102] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/12] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]\n*Defect
       Dojo link:* http://localhost:8080/finding/293 (293)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -2961,27 +3180,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1957'
+      - '1929'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16114
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18235
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - a271d21a-3f8a-45e8-bec5-97647a03d256
+      - 6d7f7f87-332b-4e6e-88ec-226e24e26c1e
       Atl-Traceid:
-      - a271d21a3f8a45e8bec597647a03d256
+      - 6d7f7f87332b4e6e88ec226e24e26c1e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:51 GMT
+      - Wed, 30 Apr 2025 16:27:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2991,17 +3212,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=234,atl-edge-internal;dur=12,atl-edge-upstream;dur=222,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=312,atl-edge;dur=279,atl-edge-internal;dur=14,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="b42TCaGpn7NbvsYqMLzAsSIgIpri87vIeshtZam4knGlaPfSW8Vl9A==",cdn-downstream-fbl;dur=317
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 edb5724c2fa0963fde9c6c5089b747ce.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - b42TCaGpn7NbvsYqMLzAsSIgIpri87vIeshtZam4knGlaPfSW8Vl9A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3096f4a751ea95ac725fe475973dc847
+      - 3fb186fda874ec6597076de9262ff1ed
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3025,65 +3254,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16114
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18235
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJl2VH4Uyn49py4tZ1XVlJHhyPByZXJGISYAFQR2P/9+7y
-        kOKDmdqdZvRAXHtg99sPqy8OrEouEydyNMgENCRHAvLEDCQvwAxMnEHBB6oEza1Q0gwgEbYAywdx
-        xmUKuUoHC9AG9yCZQqnBgLTt2bgyVhVzUngV+H7guxr+qsDY2bqEM81jK2JwBo4g+8FeEIxwYiCf
-        4zSztjSR5yUwh9gm6rNyuc25MYJLV4L10JL1eCm80BPGVOB1Cm5gjfKns8n5bBjs7fi4VLtgnOiL
-        Y9C3ysTcQqr0urlDgjOUCP1wd+gHw8CfhX4UvI5Gu+54PP4R/SYdtRGLjtdqXugkyXuozw83124n
-        CZhYi5ICh6v7zBQ8zwcsEcYKGVtWCoiBqTlbKn3jknSs5HudP9OLSgpKF8+v+IJbrr2FgKVXu7V1
-        sN0K/J1g/LMRf8NPBaa9KtAqwQJNzri5oVxV15ZG0ZznBgZOI3iM96plB04mEDg6ztYnsAD01b8b
-        OFYgskpEiRPJCu/oPIAJZqzdKLX6jDd6YcBb6TrcdQK7cNPkK5Bsb/VeCmtRgXE2tgmpv9VnjZrb
-        JdeEVyOKMhfocPLg5piPGmWj8Wo0fqa738hMd5NNXkb+a3QjHK3C0f9rpcl+jUU0GOytgr3vYXDV
-        WdwJVzvh97DYAvzu7jEcgz6cht3GXKw+NByI2b+4fHxypzvJ01RDinzzqAjwAiqvmvJ/2txu38Ze
-        38brno2wd2Pct/HmsZ8NbTarREr1C+FEwwCn3OLD0RDu8wu3ofMtgXuNOk1lWQ8PVEWBC4iUP9KC
-        kKkTWV3BXcvTpE2LuAnnl0dr5BkeNZmq8uRQmDLn67aUcRndsh8QM1TebTQ04GWJP556JHZHQfdI
-        PAzbhsoebvSBKtyAqtRCaWHXLwxiJ+7VL82/fytEwVMwHkmYTonAhUykmWsW6ZYt3+FKR6uh87hw
-        wg3qc34NRIxPlAbxyZOBCPowGowpIhk3k1LEJ0LeHNHOIZTUv8i4y2Od3WW9t1mRSk6wfeHXOUyB
-        mwYbuh05Zyfv3x6fXp0cH0xOzydXk+n0jyneD+vUYEjwwCwDdoYvgLSM7DJhmJL5miGbiJyUMqvY
-        r0JzdqahQDphlUHUuk+xSoAF5fi3wvfLahE5zauI2cPwb6vqHltgIlIhef7wUNt9teGtkZ6jd+2c
-        MptK2JyuSirbPiRjsXVIbhqlF4KvEd68vPd7m+fhcYu3X3h8g+1mB7lOeWProO3o/pPDXVvY1Awa
-        CbtGQcKSqlvlSp823lznFQxTjbyxbYoUO1RNslVRYkMs7dOg3+2jhd0NLXwr4/fD+Ul+/dtnqVZV
-        SY3ikZAJEqNhWCvsGkCysjIZJDVKj6f79L0GJuSCDBDMEoZ/BRi+ZpBEpCwLXfaW1H2Sr+rvq4hd
-        bNQKGbE5xjCLfHfH9W8p3hjuXMU8z5Sx0dgf+968OX5Vu4WICC9RkF2cQ1wRPbF3ajm0qkcY3+uk
-        wvcahTx2ERjL/qy4tqDZRKZYlAWGuEcUNge8oJY+Pfud7VdY/uw85rJHiro/LwiCyyaat7fsHBvX
-        2lEcH3yY1J+PzadLMk3a95+GM2GRCki0BhWOUBEjtmS37AJ1DENktyH9XXlTu0EglYvEldjru6la
-        eIsqlwhbi7Ti3T9/SSpGfhNskouX4BbCanCVTj2sbU54F9jIEid4eNTNbJGTXJ0r/NbZIj1TSKuc
-        YyxX9Letdv8QpOA5oecc9AL/nbEh++FIwz8AAAD//+xZ207bQBD9lVUlEIli48QOuSBEIygSD6mq
-        Vu0DfWGzXhNXSRz5ElTBx/fM7mZJTJa2VEU8oESJvbM3z8yeOTMupi22PyuPMbjrdxoO7RlbH3YG
-        IS04QqxdyRbpRpFldk86ba41OmwqpVAba55Xkp3DBdF4ISc+G7QYARTb9u71Z9r2rXur+9D/z4+D
-        fZ8rHMER/5ExQlhs9bfj2AF+Grse+qlHZk24GJq/4897lrWxIhxHTfFv/rat9+aXrMqhxYt0JoEF
-        Umt6/6Y8Vs610fH8AaOawBK7bAbwMkffT7NDHq/SAjgHgtHtHAG+EtIxXGUd1ch212rya4bQy2ir
-        SClNsM2Nyc1GyOSxNXlhTH47JejjmG9xw8C5BeSI2iLnCa1EMRqQtKxKH5r/9jD/GNgzkwbjtkVr
-        tj/c8CL0+KR4arwWQwrNnFjxxgToOcVoNMIj1YEc1pXZ2mgowG0cgnwlPYpeqXjcUUsTvqJ4u2El
-        QrAh/ZBz4XYkBOYbIj5MZqkwFhynKigYA35VvIF0biyjn4plOZtBkPvW8pfzJRcljfmYsVTdMOD4
-        Ko1lvOVLn3GeQKaw9N94iBm6zCgMkIMf8HieLhrsoHE/hwOX2RBO+5iKdy0brTMxVzBuRy6BzcQo
-        Spc5eIlKQCilqHWNbN5UEwSubC5wEeLAEuK1elwdXUlcYDezRSzr9IKXJRdTipyavBTVfM6JWb1z
-        hX7SNmVIWf5M+kVn8JQLQXndZXzSjcN+rz9p9wIZikEgBt1OMmgnR1jHdsIKT3ST5AqjOKZzgp4i
-        i3++39gI+BnN9WTNRmlZ+qB4qhuNWdcNIokshMftKDrqiX6vGw4mYtILsHzCZdIXp/GJmmUvHO11
-        LvDV47w5XxhO4nm6qfCrwruFIryOT2TH10eQNOUtOS9IURivEB45DC7Pxl7gLxdEg+v1n9e/43oB
-        6fXvuF6Aeu07BgTFup5h8pQzuD4b8ySphEjVASJSpqslGsCuQGLR8UOVZ0t5eAVoEZTXm5NGBVBI
-        7dGlFUzZd3dyE7nwNHLVPCJb86gLLGbnBvDf8OXFPOkNX15ix2/4sgNf6jBgiZjlLdj1jT57d/Sm
-        xlwHWDAruXnPVJ/FybicuOSkYp3dyOcqWQYu7kmAsFMQuLhn6BoRWnInF6s0zxaawOmmuDIvOfXt
-        H2kvm+sZ7ujyFwAAAP//AjGhxT0ZxS/S/Kw+zFwdpdzEiqDU4tIckMFIdoNH9IpKHEsg7ijLL6He
-        RALEMLihQLsyEovD8sEDorDRf9BUBmiYEWQl3CGorjVCcS5UAzh4amtrAQAAAP//AwAm39GeUx8A
-        AA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18235","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18235","key":"NTEST-1870","fields":{"statuscategorychangedate":"2025-04-30T18:26:57.815+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1870/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:26:57.491+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t5z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:26:57.583+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/12]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/111]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/293]\n*Defect
+        Dojo link:* http://localhost:8080/finding/293 (293)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1870/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18235/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 159b1728-7e17-474c-8e6e-e1ff54540d01
+      - 0e42fe7b-2544-49fd-97a6-de68b62dde04
       Atl-Traceid:
-      - 159b17287e17474c8e6ee1ff54540d01
+      - 0e42fe7b254449fd97a6de68b62dde04
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:52 GMT
+      - Wed, 30 Apr 2025 16:27:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3093,7 +3308,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=250,atl-edge-internal;dur=13,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=375,atl-edge;dur=246,atl-edge-internal;dur=17,atl-edge-upstream;dur=230,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="qd378KNUsowzi21eFfytwGwk5PyeiYfER9U3SOODCDcmxLRNY9LMNA==",cdn-downstream-fbl;dur=378
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3102,10 +3317,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 de5b26aba33b480d2b740b96a34fe916.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qd378KNUsowzi21eFfytwGwk5PyeiYfER9U3SOODCDcmxLRNY9LMNA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - aa257534bf02a564376c1119b7fa1715
+      - 9448b52adfc133e8a25e5122aa5c7a35
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3125,7 +3348,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       111, "url_ui": "http://localhost:8080/test/111", "url_api": "http://localhost:8080/api/v2/tests/111/"},
       "finding_count": 0, "findings": {"new": [], "reactivated": [], "mitigated":
-      [], "untouched": []}}'
+      [], "untouched": [{"id": 290, "title": "Regular Expression Denial of Service
+      - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/290",
+      "url_api": "http://localhost:8080/api/v2/findings/290/"}, {"id": 291, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/291", "url_api": "http://localhost:8080/api/v2/findings/291/"},
+      {"id": 292, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/292",
+      "url_api": "http://localhost:8080/api/v2/findings/292/"}, {"id": 293, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/293", "url_api": "http://localhost:8080/api/v2/findings/293/"},
+      {"id": 294, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/294",
+      "url_api": "http://localhost:8080/api/v2/findings/294/"}]}}'
     headers:
       Accept:
       - application/json
@@ -3136,11 +3375,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '967'
+      - '2378'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added_empty
       X-DefectDojo-Instance:
@@ -3152,12 +3391,12 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"967\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2378\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added_empty\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
         \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
-        \"172.18.0.2:39842\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \"172.18.0.9:56618\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
         \ \"data\": \"{\\\"description\\\": \\\"Event scan_added_empty has occurred.\\\",
         \\\"title\\\": \\\"Created/Updated 0 findings for Security How-to: 1st Quarter
         Engagement: NPM Audit Scan\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/111\\\",
@@ -3171,16 +3410,58 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 111, \\\"url_ui\\\": \\\"http://localhost:8080/test/111\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/111/\\\"}, \\\"finding_count\\\":
         0, \\\"findings\\\": {\\\"new\\\": [], \\\"reactivated\\\": [], \\\"mitigated\\\":
-        [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n  \"form\": {},\n  \"json\":
-        {\n    \"description\": \"Event scan_added_empty has occurred.\",\n    \"engagement\":
-        {\n      \"id\": 1,\n      \"name\": \"1st Quarter Engagement\",\n      \"url_api\":
-        \"http://localhost:8080/api/v2/engagements/1/\",\n      \"url_ui\": \"http://localhost:8080/engagement/1\"\n
-        \   },\n    \"finding_count\": 0,\n    \"findings\": {\n      \"mitigated\":
-        [],\n      \"new\": [],\n      \"reactivated\": [],\n      \"untouched\":
-        []\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\": \"Security
-        How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
+        [], \\\"untouched\\\": [{\\\"id\\\": 290, \\\"title\\\": \\\"Regular Expression
+        Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/290\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/290/\\\"}, {\\\"id\\\": 291, \\\"title\\\":
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
+        \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/291\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/291/\\\"}, {\\\"id\\\":
+        292, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/292\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/292/\\\"}, {\\\"id\\\": 293, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/293\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/293/\\\"}, {\\\"id\\\": 294, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/294\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/294/\\\"}]}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added_empty has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n
+        \     \"name\": \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        0,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [],\n      \"reactivated\":
+        [],\n      \"untouched\": [\n        {\n          \"id\": 290,\n          \"severity\":
+        \"High\",\n          \"title\": \"Regular Expression Denial of Service - (Negotiator,
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/290/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/290\"\n        },\n
+        \       {\n          \"id\": 291,\n          \"severity\": \"High\",\n          \"title\":
+        \"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/291/\",\n          \"url_ui\": \"http://localhost:8080/finding/291\"\n
+        \       },\n        {\n          \"id\": 292,\n          \"severity\": \"High\",\n
+        \         \"title\": \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 <
+        3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+        < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >=
+        7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/292/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/292\"\n        },\n
+        \       {\n          \"id\": 293,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/293/\",\n          \"url_ui\": \"http://localhost:8080/finding/293\"\n
+        \       },\n        {\n          \"id\": 294,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/294/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/294\"\n        }\n      ]\n
+        \   },\n    \"product\": {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/2\"\n    },\n    \"product_type\": {\n      \"id\":
+        2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
         \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
         {\n      \"id\": 111,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/111/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/111\"\n    },\n    \"title\":
@@ -3196,7 +3477,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:52 GMT
+      - Wed, 30 Apr 2025 16:27:06 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_no_push_to_jira_reimport_push_to_jira_is_false_but_push_all_issues.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_no_push_to_jira_reimport_push_to_jira_is_false_but_push_all_issues.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2bfm25oSExEAykdhcQQmnqiEKaVE06aZr230nEBDsCN8t+
-        Xj+WD6ThFrejIoy8OTdYNp+3KFG41rybmDvFre24jjU6MiNtZwfF9//gKxx3ncAW7cca1bBC7XD8
-        65KV0VJNqAX+LrnD0XZGezgBSGKIIao2l4/V+qH+mW6mvvEVYc8BmsEMXrwTB2X2vb+y3g/BtlJm
-        an2omTrVfkUI8wFalqfmFXcBpEDzCJIIljWlLEtZ5sUAF+Bhn7f+DzjWXX/OJlBTYEnJchoXWfrN
-        iv5GS+PBLCkWggPmKEWSlsgzKTMJQtJlmi8aWWRICwn0TOBUMNx2Iw8vRMkn5e6M4KF9IOpUEdSv
-        24oczw97MjpMru9rcvwEAAD//wMAqXvlzCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:06.657+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - ccd87aec-d252-46b7-b3f2-aecb51da0340
+      - baf70614-ea69-421f-8324-762c0ba29a32
       Atl-Traceid:
-      - ccd87aecd25246b7b3f2aecb51da0340
+      - baf70614ea69421f8324762c0ba29a32
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:52 GMT
+      - Wed, 30 Apr 2025 16:27:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=177,atl-edge-internal;dur=16,atl-edge-upstream;dur=161,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=188,atl-edge;dur=156,atl-edge-internal;dur=13,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="f-flpPnlZmIKk_MdmRk7hNATPsqYclRDdofqXnEBYqfzKb-j2yWTSQ==",cdn-downstream-fbl;dur=192
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - f-flpPnlZmIKk_MdmRk7hNATPsqYclRDdofqXnEBYqfzKb-j2yWTSQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 0f35591118f97711dd0c6e653c344b33
+      - 5c562bbd660ce496e321345612fdaa27
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - a1e4f0c9-ed7a-4ebd-89c0-02c95cd8edfb
+      - 3ffee7ec-2a96-4922-bacf-eceda04f0689
       Atl-Traceid:
-      - a1e4f0c9ed7a4ebd89c002c95cd8edfb
+      - 3ffee7ec2a964922bacfeceda04f0689
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:53 GMT
+      - Wed, 30 Apr 2025 16:27:07 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=331,atl-edge-internal;dur=23,atl-edge-upstream;dur=310,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="F-9FIygu8hv1AjUuk43ABoOXCpzU_Tn9t2UAwDj96oEeXuqCwjvVIA==",cdn-downstream-fbl;dur=357,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=355,atl-edge;dur=281,atl-edge-internal;dur=19,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 6bddabf0adf0131ec8169647c939d30c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - F-9FIygu8hv1AjUuk43ABoOXCpzU_Tn9t2UAwDj96oEeXuqCwjvVIA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - f6cab7891f2b9c4f6a5050d289734272
+      - a9ff00c7c1dc580dc9c1301dd793958a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -157,7 +156,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/103]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -166,28 +165,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
-      (296)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
       Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -201,7 +200,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3359'
+      - '3334'
       Content-Type:
       - application/json
       User-Agent:
@@ -210,18 +209,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16115","key":"NTEST-1631","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16115"}'
+      string: '{"id":"18237","key":"NTEST-1871","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237"}'
     headers:
       Atl-Request-Id:
-      - 7e5ae842-d3c3-490b-aba1-1446402ed8df
+      - 5787c8b9-9028-4adb-9b55-ba75f49fc947
       Atl-Traceid:
-      - 7e5ae842d3c3490baba11446402ed8df
+      - 5787c8b990284adb9b55ba75f49fc947
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:53 GMT
+      - Wed, 30 Apr 2025 16:27:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -231,7 +232,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=722,atl-edge-internal;dur=14,atl-edge-upstream;dur=709,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="5x79LKruCJTUqCGJsndSFYpU0pUOloo90YDv_L5AoW9SM9m4RLz6Iw==",cdn-downstream-fbl;dur=753,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=60,cdn-upstream-fbl;dur=751,atl-edge;dur=670,atl-edge-internal;dur=15,atl-edge-upstream;dur=655,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -240,10 +241,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 124fcc45b0cac625cd0077abe70a7c60.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 5x79LKruCJTUqCGJsndSFYpU0pUOloo90YDv_L5AoW9SM9m4RLz6Iw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 3e77f120b1096dfd65c26502b4650914
+      - de725dfdf78f5df9cb09fcc10c45e7f8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -267,67 +276,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1631
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbCmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxv7v3SVF
-        KT6Y1u409gNx7YHdbz+svjiwKrlMnMjRIBPQkLwRkCemJ3kBpmfiDAreUyVoboWSpgeJsAVY3osz
-        LlPIVdpbgDa4B8kUSg0GpN2cjStjVTEnhVeB7we+q+HPCoydrUs40zy2Igan5wiyH+wFwQgnBvI5
-        TjNrSxN5XgJziG2iPiuX25wbI7h0JVgPLVmPl8ILPWFMBV6r4AbWKH86m5zP+sHeIMCl2gXjRF8c
-        g75VJuYWUqXXzR0SnKFE6Iejvh/0A38W+lGwH40G7nj4+gf02ycnyYhFx2s1L3SS5D3U54fba28m
-        CZhYi5ICh6sHzBQ8z3ssEcYKGVtWCoiBqTlbKn3jknSs5HudP9OLSgpKF8+v+IJbrr2FgKVXu7Vz
-        cLMV+INg/JMRf8GPBaa9KtAqwQJNzri5oVxV15ZG0ZznBnpOI3iM96ple04mEDg6ztYnsAD01b/r
-        OVYgskpEiRPJCu/oPIDJwG83Sq0+441eGPCNdB3uOoFtuGnyFUh2t3ovhbWowDhb24TUX+uzRs3t
-        kmvCqxFFmQt0OHlwc8xHjbLheDUcP9Pdb2Smvck2L0N/H90Ih6tw+P9aabJfYxENBnurYO97GFy1
-        FgfhahB+D4sbgN/dPYZj0IXTsGtj0G7MxepDQ44Ii4tLhEmaakiRb/6xCEbtBt5M5VXDC08f3eva
-        2O/YCDs3xl0brx+709Bms0qkVL8QTtQPcMotPhwN4T6/cBs63xG416jTVJb18FBVFLiASPkjLQiZ
-        OpHVFdxteJq0aRE3UfvyaI08w6MmU1WeHAlT5ny9KWVcRrfsB8QMlfcmGhrwssQfTz0Sw9d77SPx
-        MGxbKnu40QWqcAuqUgulhV2/MIituFe/NP/+rRAFT8F4JGFaJQIXMpFmrlmkO7Z8hystrYbO48IJ
-        t2WQ82sgYqQKeNgTdIE36MJoMKaIZNxMShGfCHnzhnaOoKT+RcZtHuvsLuu97YpUcoLtC7/OYQrc
-        NNjQm5FzdvL+7fHp1cnx4eT0fHI1mU5/n+L9sE4NhgQPzDJgZ/gCSMvILhOGKZmvGbKJyEkps4r9
-        IjRnZxoKpBNWGUSt+xSrBFhQjn8rfL9cDCKneRUxexj+XVXdYwtMRCokzx8e2nRfm/DWSM/Ru5Zw
-        MLOphO3pqqSy7ULyaDxskdw0Si8EXyO8fXnv9zbPw+MObz/z+AbbzRZyrfLG1uGmo/tPDrdtYVMz
-        aCRsGwUJS6pulSt92nhznVfQTzXyxq4pUuxINclWRYkNsbRPg37URQujLS18K+P3w/lJfv1/wFKt
-        qpIaxTdCJkiMhmGtsGsAycrKZJDUKD2eHtD3GpiQCzJAMEsY/hRg+GhBEpGyLHTZW1L3Sb6qv68i
-        drFVK2TEJMbLCm6Vjnx35A5uKegY81zFPM+UsdHYH/vevJG5qn2jvvISpdnFOcQVcRR7p5Z9qzqE
-        8dFOKny0w0vmsYvAWPZHxbUFzSYyxcosMM4dorA94AW19OnZb+ygQg5g5zGXHVLUAnpBEF42Ib29
-        ZefYvdaO4vjww6T+fGw+baZpsnnraTgTFvmARGtk4QgVMaJMdssuUEc/RA7A4huEQe0GIVUuEldi
-        w++mauEtqlwidi1yi3f//CWpGPj+Vi5eglsIq8FVOvWwwDmBXmA3S8Tg4VE3s0VOcruE4aROGSkL
-        8W8KaZVzDOqKfsTV9zgCKXhOWPobAAD//+xZbW/aMBD+K9akVoBIGiDhrao61K5SpVFNq7YP3ReM
-        40AmIFFCqCbtx+85xwmQEuioWnXS1AqI7bPP57vnfE/uZbRCrcYMVrnLZ6iz09ny/ALTtE2rWmJM
-        ffRnzV6b1h8g/65knUylLtBsl13a2KfT6j3bLnq8sov9fLvYB+3y6jZxymyCiMucrl9T9qE2VrtO
-        JLtGqKLxRo5N1qszAnK2jQLZ37Rh5jCgnlvmmx02dnCtkBeg+DNglJOg9EE5VsFHddf2922e1RCP
-        aP6BL+Oo0MCK8CY1xcuCc/sEavdBEsGWN/5MAj1lau/TyfKcCyHDpfq5dr4Nwes1yteAxrkaAeBf
-        46bpB2fcXfkxMoWkdNtBAvDI5nCi7F5AJzparzBiuMEw0h+Vub6zRNobtHbkDW7uDbH2Br5cIgHH
-        dfY49cWU4So9mQCDE8AfCznWWkwYZ6hpBARxKxIR90iP0UBt1PjMF5MEaDxiU8ldSK44UqiZ7pZ9
-        Xys0BNzP5GZu2e7PKqr+pkdiyBdVJbhZP7onWXdjewaMnEIcjfBxFez9wwdDiN+nD/IvPNK2YswS
-        JuOZL/ShDX2VSfWZfVOXLbKwPoxUGQaQmaEj0puH3O085GJJMncB89UDQ95b+a50t9zpK0IKN1As
-        /TdOoUXDgNIm+XiFu3N/UWWV6u85fHgZ9HO/3YkZr44XzpF44RBeOC/Di6NSxhO8ODZpbR7vW+NF
-        +z9evAFe2P8WXrRz0QN48ZTvcPKSv1jullU8DbusIyfAqBRaRvAlxfIQb1MYaufkVKHDyucodpSx
-        DlbOOmTmKRtYxpRZuTJb1XuxhlPRMaXKJK0Q42Q+51S+fthbX5HJiYsKoiMLXWIkLuGxxKDduheO
-        2+p2uuNGx5It0bNEz2l6vYbXxjr5IKywZ5gkfxi4LkUDRorA/fVxQxFUwjTXXnZcmVqaKKbVMJLJ
-        GFpbWo0udxu23e6Ibgd4ORbjjoXlPS69rrh0L9QsJ63BSfMG/6mcMecLXfgZRtoUm0lsPMIQRtOk
-        itJM45AsZYScx2QoyCuk57MYP6+GhmWGCyIcikz7+9e4SNW/f42LVP971xg45KbMsWaEruD6bMg9
-        LxHCVwFEZV3KS6co9hAsaOCnJApCefYAfBHEoOpIo1dN6M1Dl1bQL9h200h2GajaZeyyXfbKws6B
-        O9Kov40vfwAAAP//Gi1faJiSBrB8AQAAAP//ItvFo+ULrV1Ml/IFvRiAt8bgjRegq9Mhea8aNCcO
-        ZRsALcwvSYTO6KObgrPZhbNcwtkeM8Je8uGaHDLA1QAFFQhYJQxwNUCNcekwhrfwUvPKMovy8yCt
-        OIhQSil0OQmES1To5edCTKiGMaHFPRnFL9JKGH2YuTpKuYkVQanFpTkgg5HsBs+dFJU4lkDcUZZf
-        Qr0pW4hhcEOBdmUkFoflg6eeYPOsoElj0IQOyEq4Q1Bda4TiXKgGcPDU1tYCAAAA//8DAOf2ILq9
-        JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18237","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237","key":"NTEST-1871","fields":{"statuscategorychangedate":"2025-04-30T18:27:07.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:07.681+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t67:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:07.763+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
+        (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
+        Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - badd3f67-0948-4f65-bf84-e2eaff4df031
+      - baaa5cda-f495-4607-bb72-ca88a33694ff
       Atl-Traceid:
-      - badd3f6709484f65bf84e2eaff4df031
+      - baaa5cdaf4954607bb72ca88a33694ff
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:54 GMT
+      - Wed, 30 Apr 2025 16:27:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -337,7 +346,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=301,atl-edge-internal;dur=13,atl-edge-upstream;dur=288,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="RL9FYT8Tucz6Ki641TW5_7iEfztNfKkwcOzU7jYJwf4d3JnfOsKIsQ==",cdn-downstream-fbl;dur=332,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=59,cdn-upstream-fbl;dur=330,atl-edge;dur=249,atl-edge-internal;dur=17,atl-edge-upstream;dur=233,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -346,10 +355,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9b5b156d64ffeaa3e7df806f8b45cd5c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - RL9FYT8Tucz6Ki641TW5_7iEfztNfKkwcOzU7jYJwf4d3JnfOsKIsQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 51302a90b2987a3574fd75abd8403a78
+      - 23db20188537a63454e0ac1a27ecb532
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -373,67 +390,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16115
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18237
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSY7MmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxv7v3SVF
-        KT6Y1u409gNx7YHdbz+svjiwKrlMnMjRIBPQkLwRkCemJ3kBpmfiDAreUyVoboWSpgeJsAVY3osz
-        LlPIVdpbgDa4B8kUSg0GpN2cjStjVTEnhVeB7we+q+HPCoydrUs40zy2Igan5wiyH+wFwQgnBvI5
-        TjNrSxN5XgJziG2iPiuX25wbI7h0JVgPLVmPl8ILPWFMBV6r4AbWKH86m5zP+sHeIMCl2gXjRF8c
-        g75VJuYWUqXXzR0SnKFE6Iejvh/0A38W+lHwOhoN3PFw/wf02ycnyYhFx2s1L3SS5D3U54fba28m
-        CZhYi5ICh6sHzBQ8z3ssEcYKGVtWCoiBqTlbKn3jknSs5HudP9OLSgpKF8+v+IJbrr2FgKVXu7Vz
-        cLMV+INg/JMRf8GPBaa9KtAqwQJNzri5oVxV15ZG0ZznBnpOI3iM96ple04mEDg6ztYnsAD01b/r
-        OVYgskpEiRPJCu/oPIDJwG83Sq0+441eGPCNdB3uOoFtuGnyFUh2t3ovhbWowDhb24TUX+uzRs3t
-        kmvCqxFFmQt0OHlwc8xHjbLheDUcP9Pdb2Smvck2L0P/NboRDlfh8P+10mS/xiIaDPZWwd73MLhq
-        LQ7C1SD8HhY3AL+7ewzHoAunYdfGoN2Yi9WHhhwRFheXCJM01ZAi3/xjEYzaDbyZyquGF54+ute1
-        8bpjI+zcGHdt7D92p6HNZpVIqX4hnKgf4JRbfDgawn1+4TZ0viNwr1GnqSzr4aGqKHABkfJHWhAy
-        dSKrK8D0oVL7ATNOxdk4V+sj/VrETRy/PFojX1HYZKrKkyNhypyvN8VNkNCAlyX+eOqRGO7vtY/E
-        w7BtqezhRheowi2oSi2UFnb9wiC24l790vz7t0IUPAXjkYRplQhcyESauWaR7tjyHa60tBo6jwsn
-        3JZBzq+BiJEq4GFP0AXeoAujwZgiknEzKUV8IuTNG9o5gpL6Fxm3Watzuaz3titSyQm2L/w6hylw
-        0yBBb0bO2cn7t8enVyfHh5PT88nVZDr9fYr3wzo1GBI8MMuAneELIC0ju0wYpmS+ZsgmIielzCr2
-        i9CcnWkokE5YZRC17lOsEmBBOf6t8P1yMYic5lXE7GH4d1V1jy0wEamQPH94aNN9bcJb4zpH71rC
-        wcymEranq5LKtgvJo/GwRXLTKL0QfI3w9uW939s8D487vP3M4xtsN1vItcobW4ebju4/Ody2hU3N
-        oJGwbRQkLKm6Va70aePNdV5BP9XIErumSLEj1SRbFSU2xNI+DfpRFy2MtrTwrYzfD+cn+fX/AUu1
-        qkpqFN8ImSAxGoa1wq4BJCsrk0FSo/R4ekDfa2BCLsgAwSxh+FOA4aMFSUTKstBlb0ndJ/mq/r6K
-        2MVWrZARkxgvK7hVOvLdkTu4paBjzHMV8zxTxkZjf+x780bmqvaN+spLlGYX5xBXxFHsnVr2reoQ
-        xkc7qfDRDi+Zxy4CY9kfFdcWNJvIFCuzwDh3iML2gBfU0qdnv7GDCjmAncdcdkhRC+gFQXjZhPT2
-        lp1j91o7iuPDD5P687H5tJmmyeatp+FMWOQDEq2RhSNUxIgy2S27QB39EDkAi28QBrUbhFS5SFyJ
-        Db+bqoW3qHKJ2LXILd7985ekYuD7W7l4CW4hrAZX6dTDAucEeoHdLBGDh0fdzBY5ye0ShpM6ZaQs
-        xL8ppFXOMagr+hFX3+MIpOA5YelvAAAA///sWW1v2jAQ/ivWpFaASBog4a2qOtSuUqVRTau2D90X
-        jONAJiBRQqgm7cfvOccJkBLoqFp10tQKiO2zz+e753xP7mW0Qq3GDFa5y2eos9PZ8vwC07RNq1pi
-        TH30Z81em9YfINuuZJ1MpS7QbJdd2tin0+o92y56vLKL/Xy72Aft8uo2ccpsgojLnK5fU/ahNla7
-        TiS7Rqii8UaOTdarMwJyto0C2d+0YeYwoJ5b5psdNnZwrZAXoPgzYJSToPRBOVbBR3XX9vdtntUQ
-        j2j+gS/jqNDAivAmNcXLgnP7BGr3QRLBljf+TAI9ZWrv08nynAshw6X6uXa+DcHrNcrXgMa5GgHg
-        X+Om6Qdn3F35MTKFpHTbQQLwyOZwouxeQCc6Wq8wYrjBMNIflbm+s0TaG7R25A1u7g2x9ga+XCIB
-        x3X2OPXFlOHiPJkAgxPAHws51lpMGGeoaQQEcSsSEfdIj9FAbdT4zBeTBGg8YlPJXUiuOFKome6W
-        fV8rNATcz+Rmbtnuzyqq/qZHYsgXVSW4WT+6J1l3Y3sGjJxCHI3wcRXs/cMHQ4jfpw/yLzzStmLM
-        EibjmS/0oQ19lUn1mX1Tly2ysD6MVBkGkJmhI9Kbh9ztPORiSTJ3AfPVA0PeW/mudLfc6StCCjdQ
-        LP03TqFFw4DSJvl4hbtzf1FllervOXx4GfRzv92JGa+OF86ReOEQXjgvw4ujUsYTvDg2aW0e71vj
-        Rfs/XrwBXtj/Fl60c9EDePGU73Dykr9Y7pZVPA27rCMnwKgUWkbwJcXyEEtTGGrn5FShw8rnKHaU
-        sQ5Wzjpk5ikbWMaUWbkyW9V7sYZT0TGlyiStEONkPudUvn7YW1+RyYmLCqIjC11iJC7hscSg3boX
-        jtvqdrrjRseSLdGzRM9per2G18Y6+SCssGeYJH8YuC5FA0aKwP31cUMRVMI01152XJlamiim1TCS
-        yRhaW1qNLncbtt3uiG4HeDkW446F5T0uva64dC/ULCetwUnzBv+pnDHnC134GUbaFJtJbDzCEEbT
-        pIrSTOOQLGWEnMdkKMgrpOezGD+vhoZlhgsiHIpM+/vXuEjVv3+Ni1T/e9cYOOSmPLFmhK7g+mzI
-        PS8RwlcBRGVdykunKPYQLGjgpyQKQnn2AHwRxKDqSKNXTejNQ5dW0C/YdtNIdhmo2mXssl32ysLO
-        gTvSqL+NL38AAAD//xotX2iYkgawfAEAAAD//yLbxaPlC61dTJfyBb0YgLfG4I0XoKvTIXmvGjQn
-        DmUbAC3ML0mEzuijm4Kz2YWzXMLZHjPCXvLhmhwywNUABRUIWCUMcDVAjXHpMIa38FLzyjKL8vMg
-        rTiIUEopdDkJhEtU6OXnQkyohjGhxT0ZxS/SShh9mLk6SrmJFUGpxaU5IIOR7AbPnRSVOJZA3FGW
-        X0K9KVuIYXBDgXZlJBaH5YOnnmCzqqBJY9CEDshKuENQXWuE4lyoBnDw1NbWAgAAAP//AwBZ+QKC
-        vSQAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18237","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237","key":"NTEST-1871","fields":{"statuscategorychangedate":"2025-04-30T18:27:07.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:07.681+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t67:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:07.763+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
+        (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
+        Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - e6d86d5f-2612-4609-8ece-5822c3a074f4
+      - 50cf6bd7-8731-4509-8edd-75feb5046727
       Atl-Traceid:
-      - e6d86d5f261246098ece5822c3a074f4
+      - 50cf6bd7873145098edd75feb5046727
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:54 GMT
+      - Wed, 30 Apr 2025 16:27:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -443,7 +460,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=277,atl-edge-internal;dur=12,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=284,atl-edge;dur=250,atl-edge-internal;dur=16,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="J4_RJa6NATJvTb0clXQ-ldbqeckMxfWo1jeevqe1CXf7tQ5YKQ4mGQ==",cdn-downstream-fbl;dur=288
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -452,10 +469,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ad310b4d7c581c35032fa3fce068e53c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - J4_RJa6NATJvTb0clXQ-ldbqeckMxfWo1jeevqe1CXf7tQ5YKQ4mGQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 9b1304a458c69193e3076354789c4da6
+      - df80d564afd75418aa52dc7dd9a73d72
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -482,26 +507,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrlq5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCXAGkKWQQlJuLh/L9UP1M92MXR0qwp8jNIEJvAQn9truu3Blte+jbaXt
-        2IRQPba6+YoQHgK0KE7NK+EjSIHmCWQJLCtKOZtxFsQAFxDgkHfhDzhUbXfOZlBR4FnBc5Yu2eKb
-        ld2NUTaALJsvpADMUclsVqBgSjEFUtHlLF/Uas6QzhXQM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMA2eKm2SACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:09.302+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 9977414f-5bce-48fd-9217-b2b650427d2f
+      - ae5a8208-76e6-4fbb-a4e8-ac21901c9d51
       Atl-Traceid:
-      - 9977414f5bce48fd9217b2b650427d2f
+      - ae5a820876e64fbba4e8ac21901c9d51
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:54 GMT
+      - Wed, 30 Apr 2025 16:27:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -511,7 +532,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=177,atl-edge-internal;dur=13,atl-edge-upstream;dur=164,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=201,atl-edge;dur=169,atl-edge-internal;dur=14,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="wNVtZufip32hTKNBSIUfKiNk1VVmJJcwL2xGRONPeWquWIUAQODU1A==",cdn-downstream-fbl;dur=205
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -520,10 +541,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 4bbf91f2f9edc22eb68408b6405ae452.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - wNVtZufip32hTKNBSIUfKiNk1VVmJJcwL2xGRONPeWquWIUAQODU1A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - fe9d953c6e598fd5c9d260c581b6f0bd
+      - b6fc35966d4bea320f56efb9e9e5a668
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -550,41 +579,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 143b649a-be06-4dd2-9515-e12cca45727e
+      - 2b0a5e53-9c72-49de-a765-c52d05eee9c9
       Atl-Traceid:
-      - 143b649abe064dd29515e12cca45727e
+      - 2b0a5e539c7249dea765c52d05eee9c9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:55 GMT
+      - Wed, 30 Apr 2025 16:27:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -594,7 +610,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=279,atl-edge-internal;dur=15,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=312,atl-edge;dur=280,atl-edge-internal;dur=14,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="pHSRmE3QD0PJu30mMjUR16AXMcW6fXzMrmy4-4aCMCeTIVfU7EHd-g==",cdn-downstream-fbl;dur=316
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -603,13 +619,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - pHSRmE3QD0PJu30mMjUR16AXMcW6fXzMrmy4-4aCMCeTIVfU7EHd-g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4874592d798607699c1e441f639a9604
+      - c5a3b4d30796c4610f812b34602e2e00
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -621,7 +645,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/104] in [Security
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
@@ -636,13 +660,13 @@ interactions:
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
       Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -651,31 +675,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:* http://localhost:8080/finding/297
-      (297)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (297)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -684,25 +706,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
     headers:
       Accept:
@@ -714,7 +734,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7141'
+      - '6804'
       Content-Type:
       - application/json
       User-Agent:
@@ -723,18 +743,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16116","key":"NTEST-1632","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16116"}'
+      string: '{"id":"18239","key":"NTEST-1872","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239"}'
     headers:
       Atl-Request-Id:
-      - 7fd0e4c0-acfa-4db1-a38f-b430758405a1
+      - bf96c8d7-b500-4623-8987-0cad5e00d0b2
       Atl-Traceid:
-      - 7fd0e4c0acfa4db1a38fb430758405a1
+      - bf96c8d7b500462389870cad5e00d0b2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:56 GMT
+      - Wed, 30 Apr 2025 16:27:10 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -744,7 +766,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=757,atl-edge-internal;dur=20,atl-edge-upstream;dur=737,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="-AbmJU8YaGI-UW1G6BFG5WA2xKOUs84_fpDq5pEw-aDcZjYpY5Pd2A==",cdn-downstream-fbl;dur=855,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=852,atl-edge;dur=767,atl-edge-internal;dur=17,atl-edge-upstream;dur=750,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -753,10 +775,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -AbmJU8YaGI-UW1G6BFG5WA2xKOUs84_fpDq5pEw-aDcZjYpY5Pd2A==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - d6b2f3f73e3beffa332a9b20618c2f05
+      - 325fec219066c1d61b6c13e802cd7437
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -780,78 +810,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1632
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf6kOmktt4wYJTJdChxElpKqTHJB8IwZ2ktXZDu1LuTXwr89+5K
-        lh1MnBY6Dcwg6e725XaffXa5dWBecpk4kaNBJqAheSsgT0xH8gJMx8QZFLyjStDcCiVNBxJhC7C8
-        E2dcppCrtDMFbXAPkiGUGgxIuzwbV8aqYkIKrwPfD3xXw58VGDtalHCmeWxFDE7HEWQ/2AuCPfww
-        kE/wM7O2NJHnJTCB2Cbqs3K5zbkxgktXgvXQkvV4KbzQE8ZU4LUKbmCB8qejwfmoG+zthLhUu2Cc
-        6NYx6FtlYm4hVXrR3CHBL5QI/XC36wfdwB+FfhTsR7t7btDr/4h+++QkGbHoeK3mmU6SvIf6fPKq
-        ufbyIwETa1FS4HD1kJmC53mHJcJYIWPLSgExMDVhM6VvXJKOlbzQ+RO9qKSgdPH8mk+55dqbCph5
-        tVtrB5dbgb8T9H8y4i94XWDaqwKtEizQ5IibG8pVNbb0Fk14bqDjNILHeK9atuNkAoGj42xxAlNA
-        X/37jmMFIqtElDiRrPCOzgZMdvx2o9TqM97omQFfStfhrhPYhps+vgDJ+lYXUliLCoyzsk1I/bU+
-        a9TEzrgmvBpRlLlAh5ONm2M+apT1+vNe/4nufiMz7U1Ween5++hG2JuHvf/XSpP9GotoMNibY4V9
-        B4Pz1uJOOMcC/g4WlwC/v38Mx2AbTsNtGzvtxkTMPzTkiLC4vEKYpKmGFPnmH4tgt93Am6m8anjh
-        60f3tm3sb9kIt270t20cPHanoc1mlUip7hBO1A3wk1tsHA3hPr1wGzpfE7jXqNNUlvXrkaoocAGR
-        8kdaEDJ1IqsruF/yNGnTIm6idvtojTzDoyZTVZ68EabM+WJZyriMbtkPiBkq72U0NOBliT8eN4ld
-        d7/vt01iM2wrKtvc2AaqcAWqUgulhV08M4ituFd3mn/fK0TBUzAeSZhWicCFTKSZa6bpmi3f40pL
-        q6HzuHDCVRnkfAxEjFQBmzPBNvAG2zAa9CkiGTeDUsQnQt68pZ03UNL8IuM2j3V2Z/XeakUqOcDx
-        hY9zGAI3DTb08s05O7l4d3x6fXJ8NDg9H1wPhsPfh3g/rFODIcEDowzYGXYAaRnZZcIwJfMFQzYR
-        OSllVrFfhObsTEOBdMIqg6h1v8YqARaU498J3y+n48hpuiJmD8O/rqoHbIGJSIXk+eah5fS1DG+N
-        9By9awkHM5tKWJ2uSirbbUju98MWyc2g9EzwNcKrzvtwtnkaHtd4+5nHNzhutpBrlTe2jpYT3X9y
-        uB0Lm5pBI2E7KEiYUXWrXOnTxptxXkE31cgb66FIsTeqSbYqShyIpf066HdXtPCtxG4KrSjjYTg/
-        yS9/D1mqVVXSoPhWyASJ0TCsFTYGkKysTAZJjdLj4SE9x8CEnJJlglnC8F8Bhk0LkoiUZaHL3pG6
-        T/Jl/XwZscuVWiEjVqbRrhu4/h0FG2Odq5jnmTI26vt935s0Z69rn6jdXqEUuzyHuCJuYu/VrGvV
-        FmFs1kmFzTq8Yh67DIxlf1RcW9BsIFOsyALju0UUVge8oJY+PfuNHVZY++w85nKLFI1+XhCEV00o
-        7+7YOU6ttaP4fvRhUD8+No82w/Sx7PH0OhIWeYBEa0ThGypiRJXsjl2ijm6ItY9tze+HtRuEUDlN
-        XImDvpuqqTetcomYtcgp3sPzV6TioLcSi2fgFsJqcJVOPaxrTlgXOMQSH3gHPTezRU5SZYp/6kSR
-        ihB/hlAoC3iNBNhgjvkgGdZlP5ylHfYit69Y6AaBGzL2IrWvXv8NAAD//+xYUW/bOAz+KwQKDI4v
-        Va5O0qAZ+lC0O+CA2zCs214uB8R11MWbY6eW3XXY9t/3UZJluYk3rNu9tS1ShxQl6iNFfjKNxZ8w
-        1oqxOBYTahSTVjER6IWNfNrKpwJzNfLjVs6P01bO3ln5kThu5VErj/zx41Y+FuNWPmnlk3YDs3Zd
-        fvTkbl1+jAY9yWFTeRSdnDCiZ+ARt3LIodcXAdoX59lPxtmO/11xfozxg2M864sxKmFTFOahjjfL
-        KLyoJV2ghEL4l7wSdDIkbrDUrc7N7/pIuPKsv4/F47H8xZCdoGyHF7rXow2/L4hZEMLxQzsK8DHY
-        F9jvhZVCdAKI/8W/wwccVqyHU68n+LWm0M2s8LKoy0QiuzIZcn8+RBvdpEoyrNt33sCLlkWE6PZu
-        WaSesv1ZpMUoXt2mChQFV4BpFIFgXDPCOAwN72Sqsdy+WxI4HfzLKabSZHHCWSxdFvMeZBlfpRl3
-        1GodV1QkWEjRxzXISQV2bQ0ZtatYSSpKusHF7RPhqpzwGVSYPSnja3YAbKze5MTkS+hzBn5eSgJB
-        p+pj0ZgkpBKZx7jIMGPBUmmyJvAAkPcs/SBB36+xSgy3t9ssTfSbS8uMGoczCXxwYpn/+6PM1uBT
-        nav4GoWC6f6hqnkI/FM3mV3OIqNoE8M4LcALPOeVWOTR7uwwyoG0YmfgHm68JQgh5nXoMFlzPsQW
-        qVJWdZkjtfGk6qxidD0fMG6vE4IBPDjAzaVAPPF3XuSJ3FaLfLlcLnK+DVb0mc6xM3Cer3RK/Co3
-        LWXw5OAumiG1zP9BMzYxI08J1NmaBazUT8JujiWNAcN1SsvLZ/88O39NR3R2SU9u6qJ6usCPmXwU
-        GgkO4T51OFrgXP7BW1VFJgUuCwGyP8EFTsj8dvAfewMGDZN8NDLWS+2AcUoDGMCPIQWyLIeM4IBO
-        +eTQZ8xs94S5Vuz414EFh966RKHn4KzIF+Kj5sub10DzThUHT+yp49D0VXJntFPLnWanmnuae/Xc
-        09yr6J7mXk33NPequtPs1HVP063swOmlfr+zakCa25EWJIsK5vPgYowsJryQDxdjZEGxqgYuxsiB
-        4mmajteg0lExSA6VjoZBcqh0NAySQ6WjYZAcKp7GgORQ6WgMSF4yAa81MolT8tDQvfluoeebypw/
-        0J3w7Szhc4DErK9w/G0PeJ7qi59tAaG7yETiTtzN6Y1+WcAFyBb7JiSomBk0pfCNxn1GJlp7bSZ9
-        NiaMe22mfTYmwHttjvtsTEScDQX0gjuQ7k6uw+kkGJqID3XZNSHmVhNnqqCtSWBBTCPcorO+RXVI
-        v7+oTQh0qZ0FbOz+3mzjpOK4vSgo1V8IKXCbruSqbfMY+AqcqJSo5upn+rw13RZ842aaEsSrTZoP
-        KBh82YCGVMXcUY+9dPaRynoH2C94P6ayswdS2RlT2dn/QWW/AQAA//8irSlLbr8XOdnSuilrONqU
-        BaoCAAAA///smtFqgzAUhl9lDHoZF2ucelG6MjbYRV+gd/FEtzGsRSujb79zjIaaNR2sN14EelGa
-        E3M4mJ+//J+3st7Keit7UdUn1myi6xNrdq7s3sqO8/JW1lvZeVjZ0Gz9w8r+Tu9jE2Db4a0r1g+F
-        a8HgHJT4HRsJXz2zQBSCVSoMamEtcPMMe8GVoXOToY/jcRW6uA9umplk0XZUKY9HCR+Ut+m8s+2q
-        SlIYe38xLaRRE1FRN/+Ma8mdrCUAcSBvahWrKE3SPEx4EUHGIYuXZRaWBAOaIjzhSllB78FGKTyj
-        xUq0e6ens0agJvbtOuPVj7gI3htdRntGzkgUPEylCoV4TCBN4ijLIU84Hl/KokxhrVb9UxbRZrF8
-        xY/exyq5H2JMxvRPbdC17BsHwZYB5aOB1kCaFDtI2dKgcH/v0fG24dfnLePBYU+xuc2Lzb9jGzib
-        f8c2sDb3jlF/lOafBq4B/6+f7rayLDuAz/4CUQim6SqtXrt6T4UvXVMfiocd6goQBzTcNAImcdVc
-        XTphwEQvwxDCJabCxUgJF3gnjGA3g9p7fbntTfoBAAD//yIhJY2WL/Rw8Wj5gqV8QS8G4K0weKMF
-        6Op0SN6rBq3shrINgBbmlyRC16Wjm4KzuYWzXMLZDjPCXvLhWuJogKvhCSoQsEoY4Gp4GuPSYQxv
-        2aXmlWUW5edBWm8QoZRS6KYICJeo0MvPhZhQDWNCi3syil+k/Rz6MHN1lHITK4Ig40AodoNXABaV
-        OJZA3FEG7H6Qu2wRY+ExxDC4oUC7MhKLw/LBCyhhq4VBS59ByxJBVsIdgupaIxTnQjWAg6e2thYA
-        AAD//wMAG0BdqoMzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18239","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239","key":"NTEST-1872","fields":{"statuscategorychangedate":"2025-04-30T18:27:10.705+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:10.389+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:10.491+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
+        Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:*
+        http://localhost:8080/finding/297 (297)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3d1b0254-1a63-4175-a057-974632d71288
+      - e3502de0-168a-475f-baef-922fcf0068c6
       Atl-Traceid:
-      - 3d1b02541a634175a057974632d71288
+      - e3502de0168a475fbaef922fcf0068c6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:56 GMT
+      - Wed, 30 Apr 2025 16:27:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -861,7 +926,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=265,atl-edge-internal;dur=12,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="4DfM-yIjn8hOB1oRFiLZSwOqyhW9ulPcpGiA3T0HOlpo7uVJ7vRTsA==",cdn-downstream-fbl;dur=306,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=304,atl-edge;dur=282,atl-edge-internal;dur=17,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -870,10 +935,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 72fcd81c14e3eb0facf41fedad65e9e4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 4DfM-yIjn8hOB1oRFiLZSwOqyhW9ulPcpGiA3T0HOlpo7uVJ7vRTsA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 39fdee4f771c798b6b13cb81dba69941
+      - f24b00bd672319fd5cfcb0ec4e506860
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -897,78 +970,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16116
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18239
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf6kOmktt6wwVEm06HESWgppcZJPhCGOUtr6YJ0p96d/NKQ/95d
-        ybIDRGmh08AMku5uX2732WeXTw6sSi4TJ3I0yAQ0JK8E5InpSV6A6Zk4g4L3VAmaW6Gk6UEibAGW
-        9+KMyxRylfYWoA3uQTKBUoMBaTdn48pYVcxJ4VXg+4HvavizAmOn6xLONI+tiMHpOYLsB/tBsI8f
-        BvI5fmbWlibyvATmENtEfVQutzk3RnDpSrAeWrIeL4UXesKYCrxWwTWsUf50Oj6f9oP9vRCXaheM
-        E31yDPpWmZhbSJVeN3dI8AslQj8c9v2gH/jT0I+Cg2i47waD0Y/ot09OkhGLjtdqHukkyXuozyev
-        mmtvPhIwsRYlBQ5XD5kpeJ73WCKMFTK2rBQQA1NztlT62iXpWMm3On+gF5UUlC6eX/EFt1x7CwFL
-        r3Zr5+BmK/D3gtFPRvwFLwpMe1WgVYIFmpxyc025qmaW3qI5zw30nEbwGO9Vy/acTCBwdJytT2AB
-        6Kv/uedYgcgqESVOJCu8o3MHJnt+10bQbpRafcSrPjITG+k6D3Vm2zzQxxfo2V33rRTWogLjbG0T
-        hH+tzxo1t0uuCchGFGUu0OHkTkgwUTX8BqPVYPRAd7+RsvYm24QN/AN0IxyswsH/a6WBRQ1SNBjs
-        r7D0voPBVWtxL1xhZX8Hixvkf/58H45hF0732o25WL1ryBGzf3GJaEhTDSnyzT8WwbDdwAuovGp4
-        4etH97s2Djo2ws6NUdfGs/vuNLTZrBIp1R3CifoBfnKLjaMh3IfXZ0PnOwL3GnWaqq9+PVIVBS4g
-        Un5PC0KmTmR1BZglVGrfYWKpBhvnan2kX4u4ieOne2vkKwqbTFV58lKYMufrTQ1T5jXgZYkm7jeJ
-        oXsw8tsmcTdsXVQWbqns7sYWVKUWSgu7fmQQW3Gv7jT/vleIgqdgPJIwrRKBC5lIM9cs0h0pvsGV
-        lj1D5359hNsyyPkMiP+oAu7OBF3gDbowGowoIhk341LEJ0Jev6Kdl1DS/CLjNmt1Lpf13nZFKjnG
-        8YXPcpgANw0S9ObNOTt5+/r49Ork+Gh8ej6+Gk8mv0/wflinBkOCB6YZsDMkemkZ2WXCMCXzNUPS
-        EDkpZVaxX4Tm7ExDgazBKoOodb9GHgEWlOPfCN8vF7PIaboiZg/Dv6uqW2yBiUiF5PndQ5vpaxPe
-        Gtc5etcSDmY2lbA9XZVUtl1IHo3CFsnNoPRI8DXC2wZ7e7Z5GB53ePuZx9c4braQa5U3to42E91/
-        crgdC5uaQSNhOw9IWFJ1q1zp08abWV5BP9XIEruhSLGXqkm2KkociKX9OuiHXbQw3NLCtzJ+O5wf
-        5Je/hyzVqippUHwlZILEaBjWCpsBSFZWJoOkRunx5JCeM2BCLsgAwSxh+K8Aw6YFSUTKstBlr0nd
-        B/m0fj6N2MVWrZARK9No6Aauf0PBxljnKuZ5poyNRv7I9+bN2avaJ+qqlyjFLs4hroib2Bu17FvV
-        IYw9OamwJ4eXzGMXgbHsj4prC5qNZYoVWWB8O0Rhe8ALaunTs9/YYYW1z85jLjukaMLzgiC8bEJ5
-        c8POcWqtHcX3o3fj+vG+ebQZpo9Nj6fXqbDIAyRaIwrfUBEjqmQ37AJ19EOsfWxr/iis3SCEykXi
-        Shz03VQtvEWVS8SsRU7xbp+/JBXPBluxeAluIawGV+nUw7rmhHWBsyrxgfds4Ga2yEmqTPFPnShS
-        EeLPBAplAa+RABuvMB8kw/rsh7O0x57k9jkL3SBwQ8aepPb5i78BAAD//+xYUW/bOAz+KwQKDI4v
-        Va5O0qAZ+lC0O+CA2zCs214uB8R11MWbY6eW3XXY9t/3UZJluYk3rNu9tS1ShxQl6iNFfjKNxZ8w
-        1oqxOBYTahSTVjER6IWNfNrKpwJzNfLjVs6P01bO3ln5kThu5VErj/zx41Y+FuNWPmnlk3YDs3Zd
-        fvTkbl1+jAY9yWFTeRSdnDCiZ2ANt3LIodd8n/bFefaTcbbjf1ecH2P84BjP+mKMStgUhXmo480y
-        Ci9qSRcooRD+Ja8EnQyJGyx1q3Pzuz4Srjzr72PxeCx/MWQnKNvhhe71aMPvC2IWhHD80I4CfAz2
-        BfZ7YaUQnQDif/Hv8AGHFevh1OsJfq0pdDMrvCzqMpHIrkyG3J8P0UY3qZIM6/adN/CiZREhur1b
-        FqmnbH8WaTGKV7epAhPBFWAaRSAY14wwDkPDO5lqLLfvlgROB/9yiqk0WZxwFkuXxbwHWcZXacYd
-        tVrHFRUJFlL0cQ1yUoFdW0NG7SpWkoqSbnBN+0S4Kid8BhVmT8r4mh0AG6s3OTH5EvqcgZ+XkkDQ
-        qfpYNCYJqUTmMS4yzFiwVJqsCTwA5D1LP0jQ92usEsPt7TZLE/3m0jKjxuFMAh+cWOb//iizNfhU
-        5yq+RqFgun+oah4C/9RNZpezyCjaxDBOC/ACz3klFnm0OzuMciCt2Bm4hxtvCbKIeR06TNacD7FF
-        qpRVXeZIbTypOqsYXc8HjNvrhGAADw5wcykQT/ydF3kit9UiXy6Xi5xvgxV9pnPsDJznK50Sv8pN
-        Sxk8ObiLZkgt83/QjE3MyFMCdbZmASv1k7CbY0ljwHCd0vLy2T/Pzl/TEZ1d0pObuqieLvBjJh+F
-        RoJDuE8djhY4l3/wVlWRSYHLQoDsT3CBEzK/HfzH3oBBwyQfjYz1UjtgnNIABvBjSIEsyyEjOKBT
-        Pjn0GTPbPWGuFTv+dWDBobcuUeg5OCvyhfio+fLmNdC8U8XBE3vqODR9ldwZ7dRyp9mp5p7mXj33
-        NPcquqe5V9M9zb2q7jQ7dd3TdCs7cHqp3++sGpDmdqQFyaKC+Ty4GCOLCS/kw8UYWVCsqoGLMXKg
-        eJqm4zWodFQMkkOlo2GQHCodDYPkUOloGCSHiqcxIDlUOhoDkpdMwGuNTOKUPDR0b75b6PmmMucP
-        dCd8O0v4HCAx6yscf9sDnqf64mdbQOguMpG4E3dzeqNfFnABssW+CQkqZgZNKXyjcZ+RidZem0mf
-        jQnjXptpn40J8F6b4z4bExFnQwG94A6ku5PrcDoJhibiQ112TYi51cSZKmhrElgQ0wi36KxvUR3S
-        7y9qEwJdamcBG7u/N9s4qThuLwpK9RdCCtymK7lq2zwGvgInKiWqufqZPm9NtwXfuJmmBPFqk+YD
-        CgZfNqAhVTF31GMvnX2kst4B9gvej6ns7IFUdsZUdvZ/UNlvAAAA//8irSlLbr8XOdnSuilrONqU
-        BaoCAAAA///smtFqgzAUhl9lDHoZFzVOvShdGRvsoi/Qu/REtzHUopXRt985xoaaNR2sN14EeiHN
-        SXM4mJ+//J+3st7Keit7UdUn1myi6xNrdq7s3sqe5uWtrLey87Cyodn6h5X9nd4nJsC2w1tXfheK
-        8/zu0Er4GtAEQgvsUgN4WAvCoBbWAnft4K4MnZsM/TQeV6GL++CmmUkWbSeS8nCQ8EF5m847u76q
-        JIWx9xfTQho1ERVN+8+4ltzJSgIQB/KmlomKszTbhSkvYsg55ElU5mFJMKApwhOulBX0HqyVwjM6
-        rES7d3w6awQaYt+uo1zDiIvgvdVltOeEE4mCh5lUoRCPKWRpEuc72KUcjy9lUWawUsvhVxbxehG9
-        4kfvY5WsxxiTMf1VF/Qd+8ZBsCigfDTQGkiTYnspOxoU7h88Ot42fHzeMB7sa4rNbSxs/h3bXNn8
-        O7a5tLl3jMKkNO00cg34f/14t5Fl2QN8DheIQjBNV2lZ2zY1Fb70bbMvHraoK0Ac0HjTiIvEVXN1
-        6YQRE70MQwiXmAoXIyVc4J0wgt2Oau/15bY36QcAAP//IiEljZYv9HDxaPmCpXxBLwbgrTB4owXo
-        6nRI3qsGLeCGsg2AFuaXJELXpaObgrO5hbNcwtkOM8Je8uFa4miAq+EJKhCwShjAvYwmYYxLhzG8
-        ZZeaV5ZZlJ8Hab1BhFJKoZsiIFyiQi8/F2JCNYwJLe7JKH6R9nPow8zVUcpNrAiCjAOh2A1eAVhU
-        4lgCcUcZsPtB7rJFjIXHEMPghgLtykgsDssHL6CErQ0GLX0GLUsEWQl3CKprjVCcC9UADp7a2loA
-        AAAA//8DACtvkBmDMwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18239","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239","key":"NTEST-1872","fields":{"statuscategorychangedate":"2025-04-30T18:27:10.705+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:10.389+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:10.491+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
+        Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:*
+        http://localhost:8080/finding/297 (297)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 7ef2ef3d-b48d-4701-9d85-4c01054810b6
+      - 51855ece-df0e-4a9f-9684-bdfead3ea68d
       Atl-Traceid:
-      - 7ef2ef3db48d47019d854c01054810b6
+      - 51855ecedf0e4a9f9684bdfead3ea68d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:56 GMT
+      - Wed, 30 Apr 2025 16:27:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -978,7 +1086,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=338,atl-edge-internal;dur=12,atl-edge-upstream;dur=327,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=307,atl-edge;dur=274,atl-edge-internal;dur=15,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="aATX_Rkd3p_8i97X0oZshfSjGSy6KHZIDfWmKAtWMuqkmUfgthLZzA==",cdn-downstream-fbl;dur=311
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -987,10 +1095,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 60b2b330807c6611e06e3923c8e315cc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - aATX_Rkd3p_8i97X0oZshfSjGSy6KHZIDfWmKAtWMuqkmUfgthLZzA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 5c372cbcb8b9f27fcd30d6ab213977b3
+      - 9058453bcbaee95f842397c45a72f91e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1017,26 +1133,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2T9WPLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPARYUZyaV8JHkAHLpkCnsKwY4+mcp0EMcAEBDnkX/oBD1XbnLIWKAacFz4qE5Ytv
-        VnY3RtkApjRfSAGYoZJ0XqBIlUoVSMWW82xRqzxFlitgZwKvo+G2HUR8ISoxan9npYjtA9GniqB5
-        3ZbkeH7YkzVxcn1fkeMnAAAA//8DAPVaXr4gAgAA
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:12.019+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 2410cefc-d7b8-48b6-b8ea-3a64192a3a14
+      - 3d58a454-1bc5-4d2b-9f77-1a3c1e5ca7fa
       Atl-Traceid:
-      - 2410cefcd7b848b6b8ea3a64192a3a14
+      - 3d58a4541bc54d2b9f771a3c1e5ca7fa
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:57 GMT
+      - Wed, 30 Apr 2025 16:27:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1046,7 +1158,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=185,atl-edge-internal;dur=33,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=172,atl-edge;dur=140,atl-edge-internal;dur=11,atl-edge-upstream;dur=129,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ZArIC5qamMsF3aoibNFepG1xaGPJrKc--xUJ-1PU4KaMsAoYmTgjLg==",cdn-downstream-fbl;dur=176
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1055,10 +1167,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 995d6494814d695ff2add6899f970080.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ZArIC5qamMsF3aoibNFepG1xaGPJrKc--xUJ-1PU4KaMsAoYmTgjLg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7c28e1d5f1d9d36d9487593843f6c872
+      - 5f687ccefbc626e6e1ea953f6c9bde34
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1085,41 +1205,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 39d25ad5-3173-441d-9104-faf0e95032c2
+      - e595053c-b189-4782-9308-10a016fd46ee
       Atl-Traceid:
-      - 39d25ad53173441d9104faf0e95032c2
+      - e595053cb1894782930810a016fd46ee
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:57 GMT
+      - Wed, 30 Apr 2025 16:27:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1129,7 +1236,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=371,atl-edge-internal;dur=17,atl-edge-upstream;dur=353,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=323,atl-edge;dur=290,atl-edge-internal;dur=17,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="I-2Jq2Jkp3MAa3ooel-DwmFt5pXvEU0_vdJL4VVxIgOdNBZnwrWa4A==",cdn-downstream-fbl;dur=326
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1138,13 +1245,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8139bc666c011a53bdc5037ba6d5931e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - I-2Jq2Jkp3MAa3ooel-DwmFt5pXvEU0_vdJL4VVxIgOdNBZnwrWa4A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 071c50803764a764519fa75072a44607
+      - 59557da26c3c21ec75d3f92fbe2cb409
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1156,22 +1271,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/105] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/15] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]\n*Defect
       Dojo link:* http://localhost:8080/finding/298 (298)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -1185,7 +1299,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1973'
+      - '1945'
       Content-Type:
       - application/json
       User-Agent:
@@ -1194,18 +1308,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16117","key":"NTEST-1633","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16117"}'
+      string: '{"id":"18241","key":"NTEST-1873","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241"}'
     headers:
       Atl-Request-Id:
-      - 127e3f45-ec9d-488a-bf64-e537e17461bc
+      - 2fa8d22e-31fb-4393-a07b-f062358e19dc
       Atl-Traceid:
-      - 127e3f45ec9d488abf64e537e17461bc
+      - 2fa8d22e31fb4393a07bf062358e19dc
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:58 GMT
+      - Wed, 30 Apr 2025 16:27:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1215,7 +1331,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=695,atl-edge-internal;dur=15,atl-edge-upstream;dur=680,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="27lhmFKSvlzeZ6FxZxE_ojQEDV-IUkcShGkta0w8mLcr-uWwrJvbww==",cdn-downstream-fbl;dur=791,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=70,cdn-upstream-fbl;dur=789,atl-edge;dur=695,atl-edge-internal;dur=16,atl-edge-upstream;dur=679,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1224,10 +1340,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 87d6d7b4889aec5ce2bf57d717a99d3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 27lhmFKSvlzeZ6FxZxE_ojQEDV-IUkcShGkta0w8mLcr-uWwrJvbww==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - fb1111987c42ede43f8dc24af6b43003
+      - 9f6ef5c36c4fc8e94ddbaaf3a54f775b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1251,65 +1375,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1633
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJlyRb4Uyn49py4tZ1XVlJHhyPByZXJGISYAFQR+P89+7y
-        kOJDmdqdZvRAEsAe2P3229VnB1Yll4kTORpkAhqSYwF5YnqSF2B6Js6g4D1VguZWKGl6kAhbgOW9
-        OOMyhVylvQVog3uQTKHUYEDa9mxcGauKOSm8Dnw/8F0Nf1Vg7GxdwrnmsRUxOD1HkP1gLwj28cNA
-        PsfPzNrSRJ6XwBxim6hPyuU258YILl0J1kNL1uOl8EJPGFOB1ym4hTXKn80mF7N+sDcY4FLtgnGi
-        z45B3yoTcwup0uvmDgl+oUToh6O+H/QDfxb6UbAfjcbucD/4Ef32yUkyYtHxWs0LnSR5D/X54eba
-        7UcCJtaipMDh6gEzBc/zHkuEsULGlpUCYmBqzpZK37okHSv5TufP9KKSgtLF82u+4JZrbyFg6dVu
-        bR1stwJ/EIx/NuJv+KnAtFcFWiVYoMkZN7eUq+rG0ls057mBntMInuC9atmekwkEjo6z9SksAH31
-        v/QcKxBZJaLEiWSFd3QewGTgdxulVp/wRi8MeCtdh7tOYBdu+vgKJNtbvZPCWlRgnI1tQupv9Vmj
-        5nbJNeHViKLMBTqcPLg55qNG2XC8Go6f6e43MtPdZJOXoU9AD4ercPj/WmmyX2MRDQZ7q2Dvexhc
-        dRYH4WoQfg+LLcC/fHkMx2AXTsNuYy5W7xsOxOxfXj0+OehO8jTVkCLfPCoCvIDKq6b8nzY32rWx
-        t2tjf8dGuHNjvGvj9WM/G9psVomU6g7hRP2g5UpKiRZxc6XPj9aoUDDaJlNVnhwJU+Z83ZYTLi+5
-        xdbTUPbzS79pCNsW4DXqNBV2/XqoKgp97eoHWhAydSKrK7KNSu17xAyVdxsNDXhZ4o+nmkQwGnVN
-        4mHYNlT2cGMXqMINqEotlBZ2/cIQdOJe3Wn+fa8QBU/BeCRhOiUCFzKRZq5ZpFu2fIsrHa2GzuPC
-        CTeoz/kNEDE+URrEJ08GItiF0WBMEcm4mZQiPhXy9ph2jqCk+UXGHYZqZC3rvc2KVHKC4wu/yWEK
-        3DS41O2bc3767s3J2fXpyeHk7GJyPZlO/5ji/bBODYYED8wyYOfYAaRlZJcJw5TM1wzZROSklFnF
-        fhWas3MNBdIJqwxizn2KVQIsKMe/E75fLj5FTtMVMXsY/m1V3WMLTEQqJM8fHmqnrza8NfJz9K79
-        psymEjanq5LKdheSw4HfIbkZlF4IvkZ403nvzzbPw+MWb7/w+BbHzQ5ynfLG1mE70f0nh7uxsKkZ
-        NBJ2g4KEJVW3ypU+a7y5ySvopxo5azsUKXakmmSrosSBWNqnQT/a0MK3EvtQaEMZ98P5UX79O2Cp
-        VlVJg+KxkAnSmmFYK+wGQLKyMhkkNUpPpgf0vAEm5IIsE8wShn8FGHYzSCJSloUue0PqPspX9fNV
-        xC43aoWM2BxjmEW+O3D9O4o3hjtXMc8zZWw09se+N2+OX9duISJGVyjILi8groie2Fu17Fu1Qxj7
-        dVJhvw6vmMcuA2PZnxXXFjSbyBSLssAQ7xCFzQEvqKXPzn9nBxWWP7uIudwhRdOfFwThVRPNuzt2
-        gYNr7Si+H76f1I8PzaNLMn20/Z9eZ8IiFZBoDSp8Q0WM2JLdsUvU0Q+R3fr0d+V17QaBVC4SV+Ks
-        76Zq4S2qXCJsLdKKd//8FakY+k2wSS5eglsIq8FVOvWwtjnhXeAgS5zg4VE3s0VOcnWu8Flni/RM
-        Ia1yjrFc0d+22v0jkILnhJ4L0Av8d8b67IdjDf8AAAD//+xZ207bQBD9lVWlIhLFxkkcckGIRqRI
-        PKSqWrUP9IXN7pq4SuLIl6CqfHzPrDeLY7K0pSriAYGSeGevM7NnzoyzeYsdLPITDO75nYZDe8bW
-        R53hgBYcI85vVIt0o8kyuyOdNrcaHTW1UqiNNSeFYhO4IBov1MxnwxYjgGK73r39m7d96976uev/
-        5+Ng3xONI7ji3xNGCIut/nYcO8RHY9+hHzsya8LF0PwNX96TrI0V4Th6in/zt129Nz8nRQotXsQL
-        BSxQpaYPbvIT7VyVjpN7jGoCS+yyCcDLXH0/To643MQZABAEo9c5BnxFpGO4yjaqke2u9eTXDKGX
-        0VaRUppgmxqTm42QyaU1eWZMfjsn6OOYb3XDwLkF5IjaIuURrUQxGpC0LnIfmv96P/8U2LNQBuN2
-        RVu2P6p4EXp81CxTbsWQQjOnVlyZAD3nGI1GeKS+kKO6MluVhgzcxiFIN8qj6BWLhx1LacQ3FG8r
-        ViIEG9EHORcex0JgvhHiw2wRC2PBaayDgjHgF80bSOfGMuWpWJKyBQSpby1/uVxzkdOYDwmL9QMD
-        jm9iqeSOL33CfQKZwtJ/4yFm6DqhMEAOfsjlMl412GHjbgkHzpMRnPYhFe9ZNlpnYi6O3g6rUTpP
-        QT90lkBZS72rKzcLXILQJlT1EZYQb7Xg6ugiyIEriQvsmjzPuZhTcDQssUo06zwkK5ZLTszqjSv0
-        k7YpQ0rSJ9IvuoNnXAjKyi7laU92B/3BrN0PVFcMAzHsdaJhOzrGOrYTVnikmyJXGEtJ9wQ9RSJ/
-        vKtsBPyM5nq0ZqPVr3xQPN2NxmzrBqFCFsJlOwyP+2LQ73WHMzHrB1g+4ioaiDN5qmd52x2/7Vzg
-        vxznLfnKcBLPK5syv8i8WyjC6/hEdvzyCpKmvDXnGSkK4zXCI4fBz/OpF/jrFdHgev3n5e+4XkB6
-        +TuuF6Be+o6BTbKspZg85Ryuz6Y8igohYn2BiJSVtY4S2a5AYtHxfZEma3V0BcwRlNebm0YFUEjt
-        1aUVTNl3f3ITuvA0dNU8QlvzSA2uv8LIsznMK4w8x45fYWQPjNRhwMXQQkvELE/BcW7KS/mT3tSY
-        3wF2kuTcvGeqz+KiYoELl4LOfoBzlSwD5wGcVM2erD7CxeG6ToEld2q1idNkVbK7skkW5iVn+fgn
-        2tskeaX8/gsAAP//Iq0cxhh+hxgGNxRoU0ZicVg+eCASNuIPzAIQJ1fDmND6hWwHgCeE9WHm6ijl
-        JlYEpRaX5oAMRvIseAixqMSxBOJx0FQGaJgR5HW4OKpmIxTdUA1g19bW1gIAAAD//wMAZBi9SFMf
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18241","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241","key":"NTEST-1873","fields":{"statuscategorychangedate":"2025-04-30T18:27:13.285+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:12.994+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:13.082+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/15]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]\n*Defect
+        Dojo link:* http://localhost:8080/finding/298 (298)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a0bce1c1-8b05-4eee-9c3d-b87aca040e10
+      - 15a3f501-d393-4dc3-bda1-0e6181bf5425
       Atl-Traceid:
-      - a0bce1c18b054eee9c3db87aca040e10
+      - 15a3f501d3934dc3bda10e6181bf5425
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:58 GMT
+      - Wed, 30 Apr 2025 16:27:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1319,7 +1429,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=267,atl-edge-internal;dur=14,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="E0Bp2n8Lj_mWfw3j__Ud8yqrihLS38N1VTUn1N318Hk8sXzidzAlnw==",cdn-downstream-fbl;dur=409,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=96,cdn-upstream-fbl;dur=406,atl-edge;dur=277,atl-edge-internal;dur=16,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1328,10 +1438,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - E0Bp2n8Lj_mWfw3j__Ud8yqrihLS38N1VTUn1N318Hk8sXzidzAlnw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - bb864685cd5b842ed01b95971cfac299
+      - 8f50900a67b41e788eaae12b968ea417
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1355,65 +1473,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16117
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18241
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf61EltvdkGRzOdDgWTkFJKjZN8IAxzSGvpgnSn3p38Ush/765k
-        2cHgtNBpxh90b/tyu88+t75zYFFymTiRo0EmoCE5FpAnpiN5AaZj4gwK3lElaG6FkqYDibAFWN6J
-        My5TyFXamYE2uAfJGEoNBqRdnY0rY1UxJYXXge8HvqvhzwqMnSxLONc8tiIGp+MIsh/sBcE+Tgzk
-        U5xm1pYm8rwEphDbRH1WLrc5N0Zw6UqwHlqyHi+FF3rCmAq8VsEtLFH+bDK6mHSDvV4Pl2oXjBPd
-        OQZ9q0zMLaRKL5s7JDhDidAPB10/6Ab+JPSjYD8aDN3+fvAj+u2Tk2TEouO1mhc6SfIe6vPD9bVX
-        kwRMrEVJgcPVA2YKnucdlghjhYwtKwXEwNSUzZW+dUk6VvK9zp/pRSUFpYvn13zGLdfeTMDcq93a
-        OLjaCvxeMPzZiL/gpwLTXhVolWCBJifc3FKuqhtLo2jKcwMdpxE8wXvVsh0nEwgcHWfLU5gB+up/
-        6ThWILJKRIkTyQrv6GzBpOe3G6VWn/FGLwz4SroOd53ANtw0+Qokm1u9l8JaVGCctW1C6q/1WaOm
-        ds414dWIoswFOpxs3RzzUaOsP1z0h8909xuZaW+yzkvfJ6CH/UXY/3+tNNmvsYgGg71FsPc9DC5a
-        i71w0Qu/h8UVwL98eQzHYBdOw10bvXZjKhYfGnJEWFxeIUzSVEOKfPOPRTBoN/BmKq8aXnj66N6u
-        jf0dG+HOjeGujdeP3Wlos1klUqpfCCfqBjjlFh+OhnCfX7gNnW8I3GvUaSrLenioKgpcQKT8kRaE
-        TJ3I6gowfajUfsCMU3E2ztX6SL8WcRPHu0dr5CsKm0xVeXIkTJnz5aq4CRIa8LLEH089EsFg0D4S
-        22FbU9n2xi5QhWtQlVooLezyhUFsxb36pfn3b4UoeArGIwnTKhG4kIk0c80s3bDlW1xpaTV0HhdO
-        uC6DnN8AESNVwHZPsAu8wS6MBkOKSMbNqBTxqZC3x7RzBCX1LzJus1bncl7vrVekkiNsX/hNDmPg
-        pkGCXo2c89P3b07Ork9PDkdnF6Pr0Xj8+xjvh3VqMCR4YJIBO8cXQFpGdpkwTMl8yZBNRE5KmVXs
-        ndCcnWsokE5YZRC17lOsEmBBOf698P1y9jlymlcRs4fh31TVA7bARKRC8nz70Kr7WoW3xnWO3rWE
-        g5lNJaxPVyWV7S4khz2/RXLTKL0QfI3w+uV92Ns8D48bvP3C41tsN1vItcobW4erju4/Ody2hU3N
-        oJGwbRQkzKm6Va70WePNTV5BN9XIEpumSLEj1SRbFSU2xNI+DfrBmha+ldhtoTVlPAznJ/n174Cl
-        WlUlNYrHQiZIjIZhrbAbAMnKymSQ1Cg9GR/Q9waYkDOyTDBLGP4VYPhoQRKRsix02RtS90m+qr+v
-        Ina5VitkxKYYwyzy3Z7r31O8Mdy5inmeKWOjoT/0vWlz/Lp2CxExuEJBdnkBcUX0xN6qedeqHcL4
-        XicVvtfhFfPYZWAs+6Pi2oJmI5liURYY4h2isD7gBbX02flv7KDC8mcXMZc7pKj784IgvGqieX/P
-        LrBxrR3F8eGHUf352HzaJNNk9czTcCIsUgGJ1qDCESpixJbsnl2ijm6I7NalvyuvazcIpHKWuBJ7
-        fTdVM29W5RJha5FWvIfnr0hF32+CTXLxHNxCWA2u0qmHtc0J7wIbWeIED4+6mS1ykqtzhd86W6Rn
-        DGmVc4zlgv621e4fgRQ8J/RcgJ7hvzPWZT8ca/gbAAD//+xZ227aQBD9lVWlRAFhx4C5RlGKQiPl
-        gapq1T6kL1nW6+AKMPKFqEo+vmd2lw04bNqmapSHCAT2zt48M3vmzDifNdjhvDjB4I7fqjm0Z2x9
-        3Br0acERIutaNkg3iiyze9JpfaPRYV0phdpYfVxKNoYLovFCTn02aDACKLbr3ZvPrOlb91b3bf8/
-        Pw72PVY4giP+I2WEsNjqb8exI/zU9j30U4/M6nAxNH/Hn/csa2NFOI6a4t/8bVfv9S9pmUGLF8lc
-        Aguk1vThTXGinGur4/gBo+rAErtsCvAyR99P0mMerZMcAAiC0Wl1AV8x6RiusolqZLtrNfk1Q+hl
-        tFWklCbYZsbkZiNk8siaPDcmv50R9HHMt7xh4NwCckRtkfGYVqIYDUhalYUPzX97mH8C7JlLg3G7
-        og2pH255EXp8Ujw12oghhWZOrXhrAvScYTQa4ZHqQA6rymxsNeTgNg5BtpYeRa9EPO6opTFfU7zd
-        shIh2JB+yLlwOxIC8w0RH6bzRBgLThIVFIwBvyreQDo3ltFPxdKMzSHIfGv5y8WKi4LGfExZom4Y
-        cHydRDLa8aXPOE8gU1j6bzzEDF2lFAbIwY94tEiWNXZUu1/AgYt0CKd9TMU7lo1WmZiLozdDl8Dm
-        ZhS+iwy8RCUglEBUuoY2b6oIAjtHVeAixIElxBv1uDq6krjAbmaHWFZ5By8KLmYUOTV5ycvFghOz
-        eucK/aRtypDS7Jn0i87gGReC8rrL6LQTtfu9/rTZC2RbDAIx6LTiQTPuYh3bCSs80U2SK4yiiM4J
-        eoo0+vl+ayPgZzTXkzUbpWXpg+KpbjRmUzcIJbIQHjXDsNsT/V6nPZiKaS/A8jGXcV+cRadqloP2
-        6KB1ga8e5y340nASz9NNuV/m3i0U4bV8Iju+PoKkKW/FeU6KwniF8MhhcHk+8QJ/tSQaXK3/vP4d
-        VwtIr3/H1QLUa98xICjS1QuTp5zD9dmEx3EpRKIOEJEyXS3RAHYFEouOH8osXcnjK0CLoLzenDQq
-        gEJqjy6tYMq++5Ob0IWnoavmEboKaaHF7MwA/hu+vJgnveHLS+z4DV/24EsVBiwRs7wFu77RZ++O
-        3tSY6wALpgU375mqszgZlxOXnFSstR/5XCXLwMU9CRD2CgIX92y7RrQtuZPLdZKlS03gdFNUmpec
-        +vaPtJcu9Ax3dPkLAAD//wIxocU9GcUv0vysPsxcHaXcxIqg1OLSHJDBSHaDR/SKShxLIO4oyy+h
-        3kQCxDC4oUC7MhKLw/LBA6KwsX7QVAZomBFkJdwhqK41QnEuVAM4eGprawEAAAD//wMA1vp5nFMf
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18241","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241","key":"NTEST-1873","fields":{"statuscategorychangedate":"2025-04-30T18:27:13.285+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:12.994+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:13.082+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/15]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]\n*Defect
+        Dojo link:* http://localhost:8080/finding/298 (298)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - c2f528ff-6983-4cf6-a601-db12841ef709
+      - b561eebf-c920-4660-9a78-c25abf35b855
       Atl-Traceid:
-      - c2f528ff69834cf6a601db12841ef709
+      - b561eebfc92046609a78c25abf35b855
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:59 GMT
+      - Wed, 30 Apr 2025 16:27:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1423,7 +1527,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=259,atl-edge-internal;dur=12,atl-edge-upstream;dur=247,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="w8wY7HZvCJfs21GjZvzMsi2TC5qafGFKFyUk9MwXtPdkK3pLSRYuxQ==",cdn-downstream-fbl;dur=352,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=349,atl-edge;dur=276,atl-edge-internal;dur=16,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1432,10 +1536,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9a3eef6ee6df44793fb3d5e366a7238.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - w8wY7HZvCJfs21GjZvzMsi2TC5qafGFKFyUk9MwXtPdkK3pLSRYuxQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - e61f1159a920930ed4a4fab6fb72f186
+      - 263bd2f59d960d466cf5fc92410bbe78
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1468,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1482,9 +1594,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"849\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:41430\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:59800\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -1520,7 +1632,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:59 GMT
+      - Wed, 30 Apr 2025 16:27:14 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1538,25 +1650,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       112, "url_ui": "http://localhost:8080/test/112", "url_api": "http://localhost:8080/api/v2/tests/112/"},
       "finding_count": 5, "findings": {"new": [{"id": 295, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/295", "url_api": "http://localhost:8080/api/v2/findings/295/"},
-      {"id": 296, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/296",
-      "url_api": "http://localhost:8080/api/v2/findings/296/"}, {"id": 297, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/297", "url_api": "http://localhost:8080/api/v2/findings/297/"},
-      {"id": 298, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/298", "url_api":
-      "http://localhost:8080/api/v2/findings/298/"}, {"id": 299, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/299", "url_api": "http://localhost:8080/api/v2/findings/299/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/295",
+      "url_api": "http://localhost:8080/api/v2/findings/295/"}, {"id": 296, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/296", "url_api": "http://localhost:8080/api/v2/findings/296/"},
+      {"id": 297, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/297",
+      "url_api": "http://localhost:8080/api/v2/findings/297/"}, {"id": 298, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/298", "url_api": "http://localhost:8080/api/v2/findings/298/"},
+      {"id": 299, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/299",
+      "url_api": "http://localhost:8080/api/v2/findings/299/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -1567,11 +1677,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2507'
+      - '2372'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -1583,11 +1693,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2507\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2372\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:41442\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:59802\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -1602,63 +1712,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 112, \\\"url_ui\\\": \\\"http://localhost:8080/test/112\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/112/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 295, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/295\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/295/\\\"}, {\\\"id\\\": 296, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/296\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/296/\\\"}, {\\\"id\\\":
-        297, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/297\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/297/\\\"}, {\\\"id\\\":
-        298, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/298\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/298/\\\"}, {\\\"id\\\":
-        299, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/299\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/299/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        297, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/297\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/297/\\\"}, {\\\"id\\\": 298, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/298\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/298/\\\"}, {\\\"id\\\": 299, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/299\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/299/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 295,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/295/\",\n          \"url_ui\": \"http://localhost:8080/finding/295\"\n
         \       },\n        {\n          \"id\": 296,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/296/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/296/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/296\"\n        },\n
         \       {\n          \"id\": 297,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/297/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/297\"\n        },\n        {\n          \"id\":
-        298,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/298/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/298\"\n        },\n
-        \       {\n          \"id\": 299,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/299/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/299\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 112,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/112/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/297/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/297\"\n        },\n
+        \       {\n          \"id\": 298,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/298/\",\n          \"url_ui\": \"http://localhost:8080/finding/298\"\n
+        \       },\n        {\n          \"id\": 299,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/299/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/299\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        112,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/112/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/112\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/112/\",\n
@@ -1672,7 +1780,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:17:59 GMT
+      - Wed, 30 Apr 2025 16:27:14 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1697,26 +1805,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2T9WPLDQ2JgWAgtbuAEEpTRxTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC1cLgdNOHkzfve8dmsQYXSN/bdJsJr4VwrTGLQkwlpWtdrsf8HX+KwayU26D7WqPsVGo/D
-        X5esrFF6RCPxd8kdDq61JsAUgCaQwLTcXD6W64fqZ7oZuzpUhD9HaAITeAlO7LXdd+HKat9H20rb
-        sQmhemx18xUhPARYUZyaV8JHkAHLpkCnsKwY4+mcp0EMcAEBDnkX/oBD1XbnLIWKAacFz5ZJVuTf
-        rOxujLIBTGm+kAIwQyXpvECRKpUqkIot59miVnmKLFfAzgReR8NtO4j4QlRi1P7OShHbB6JPFUHz
-        ui3J8fywJ2vi5Pq+IsdPAAAA//8DAN+xUmogAgAA
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:14.845+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 21cfbffc-ac10-4674-bda4-f30cc3062e66
+      - 382c3606-5b0c-4b63-87ca-d94d703ab485
       Atl-Traceid:
-      - 21cfbffcac104674bda4f30cc3062e66
+      - 382c36065b0c4b6387cad94d703ab485
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:17:59 GMT
+      - Wed, 30 Apr 2025 16:27:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1726,7 +1830,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=146,atl-edge-internal;dur=24,atl-edge-upstream;dur=130,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=236,atl-edge;dur=150,atl-edge-internal;dur=18,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="IcJUDto9OkRn4-LosCwKtIQ8TYGsd7epzYM7yqX9PrbtYLUgMWPR9g==",cdn-downstream-fbl;dur=240
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1735,10 +1839,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 87d6d7b4889aec5ce2bf57d717a99d3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - IcJUDto9OkRn4-LosCwKtIQ8TYGsd7epzYM7yqX9PrbtYLUgMWPR9g==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 8fe7bef8fa372f7f0609292d49029fe6
+      - c8986911d728c8386da25e3e958f57da
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1762,135 +1874,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16115
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18237
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbCmU7HtZXEreu6spI8OB4PTK5IxCTAAKCOxv7v3eUh
-        xYcytTuN/UBce2D32w+rrw6sSi4TJ3I0yAQ0JG8E5InpSV6A6Zk4g4L3VAmaW6Gk6UEibAGW9+KM
-        yxRylfYWoA3uQTKFUoMBaduzcWWsKuak8Crw/cB3NXypwNjZuoQzzWMrYnB6jiD7wV4QjHBiIJ/j
-        NLO2NJHnJTCH2Cbqs3K5zbkxgktXgvXQkvV4KbzQE8ZU4HUKbmCN8qezyfmsH+wNAlyqXTBO9NUx
-        6FtlYm4hVXrd3CHBGUqEfjjq+0E/8GehHwX70Wjgjoevf0K/fXKSjFh0vFbzQidJ3kN9fri5djtJ
-        wMRalBQ4XD1gpuB53mOJMFbI2LJSQAxMzdlS6RuXpGMl3+v8mV5UUlC6eH7FF9xy7S0ELL3ara2D
-        7VbgD4LxL0b8DT8XmPaqQKsECzQ54+aGclVdWxpFc54b6DmN4DHeq5btOZlA4Og4W5/AAtBX/67n
-        WIHIKhElTiQrvKPzACYDv9sotfqMN3phwFvpOtx1Artw0+QbkGxv9V4Ka1GBcTa2Cam/12eNmtsl
-        14RXI4oyF+hw8uDmmI8aZcPxajh+prvfyUx3k01ehv4+uhEOV+Hw/7XSZL/GIhoM9lbB3o8wuOos
-        DsLVIPwRFluA3909hmOwC6dhtzEXqw8NB2L2Ly4fnxx0J3maakiRbx4VAV5A5VVT/k+bG+3a2Nu1
-        sb9jI9y5Md618fqxnw1tNqtESvUL4UT9AKfc4sPREO7zC7eh8y2Be406TWVZDw9VRYELiJQ/0oKQ
-        qRNZXcFdy9OkTYu4CefXR2vkGR41mary5EiYMufrtpRxGd2yHxAzVN5tNDTgZYk/nnokhq/3ukfi
-        Ydg2VPZwYxeowg2oSi2UFnb9wiB24l790vz7t0IUPAXjkYTplAhcyESauWaRbtnyHa50tBo6jwsn
-        3KA+59dAxPhEaRCfPBmIYBdGgzFFJONmUor4RMibN7RzBCX1LzLu8lhnd1nvbVakkhNsX/h1DlPg
-        psGGbkfO2cn7t8enVyfHh5PT88nVZDr9c4r3wzo1GBI8MMuAneELIC0ju0wYpmS+ZsgmIielzCr2
-        m9CcnWkokE5YZRC17lOsEmBBOf6t8P1yMYic5lXE7GH4t1V1jy0wEamQPH94qO2+2vDWSM/Ru3ZO
-        mU0lbE5XJZXtLiSPxsMOyU2j9ELwNcKbl/d+b/M8PG7x9iuPb7Dd7CDXKW9sHbYd3X9yuGsLm5pB
-        I2HXKEhYUnWrXOnTxpvrvIJ+qpE3tk2RYkeqSbYqSmyIpX0a9KNdtDDa0ML3Mn4/nJ/kt/8HLNWq
-        KqlRfCNkgsRoGNYKuwaQrKxMBkmN0uPpAX2vgQm5IAMEs4ThTwGGrxkkESnLQpe9JXWf5Kv6+ypi
-        Fxu1QkZMYrys4FbpyHdH7uCWgo4xz1XM80wZG439se/NG5mr2jfqKy9Rml2cQ1wRR7F3atm3aocw
-        PtpJhY92eMk8dhEYy/6quLag2USmWJkFxnmHKGwOeEEtfXr2BzuokAPYeczlDilqAb0gCC+bkN7e
-        snPsXmtHcXz4YVJ/PjafLtM0aZsAGs6ERT4g0RpZOEJFjCiT3bIL1NEPkQOw+AZhULtBSJWLxJXY
-        8LupWniLKpeIXYvc4t0/f0kqBr6/kYuX4BbCanCVTj0scE6gF9jNEjF4eNTNbJGT3DZhOKlTRspC
-        /JtCWuUcg7qiH3H1PY5ACp4Tlv4BAAD//+xZbW/aMBD+K9akVoBIGiDhrao61K5SpVFNq7YP3ReM
-        40AmIFFCqCbtx+85xwmQEuioWnXSBAJi++zz+e4538O9jFao1ZjBKnf5DHV2OlueX2CatmlVS4yp
-        j/6s2WvT+gPk35Wsk6nUBZrtsksb+3RavWfbRY9XdrGfbxf7oF1e3SZOmU0QcZnT9WvKPtTGateJ
-        ZNcIVTTeyLHJenVGQM62USB7TRtmDgPquWW+2WFjB9cKeQGKPwNGOQlKH5RjFXxUd21/3+ZZDfGI
-        5h/4Mo4KDawIb1JTvCw4t0+gdh8kEWx5488k0FOm9j6dLM+5EDJcqp9r59sQvF6jfA1onKsRAP41
-        bpp+cMbdlR8jU0hKtx0kAI9sDifK7gV0oqP1CiOGGwwj/VGZ6ztLpL1Ba0fe4ObeEGtv4MslEnBc
-        Z49TX0wZrtKTCTA4AfyxkGOtxYRxhppGQBC3IhFxj/QYDdRGjc98MUmAxiM2ldyF5IojhZrpbtn3
-        tUJDwP1MbuaW7f6s1OpveiSGfFFVgpv1o3uSdTe2Z8DIKcTRCB9Xwd4/fDCE+H36IP/CI20rxixh
-        Mp75Qh/a0FeZVJ/ZN3XZIgvrw0iVYQCZGToivXnI3c5DLpYkcxcwXz0w5L2V70p3y52+IqRwA8XS
-        f+MUWjQMKG2Sj1e4O/cXVVap/p7Dh5dBP/fbnZjx6njhHIkXDuGF8zK8OCplPMGLY5PW5vG+NV60
-        /+PFG+CF/W/hRTsXPYAXT/kOJy/5i+VuWcXTsMs6crqLSqFlBF9SLA/xNoWhdk5OFTqsMsrMKmMd
-        rJx1yMxTNrCMKbNyZbaq92INp6JjSpVJWiHGyXzOqXz9sLe+IpMTFxVERxa6xEhcwmOJQbt1Lxy3
-        1e10x42OJVuiZ4me0/R6Da+NdfJBWGHPMEn+MHBdigaMFIH76+OGIqiEaa697LgytTRRTKthJJMx
-        tLa0Gl3uNmy73RHdDvByLMYdC8t7XHpdceleqFlOWoOT5g3eqZwx5wtd+BlG2hSbSWw8whBG06SK
-        0kzjkCxlhJzHZCjIK6Tnsxg/r4aGZYYLIhyKTPv717hI1b9/jYtU/3vXGDjkpsyxZoSu4PpsyD0v
-        EcJXAURlXcpLpyj2ECxo4KckCkJ59gB8EcSg6kijv5rQm4curaD/YNtNI9lloGqXsct2zi4XO3Lg
-        jjTqb+PLHwAAAP//Gi1faJiSBrB8AQAAAP//ItvFo+ULrV1Ml/IFvRiAt8bgjRegq9Mhea8aNCcO
-        ZRsALcwvSYTO6KObgrPZhbNcwtkeM8Je8uGaHDLA1QAFFQhYJQxwNUCNcekwhrfwUvPKMovy8yCt
-        OIhQSil0OQmES1To5edCTKiGMaHFPRnFL9JKGH2YuTpKuYkVQanFpTkgg5HsBs+dFJU4lkDcUZZf
-        Qr0pW4hhcEOBdmUkFoflg6eeYPOsoElj0IQOyEq4Q1Bda4TiXKgGcPDU1tYCAAAA//8DAClJk8C9
-        JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18237","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237","key":"NTEST-1871","fields":{"statuscategorychangedate":"2025-04-30T18:27:07.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:07.681+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t67:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:07.763+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
+        (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
+        Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - aec2b7b0-e66f-415c-98b5-7d12efce4126
+      - 3cd06cc0-7589-46db-99ed-f0db827a22f5
       Atl-Traceid:
-      - aec2b7b0e66f415c98b57d12efce4126
+      - 3cd06cc0758946db99edf0db827a22f5
       Cache-Control:
       - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:00 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=334,atl-edge-internal;dur=17,atl-edge-upstream;dur=317,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - 240fe726be670a2a62eb39967eaaf683
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2Tdl+5oSExEAykdhcQQmnqiECaVE06aZr230nEBDsCN8t+
-        Xj+WD6QWHre9IZy8hdB5Ppk0qFCGxr27TAQjvNfCZhYDGZFG+86I/T/4Evudltig/1ij6VZoA/Z/
-        XbJyVpkBrcTfJXfYe+1shCkAzSCDcbm5fCzXD9XPdDO0dawIf07QCEbwEp3YGbdv45XVvku2lXFD
-        E0P1oE3zFSE8Bth8fmpeiZBABmw6BjqGZcUYL3JeRDHABUQ45n38A/aVbs9ZChUDThccIMtp/s3K
-        9sYqF8GCzhZSAE5RSZrPURRKFQqkYst8uqjVrEA2U8DOBMEkw63uRXohKjGYcOekSO0DMaeKoH3d
-        luR4ftiTs2lyfV+R4ycAAAD//wMAsz4LXSACAAA=
-    headers:
-      Atl-Request-Id:
-      - 4b7963ca-76d5-4206-b5ae-b989d6ba54c1
-      Atl-Traceid:
-      - 4b7963ca76d54206b5aeb989d6ba54c1
-      Cache-Control:
-      - no-cache, no-store, no-transform
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:00 GMT
+      - Wed, 30 Apr 2025 16:27:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1900,7 +1944,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=169,atl-edge-internal;dur=19,atl-edge-upstream;dur=151,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=311,atl-edge;dur=279,atl-edge-internal;dur=16,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="KNVBiwVNKuOUwuQ_rV0Y8sti0SE0SzCmPGUl9uqzxgDFpkN4T6v3GA==",cdn-downstream-fbl;dur=315
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1909,127 +1953,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5ea7f8bcbac3004590a821cdd0466e1c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - KNVBiwVNKuOUwuQ_rV0Y8sti0SE0SzCmPGUl9uqzxgDFpkN4T6v3GA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7166b042a7e55dcfb6d66bc7eaa599b3
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16116
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61PbRhD/V270IdNJbb0w4CiT6VDiJLSUUuMkHwjDnKW1dEG6U+9OfjTwv3dX
-        Dzs8nBY6Dcyge+3jdn/7u+WLA8uSy8SJHA0yAQ3JGwF5YnqSF2B6Js6g4D1VguZWKGl6kAhbgOW9
-        OOMyhVylvTlog3uQjKHUYEDa9mxcGauKGSm8DHw/8F0Nf1Zg7GRVwqnmsRUxOD1HkP1gLwj2cGIg
-        n+E0s7Y0keclMIPYJuqzcrnNuTGCS1eC9dCS9XgpvNATxlTgdQquYIXyJ5PR2aQf7O2EuFS7YJzo
-        i2PQt8rE3EKq9Kq5Q4IzlAj9cLfvB/3An4R+FOxHu3tuMBj+iH775CQZseh4reaJTpK8h/p88qq5
-        djtJwMRalBQ4XD1gpuB53mOJMFbI2LJSQAxMzdhC6SuXpGMl3+v8kV5UUlC6eH7J59xy7c0FLLza
-        rY2D7Vbg7wTDn4z4C14VmPaqQKsECzQ54eaKclVNLY2iGc8N9JxG8AjvVcv2nEwgcHScrY5hDuir
-        f9NzrEBklYgSJ5IV3tG5A5Mdf9tG0G2UWn3Gqz4xE610nYc6s10eaPIVejbXfS+FtajAOGvbBOFf
-        67NGzeyCawKyEUWZC3Q4uRMSTFQNv8FwORg+0t1vpKy7yTphA38f3QgHy3Dw/1ppYFGDFA0Ge0ss
-        ve9gcNlZ3AmXWNnfwWKL/Jub+3AMOzjOxPJDw4GY5POL+yd3upM8TTWkyDf/WAS73QZeQOVVwwsP
-        H93btrG/ZSPcujHctvHivjsNbTarREr1C+FE/QCn3OLD0RDu4+uzofMNgXuNOk3VVw8PVUWBC4iU
-        P9KCkKkTWV3BTcvTpE2LuInal3tr5BkeNZmq8uS1MGXOV23F4jK6ZT8gNKiK22howMsSTdx/JHbd
-        /aHfPRJ3w7aNysI1ld3dWIOq1EJpYVdPDGIn7tUvzb9/K0TBUzAeSZhOicCFTKSZa+bphhTf4UrH
-        nqFzvz7CNepzPgXivwdKg2jjwUAE2zAaDCkiGTejUsTHQl69oZ3XUFL/IuMuj3V2F/XeekUqOcL2
-        hU9zGAM3DTZ0O3JOj9+/PTq5PD46HJ2cjS5H4/HvY7wf1qnBkOCBSQbsFIleWkZ2mTBMyXzFkDRE
-        TkqZVewXoTk71VAga7DKIGrdh8gjwIJy/Gvh++V8GjnNq4jZw/BvquoWW2AiUiF5fvdQ23214a2R
-        nqN37Zwym0pYn65KKtttSB4Oww7JTaP0RPA1wusH9nZv8zg8bvD2M4+vsN3sINcpb2wdth3df3K4
-        awubmkEjYdcPSFhQdatc6ZPGm2leQT/VyBubpkix16pJtipKbIilfRj0u2ta+FZi7wqtKeN2OD/J
-        r38PWKpVVVKj+EbIBInRMKwVNgWQrKxMBkmN0qPxAX2nwISck2WCWcLwXwGGrxkkESnLQpe9JXWf
-        5PP6+zxi52u1QkasTKNdN3D9awo2xjpXMc8zZWw09Ie+N2vOXtY+0at6gVLs/AziiriJvVOLvlVb
-        hPFNTip8k8ML5rHzwFj2R8W1Bc1GMsWKLDC+W0RhfcALaumT09/YQYW1z85iLrdIUYfnBUF40YTy
-        +pqdYddaO4rjww+j+vOx+XQZpkn7+NNwIizyAInWiMIRKmJEleyanaOOfoi1j8+aPwxrNwihcp64
-        Eht9N1Vzb17lEjFrkVO82+cvSMWLwVosXoBbCKvBVTr1sK45YV1gr0p84L0YuJktcpIqU/xTJ4pU
-        hPgzhkJZwGskwEZLzAfJsD774TTtsWe5fclCNwjckLFnqX356m8AAAD//+xYUW/bOAz+KwQKDI4v
-        Va5O0qAZ+lC0O+CA2zCs214uB8R11MWbY6eW3XXY9t/3UZJluYk3rNu9tS1ShxQl6iNFfjKNxZ8w
-        1oqxOBYTahSTVjER6IWNfNrKpwJzNfLjVs6P01bO3ln5kThu5VErj/zx41Y+FuNWPmnlk3YDs3Zd
-        fvTkbl1+jAY9yWFTeRSdnDCiZ+ARt3LIodd8n/bFefaTcbbjf1ecH2P84BjP+mKMStgUhXmo480y
-        Ci9qSRcooRD+Ja8EnQyJGyx1q3Pzuz4Srjzr72PxeCx/MWQnKNvhhe71aMPvC2IWhHD80I4CfAz2
-        BfZ7YaUQnQDif/Hv8AGHFevh1OsJfq0pdDMrvCzqMpHIrkyG3J8P0UY3qZIM6/adN/CiZREhur1b
-        FqmnbH8WaTGKV7epAkXBFWAaRSAY14wwDkPDO5lqLLfvlgROB/9yiqk0WZxwFkuXxbwHWcZXacYd
-        tVrHFRUJFlL0cQ1yUoFdW0NG7SpWkoqSbnBx+0S4Kid8BhVmT8r4mh0AG6s3OTH5EvqcgZ+XkkDQ
-        qfpYNCYJqUTmMS4yzFiwVJqsCTwA5D1LP0jQ92usEsPt7TZLE/3m0jKjxuFMAh+cWOb//iizNfhU
-        5yq+RqFgun+oah4C/9RNZpezyCjaxDBOC/ACz3klFnm0OzuMciCt2Bm4hxtvCUKIeR06TNacD7FF
-        qpRVXeZIbTypOqsYXc8HjNvrhGAADw5wcykQT/ydF3kit9UiXy6Xi5xvgxV9pnPsDJznK50Sv8pN
-        Sxk8ObiLZkgt83/QjE3MyFMCdbZmASv1k7CbY0ljwHCd0vLy2T/Pzl/TEZ1d0pObuqieLvBjJh+F
-        RoJDuE8djhY4l3/wVlWRSYHLQoDsT3CBEzK/HfzH3oBBwyQfjYz1UjtgnNIABvBjSIEsyyEjOKBT
-        Pjn0GTPbPWGuFTv+dWDBobcuUeg5OCvyhfio+fLm/dC8U8XBE3vqODR9ldwZ7dRyp9mp5p7mXj33
-        NPcquqe5V9M9zb2q7jQ7dd3TdCs7cHqp3++sGpDmdqQFyaKC+Ty4GCOLCS/kw8UYWVCsqoGLMXKg
-        eJqm4zWodFQMkkOlo2GQHCodDYPkUOloGCSHiqcxIDlUOhoDkpdMwGuNTOKUPDR0b75b6PmmMucP
-        dCd8O0v4HCAx6yscf9sDnqf64mdbQOguMpG4E3dzeqNfFnABssW+CQkqZgZNKXyjcZ+RidZem0mf
-        jQnjXptpn40J8F6b4z4bExFnQwG94A6ku5PrcDoJhibiQ112TYi51cSZKmhrElgQ0wi36KxvUR3S
-        7y9qEwJdamcBG7u/N9s4qThuLwpK9RdCCtymK7lq2zwGvgInKiWqufqZPm9NtwXfuJmmBPFqk+YD
-        CgZfNqAhVTF31GMvnX2kst4B9gvej6ns7IFUdsZUdvZ/UNlvAAAA//8irSlLbr8XOdnSuilrONqU
-        BaoCAAAA///smtFqgzAUhl9lDHoZFzVOvShdGRvsoi/Qu/REtzHUopXRt985xoaaNR0MCl4EeiHN
-        SU84mJ+//J+3st7Keit7UdUn1myi6xNrdq7s3sqe5uWtrLey87Cyodn6h5X9nd4nJsC2w1tXrB+K
-        82Dv0Er4GtAEgg3sUgN4WAvctSAMg2HvMBn6aQquQlemzl3cBzc9J1m0HVXKw0HCB+VtOu/s+qqS
-        FMbeX0wLadREVDTtP+NacicrCUAcyJtaJirO0mwXpryIIeeQJ1GZhyXBgKYIO1wpK+g9WCuFPTqs
-        RLt3fDo7CDTEvl1HuYbZF8F7q8tozwknEgUPM6lCIR5TyNIkznewSzm2L2VRZrBSy+FXFvF6Eb3i
-        R+9jlazHGJMx/VUX9B37xkGwKKB8NNAaSJNieyk7GhTuHzw63jZ8fN4wHuxris1tLGz+J7a5svmf
-        2ObS5n5iFCal+aeRa8D/68e7jSzLHuBzuEAUgmm6Ssvatqmp8KVvm33xsEXBAeKAxptGXCSumqtL
-        HUZM9DIMIVxiKlyMlDCMVDuKupeRG70wPwAAAP//wkwwo8UIPVw8WoxgKUbQiwFczTMTeCsM3mgB
-        eicdkimrQQu4oWwDoEvySxKh69LRTcHVDjPAVS4ZGGEv4HAtcTTA6QGc7TS4z9B14GrAGeOUgLfs
-        UvPKMovy8yCtN4hQSil0UwSES0zolQGb/eQuF8RY8AsxDG4o0KaMxOKwfPDCRdgqXWAWgDi5GsaE
-        1i9kOwC8gUQfZq6OUm5iRRBk4AnFs+Alh0UljiUQj4OWPoOWJYK8DhdH1WyEohuqAeza2tpaAAAA
-        AP//AwBKNUcTgzMAAA==
-    headers:
-      Atl-Request-Id:
-      - aaaac6db-76ca-4227-b6b2-c44d6c8a9d6d
-      Atl-Traceid:
-      - aaaac6db76ca4227b6b2c44d6c8a9d6d
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:00 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=13,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - fcd1cfc9083f0f02653927b54c74e575
+      - 3df13d041090b39107dd85d005d49720
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2056,26 +1991,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1m1d3mSCU3QK7V4UkTS9YDRNSpMOxth3N8HB9qi+HXe/
-        //2OO5BaeNz2hnDyEULn+WTSoEIZGvfpMhGM8F4Lm1kMZEQa7Tsj9v/gS+x3WmKD/muNpluhDdj/
-        dcnKWWUGtBJ/l9xh77WzEaYANIMMxuXm+rlcP1Xn6WZo61gR/pqgEYzgLTqxM27fxiurfZdsK+OG
-        JobqQZvmJ0J4DLDF4tS8ESGBDNhsDHQMy4oxnk95HsUAVxDhmPfxD9hXur1kKVQMOC04QLYszqxs
-        76xyEczpvJACcIZK0ukCRa5UrkAqtpzOilrNc2RzBexCEEwy3OtepBeiEoMJD06K1D4Qc6oI2vdt
-        SY6Xh704mya3jxU5fgMAAP//AwBdEtL8IAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:15.661+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 1fe1ddef-b0f1-4013-ad0c-b29c48d92a7c
+      - 98d77342-ed77-484b-bd75-fddc1471ccbd
       Atl-Traceid:
-      - 1fe1ddefb0f14013ad0cb29c48d92a7c
+      - 98d77342ed77484bbd75fddc1471ccbd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:01 GMT
+      - Wed, 30 Apr 2025 16:27:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2085,7 +2016,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=156,atl-edge-internal;dur=12,atl-edge-upstream;dur=144,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=193,atl-edge;dur=160,atl-edge-internal;dur=14,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="qPYMjd-1ux8z75PiqbMXhVDbBuFmpO6BT9KsWTOoFz4wrXyT7ODBAA==",cdn-downstream-fbl;dur=198
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2094,10 +2025,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b3ac893abff0a2c3dda216fe4cd9157a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qPYMjd-1ux8z75PiqbMXhVDbBuFmpO6BT9KsWTOoFz4wrXyT7ODBAA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 31f81751d858d13e0c3e156021e53004
+      - 7d69d2d71205a901570fda2144c44746
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2121,133 +2060,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16117
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18239
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJl2Rb4Uyn49py4tR1XVlJHhyPByZXJGISYAFQR2P/9+7y
-        kOJDae1OM3ogrj2w++2H1RcHliWXiRM5GmQCGpIjAXliepIXYHomzqDgPVWC5lYoaXqQCFuA5b04
-        4zKFXKW9OWiDe5BMoNRgQNr2bFwZq4oZKbwKfD/wXQ1/VmDsdFXCmeaxFTE4PUeQ/WA3CPZwYiCf
-        4TSztjSR5yUwg9gm6rNyuc25MYJLV4L10JL1eCm80BPGVOB1Cm5ghfKn0/H5tB/sDga4VLtgnOiL
-        Y9C3ysTcQqr0qrlDgjOUCP1wp+8H/cCfhn4U7EU7I3e4F/yIfvvkJBmx6Hit5oVOkryH+vxwfe12
-        koCJtSgpcLi6z0zB87zHEmGskLFlpYAYmJqxhdI3LknHSr7X+TO9qKSgdPH8is+55dqbC1h4tVsb
-        B9utwB8Eo5+N+At+KjDtVYFWCRZocsrNDeWqurY0imY8N9BzGsFjvFct23MygcDRcbY6gTmgr/5d
-        z7ECkVUiSpxIVnhH5wFMBv62jaDbKLX6jFd9YSZa6ToPdWa7PNDkK/RsrvteCmtRgXHWtgnCv9Zn
-        jZrZBdcEZCOKMhfocPIgJJioGn7D0XI4eqa730hZd5N1woY+VUA4XIbD/9dKA4sapGgw2F0Gu9/D
-        4LKzOAiXg/B7WGyRf3f3GI5hB8eZWH5oOBCTfHH5+OSgO8nTVEOKfPOPRbDTbeAFVF41vPD00d1t
-        G3tbNsKtG6NtG68fu9PQZrNKpFS/EE7UD3DKLT4cDeE+vz4bOt8QuNeo01R99fBAVRS4gEj5Iy0I
-        mTqR1RXctTxN2rSIm6h9ebRGnuFRk6kqTw6FKXO+aisWl9Et+wGhQVXcRkMDXpZo4qlHItjZ6R6J
-        h2HbRmXhmsoebqxBVWqhtLCrFwaxE/fql+bfvxWi4CkYjyRMp0TgQibSzDXzdEOKb3GlY8/QeVwf
-        4Rr1Ob8G4r8nSoNo48lABNswGowoIhk341LEJ0LeHNHOIZTUv8i4y2Od3UW9t16RSo6xfeHXOUyA
-        mwYbuh05Zyfv3xyfXp0cH4xPz8dX48nk9wneD+vUYEjwwDQDdoZELy0ju0wYpmS+YkgaIielzCr2
-        TmjOzjQUyBqsMoha9ynyCLCgHP9W+H45/xw5zauI2cPwb6rqHltgIlIhef7wUNt9teGtkZ6jd+2c
-        MptKWJ+uSirbbUgOB36H5KZReiH4GuH1A3u/t3keHjd4+4XHN9hudpDrlDe2DtqO7j853LWFTc2g
-        kbDrByQsqLpVrvRp4811XkE/1cgbm6ZIsUPVJFsVJTbE0j4N+p01LXwrsQ+F1pRxP5yf5Ne/fZZq
-        VZXUKB4JmSAxGoa1wq4BJCsrk0FSo/R4sk/fa2BCzskywSxh+FeA4WsGSUTKstBlb0jdJ/mq/r6K
-        2MVarZARm2EMs8h3B65/S/HGcOcq5nmmjI1G/sj3Zs3xq9otRMTOJQqyi3OIK6In9lYt+lZtEcZn
-        OanwWQ4vmccuAmPZHxXXFjQbyxSLssAQbxGF9QEvqKVPz35j+xWWPzuPudwiRU2eFwThZRPN21t2
-        jo1r7SiODz6M68/H5tMlmSbt+0/DqbBIBSRagwpHqIgRW7JbdoE6+iGyW5/+rryu3SCQynniSuz1
-        3VTNvXmVS4StRVrx7p+/JBVDvwk2ycULcAthNbhKpx7WNie8C+xXiRM8POpmtshJrs4VfutskZ4J
-        pFXOMZZL+ttWu38IUvCc0HMOeo7/zlif/XCk4W8AAAD//+xZ207bQBD9lVWlIhLFxkkcckGIRqRI
-        PKSqWrUP9IXN7pq4SuLIl6CqfHzPrDeLY7K0pSriAYGSeGevM7NnzoyzeYsdLPITDO75nYZDe8bW
-        R53hgBYcI9ZuVIt0ozkxuyOdNrcaHTW1UqiNNSeFYhO4IBov1MxnwxYjgGK73r39m7d96976uev/
-        5+Ng3xONI7ji3xNGCIut/nYcO8RHY9+hHzsya8LF0PwNX96TrI0V4Th6in/zt129Nz8nRQotXsQL
-        BSxQpaYPbvIT7VyVjpN7jGoCS+yyCcDLXH0/To643MQZABAEo9c5BnxFpGO4yjaqke2u9eTXDKGX
-        0VaRUppgmxqTm42QyaU1eWZMfjsn6OOYb3XDwLkF5IjaIuURrUQxGpC0LnIfmv96P/8U2LNQBuN2
-        RVu2P6p4EXp81DxVbsWQQjOnVlyZAD3nGI1GeKS+kKO6MluVhgzcxiFIN8qj6BWLhx1LacQ3FG8r
-        ViIEG9EHORcex0JgvhHiw2wRC2PBaayDgjHgF80bSOfGMuWpWJKyBQSpby1/uVxzkdOYDwmL9QMD
-        jm9iqeSOL33CfQKZwtJ/4yFm6DqhMEAOfsjlMl412GHjbgkHzpMRnPYhFe9ZNlpnYi6O3g6rUTpP
-        QT90nkGZQ72rzdZqgsAlCG1CVR9hCfFWC66OLoIcuJK4wK65QyzrvIPnORdzipwlecmK5ZITs3rj
-        Cv2kbcqQkvSJ9Ivu4BkXgvK6S3nak91BfzBr9wPVFcNADHudaNiOjrGO7YQVHummyBXGUtI9QU+R
-        yB/vKhsBP6O5Hi3NaPUrHxRPd6Mx2/JAqJCFcNkOw+O+GPR73eFMzPoBlo+4igbiTJ7qWd52x287
-        F/gvx3lLvjKcxPPKpswvMu8WivA6PpEdv7yCpClvzXlGisJ4jfDIYfDzfOoF/npFNLhe5nn5O67X
-        iV7+jut1ppe+Y2CTLOsZJk85h+uzKY+iQohYXyAiZWW1pES2K5BYdHxfpMlaHV0BcwTl9eamUZ0T
-        Unt1aQVT9t2f3IQuPA1dNY/Q1jxSg+uvMPJsDvMKI8+x41cY2QMjdRhwMbTQEjHLW3Ccm/JS/qQX
-        MuZ3gJ0kOTfvmeqzuKhY4MKloLMf4Fwly8B5ACdVsyerj3BxuK5TYMmdWm3iNFmVBK5skoV5yVk+
-        /on2NkleKeD/AgAA//8irRzGGMCHGAY3FGhTRmJxWD54IBI26g7MAhAnV8OY0PqFbAeAJ4T1Yebq
-        KOUmVgSlFpfmgAxG8ix4CLGoxLEE4nHQVAZomBHkdbg4qmYjFN1QDWDX1tbWAgAAAP//AwAdL0u/
-        Ux8AAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18239","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239","key":"NTEST-1872","fields":{"statuscategorychangedate":"2025-04-30T18:27:10.705+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:10.389+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:10.491+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
+        Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:*
+        http://localhost:8080/finding/297 (297)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 077edc52-8a46-4bcb-ac9c-686400140042
+      - b3e34215-ec6b-4e40-9a66-063178074cf5
       Atl-Traceid:
-      - 077edc528a464bcbac9c686400140042
+      - b3e34215ec6b4e409a66063178074cf5
       Cache-Control:
       - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:01 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=286,atl-edge-internal;dur=12,atl-edge-upstream;dur=274,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - 20919ed682078ba151feaaa901818aa9
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBSF/0teXbubrF23vMkEp+gU2r0oIml6g9U0KU06GGP/3QSH7lF9u9z7
-        nXsO50Bq4XA7aMLJm/e949Npgwqlb+y7TYXXwrlWmNSgJxPStK7XYv8PvsRh10ps0H2sUfcrNB6H
-        vz5ZWaP0iEbi75Q7HFxrTYApAE0hhaTcXD6W64fq57oZuzpMhD9HaAITeAme2Gu770LKat9Ht5W2
-        YxNE9djq5ktCeBCwojgtr4SPIAOWJ0ATWFaM8WzGs2AMcAEBDnoXesChartzlkLFgNMFDyGLnH2z
-        srsxygYwo/OFFIA5KklnBYpMqUyBVGw5yxe1mmfI5grYmYHX0eG2HUSsEJUYtb+zUsT1gejTRNC8
-        bktyPA/2ZE28XN9X5PgJAAD//wMAGKsi2CACAAA=
-    headers:
-      Atl-Request-Id:
-      - 086bb794-65c7-4be4-9980-cb4bf4c2d9f2
-      Atl-Traceid:
-      - 086bb79465c74be49980cb4bf4c2d9f2
-      Cache-Control:
-      - no-cache, no-store, no-transform
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:01 GMT
+      - Wed, 30 Apr 2025 16:27:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2257,7 +2176,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=157,atl-edge-internal;dur=14,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="IER3DkjJ4ycT8laFtfE443lSrtS31H6Bs6TdREc5wx5vFeHvTExKhw==",cdn-downstream-fbl;dur=370,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=367,atl-edge;dur=281,atl-edge-internal;dur=20,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2266,115 +2185,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 35f3ad5aa26e63a13ffedf420998e698.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - IER3DkjJ4ycT8laFtfE443lSrtS31H6Bs6TdREc5wx5vFeHvTExKhw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 441194036ca96c8aabd59b0c60d2ed40
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16115
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvyY7CmU7HtZXEreu6spI8OB4PTK5IxCTAAKCOxvnv3eWl
-        +FCmdqexH4hrD+x++2H1xYF1yWXiRI4GmYCG5LWAPDEDyQswAxNnUPCBKkFzK5Q0A0iELcDyQZxx
-        mUKu0sEStME9SGZQajAgbXs2roxVxYIUXgW+H/iuhs8VGDvflHCmeWxFDM7AEWQ/2A+CPZwYyBc4
-        zawtTeR5CSwgton6pFxuc26M4NKVYD20ZD1eCi/0hDEVeJ2CG9ig/Ol8ej4fBvujAJdqF4wTfXEM
-        +laZmFtIld40d0hwhhKhH+4N/WAY+PPQj4KX0d7InYxf/YR+++QkGbHoeK3mmU6SvIf6/LC/djtJ
-        wMRalBQ4XD1gpuB5PmCJMFbI2LJSQAxMLdhK6RuXpGMl3+n8iV5UUlC6eH7Fl9xy7S0FrLzara2D
-        7Vbgj4LJL0b8DT8XmPaqQKsECzQ55+aGclVdWxpFC54bGDiN4DHeq5YdOJlA4Og425zAEtBX/+vA
-        sQKRVSJKnEhWeEfnHkxG/q6NoNsotfqEV31mJlrpOg91Zrs80OQb9Gyv+04Ka1GBcXrbBOHf67NG
-        LeyKawKyEUWZC3Q4uRcSTFQNv/FkPZ480d3vpKy7SZ+wsf8S3QjH63D8/1ppYFGDFA0G++tg/0cY
-        XHcWR+F6FP4Iiy3yv359CMewg+NCrN83HIhJvrh8eHLUneRpqiFFvnlQBOinyqum/B9H/96ujf1d
-        Gy93bIQ7Nya7Nl499LOhzWaVSKl+IZxoGLRcSZHXIm6u9OXBGtUDBtVkqsqTI2HKnG/aqsFlTKF9
-        j+mhSmpNcIuPUUPiT6/55onYPgpeo05TRdfDQ1VRMmrnP9CCkKkTWV2RN7EGvCzRxGOPxPjVfvdI
-        3A/bLioLeyq7v9GDqtRCaWE3z7xwJ+7VL82/fytEwVMwHkmYTonAhUykmWuW6ZYU3+JKx56h87A+
-        wh71Ob8G4r9HSoNo49FABLswGkwoIhk301LEJ0LevKadIyipf5Fxh6EaWat6r1+RSk6xfeHXOcyA
-        mwaXuh05Zyfv3hyfXp0cH05Pz6dX09nszxneD+vUYEjwwDwDdoZELy0ju0wYpmS+YUgaIielzCr2
-        m9CcnWkokDVYZRBh7mPkEWBBOf6t8P1yOYqc5lXE7GH4t1V1hy0wEamQPL9/qO2+2vDWOM/Ru3ZO
-        mU0l9Kerksp2F5L3JuMOyU2j9EzwNcL9A3u3t3kaHrd4+5XHN9hudpDrlDe2DtuO7j853LWFTc2g
-        kbDrBySsqLpVrvRp4811XsEw1chZ26ZIsSPVJFsVJTbE0j4O+r2eFr6X2PtCPWXcDedH+e3/AUu1
-        qkpqFF8LmSCJGYa1wq4BJCsrk0FSo/R4dkDfa2BCLskywSxh+FOA4WsGSUTKstBlb0jdR/mi/r6I
-        2EWvVsiISYyXFdwqHfnunju6paBjzHMV8zxTxkYTf+J7i0bmqvaN+spLlGYX5xBXxFHsrVoNrdoh
-        jG9zUuHbHF4yj10ExrK/Kq4taDaVKVZmgXHeIQr9AS+opU/P/mAHFXIAO4+53CFFnZ4XBOFlE9Lb
-        W3aO3WvtKI4P30/rz4fm02WaJm0TQMO5sMgHJFojC0eoiBFlslt2gTqGIXIAFt8oDGo3CKlymbgS
-        G343VUtvWeUSsWuRW7y75y9Jxcj3e7l4BW4hrAZX6dTDAucEeoFNKxGDh0fdzBY5yW0ThpM6ZaQs
-        xL8ZpFXOMahr+hFX3+MIpOA5YekfAAAA///sWW1v2jAQ/ivWpFaASBog4a2qOtSuUqVRTau2D90X
-        jONAJiBRXqgm7cfvOccJLyXQUbXqpAkExPbZ5/Pdc76HexktUasxg1Xuihnq7HSWnF9gmrZpVUuM
-        qY/+rNlr0/oD5P6lrJOp1D2Z7bJLG/t0Wr1n20WPV3axn28X+6BdXt0mTplNEHG50/Vryj7UxmrX
-        qWTXCFU03sixyXp1RkDONlEgf00bZgED6rllvtlhYwfXCnkBij8DRjkJSh+UYxV8VHdtf9/mWQ3x
-        iOYf+DKOCg2sCG9SU7wsODdPoHYfpBFseePPJNBTZvY+nSTnXAgZJurnyvnWBK9XKF8DGhdqBIB/
-        jZumH5xxd+nHSCGS0m0HCcAjm8OJ8nsBnehotcKI4QbDSH9U5vrOEmlv0NqRN7iFN8TaG3iSIAHH
-        dfY49cWU4Ro/mQCDU8AfCznWWkwYZ6hpBARxKxIR90iP0UBt1PjMF5MUaDxiU8ldSC45UqiZ7ZZ9
-        Xyk0BNzP5Hpu2ezPS63+ukdiyBd1o3fzfnRP8u7G5gwYOYU4GuHjKtj7hw+GEL9PH+RfeKRtxZgl
-        TMczX+hDG/oqk+oz+6YuW2RhfRiZMgwgM0NHpDcPudt5yEVCMncB89UDQ95b+q50N9zpK0IKN1As
-        /TdOoUXDgNIm+XiFu3N/UWWV6u85fDgJ+oXf7sSMV8cL50i8cAgvnJfhxVEp4wleHJu01o/3rfGi
-        /R8v3gAv7H8LL9qF6AG8eMp3OEXJv13ulhEhDXu9FEoiuIwiXoga2h5aRoBZZR12wVptSxSsQ26F
-        soFlLIRVxpRZxZoqAKZUfOhSfL2a3y724nQ+51S+fthbX5HJiYsKoiMLXWIkLuGxxHbduheO2+p2
-        uuNGx5It0bNEz2l6vYbXxjrFIKywZ5gkfxi4LkUDRorA/fVxTRFUwjTXXhJcnYE0UUyrYSSTE7G2
-        tBpd7jZsu90R3Q7wcizGHQvLe1x6XXHpXqhZTlqDk+YN3pmcMecLXfgZRtYUm2lsPMIQRtOkitLM
-        4pAsZYScx2QoyCuk57MYP6+GhmWGCyIctgn196/xNiP//jXeZvTfu8YAKDdjrTUjdAXXZ0PueakQ
-        vgogKusyDjmDt4dgQQM/pVEQyrMHAI8gBlVHGv2jhN4idGkF/QfbbhrJLgNVu4xdtgt2OdLg/kwY
-        +QMAAP//Gi1GKE8wg7EYAQAAAP//IuTi0WKE1i6mSzGCXgzgaqaZwFtj8MYK0DvpkExZDZr6hrIN
-        gC7JL0mEzuijm4KrPWaAq1wyMMJewOGaHDLA6QGc7TW4z9B14GrIGeOUgLfwUvPKMovy8yBNPIhQ
-        Sil0OQmES0zoleWXUG9aE2IY3FCgTRmJxWH54Ckf2NwqMAtAnFwNY0LrF7IdAF56ow8zV0cpN7Ei
-        KLW4NAdkMJJnwZM1RSWOJRCPgyaNQRM6IK/DxVE1G6HohmoAu7a2thYAAAD//wMAaLFYAr0kAAA=
-    headers:
-      Atl-Request-Id:
-      - afbd2e02-0675-47d6-91ea-e7d3b30ba5ef
-      Atl-Traceid:
-      - afbd2e02067547d691eae7d3b30ba5ef
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:02 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=265,atl-edge-internal;dur=16,atl-edge-upstream;dur=250,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - e3bf1adb37c7621b830ade2ca9953e38
+      - 1882ee5d9b0c29a7df092a8c45bd6e87
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2401,26 +2223,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2TdV+5oSExEAykdhcQQmnqiECaVE06aZr230nEBDsCN8t+
-        Xj+WD6QWHre9IZy8hdB5Ph43qFCGxr27XAQjvNfC5hYDGZFG+86I/T/4Evudltig/1ij6VZoA/Z/
-        XbJyVpkBrcTfJXfYe+1shCkAzSGHrNxcPpbrh+pnuhnaOlaEPydoBCN4iU7sjNu38cpq3yXbyrih
-        iaF60Kb5ihAeA2w+PzWvREggAzbNgGawrBjjxYQXUQxwARGOeR//gH2l23OWQsWA0wUHlhfAvlnZ
-        3ljlIljQ2UIKwCkqSSdzFIVShQKp2HIyXdRqViCbKWBngmCS4Vb3Ir0QlRhMuHNSpPaBmFNF0L5u
-        S3I8P+zJ2TS5vq/I8RMAAP//AwDAsEn/IAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:16.483+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - b8bb6306-2085-4774-bd49-b2e82b7d347b
+      - 9b0312d4-900c-46c3-9f17-601183a97215
       Atl-Traceid:
-      - b8bb630620854774bd49b2e82b7d347b
+      - 9b0312d4900c46c39f17601183a97215
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:02 GMT
+      - Wed, 30 Apr 2025 16:27:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2430,7 +2248,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=163,atl-edge-internal;dur=15,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="XW8ZfMs8OOJW4BuIHUzZ6XZc5syuxAb_GlOSAtIxD1Yz6l-v5-zViw==",cdn-downstream-fbl;dur=229,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=227,atl-edge;dur=138,atl-edge-internal;dur=13,atl-edge-upstream;dur=125,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2439,10 +2257,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c80d7d73c19744418338fdf12216d306.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - XW8ZfMs8OOJW4BuIHUzZ6XZc5syuxAb_GlOSAtIxD1Yz6l-v5-zViw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 2cc023b96c38f9fdac9dab6ade02912b
+      - 467405bde6bb74b72e296e7f81dc7958
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2466,78 +2292,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16116
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18241
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX6VPbRhT/V3b0IdNJbV0YcJTJdChxGlpKqXGSD4Rh1tKztEHaVXdXPhryv/c9
-        HXbAOFPoNDCD9nr37x18dmBZcpk4kaNBJqAheSMgT0xP8gJMz8QZFLynStDcCiVNDxJhC7C8F2dc
-        ppCrtDcHbfAOkjGUGgxI276NK2NVMSOG14HvB76r4a8KjJ2sSjjXPLYiBqfnCJIfHATBAW4M5DPc
-        ZtaWJvK8BGYQ20R9Ui63OTdGcOlKsB5Ksh4vhRd6wpgKvI7BDayQ/mwyupj0g4O9EI9qFYwTfXYM
-        6laZmFtIlV41NiS4Q4rQD/f7ftAP/EnoR8FhtH/gBoPhj6i3T0qSEIuK12yeqCTRe8jPJ60as9tN
-        AibWoiTH4ekRMwXP8x5LhLFCxpaVAmJgasYWSt+4RB0r+U7nj9SikoLCxfNrPueWa28uYOHVam0U
-        bK8Cfy8Y/mTE3/CqwLBXBUolWKDICTc3FKtqamkVzXhuoOc0hCdoV03bczKBwNFxtjqFOaCu/pee
-        YwUiq0SUOJGs0EbnHkz2/O6i1OoTWvREh7fUtbvrAHbups1XINlY9U4Ka5GBcdayCam/1W+NmtkF
-        14RXI4oyF6hwcs9yjEeNssFwORg+Ut1vRKazZB2XgX+IaoSDZTj4f6U00a+xiAKDgyVm2HcQuOwk
-        7oVLTODvILEF+Jcv23AMduE07C5mYvm+qYEY/cur7Zd73UuephpSrDdbSYAGqLxq0v9hcfu7Lg52
-        XRzuuAh3Xgx3XbzY1rMpm80pFaW6QzhRP2hrJYVEi7gx6fPWGSUKettkqsqT18KUOV+16YTHC26x
-        9TQl+/Gp3zSETQvwGnaaErteHquKXF+r+oEOhEydyOqKZCNT+x4xQ+ndekMDGkv1Y7tJ7LuHQ79r
-        Evfdti5l9y92gSpcg6rUQmlhV090QUfu1Z3m3/cKUfAUjEcUpmMi8CATaeaaebqplm/xpCurobOd
-        OOEa9TmfAhXGB1KD6smDjgh2YTQYkkcybkaliE+FvHlDN6+hpPlFxh2GamQt6rv1iVRyhOMLn+Yw
-        Bm4aXOp25Zyfvvvl5Oz69OR4dHYxuh6Nx3+M0T7MU4MuwQeTDNg5dgBpGcllwjAl8xXDaiJyYsqs
-        Yr8Kzdm5hgLLCasMYs59qKoEmFCOfyt8v5xPI6fpihg9dP8mq+5UCwxEKiTP7z9qp6/WvTXyc9Su
-        3VNkUwnr11VJabsLycNh2CG5GZSeCL6GeN157842j8PjBm8/8/gGx80Och3zRtZxO9H9J4W7sbDJ
-        GRQSdoOChAVlt8qVPmu0meYV9FONNWszFCn2WjXBVkWJA7G0D4N+f10WvhXY+0TrknHXnR/l179H
-        LNWqKmlQfCNkgmXNMMwVNgWQrKxMBkmN0pPxEX2nwISck2SCWcLwXwGG3QySiJhloct+IXYf5fP6
-        +zxil2u2QkasTKN9N3D9W3I2+jpXMc8zZWw09Ie+N2veXtc6Ubu9Qip2eQFxRbWJvVWLvlU7iLFZ
-        JxU26/CKeewyMJb9WXFtQbORTDEjC/TvDlJYP/CCmvrs/Hd2VGHus4uYyx1UNPp5QRBeNa68vWUX
-        OLXWiuL6+P2o/nxoPl2EadM2f1pOhMU6QKQ1onCFjBiVSnbLLpFHP8Tcx6bkD8NaDUKonCeuxEHf
-        TdXcm1e5RMxarCne3fdXxOLFYE0WL8AthNXgKp16mNecsC5wiKV64L0YuJktcqIqU/xTB4pYhPgz
-        hkJZQDMSYKMlxoNoWJ/9cJ722LPcvmShGwRuyNiz1L589Q8AAAD//+xYUW/bOAz+KwQKDI4vVa5O
-        0qAZ+lC0O+CA2zCs214uB8R11MWbY6eW3XXY9t/3UZJluYk3rNu9tS1ShxQl6iNFfjKNxZ8w1oqx
-        OBYTahSTVjER6IWNfNrKpwJzNfLjVs6P01bO3ln5kThu5VErj/zx41Y+FuNWPmnlk3YDs3ZdfvTk
-        bl1+jAY9yWFTeRSdnDCiZ+Awt3LIodcXAdoX59lPxtmO/11xfozxg2M864sxKmFTFOahjjfLKLyo
-        JV2ghEL4l7wSdDIkbrDUrc7N7/pIuPKsv4/F47H8xZCdoGyHF7rXow2/L4hZEMLxQzsK8DHYF9jv
-        hZVCdAKI/8W/wwccVqyHU68n+LWm0M2s8LKoy0QiuzIZcn8+RBvdpEoyrNt33sCLlkWE6PZuWaSe
-        sv1ZpMUoXt2mChQFV4BpFIFgXDPCOAwN72Sqsdy+WxI4HfzLKabSZHHCWSxdFvMeZBlfpRl31God
-        V1QkWEjRxzXISQV2bQ0ZtatYSSpKusGl8RPhqpzwGVSYPSnja3YAbKze5MTkS+hzBn5eSgJBp+pj
-        0ZgkpBKZx7jIMGPBUmmyJvAAkPcs/SBB36+xSgy3t9ssTfSbS8uMGoczCXxwYpn/+6PM1uBTnav4
-        GoWC6f6hqnkI/FM3mV3OIqNoE8M4LcALPOeVWOTR7uwwyoG0YmfgHu6rJQgh5nXoMFlzPsQWqVJW
-        dZkjtfGk6qxidD0fMG6vE4IBPDjAzaVAPPF3XuSJ3FaLfLlcLnK+DVb0mc6xM3Cer3RK/Co3LWXw
-        5OAumiG1zP9BMzYxI08J1NmaBazUT8JujiWNAcN1SsvLZ/88O39NR3R2SU9u6qJ6usCPmXwUGgkO
-        4T51OFrgXP7BW1VFJgUuCwGyP8EFTsj8dvAfewMGDZN8NDLWS+2AcUoDGMCPIQWyLIeM4IBO+eTQ
-        Z8xs94S5Vuz414EFh966RKHn4KzIF+Kj5sub90PzThUHT+yp49D0VXJntFPLnWanmnuae/Xc09yr
-        6J7mXk33NPequtPs1HVP063swOmlfjuzakCa25EWJIsK5vPgYowsJryQDxdjZEGxqgYuxsiB4mma
-        jteg0lExSA6VjoZBcqh0NAySQ6WjYZAcKp7GgORQ6WgMSF4yAa81MolT8tDQvfluoeebypw/0J3w
-        7Szhc4DErK9w/G0PeJ7qi59tAaG7yETiTtzN6Y1+WcAFyBb7JiSomBk0pfCNxn1GJlp7bSZ9NiaM
-        e22mfTYmwHttjvtsTEScDQX0gjuQ7k6uw+kkGJqID3XZNSHmVhNnqqCtSWBBTCPcorO+RXVIv7+o
-        TQh0qZ0FbOz+3mzjpOK4vSgo1V8IKXCbruSqbfMY+AqcqJSo5upn+rw13RZ842aaEsSrTZoPKBh8
-        2YCGVMXcUY+9dPaRynoH2C94P6ayswdS2RlT2dn/QWW/AQAA//8irSlLbr8XOdnSuilrONqUBaoC
-        AAAA///smtFqgzAUhl9lDHoZFzVOvShdGRvsoi/Qu/REtzHUopXRt985xgabNR0MCl4EeiH1xBMO
-        5ueX//NW1ltZb2UvqvqZNTvT9TNrNlV2b2VP8/JW1lvZeVjZ0Cz9w8r+Tu8TE2Db4a0r1g/FNNg7
-        tBK+BrCAQAe71IVzcNcNYRgMe4XJ0E9TcBW6MnXu4j646SkPBwkfFKmNwfI0m7ajy66vKklh7P3F
-        tJBGTURF0/4zriV3spIARHG8qWWi4izNdmHKixhyDnkSlXlYEgxoirDDlbKC3oO1Utijw0q0e8en
-        yUagIfbtOuM1zL4I3ltdRmtOnJEoeJhJFQrxmEKWJnG+g13KsX0pizKDlVoOT1nE60X0ij+9jlWy
-        HmNMxvRfXdB37BsHwaKA8tFAayBNiu2l7GhQuH7w6Hja8PJ5w3iwryk2t3mx+e/YBs7mv2MbWJv7
-        jlGYlGavRq4Bv9ePdxtZlj3A53CAKATTbJSWtW1TU+FL3zb74mGLggPEAY0njYBJvGuOLnUYMdHL
-        MIRwialwMVLCMFLtKOpeRm70wvwAAAD//8JMMKPFCD1cPFqMYClG0IsBXM0zE3grDN5IAXonHZIp
-        q0Eru6FsA6BL8ksSoevS0U3B1Q4zwFUuGRhhL+BwLXE0wOkBnO00uM/QdeBqwBnjlIC37FLzyjKL
-        8vMgTTuIUEopdFMEhEtM6JUBm/3kLhfEWK4LMQxuKNCmjMTisHzwwkXYCmFgFoA4uRrGhNYvZDsA
-        vIFEH2aujlJuYkUQZOAJxbPgJYdFJY4lEI+Dlj6DliWCvA4XR9VshKIbqgHs2traWgAAAAD//wMA
-        9LtMAIMzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18241","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241","key":"NTEST-1873","fields":{"statuscategorychangedate":"2025-04-30T18:27:13.285+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:12.994+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:13.082+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/15]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]\n*Defect
+        Dojo link:* http://localhost:8080/finding/298 (298)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 5afa668e-3451-4557-83c4-bac664371080
+      - 6b286c97-9726-48ee-97c5-e892bf56fb0f
       Atl-Traceid:
-      - 5afa668e3451455783c4bac664371080
+      - 6b286c97972648ee97c5e892bf56fb0f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:02 GMT
+      - Wed, 30 Apr 2025 16:27:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2547,7 +2346,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=242,atl-edge-internal;dur=14,atl-edge-upstream;dur=228,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=283,atl-edge;dur=250,atl-edge-internal;dur=16,atl-edge-upstream;dur=234,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="hlI1DyJcBukiItVrqHMP8wGyQBK9TbYVC92lE2Vu5_YSyqanBqQLKQ==",cdn-downstream-fbl;dur=287
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2556,10 +2355,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 535c2b5354e6ba6798fd64420ee97a2c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - hlI1DyJcBukiItVrqHMP8wGyQBK9TbYVC92lE2Vu5_YSyqanBqQLKQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - dbeb0c4684ae7a3d4945a059cc49eec2
+      - 2453cbbf73f38771c1a25151c73a90c4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2586,26 +2393,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL2m1d3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwBbLE7NK+EjyIDNEqAJLCvGeJ7xPIgBLiDAIe/CH3Co2u6cpVAx4LTgkKW0KL5Z
-        2d0YZQOY03khBeAMlaTZAkWuVK5AKrbMZkWt5jmyuQJ2JvA6Gm7bQcQXohKj9ndWitg+EH2qCJrX
-        bUmO54c9WRMn1/cVOX4CAAD//wMAK5oEniACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:17.139+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 53c13bef-874d-4678-89c4-5d29b5bcfc1d
+      - 88b7f058-44c5-4647-a355-16126b8d464e
       Atl-Traceid:
-      - 53c13bef874d467889c45d29b5bcfc1d
+      - 88b7f05844c54647a35516126b8d464e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:03 GMT
+      - Wed, 30 Apr 2025 16:27:17 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2615,7 +2418,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=157,atl-edge-internal;dur=13,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=186,atl-edge;dur=153,atl-edge-internal;dur=13,atl-edge-upstream;dur=141,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="k0waTFgVJWJuNYgtRHg1d7ufGZlDGGSD3TBLFxmquTC3K4k1ZL5BMA==",cdn-downstream-fbl;dur=189
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2624,10 +2427,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - k0waTFgVJWJuNYgtRHg1d7ufGZlDGGSD3TBLFxmquTC3K4k1ZL5BMA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f08fe2c8a6c2f59a93bd5182018af149
+      - d9c5eabe4f49478c1dc921bb650f37a9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2651,78 +2462,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16116
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18237
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61PbRhD/V270IdNJbb2wwVEm06HESWgppcZJPhCGOUtr6YJ0p9yd/GjI/95d
-        ybIDRJlCp4EZJN3evn/74LMDq5LLxIkcDTIBDckrAXliepIXYHomzqDgPVWC5lYoaXqQCFuA5b04
-        4zKFXKW9BWiDNEgmUGowIO3mblwZq4o5CbwKfD/wXQ2fKjB2ui7hTPPYihicniNIf7AfBPv4YSCf
-        42dmbWkiz0tgDrFN1EflcptzYwSXrgTroSbr8VJ4oSeMqcBrBVzDGvlPp+PzaT/Y3wvxqDbBONFn
-        x6BtlYm5hVTpdeNDgl/IEfrhsO8H/cCfhn4UHETDfTcYjH5Gu30ykpRYNLwW80gjid9DeT5Z1bi9
-        +UjAxFqUFDg8PWSm4HneY4kwVsjYslJADEzN2VLpa5e4YyXf6vyBVlRSULp4fsUX3HLtLQQsvdqs
-        nYEbUuDvBaNfjPgbXhSY9qpArQQLVDnl5ppyVc0svUVznhvoOQ3jMfpV8/acTCBwdJytT2ABaKv/
-        pedYgcgqESVOJCv00bkDkz2/JZRafUSPHhnwDXcd7jqBbbjp4yuQ7Lx6K4W1KMA4W92E1N/ru0bN
-        7ZJrwqsRRZkLNDi54znmo0bZYLQajB5o7ncy03qyzcvAP0AzwsEqHPy/Wprs11hEhcH+CivsByhc
-        tRr3whUW8A/QuAH4ly/34Rh04TTsIuy1hLlYvWuaI8Li4hJhkqYaUuw394oAHVB51ZT/t6UOuwj7
-        XYSDDkLYSRh1EZ7dt7Npm80pNaV6QjhRP+g5mBn7DqNOBdJcqJsLJUmLuHHy870zKh2Mv8lUlScv
-        hSlzvt4UGB4vucVh1DTxhzeDZkTshoLXiNNU6vXrkaooGQGZ+p4OhEydyOqKdMca0FnqH/eHxNA9
-        GPntkLgbtm0ru0voAlW4BVWphdLCrh/pcMvu1ZPm388KUfAUjEccphUi8CATaeaaRbrrlm/wpG2r
-        oXO/cMJtGeR8BtQYqQLu7gRd4A26MBqMKCIZN+NSxCdCXr8iyksoaX+RcYuYGkfLmrY9kUqOcX3h
-        sxwmwE2DQr15c85O3r4+Pr06OT4an56Pr8aTyZ8T9A/r1GBI8MI0A3aGE0BaRnqZMEzJfM2wm4ic
-        hDKr2G9Cc3amocB2wiqDCHO/1VUCLCjHvxG+Xy5mkdNMRcwehn9XVbe6BSYiFZLndy9ttq9NeGuc
-        52hd23Aws6mE7e2qpLLtQvJoFLZIbhalR4KvYd5O3tu7zcPwuMPbrzy+xnWzhVwrvNF1tNno/pPB
-        7VrY1AwqCdtFQcKSqlvlSp821szyCvqpxg61W4oUe6maZKuixIVY2m+DftjVFobbtvC9jN8O5wf5
-        9e8hS7WqSloUXwmZYBMzDGuFzQAkKyuTQVKj9HhySM8ZMCEXpIBgljD8V4Dh0IIkImFZ6LLXJO6D
-        fFo/n0bsYitWyIiVaTR0A9e/oWBjrHMV8zxTxkYjf+R78+buVW0TjdtL5GIX5xBX1JvYG7XsW9XB
-        jMM6qXBYh5fMYxeBseyvimsLmo1lihVZYHw7WGF7wQtq7tOzP9hhhbXPzmMuO7ho9fOCILxsQnlz
-        w85xa60Nxfejd+P68b55tBmmj82Mp9epsNgHiLVGFL6hIEatkt2wC5TRD7H2cQT5o7A2gxAqF4kr
-        cdF3U7XwFlUuEbMWe4p3+/4liXg22LLFS3ALYTW4Sqce1jUnrAtcYqkfeM8GbmaLnLjKFP/UiSIR
-        If5MoFAW0I0E2HiF+SAe1mc/naU99iS3z1noBoEbMvYktc9f/AMAAP//7FhRb9s4DP4rBAoMji9V
-        rk7SoBn6ULQ74IDbMKzbXi4HxHXUxZtjp5bdddj23/dRkmW5iTes2721LVKHFCXqI0V+Mo3FnzDW
-        irE4FhNqFJNWMRHohY182sqnAnM18uNWzo/TVs7eWfmROG7lUSuP/PHjVj4W41Y+aeWTdgOzdl1+
-        9ORuXX6MBj3JYVN5FJ2cMKJnYCy3csih1xcB2hfn2U/G2Y7/XXF+jPGDYzzrizEqYVMU5qGON8so
-        vKglXaCEQviXvBJ0MiRusNStzs3v+ki48qy/j8XjsfzFkJ2gbIcXutejDb8viFkQwvFDOwrwMdgX
-        2O+FlUJ0Aoj/xb/DBxxWrIdTryf4tabQzazwsqjLRCK7Mhlyfz5EG92kSjKs23fewIuWRYTo9m5Z
-        pJ6y/VmkxShe3aYKTARXgGkUgWBcM8I4DA3vZKqx3L5bEjgd/MspptJkccJZLF0W8x5kGV+lGXfU
-        ah1XVCRYSNHHNchJBXZtDRm1q1hJKkq6wRXxE+GqnPAZVJg9KeNrdgBsrN7kxORL6HMGfl5KAkGn
-        6mPRmCSkEpnHuMgwY8FSabIm8ACQ9yz9IEHfr7FKDLe32yxN9JtLy4wahzMJfHBimf/7o8zW4FOd
-        q/gahYLp/qGqeQj8UzeZXc4io2gTwzgtwAs855VY5NHu7DDKgbRiZ+AebqclyCLmdegwWXM+xBap
-        UlZ1mSO18aTqrGJ0PR8wbq8TggE8OMDNpUA88Xde5IncVot8uVwucr4NVvSZzrEzcJ6vdEr8Kjct
-        ZfDk4C6aIbXM/0EzNjEjTwnU2ZoFrNRPwm6OJY0Bw3VKy8tn/zw7f01HdHZJT27qonq6wI+ZfBQa
-        CQ7hPnU4WuBc/sFbVUUmBS4LAbI/wQVOyPx28B97AwYNk3w0MtZL7YBxSgMYwI8hBbIsh4zggE75
-        5NBnzGz3hLlW7PjXgQWH3rpEoefgrMgX4qPmy5vXQPNOFQdP7Knj0PRVcme0U8udZqeae5p79dzT
-        3KvonuZeTfc096q60+zUdU/TrezA6aV+F7NqQJrbkRYkiwrm8+BijCwmvJAPF2NkQbGqBi7GyIHi
-        aZqO16DSUTFIDpWOhkFyqHQ0DJJDpaNhkBwqnsaA5FDpaAxIXjIBrzUyiVPy0NC9+W6h55vKnD/Q
-        nfDtLOFzgMSsr3D8bQ94nuqLn20BobvIROJO3M3pjX5ZwAXIFvsmJKiYGTSl8I3GfUYmWnttJn02
-        Jox7baZ9NibAe22O+2xMRJwNBfSCO5DuTq7D6SQYmogPddk1IeZWE2eqoK1JYEFMI9yis75FdUi/
-        v6hNCHSpnQVs7P7ebOOk4ri9KCjVXwgpcJuu5Kpt8xj4CpyolKjm6mf6vDXdFnzjZpoSxKtNmg8o
-        GHzZgIZUxdxRj7109pHKegfYL3g/prKzB1LZGVPZ2f9BZb8BAAD//yKtKUtuvxc52dK6KWs42pQF
-        qgIAAAD//+ya0WqDMBSGX2UMehkXa5x6UboyNthFX6B36YluY1iLVkbffucYDTUzHaw3XgR6Ic1J
-        cziYn7/8n7ey3sp6Kzup6iNrNtL1kTW7VHZvZYd5eSvrrew8rGxotv5hZX+n97EJsO3w1pXfhcK1
-        YOANCvZOtYSvji8g3sEqFQa1sBa4CwDhrgydmwx9GI+r0MV9cNOMPJ0kfFCkNkGy2All05alpDD2
-        fjItpFETUVHV/4xryZ2sJQAxG29qFasoTdJ9mPA8goxDFi+LLCwIBjRFeMKVspzeg41SeEaDlWj3
-        zk8XjUBF7Nt1xqsbcR6817qM9gyckch5mEoVCvGYQJrEUbaHfcLx+ELmRQprtep+ZRFtFstX/Oh9
-        rJSHPsZkTH/VBG3DvnEQbBlQPhpoDaRJsaOUDQ0K93ceHW8bPj5vGQ+OB4rNbV5s/h3bwNn8O7aB
-        tbl3jPqjNGnVcw34f/18t5VF0QJ8dheIQjBNQmn12lUHKnxp6+qYP+xQV4A4oP6mETCJq+bq0gk9
-        JjoNQwiXmAoXIyVc4J0wgl33au/15bY36QcAAP//IiEljZYv9HDxaPmCpXxBLwbgrTB4IwXo6nRI
-        3qsGreyGsg2AFuaXJELXpaObgrO5hbNcwtkOM8Je8uFa4miAq+EJKhCwShjganga49JhDG/ZpeaV
-        ZRbl50GadhChlFLopggIl6jQy8+FmFANY0KLezKKX6T9HPowc3WUchMrgiDjQCh2g1cAFpU4lkDc
-        UQbsfpC7bBFjkTDEMLihQLsyEovD8sELKOHrkvOLwMsSQVbCHYLqWiMU50I1gIOntrYWAAAA//8D
-        ADV3+dODMwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18237","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237","key":"NTEST-1871","fields":{"statuscategorychangedate":"2025-04-30T18:27:07.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:07.681+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t67:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:07.763+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
+        (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
+        Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 90e47bc9-1185-4916-84f0-54c3b0499b2c
+      - 3b8476f9-278e-4841-8a22-29760e92603a
       Atl-Traceid:
-      - 90e47bc91185491684f054c3b0499b2c
+      - 3b8476f9278e48418a2229760e92603a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:03 GMT
+      - Wed, 30 Apr 2025 16:27:17 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2732,7 +2532,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=285,atl-edge-internal;dur=16,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=270,atl-edge;dur=237,atl-edge-internal;dur=17,atl-edge-upstream;dur=220,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="56L_LuHKqS3g61WDaIrM3LaiMXEfVjezYlAJfmnABWtyUIkDAFV5mg==",cdn-downstream-fbl;dur=274
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2741,10 +2541,436 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 895116b5366f3f5264f7b6361d3fd564.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 56L_LuHKqS3g61WDaIrM3LaiMXEfVjezYlAJfmnABWtyUIkDAFV5mg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ab1507e5662858cd5b3b5d4e85401225
+      - 88f65248912853bac5d8ebe3439a8b38
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:17.943+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
+    headers:
+      Atl-Request-Id:
+      - 8e7cd073-2e82-4005-810e-d18303b60db4
+      Atl-Traceid:
+      - 8e7cd0732e824005810ed18303b60db4
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:17 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=18,cdn-upstream-fbl;dur=233,atl-edge;dur=160,atl-edge-internal;dur=14,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="BFWvDxDEvPh9sGnsFwCr_eyi077laEGV3dfBBhiZw0NxMAbqjjnNag==",cdn-downstream-fbl;dur=237
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 471c951325b4c2c11c6c583a1d28e92a.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - BFWvDxDEvPh9sGnsFwCr_eyi077laEGV3dfBBhiZw0NxMAbqjjnNag==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
+      X-Arequestid:
+      - 0148bafb821dfec54187a9e6b8bfebf0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18239
+  response:
+    body:
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18239","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239","key":"NTEST-1872","fields":{"statuscategorychangedate":"2025-04-30T18:27:10.705+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:10.389+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:10.491+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
+        Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:*
+        http://localhost:8080/finding/297 (297)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
+    headers:
+      Atl-Request-Id:
+      - 0f728370-3b4e-411b-b532-e59c6ec7b071
+      Atl-Traceid:
+      - 0f7283703b4e411bb532e59c6ec7b071
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:18 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=269,atl-edge;dur=236,atl-edge-internal;dur=23,atl-edge-upstream;dur=213,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="QwZBFrhG_fo2pmdx-nbVzOrmOGbM2XX1wgZvDi3M3c5g9vBjJaKrEg==",cdn-downstream-fbl;dur=273
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QwZBFrhG_fo2pmdx-nbVzOrmOGbM2XX1wgZvDi3M3c5g9vBjJaKrEg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - c9c14e3a3372b643780f8b2934d12e89
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:18.773+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
+    headers:
+      Atl-Request-Id:
+      - 26e9a737-6ff4-4068-b159-66a459ba6c4f
+      Atl-Traceid:
+      - 26e9a7376ff44068b15966a459ba6c4f
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:18 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="7w_JXsRUOSRWVZwo0a9md1o-12wKYI-Jn4jzOyZnWgFF_G8jE-VgAA==",cdn-downstream-fbl;dur=264,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=73,cdn-upstream-fbl;dur=262,atl-edge;dur=163,atl-edge-internal;dur=15,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 f82a4020c8fc9b14a403737c65661074.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 7w_JXsRUOSRWVZwo0a9md1o-12wKYI-Jn4jzOyZnWgFF_G8jE-VgAA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
+      X-Arequestid:
+      - 823df7f5cdbfd608825aa35fcb96ee9c
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18237
+  response:
+    body:
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18237","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237","key":"NTEST-1871","fields":{"statuscategorychangedate":"2025-04-30T18:27:07.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:07.681+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t67:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:07.763+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
+        (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
+        Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
+    headers:
+      Atl-Request-Id:
+      - b77beb98-6eb6-46a4-9168-7d5c2f0adb67
+      Atl-Traceid:
+      - b77beb986eb646a491687d5c2f0adb67
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:19 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=353,atl-edge;dur=320,atl-edge-internal;dur=15,atl-edge-upstream;dur=306,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="CpxIcnIddJ05q2ZdTlm0xaCTw8abcRunQC5ryzuEM9yB9hbb8St5kw==",cdn-downstream-fbl;dur=377
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 22067fb5d7eb764108747a104222f50a.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - CpxIcnIddJ05q2ZdTlm0xaCTw8abcRunQC5ryzuEM9yB9hbb8St5kw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - 260a5e105fa6a6223399c7268c8a5a83
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2771,41 +2997,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 2557fcfc-7255-4186-b9fa-b170cb6c6bb3
+      - 02a06098-5469-45d9-ae8f-8cca5e810651
       Atl-Traceid:
-      - 2557fcfc72554186b9fab170cb6c6bb3
+      - 02a06098546945d9ae8f8cca5e810651
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:03 GMT
+      - Wed, 30 Apr 2025 16:27:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2815,7 +3028,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=310,atl-edge-internal;dur=13,atl-edge-upstream;dur=297,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="I4N5lnnND8e60zU36QmGTbRbhNiZ2OM_ks8_y6J9YmpDkwuzl6WhDQ==",cdn-downstream-fbl;dur=562,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=59,cdn-upstream-fbl;dur=559,atl-edge;dur=477,atl-edge-internal;dur=17,atl-edge-upstream;dur=458,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2824,13 +3037,554 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 471c951325b4c2c11c6c583a1d28e92a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - I4N5lnnND8e60zU36QmGTbRbhNiZ2OM_ks8_y6J9YmpDkwuzl6WhDQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 453552c0da5ea20f9a63611edcb36c6a
+      - 49e72c2223cdd596591c510a666ded12
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
+      group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
+      in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+      | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+      | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
+      | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+      | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+      | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+      0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
+      (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+      CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
+      Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
+      Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3318'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18237
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - e30ad935-41e6-4596-8660-93b7fa467a7a
+      Atl-Traceid:
+      - e30ad93541e64596866093b7fa467a7a
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:20 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="p2KD9DxP579KSVzRqYNU0MZbJpLQ-4d47uSgIIa-WBLKGwu14E9nPw==",cdn-downstream-fbl;dur=424,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=97,cdn-upstream-fbl;dur=421,atl-edge;dur=290,atl-edge-internal;dur=22,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - p2KD9DxP579KSVzRqYNU0MZbJpLQ-4d47uSgIIa-WBLKGwu14E9nPw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - b65a3bcd8fa3767ea5b42bc63a051635
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18237
+  response:
+    body:
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18237","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237","key":"NTEST-1871","fields":{"statuscategorychangedate":"2025-04-30T18:27:07.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:07.681+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t67:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:07.763+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
+        (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
+        Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
+    headers:
+      Atl-Request-Id:
+      - d1433816-c868-41be-a2cf-93e40b170a4d
+      Atl-Traceid:
+      - d1433816c86841bea2cf93e40b170a4d
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:21 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=282,atl-edge;dur=248,atl-edge-internal;dur=16,atl-edge-upstream;dur=233,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="uhmOPzWG-KH9yzfXFX8MXz-DktnAmhkuzkAupqHsklnqzxw2NU4_yQ==",cdn-downstream-fbl;dur=287
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 73e04d645babcbb9ee8f20cc865b009c.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - uhmOPzWG-KH9yzfXFX8MXz-DktnAmhkuzkAupqHsklnqzxw2NU4_yQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - 2af0cb7fc8819465cc64c3eb5b878cb6
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:21.504+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
+    headers:
+      Atl-Request-Id:
+      - 8e30a877-ce63-4817-b008-00e98799dfde
+      Atl-Traceid:
+      - 8e30a877ce634817b00800e98799dfde
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:21 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="-NFlI-maCVdtJOtCG1-vFpK1r9zEC5aWQoRs20ER8ExE7xhci0QAbQ==",cdn-downstream-fbl;dur=330,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=97,cdn-upstream-fbl;dur=328,atl-edge;dur=197,atl-edge-internal;dur=14,atl-edge-upstream;dur=183,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 60b2b330807c6611e06e3923c8e315cc.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -NFlI-maCVdtJOtCG1-vFpK1r9zEC5aWQoRs20ER8ExE7xhci0QAbQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - 969fae0bf299bd07b479b5d919e26309
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18239
+  response:
+    body:
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18239","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239","key":"NTEST-1872","fields":{"statuscategorychangedate":"2025-04-30T18:27:10.705+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:10.389+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:10.491+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
+        Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:*
+        http://localhost:8080/finding/297 (297)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
+    headers:
+      Atl-Request-Id:
+      - 312c0944-dd69-40de-b2df-dcde3226762c
+      Atl-Traceid:
+      - 312c0944dd6940deb2dfdcde3226762c
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:22 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="Yx47jXO6QrNZqPRtu7BtCdGkGiTpPA69lPBffs9knaYXXu2PMx6AvQ==",cdn-downstream-fbl;dur=360,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=60,cdn-upstream-fbl;dur=357,atl-edge;dur=276,atl-edge-internal;dur=17,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 f5c1da639a075ecd7bb86ffc181e3dd8.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Yx47jXO6QrNZqPRtu7BtCdGkGiTpPA69lPBffs9knaYXXu2PMx6AvQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
+      X-Arequestid:
+      - 234b4e070fa408293a6a4b26817858a4
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
+    headers:
+      Atl-Request-Id:
+      - 5072521a-b743-4bf7-96fa-f417fe618a45
+      Atl-Traceid:
+      - 5072521ab7434bf796faf417fe618a45
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:22 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=326,atl-edge;dur=304,atl-edge-internal;dur=15,atl-edge-upstream;dur=288,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="MfdS3o6C--vMlfpbYu66bMs_MDsIYf4gROSAKpXHpqSrnkc83HkvRw==",cdn-downstream-fbl;dur=329
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 36e36df999d8d13e1e708941d33a5866.cloudfront.net (CloudFront)
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MfdS3o6C--vMlfpbYu66bMs_MDsIYf4gROSAKpXHpqSrnkc83HkvRw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
+      X-Arequestid:
+      - 40ce7ed954af62abdfe046c7e5ed68d9
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2842,7 +3596,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/104] in [Security
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
@@ -2857,13 +3611,13 @@ interactions:
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
       Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -2872,31 +3626,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:* http://localhost:8080/finding/297
-      (297)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (297)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -2905,25 +3657,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -2935,27 +3685,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7125'
+      - '6788'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16116
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18239
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - f8c8f4ef-54a8-4323-9557-0a1dcc592c47
+      - 2ef3c624-f6f8-4add-8303-8eeab3e1f9d1
       Atl-Traceid:
-      - f8c8f4ef54a8432395570a1dcc592c47
+      - 2ef3c624f6f84add83038eeab3e1f9d1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:04 GMT
+      - Wed, 30 Apr 2025 16:27:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2965,17 +3717,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=292,atl-edge-internal;dur=12,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="yMXPvssp9BIPHqH23qJWa3UUxH2DqaORjzlqXKZHriS36ycW-jPqbg==",cdn-downstream-fbl;dur=361,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=357,atl-edge;dur=270,atl-edge-internal;dur=15,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 595c26368a4c8eede29e4b5da7206efc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - yMXPvssp9BIPHqH23qJWa3UUxH2DqaORjzlqXKZHriS36ycW-jPqbg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - c4fab944eddbf7b44c67cbd006067aa7
+      - 0f04e02fc2ae89cd24ec16b4df63cb34
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2999,78 +3759,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16116
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18239
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf6kOmktt6wwVEm06HESWgppcZJPhCGOUtr6YJ0p96d/FLgv3dX
-        skyAKC10GphB0t3ty+0+++xy5cCq5DJxIkeDTEBD8kZAnpie5AWYnokzKHhPlaC5FUqaHiTCFmB5
-        L864TCFXaW8B2uAeJBMoNRiQdnM2roxVxZwUXgS+H/iuhj8rMHa6LuFE89iKGJyeI8h+sBsEu/hh
-        IJ/jZ2ZtaSLPS2AOsU3UZ+Vym3NjBJeuBOuhJevxUnihJ4ypwGsVXMIa5Y+n49NpP9jdCXGpdsE4
-        0ZVj0LfKxNxCqvS6uUOCXygR+uGw7wf9wJ+GfhTsRcNdNxiMfkS/fXKSjFh0vFbzRCdJ3kN9PnnV
-        XHvzkYCJtSgpcLi6z0zB87zHEmGskLFlpYAYmJqzpdKXLknHSr7X+SO9qKSgdPH8gi+45dpbCFh6
-        tVu3Dm62An8nGP1kxF/wqsC0VwVaJVigySk3l5SrambpLZrz3EDPaQQP8V61bM/JBAJHx9n6CBaA
-        vvo3PccKRFaJKHEiWeEdnXsw2fHbjVKrz3ijJwZ8I12Hu05gG276+AIkt7d6L4W1qMA4W9uE1F/r
-        s0bN7ZJrwqsRRZkLdDi5d3PMR42ywWg1GD3S3W9kpr3JNi8Dfw/dCAercPD/WmmyX2MRDQa7K6yw
-        72Bw1VrcCVdYwN/B4gbgNzcP4Rh04TTs2thpN+Zi9aEhR4TF2TnCJE01pMg3/1gEw3YDb6byquGF
-        rx/d7drY69gIOzdGXRsvHrrT0GazSqRUdwgn6gf4yS02joZwH1+4DZ3fErjXqNNUlvXrgaoocAGR
-        8kdaEDJ1IqsruNnwNGnTIm6idvVgjTzDoyZTVZ68FqbM+XpTyriMbtkPiBkq7000NOBliT8eNomh
-        uzfy2yZxP2xbKru/0QWqcAuqUgulhV0/MYituFd3mn/fK0TBUzAeSZhWicCFTKSZaxbpLVu+w5WW
-        VkPnYeGE2zLI+QyIGKkC7s8EXeANujAajCgiGTfjUsRHQl6+oZ3XUNL8IuM2j3V2l/XedkUqOcbx
-        hc9ymAA3DTb05s05OXr/9vD44ujwYHx8Or4YTya/T/B+WKcGQ4IHphmwE+wA0jKyy4RhSuZrhmwi
-        clLKrGK/CM3ZiYYC6YRVBlHrfo1VAiwox78Wvl8uZpHTdEXMHob/tqrusAUmIhWS5/cPbaavTXhr
-        pOfoXUs4mNlUwvZ0VVLZdiF5NApbJDeD0hPB1whvO+/d2eZxeLzF2888vsRxs4Vcq7yxdbCZ6P6T
-        w+1Y2NQMGgnbQUHCkqpb5UofN97M8gr6qUbeuB2KFHutmmSrosSBWNqvg37YRQvDLS18K+N3w/lJ
-        fvm7z1KtqpIGxTdCJkiMhmGtsBmAZGVlMkhqlB5O9uk5AybkggwQzBKG/wowbFqQRKQsC132ltR9
-        ks/r5/OInW3VChmxMo2GbuD61xRsjHWuYp5nytho5I98b96cvah9onZ7jlLs7BTiiriJvVPLvlUd
-        wtiskwqbdXjOPHYWGMv+qLi2oNlYpliRBca3QxS2B7yglj4++Y3tV1j77DTmskOKRj8vCMLzJpTX
-        1+wUp9baUXw/+DCuHx+bR5th+tj0eHqdCos8QKI1ovANFTGiSnbNzlBHP8Tax7bmj8LaDUKoXCSu
-        xEHfTdXCW1S5RMxa5BTv7vlzUvFisBWLl+AWwmpwlU49rGtOWBc4xBIfeC8GbmaLnKTKFP/UiSIV
-        If5MoFAW8BoJsPEK80EyrM9+OEl77FluX7LQDQI3ZOxZal+++hsAAP//7FhRb9s4DP4rBAoMji9V
-        rk7SoBn6ULQ74IDbMKzbXi4HxHXUxZtjp5bdddj23/dRkmW5iTes2721LVKHFCXqI0V+Mo3FnzDW
-        irE4FhNqFJNWMRHohY182sqnAnM18uNWzo/TVs7eWfmROG7lUSuP/PHjVj4W41Y+aeWTdgOzdl1+
-        9ORuXX6MBj3JYVN5FJ2cMKJn4BG3csih1xcB2hfn2U/G2Y7/XXF+jPGDYzzrizEqYVMU5qGON8so
-        vKglXaCEQviXvBJ0MiRusNStzs3v+ki48qy/j8XjsfzFkJ2gbIcXutejDb8viFkQwvFDOwrwMdgX
-        2O+FlUJ0Aoj/xb/DBxxWrIdTryf4tabQzazwsqjLRCK7Mhlyfz5EG92kSjKs23fewIuWRYTo9m5Z
-        pJ6y/VmkxShe3aYKTARXgGkUgWBcM8I4DA3vZKqx3L5bEjgd/MspptJkccJZLF0W8x5kGV+lGXfU
-        ah1XVCRYSNHHNchJBXZtDRm1q1hJKkq6wcXtE+GqnPAZVJg9KeNrdgBsrN7kxORL6HMGfl5KAkGn
-        6mPRmCSkEpnHuMgwY8FSabIm8ACQ9yz9IEHfr7FKDLe32yxN9JtLy4wahzMJfHBimf/7o8zW4FOd
-        q/gahYLp/qGqeQj8UzeZXc4io2gTwzgtwAs855VY5NHu7DDKgbRiZ+AebrwlyCLmdegwWXM+xBap
-        UlZ1mSO18aTqrGJ0PR8wbq8TggE8OMDNpUA88Xde5IncVot8uVwucr4NVvSZzrEzcJ6vdEr8Kjct
-        ZfDk4C6aIbXM/0EzNjEjTwnU2ZoFrNRPwm6OJY0Bw3VKy8tn/zw7f01HdHZJT27qonq6wI+ZfBQa
-        CQ7hPnU4WuBc/sFbVUUmBS4LAbI/wQVOyPx28B97AwYNk3w0MtZL7YBxSgMYwI8hBbIsh4zggE75
-        5NBnzGz3hLlW7PjXgQWH3rpEoefgrMgX4qPmy5vXQPNOFQdP7Knj0PRVcme0U8udZqeae5p79dzT
-        3KvonuZeTfc096q60+zUdU/TrezA6aV+v7NqQJrbkRYkiwrm8+BijCwmvJAPF2NkQbGqBi7GyIHi
-        aZqO16DSUTFIDpWOhkFyqHQ0DJJDpaNhkBwqnsaA5FDpaAxIXjIBrzUyiVPy0NC9+W6h55vKnD/Q
-        nfDtLOFzgMSsr3D8bQ94nuqLn20BobvIROJO3M3pjX5ZwAXIFvsmJKiYGTSl8I3GfUYmWnttJn02
-        Jox7baZ9NibAe22O+2xMRJwNBfSCO5DuTq7D6SQYmogPddk1IeZWE2eqoK1JYEFMI9yis75FdUi/
-        v6hNCHSpnQVs7P7ebOOk4ri9KCjVXwgpcJuu5Kpt8xj4CpyolKjm6mf6vDXdFnzjZpoSxKtNmg8o
-        GHzZgIZUxdxRj7109pHKegfYL3g/prKzB1LZGVPZ2f9BZb8BAAD//yKtKUtuvxc52dK6KWs42pQF
-        qgIAAAD//+ya0WqDMBSGX2UMehkXa5x6UboyNthFX6B38US3MaxFK6Nvv3OMhpo1Haw3XgR6UZoT
-        cziYn7/8n7ey3sp6K3tR1SfWbKLrE2t2ruzeyo7z8lbWW9l5WNnQbP3Dyv5O72MTYNvhrSu/C4Vr
-        weAcFOwdGwlfPbNAFIJVKgxqYS1w8wx7wZWhc5Ohj+NxFbq4D26amWTRdiIpj0cJH5S36byz7apK
-        Uhh7fzEtpFETUVE3/4xryZ2sJQBxIG9qFasoTdI8THgRQcYhi5dlFpYEA5oiPOFKWUHvwUYpPKPF
-        SrR7p6ezRqAm9u0649WPuAjeG11Ge0bOSBQ8TKUKhXhMIE3iKMshTzgeX8qiTGGtVv1TFtFmsXzF
-        j97HKrkfYkzG9E9t0LXsGwfBlgHlo4HWQJoUO0jZ0qBwf+/R8bbh1+ct48FhT7G5zYvNv2MbOJt/
-        xzawNveOUX+U5p8GrgH/r5/utrIsO4DP/gJRCKbpKq1eu3pPhS9dUx+Khx3qChAHNNw0AiZx1Vxd
-        OmHARC/DEMIlpsLFSAkXeCeMYDeD2nt9ue1N+gEAAP//IiEljZYv9HDxaPmCpXxBLwbgrTB4owXo
-        6nRI3qsGreyGsg2AFuaXJELXpaObgrO5hbNcwtkOM8Je8uFa4miAq+EJKhCwShjganga49JhDG/Z
-        peaVZRbl50FabxChlFLopggIl6jQy8+FmFANY0KLezKKX6T9HPowc3WUchMrgiDjQCh2g1cAFpU4
-        lkDcUQbsfpC7bBFj4THEMLihQLsyEovD8sELKGGrhUFLn0HLEkFWwh2C6lojFOdCNYCDp7a2FgAA
-        AP//AwDPu9ibgzMAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18239","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239","key":"NTEST-1872","fields":{"statuscategorychangedate":"2025-04-30T18:27:10.705+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:10.389+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:10.491+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
+        Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:*
+        http://localhost:8080/finding/297 (297)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 29951b74-4bb8-4302-822e-05021ffc8c56
+      - def69e7a-d6ce-4a1f-a628-a634c10a4703
       Atl-Traceid:
-      - 29951b744bb84302822e05021ffc8c56
+      - def69e7ad6ce4a1fa628a634c10a4703
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:04 GMT
+      - Wed, 30 Apr 2025 16:27:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3080,7 +3875,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=323,atl-edge-internal;dur=13,atl-edge-upstream;dur=311,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="QeFDTdIyDjIocKAcmSANO8-CqcPPXkrsnNrxZvcVUWmYisTTEIlGLQ==",cdn-downstream-fbl;dur=339,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=336,atl-edge;dur=261,atl-edge-internal;dur=21,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3089,10 +3884,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b6805b08a4af317938604723e3f3424a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QeFDTdIyDjIocKAcmSANO8-CqcPPXkrsnNrxZvcVUWmYisTTEIlGLQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - bff134edcf32739c37c23f6f8c065ad4
+      - 1947227d3b473f4d8c83ac360d332c80
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3119,26 +3922,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwFWFKfmlfARZMDyKdApLCvGeJbyLIgBLiDAIe/CH3Co2u6cpVAx4HTBIU8gLb5Z
-        2d0YZQOY0flCCsAclaRpgSJTKlMgFVum+aJW8wzZXAE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMATw19UCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:23.964+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 79b60e03-cabd-4895-a2b2-e8ac5f3c8b66
+      - ddfd5c11-e3ee-4eb6-a2f4-0679675a8648
       Atl-Traceid:
-      - 79b60e03cabd4895a2b2e8ac5f3c8b66
+      - ddfd5c11e3ee4eb6a2f40679675a8648
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:05 GMT
+      - Wed, 30 Apr 2025 16:27:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3148,7 +3947,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=165,atl-edge-internal;dur=15,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=18,cdn-upstream-fbl;dur=236,atl-edge;dur=161,atl-edge-internal;dur=15,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="oBjQGjQkWSrHoDIObOxwd12Br9xnaxTjWIQdprdvTeGENbxr7H14KQ==",cdn-downstream-fbl;dur=239
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3157,10 +3956,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 452324c4cfd54555e3a2d8c074edaf78.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - oBjQGjQkWSrHoDIObOxwd12Br9xnaxTjWIQdprdvTeGENbxr7H14KQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - fe22c568779baf532dc169e140652b98
+      - 6710e6ad70d09d33ac4d014fd2418f10
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3184,65 +3991,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16117
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18241
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJl2Rb4Uyn49py4tR1XVlJHhyPByZXJGISYAFQR2P/9+7y
-        kOJDae1OM3ogrj2w++2H1RcHliWXiRM5GmQCGpIjAXliepIXYHomzqDgPVWC5lYoaXqQCFuA5b04
-        4zKFXKW9OWiDe5BMoNRgQNr2bFwZq4oZKbwKfD/wXQ1/VmDsdFXCmeaxFTE4PUeQ/WA3CPZwYiCf
-        4TSztjSR5yUwg9gm6rNyuc25MYJLV4L10JL1eCm80BPGVOB1Cm5ghfKn0/H5tB/sDga4VLtgnOiL
-        Y9C3ysTcQqr0qrlDgjOUCP1wp+8H/cCfhn4U7EU7I3e4F/yIfvvkJBmx6Hit5oVOkryH+vxwfe12
-        koCJtSgpcLi6z0zB87zHEmGskLFlpYAYmJqxhdI3LknHSr7X+TO9qKSgdPH8is+55dqbC1h4tVsb
-        B9utwB8Eo5+N+At+KjDtVYFWCRZocsrNDeWqurY0imY8N9BzGsFjvFct23MygcDRcbY6gTmgr/5d
-        z7ECkVUiSpxIVnhH5wFMBn63UWr1GW/0woC30nW46wR24abJVyDZ3Oq9FNaiAuOsbRNSf63PGjWz
-        C64Jr0YUZS7Q4eTBzTEfNcqGo+Vw9Ex3v5GZ7ibrvAx9Ano4XIbD/9dKk/0ai2gw2F0Gu9/D4LKz
-        OAiXg/B7WGwBfnf3GI7BNpyG3cZMLD80HIjZv7h8fHLQneRpqiFFvvnHItjpNvBmKq8aXnj66O62
-        jb0tG+HWjdG2jdeP3Wlos1klUqpfCCfqBzjlFh+OhnCfX7gNnW8I3GvUaSrLenigKgpcQKT8kRaE
-        TJ3I6gruWp4mbVrETdS+PFojz/CoyVSVJ4fClDlftaWMy+iW/YCYofJuo6EBL0v88dQjEezsdI/E
-        w7CtqezhxjZQhWtQlVooLezqhUHsxL36pfn3b4UoeArGIwnTKRG4kIk0c8083bDlW1zpaDV0HhdO
-        uEZ9zq+BiPGJ0iA+eTIQwTaMBiOKSMbNuBTxiZA3R7RzCCX1LzLu8lhnd1HvrVekkmNsX/h1DhPg
-        psGGbkfO2cn7N8enVyfHB+PT8/HVeDL5fYL3wzo1GBI8MM2AneELIC0ju0wYpmS+YsgmIielzCr2
-        TmjOzjQUSCesMoha9ylWCbCgHP9W+H45/xw5zauI2cPwb6rqHltgIlIhef7wUNt9teGtkZ6jd+2c
-        MptKWJ+uSirbbUgOB36H5KZReiH4GuH1y3u/t3keHjd4+4XHN9hudpDrlDe2DtqO7j853LWFTc2g
-        kbBrFCQsqLpVrvRp4811XkE/1cgbm6ZIsUPVJFsVJTbE0j4N+p01LXwrsQ+F1pRxP5yf5Ne/fZZq
-        VZXUKB4JmSAxGoa1wq4BJCsrk0FSo/R4sk/fa2BCzskywSxh+FeA4WsGSUTKstBlb0jdJ/mq/r6K
-        2MVarZARm2EMs8h3B65/S/HGcOcq5nmmjI1G/sj3Zs3xq9otRMTOJQqyi3OIK6In9lYt+lZtEcb3
-        OqnwvQ4vmccuAmPZHxXXFjQbyxSLssAQbxGF9QEvqKVPz35j+xWWPzuPudwiRd2fFwThZRPN21t2
-        jo1r7SiODz6M68/H5tMlmSbt+0/DqbBIBSRagwpHqIgRW7JbdoE6+iGyW5/+rryu3SCQynniSuz1
-        3VTNvXmVS4StRVrx7p+/JBVDvwk2ycULcAthNbhKpx7WNie8C2xkiRM8POpmtshJrs4VfutskZ4J
-        pFXOMZZL+ttWu38IUvCc0HMOeo7/zlif/XCk4W8AAAD//+xZ207bQBD9lVWlIhLFxkkcckGIRqRI
-        PKSqWrUP9IXN7pq4SuLIl6CqfHzPrDeLY7K0pSriAYGSeGevM7NnzoyzeYsdLPITDO75nYZDe8bW
-        R53hgBYcI9ZuVIt0o8kyuyOdNrcaHTW1UqiNNSeFYhO4IBov1MxnwxYjgGK73r39m7d96976uev/
-        5+Ng3xONI7ji3xNGCIut/nYcO8RHY9+hHzsya8LF0PwNX96TrI0V4Th6in/zt129Nz8nRQotXsQL
-        BSxQpaYPbvIT7VyVjpN7jGoCS+yyCcDLXH0/To643MQZABAEo9c5BnxFpGO4yjaqke2u9eTXDKGX
-        0VaRUppgmxqTm42QyaU1eWZMfjsn6OOYb3XDwLkF5IjaIuURrUQxGpC0LnIfmv96P/8U2LNQBuN2
-        RVu2P6p4EXp81DxVbsWQQjOnVlyZAD3nGI1GeKS+kKO6MluVhgzcxiFIN8qj6BWLhx1LacQ3FG8r
-        ViIEG9EHORcex0JgvhHiw2wRC2PBaayDgjHgF80bSOfGMuWpWJKyBQSpby1/uVxzkdOYDwmL9QMD
-        jm9iqeSOL33CfQKZwtJ/4yFm6DqhMEAOfsjlMl412GHjbgkHzpMRnPYhFe9ZNlpnYi6O3g6rUTpP
-        QT90nkGZQ72rzdZqgsAlCG1CVR9hCfFWC66OLoIcuJK4wK65QyzrvIPnORdzipwlecmK5ZITs3rj
-        Cv2kbcqQkvSJ9Ivu4BkXgvK6S3nak91BfzBr9wPVFcNADHudaNiOjrGO7YQVHummyBXGUtI9QU+R
-        yB/vKhsBP6O5Hq3ZaPUrHxRPd6Mx27pBqJCFcNkOw+O+GPR73eFMzPoBlo+4igbiTJ7qWd52x287
-        F/gvx3lLvjKcxPPKpswvMu8WivA6PpEdv7yCpClvzXlGisJ4jfDIYfDzfOoF/npFNLhe/3n5O64X
-        kF7+jusFqJe+Y2CTLOsZJk85h+uzKY+iQohYXyAiZWW1pES2K5BYdHxfpMlaHV0BcwTl9eamUQEU
-        Unt1aQVT9t2f3IQuPA1dNY/Q1jxSg+uvMPJsDvMKI8+x41cY2QMjdRhwMbTQEjHLW3Ccm/JS/qQ3
-        NeZ3gJ0kOTfvmeqzuKhY4MKloLMf4Fwly8B5ACdVsyerj3BxuK5TYMmdWm3iNFmVBK5skoV5yVk+
-        /on2NkleKeD/AgAA//8irRzGGMCHGAY3FGhTRmJxWD54IBI26g7MAhAnV8OY0PqFbAeAJ4T1Yebq
-        KOUmVgSlFpfmgAxG8ix4CLGoxLEE4nHQVAZomBHkdbg4qmYjFN1QDWDX1tbWAgAAAP//AwDeeMff
-        Ux8AAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18241","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241","key":"NTEST-1873","fields":{"statuscategorychangedate":"2025-04-30T18:27:13.285+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:12.994+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:13.082+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/15]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]\n*Defect
+        Dojo link:* http://localhost:8080/finding/298 (298)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - b62ac00f-d92c-4048-a94f-f9aa785507b5
+      - 474d0b26-34a1-4bd0-a67d-318b8f8791fa
       Atl-Traceid:
-      - b62ac00fd92c4048a94ff9aa785507b5
+      - 474d0b2634a14bd0a67d318b8f8791fa
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:05 GMT
+      - Wed, 30 Apr 2025 16:27:24 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3252,7 +4045,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=304,atl-edge-internal;dur=14,atl-edge-upstream;dur=290,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=303,atl-edge;dur=270,atl-edge-internal;dur=16,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="qNB3f5A4cAupBVQgS_vLGeLwNAowUXCFkrVbsknAEmLgEXP4QxV3Rg==",cdn-downstream-fbl;dur=308
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3261,10 +4054,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qNB3f5A4cAupBVQgS_vLGeLwNAowUXCFkrVbsknAEmLgEXP4QxV3Rg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 64b5dbc13641a4d1c503993538d51655
+      - d53d2d5399618301d93d29aad04412ab
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3291,41 +4092,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - b5ce60b5-796b-4fa4-90f1-8c139fd38b3e
+      - 3cd92b82-f187-42f9-88ef-5af67d50bafc
       Atl-Traceid:
-      - b5ce60b5796b4fa490f18c139fd38b3e
+      - 3cd92b82f18742f988ef5af67d50bafc
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:05 GMT
+      - Wed, 30 Apr 2025 16:27:24 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3335,7 +4123,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=305,atl-edge-internal;dur=23,atl-edge-upstream;dur=276,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=326,atl-edge;dur=304,atl-edge-internal;dur=19,atl-edge-upstream;dur=286,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="sVPgZB93y5RJDWux-I2sqrVIsjmeEjgHudX9SHqyCnMsSTNcUi0pyQ==",cdn-downstream-fbl;dur=329
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3344,13 +4132,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5a3010bd9376613ba1249daca87b27a2.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - sVPgZB93y5RJDWux-I2sqrVIsjmeEjgHudX9SHqyCnMsSTNcUi0pyQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 411e77e84729dd801aa104d254cd8c74
+      - 5be602ad6fa8f38a0b17327bf0b10d6a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3362,22 +4158,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/105] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/15] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]\n*Defect
       Dojo link:* http://localhost:8080/finding/298 (298)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
@@ -3391,27 +4186,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1957'
+      - '1929'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16117
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18241
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - 1172da7c-3381-40e6-8eac-1eb0739e67d9
+      - 11e5cdd3-b867-4849-9d4b-6819ddfef1dd
       Atl-Traceid:
-      - 1172da7c338140e68eac1eb0739e67d9
+      - 11e5cdd3b86748499d4b6819ddfef1dd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:06 GMT
+      - Wed, 30 Apr 2025 16:27:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3421,17 +4218,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=284,atl-edge-internal;dur=13,atl-edge-upstream;dur=272,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=310,atl-edge;dur=277,atl-edge-internal;dur=15,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="4qJ6dQCZgs9m-Vnt9KiIptIG1JchqvpI6GbqFvoylDJnI_qDn5IJhw==",cdn-downstream-fbl;dur=316
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e9bcf307d6ed54e3e501e39bc538dcfc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 4qJ6dQCZgs9m-Vnt9KiIptIG1JchqvpI6GbqFvoylDJnI_qDn5IJhw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 36a940c9683f85870194728cf0763d7b
+      - 189e663ca4c7a7542b2cde8b6c067c59
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -3455,65 +4260,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16117
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18241
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJlyRb4Uyn49py4tZ1XVlJHhyPByZXJGISYAFQR+P89+7y
-        kOJDmdqdZvRAEsAe2P3229VnB1Yll4kTORpkAhqSYwF5YnqSF2B6Js6g4D1VguZWKGl6kAhbgOW9
-        OOMyhVylvQVog3uQTKHUYEDa9mxcGauKOSm8Dnw/8F0Nf1Vg7GxdwrnmsRUxOD1HkP1gLwj28cNA
-        PsfPzNrSRJ6XwBxim6hPyuU258YILl0J1kNL1uOl8EJPGFOB1ym4hTXKn80mF7N+sDcY4FLtgnGi
-        z45B3yoTcwup0uvmDgl+oUToh6O+H/QDfxb6UbAfjcbucD/4Ef32yUkyYtHxWs0LnSR5D/X54eba
-        7UcCJtaipMDh6gEzBc/zHkuEsULGlpUCYmBqzpZK37okHSv5TufP9KKSgtLF82u+4JZrbyFg6dVu
-        bR1stwJ/EIx/NuJv+KnAtFcFWiVYoMkZN7eUq+rG0ls057mBntMInuC9atmekwkEjo6z9SksAH31
-        v/QcKxBZJaLEiWSFd3QewGTg79oIuo1Sq0941RdmopWu81BntssDfXyFnu1130lhLSowzsY2Qfi3
-        +qxRc7vkmoBsRFHmAh1OHoQEE1XDbzheDcfPdPcbKetusknY0KcKCIercPj/WmlgUYMUDQZ7q2Dv
-        exhcdRYH4WoQfg+LLfK/fHkMx7CD41ys3jcciEm+vHp8ctCd5GmqIUW+eVQE6KfKq6b8n0b/aNfG
-        3q6N/R0b4c6N8a6N14/9bGizWSVSqjuEE/WDlisp8lrEzZU+P1qjesCgmkxVeXIkTJnzdVs1uIwp
-        tO8xPVRJrQlusRk1JP78mm9axLYpeI06TRVdvx6qipJRO/+BFoRMncjqiryJNeBliSaeahLBaNQ1
-        iYdh20Vl4YbKHm5sQFVqobSw6xdeuBP36k7z73uFKHgKxiMJ0ykRuJCJNHPNIt2S4ltc6dgzdB7X
-        R7hBfc5vgPjvidIg2ngyEMEujAZjikjGzaQU8amQt8e0cwQlzS8y7jBUI2tZ721WpJITHF/4TQ5T
-        4KbBpW7fnPPTd29Ozq5PTw4nZxeT68l0+scU74d1ajAkeGCWATtHopeWkV0mDFMyXzMkDZGTUmYV
-        +1Vozs41FMgarDKIMPcp8giwoBz/Tvh+ufgUOU1XxOxh+LdVdY8tMBGpkDx/eKidvtrw1jjP0bv2
-        mzKbSticrkoq211IDgd+h+RmUHoh+BrhTYO9P9s8D49bvP3C41scNzvIdcobW4ftRPefHO7GwqZm
-        0EjYzQMSllTdKlf6rPHmJq+gn2rkrO1QpNiRapKtihIHYmmfBv1oQwvfSuxDoQ1l3A/nR/n174Cl
-        WlUlDYrHQiZIYoZhrbAbAMnKymSQ1Cg9mR7Q8waYkAuyTDBLGP4VYNjNIIlIWRa67A2p+yhf1c9X
-        EbvcqBUyYnOMYRb57sD17yjeGO5cxTzPlLHR2B/73rw5fl27hYgYXaEgu7yAuCJ6Ym/Vsm/VDmFs
-        y0mFbTm8Yh67DIxlf1ZcW9BsIlMsygJDvEMUNge8oJY+O/+dHVRY/uwi5nKHFA15XhCEV0007+7Y
-        BQ6utaP4fvh+Uj8+NI8uyfTR9n96nQmLVECiNajwDRUxYkt2xy5RRz9EduvT35XXtRsEUrlIXImz
-        vpuqhbeocomwtUgr3v3zV6Ri6DfBJrl4CW4hrAZX6dTD2uaEd4HzKnGCh0fdzBY5ydW5wmedLdIz
-        hbTKOcZyRX/bavePQAqeE3ouQC/w3xnrsx+ONfwDAAD//+xZ207bQBD9lVWlIhLFxkkcckGIRqRI
-        PKSqWrUP9IXN7pq4SuLIl6CqfHzPrDeLY7K0pSriAYGSeGevM7NnzoyzeYsdLPITDO75nYZDe8bW
-        R53hgBYcI85vVIt0ozkxuyOdNrcaHTW1UqiNNSeFYhO4IBov1MxnwxYjgGK73r39m7d96976uev/
-        5+Ng3xONI7ji3xNGCIut/nYcO8RHY9+hHzsya8LF0PwNX96TrI0V4Th6in/zt129Nz8nRQotXsQL
-        BSxQpaYPbvIT7VyVjpN7jGoCS+yyCcDLXH0/To643MQZABAEo9c5BnxFpGO4yjaqke2u9eTXDKGX
-        0VaRUppgmxqTm42QyaU1eWZMfjsn6OOYb3XDwLkF5IjaIuURrUQxGpC0LnIfmv96P/8U2LNQBuN2
-        RVu2P6p4EXp81JxSbsWQQjOnVlyZAD3nGI1GeKS+kKO6MluVhgzcxiFIN8qj6BWLhx1LacQ3FG8r
-        ViIEG9EHORcex0JgvhHiw2wRC2PBaayDgjHgF80bSOfGMuWpWJKyBQSpby1/uVxzkdOYDwmL9QMD
-        jm9iqeSOL33CfQKZwtJ/4yFm6DqhMEAOfsjlMl412GHjbgkHzpMRnPYhFe9ZNlpnYi6O3g6rUTpP
-        QT90TkBZS72rKzcLXILQJlT1EZYQb7Xg6ugiyIEriQvsmjzPuZhTcDQssUo06zwkK5ZLTszqjSv0
-        k7YpQ0rSJ9IvuoNnXAjKwS7laU92B/3BrN0PVFcMAzHsdaJhOzrGOrYTVnikmyJXGEtJ9wQ9RSJ/
-        vKtsBPyM5nq0NKPVr3xQPN2NxmzLA6FCFsJlOwyP+2LQ73WHMzHrB1g+4ioaiDN5qmd52x2/7Vzg
-        vxznLfnKcBLPK5syv8i8WyjC6/hEdvzyCpKmvDXnGSkK4zXCI4fBz/OpF/jrFdHgepnn5e+4Xid6
-        +Tuu15le+o6BTbKspZg85Ryuz6Y8igohYn2BiJSVlY0S2a5AYtHxfZEma3V0BcwRlNebm0Z1Tkjt
-        1aUVTNl3f3ITuvA0dNU8QlvzSA2uv8LIsznMK4w8x45fYWQPjNRhwMXQQkvELE/BcW7KS/mTXsiY
-        3wF2kuTcvGeqz+KiYoELl4LOfoBzlSwD5wGcVM2erD7CxeG6ToEld2q1idNkVbK7skkW5iVn+fgn
-        2tskeaXY/gsAAP//Iq0cxhhshxgGNxRoU0ZicVg+eCASNuIPzAIQJ1fDmND6hWwHgCeE9WHm6ijl
-        JlYEpRaX5oAMRvIseAixqMSxBOJx0FQGaJgR5HW4OKpmIxTdUA1g19bW1gIAAAD//wMAOUh7nFMf
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18241","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241","key":"NTEST-1873","fields":{"statuscategorychangedate":"2025-04-30T18:27:13.285+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:12.994+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:13.082+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/15]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]\n*Defect
+        Dojo link:* http://localhost:8080/finding/298 (298)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 37aa3b6f-310d-45f6-913e-04766ff93104
+      - ef16cf31-0620-4c77-9bdb-9c0c37c72877
       Atl-Traceid:
-      - 37aa3b6f310d45f6913e04766ff93104
+      - ef16cf3106204c779bdb9c0c37c72877
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:06 GMT
+      - Wed, 30 Apr 2025 16:27:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -3523,7 +4314,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=281,atl-edge-internal;dur=20,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="wDR4rHAljQdGR6g_-gSSF4XLh3kdzQrQ2LqhjMu7gog8MDvvnQwqAQ==",cdn-downstream-fbl;dur=345,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=342,atl-edge;dur=257,atl-edge-internal;dur=15,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -3532,471 +4323,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c973663b623c0e82cd366d5ae7837bf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - wDR4rHAljQdGR6g_-gSSF4XLh3kdzQrQ2LqhjMu7gog8MDvvnQwqAQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 3b2a2335be64aab0c499a790cc62b986
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1nVd3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwBbLE7NK+EjyIDNE6AJLCvGeDbjWRADXECAQ96FP+BQtd05S6FiwGnBIU8Lmn2z
-        srsxygYwo3khBeAclaSzBYpMqUyBVGw5mxe1yjNkuQJ2JvA6Gm7bQcQXohKj9ndWitg+EH2qCJrX
-        bUmO54c9WRMn1/cVOX4CAAD//wMAscBVeSACAAA=
-    headers:
-      Atl-Request-Id:
-      - 8533c12c-68bc-437d-8cd5-69b9156fa662
-      Atl-Traceid:
-      - 8533c12c68bc437d8cd569b9156fa662
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:06 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=150,atl-edge-internal;dur=14,atl-edge-upstream;dur=136,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - b65b3e566547b80de52951960412c2f6
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16115
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbCmU7HtZXEreu6spI8OB4PTK5IxBTAAqCOxv7v3eWl
-        +FBau9PYD8S1B3a//bD64sC64DJxIkeDTEBD8kZAnpie5AswPRNnsOA9VYDmVihpepAIuwDLe3HG
-        ZQq5SntL0Ab3IJlCocGAtM3ZuDRWLeak8Crw/cB3NfxZgrGzTQFnmsdWxOD0HEH2g70gGOHEQD7H
-        aWZtYSLPS2AOsU3UZ+Vym3NjBJeuBOuhJevxQnihJ4wpwWsV3MAG5U9nk/NZP9gbBLhUuWCc6Itj
-        0LfSxNxCqvSmvkOCM5QI/XDU94N+4M9CPwr2o9HAHQ9f/4B+++QkGbHoeKXmhU6SvIf6/LC7djNJ
-        wMRaFBQ4XD1gZsHzvMcSYayQsWWFgBiYmrOV0jcuScdKvtf5M70opaB08fyKL7nl2lsKWHmVW1sH
-        m63AHwTjn4z4C35cYNrLBVolWKDJGTc3lKvy2tIomvPcQM+pBY/xXpVsz8kEAkfH2eYEloC++nc9
-        xwpEVoEocSJZ4h2dBzAZ+Ls2gnaj0OozXvWFmWikqzxUmW3zQJOv0LO97nsprEUFxulsE4R/rc4a
-        NbcrrgnIRiyKXKDDyYOQYKIq+A3H6+H4me5+I2XtTbqEDf19dCMcrsPh/2ulhkUFUjQY7K2Dve9h
-        cN1aHITrQfg9LDbIv7t7DMewheNcrD/UHIhJvrh8fHLQnuRpqiFFvvnHIhi1G3gBlZc1Lzx9dG/X
-        xv6OjXDnxnjXxuvH7tS0Wa8SKVUvhBP1A5xyiw9HTbjPr8+azrcE7tXqNFVfNTxUJQUuIFL+SAtC
-        pk5kdQl3DU+TNi3iOmpfHq2RZ3jUZKrMkyNhipxvmorFZXTLfkBoUBU30dCAlyWaeOqRGL7eax+J
-        h2HbRWVhR2UPNzpQFVooLezmhUFsxb3qpfn3b4VY8BSMRxKmVSJwIRNp5ppluiXFd7jSsmfoPK6P
-        sEN9zq+B+O+J0iDaeDIQwS6MBmOKSMbNpBDxiZA3b2jnCArqX2Tc5rHK7qra61akkhNsX/h1DlPg
-        psaGbkbO2cn7t8enVyfHh5PT88nVZDr9fYr3wzo1GBI8MMuAnSHRS8vILhOGKZlvGJKGyEkps4r9
-        IjRnZxoWyBqsNIha9ynyCLCgHP9W+H6xHERO/Spi9jD826q6xxaYiFRInj881HRfTXgrpOfoXTOn
-        zKYSutNlQWW7C8mj8bBFct0ovRB8tXD3wN7vbZ6Hxy3efubxDbabLeRa5bWtw6aj+08Ot21hXTNo
-        JGz7AQkrqm6VK31ae3Odl9BPNfLGtilS7EjVyVaLAhtiaZ8G/aijhW8l9qFQRxn3w/lJfv1/wFKt
-        yoIaxTdCJkiMhmGtsGsAyYrSZJBUKD2eHtD3GpiQS7JMMEsY/hRg+JpBEpGyLHTZW1L3Sb6qvq8i
-        dtGpFTJiEuNlBbdKR747cge3FHSMea5inmfK2Gjsj31vXstcVb5RX3mJ0uziHOKSOIq9U6u+VTuE
-        8W1OSnybw0vmsYvAWPZHybUFzSYyxcpcYJx3iEJ3wAsq6dOz39hBiRzAzmMud0hRp+cFQXhZh/T2
-        lp1j91o5iuPDD5Pq87H+tJmmSdME0HAmLPIBiVbIwhEqYkSZ7JZdoI5+iByAxTcIg8oNQqpcJq7E
-        ht9N1dJblrlE7FrkFu/++UtSMfD9Ti5egbsQVoOrdOphgXMCvcCmlYjBw6NuZhc5yW0ThpMqZaQs
-        xL8ppGXOMahr+hFX3eMIpOA5YelvAAAA///sWW1v2jAQ/ivWpFaASBog4a2qOtSuUqVRTau2D90X
-        jONAJiBRQqgm7cfvOccJkBLoqFp10gQCYvvs8/nuOd/DvYxWqNWYwSp3+Qx1djpbnl9gmrZpVUuM
-        qY/+rNlr0/oD5N+VrJOp1D2Z7bJLG/t0Wr1n20WPV3axn28X+6BdXt0mTplNEHGZ0/Vryj7UxmrX
-        iWTXCFU03sixyXp1RkDOtlEge00bZg4D6rllvtlhYwfXCnkBij8DRjkJSh+UYxV8VHdtf9/mWQ3x
-        iOYf+DKOCg2sCG9SU7wsOLdPoHYfJBFseePPJNBTpvY+nSzPuRAyXKqfa+fbELxeo3wNaJyrEQD+
-        NW6afnDG3ZUfI4VISrcdJACPbA4nyu4FdKKj9QojhhsMI/1Rmes7S6S9QWtH3uDm3hBrb+DLJRJw
-        XGePU19MGa7SkwkwOAH8sZBjrcWEcYaaRkAQtyIRcY/0GA3URo3PfDFJgMYjNpXcheSKI4Wa6W7Z
-        97VCQ8D9TG7mlu3+rNTqb3okhnxRVYKb9aN7knU3tmfAyCnE0QgfV8HeP3wwhPh9+iD/wiNtK8Ys
-        YTKe+UIf2tBXmVSf2Td12SIL68NIlWEAmRk6Ir15yN3OQy6WJHMXMF89MOS9le9Kd8udviKkcAPF
-        0n/jFFo0DChtko9XuDv3F1VWqf6ew4eXQT/3252Y8ep44RyJFw7hhfMyvDgqZTzBi2OT1ubxvjVe
-        tP/jxRvghf1v4UU7Fz2AF0/5Dicv+YvlbhkR0rA3S6FlBJdRZA7RM8WhOSVW6LDKOuyctSpK5KxD
-        ZoWygWUshFXGlFn5mlvVe7G4U9ExpcokrRDjZD7nVL5+2FtfkcmJiwqiIwtdYiQu4bHEoN26F47b
-        6na640bHki3Rs0TPaXq9htfGOvkgrLBnmCR/GLguRQNGisD99XFDEVTCNNdeElydgTRRTKthJJMR
-        sba0Gl3uNmy73RHdDvByLMYdC8t7XHpdceleqFlOWoOT5g3eqZwx5wtd+BlG2hSbSWw8whBG06SK
-        0kzjkCxlhJzHZCjIK6Tnsxg/r4aGZYYLIhyKhPr717jIyL9/jYuM/nvXGADlpsyxZoSu4PpsyD0v
-        EcJXAURlXcpLp/D2ECxo4KckCkJ59gDgEcSg6kijf5TQm4curaD/YNtNI9lloGqXsct2zi5HGtyf
-        CSN/AAAA//8aLUYoTzCDsRgBAAAA//8i5OLRYoTWLqZLMYJeDOBqppnAW2PwxgvQO+mQTFkNmvqG
-        sg2ALskvSYTO6KObgqs9ZoCrXDIwwl7A4ZocMsDpAZztNbjP0HXgasgZ45SAt/BS88oyi/LzIK04
-        iFBKKXQ5CYRLTOiV5ZdQb6oUYhjcUKBNGYnFYfngKR/Y/CYwC0CcXA1jQusXsh0AXnqjDzNXRyk3
-        sSIotbg0B2QwkmfBkzVFJY4lEI+DJo1BEzogr8PFUTUboeiGagC7tra2FgAAAP//AwCu33etvSQA
-        AA==
-    headers:
-      Atl-Request-Id:
-      - 2ea109a1-573b-4994-972e-dbe12f671d6e
-      Atl-Traceid:
-      - 2ea109a1573b4994972edbe12f671d6e
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:07 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=293,atl-edge-internal;dur=13,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - 6025e2ba2eb180036fe68a896d2703b0
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
-    headers:
-      Atl-Request-Id:
-      - eb53dcae-7464-4119-bb72-caf9ed3caca2
-      Atl-Traceid:
-      - eb53dcae74644119bb72caf9ed3caca2
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:07 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=325,atl-edge-internal;dur=14,atl-edge-upstream;dur=311,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      Warning:
-      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
-        June 03, 2024)'
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - edef543babe79ef4074101af9a04e2c3
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
-      "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
-      group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/103]
-      in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
-      / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE ||
-      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
-      | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
-      | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
-      | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
-      | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
-      | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
-      Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
-      0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
-      (296)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
-      \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
-      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
-      versions of `negotiator` are vulnerable to regular expression denial of service
-      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
-      CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
-      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
-      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
-      Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
-      Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
-      \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
-      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
-      versions of `negotiator` are vulnerable to regular expression denial of service
-      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
-      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
-      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
-      [(admin) ()|mailto:]\n"}, "update": {}}'
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '3343'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16115
-  response:
-    body:
-      string: ''
-    headers:
-      Atl-Request-Id:
-      - 1bc93e9e-980c-4fb5-8e28-cc00b87a0742
-      Atl-Traceid:
-      - 1bc93e9e980c4fb58e28cc00b87a0742
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:08 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=344,atl-edge-internal;dur=12,atl-edge-upstream;dur=331,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - af633d0a31cdf6bc758e964d1401802d
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16115
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX6VPbRhT/V3b0MbV12RBHM50OBSehpZQaJ/lAGGaRnqUN0q6yu/LRkP+97+ly
-        OJwpdBr4oL3e/XuHvziwLrlMnMjRIBPQkLwWkCdmIHkBZmDiDAo+UCVoboWSZgCJsAVYPogzLlPI
-        VTpYgjZ4B8kMSg0GpG3fxpWxqlgQw6vA9wPf1fC5AmPnmxLONI+tiMEZOILkB/tBsIcbA/kCt5m1
-        pYk8L4EFxDZRn5TLbc6NEVy6EqyHkqzHS+GFnjCmAq9jcAMbpD+dT8/nw2B/FOBRrYJxoi+OQd0q
-        E3MLqdKbxoYEd0gR+uHe0A+GgT8P/Sh4Ge2N3Mn41U+ot09KkhCLitdsnqkk0XvIzw97s9tNAibW
-        oiTH4ekBMwXP8wFLhLFCxpaVAmJgasFWSt+4RB0r+U7nT9SikoLCxfMrvuSWa28pYOXVam0VbK8C
-        fxRMfjHib/i5wLBXBUolWKDIOTc3FKvq2tIqWvDcwMBpCI/Rrpp24GQCgaPjbHMCS0Bd/a8DxwpE
-        VokocSJZoY3OPZiM/O6i1OoTWvRMh7fUtbvrAHbups03INla9U4Ka5GBcXrZhNTf67dGLeyKa8Kr
-        EUWZC1Q4uWc5xqNG2XiyHk+eqO53ItNZ0sdl7L9ENcLxOhz/v1Ka6NdYRIHB/jrY/xEC153EUbge
-        hT9CYgvwr18fwjHYhdOwu1iI9fumBmL0Ly4fvhx1L3maakix3jxIAjRA5VWT/o+L29t1sb/r4uWO
-        i3DnxWTXxauHejZlszmlolR3CCcaBm2tpJBoETcmfXlwRomC3jaZqvLkSJgy55s2nfAYY2vfY9wo
-        xVoR3GIzaor404tB0yK2TcFr2GlK9Xp5qCoKRq38BzoQMnUiqyvSJtaAxlL9eKxJjF/td03ivtv6
-        Unb/Yheowh5UpRZKC7t5psEduVd3mn/fK0TBUzAeUZiOicCDTKSZa5bptlq+xZOurIbOw8QJe9Tn
-        /BqoMD6SGlRPHnVEsAujwYQ8knEzLUV8IuTNa7o5gpLmFxl3GKqRtarv+hOp5BTHF36dwwy4aXCp
-        25VzdvLuzfHp1cnx4fT0fHo1nc3+nKF9mKcGXYIP5hmwM+wA0jKSy4RhSuYbhtVE5MSUWcV+E5qz
-        Mw0FlhNWGUSY+1hVCTChHP9W+H65HEVO0xUxeuj+bVbdqRYYiFRInt9/1E5frXtrnOeoXbunyKYS
-        +tdVSWm7C8l7k3GH5GZQeib4GuK+896dbZ6Gxy3efuXxDY6bHeQ65o2sw3ai+08Kd2NhkzMoJOwG
-        BQkrym6VK33aaHOdVzBMNdas7VCk2JFqgq2KEgdiaR8H/V5fFr4X2PtEfcm4686P8tv/A5ZqVZU0
-        KL4WMsEiZhjmCrsGkKysTAZJjdLj2QF9r4EJuSTJBLOE4U8Bht0MkoiYZaHL3hC7j/JF/X0RsYue
-        rZARk+gvK7hVOvLdPXd0S05Hn+cq5nmmjI0m/sT3Fg3NVa0bzZWXSM0uziGuqEaxt2o1tGoHMTbt
-        pMKmHV4yj10ExrK/Kq4taDaVKWZmgX7eQQr9Ay+oqU/P/mAHFdYAdh5zuYOKRkAvCMLLxqW3t+wc
-        p9daUVwfvp/Wnw/Np4s0bdohgJZzYbEeEGmNLFwhI0Ylk92yC+QxDLEGYPKNwqBWg5Aql4krceB3
-        U7X0llUuEbsWa4t39/0lsRj5fk8Xr8AthNXgKp16mOCcQC9wmqXC4OFTN7NFTnTbgOGmDhkxC/Fv
-        BmmVc3Tqmn7E1XYcgRQ8Jyz9AwAA///sWW1v2jAQ/ivWpFaASBog4a2qOtSuUqVRTau2D90XjONA
-        JiBRXqgm7cfvOccJLyXQUbXqpAkExPbZ5/Pdc76HexktUasxg1Xuihnq7HSWnF9gmrZpVUuMqY/+
-        rNlr0/oD5P6lrJOp1AWa7bJLG/t0Wr1n20WPV3axn28X+6BdXt0mTplNEHG50/Vryj7UxmrXqWTX
-        CFU03sixyXp1RkDONlEgf00bZgED6rllvtlhYwfXCnkBij8DRjkJSh+UYxV8VHdtf9/mWQ3xiOYf
-        +DKOCg2sCG9SU7wsODdPoHYfpBFseePPJNBTZvY+nSTnXAgZJurnyvnWBK9XKF8DGhdqBIB/jZum
-        H5xxd+nHSCGS0m0HCcAjm8OJ8nsBnehotcKI4QbDSH9U5vrOEmlv0NqRN7iFN8TaG3iSIAHHdfY4
-        9cWU4Ro/mQCDU8AfCznWWkwYZ6hpBARxKxIR90iP0UBt1PjMF5MUaDxiU8ldSC45UqiZ7ZZ9Xyk0
-        BNzP5Hpu2ezPS63+ukdiyBd1o3fzfnRP8u7G5gwYOYU4GuHjKtj7hw+GEL9PH+RfeKRtxZglTMcz
-        X+hDG/oqk+oz+6YuW2RhfRiZMgwgM0NHpDcPudt5yEVCMncB89UDQ95b+q50N9zpK0IKN1As/TdO
-        oUXDgNIm+XiFu3N/UWWV6u85fDgJ+oXf7sSMV8cL50i8cAgvnJfhxVEp4wleHJu01o/3rfGi/R8v
-        3gAv7H8LL9qF6AG8eMp3OEXJv13ulhEhDbuso6C7qEZKIviSYmSIM9oaapUxY3bBWm1LFKxDboWy
-        gWUshFXGlFnFmioAplR86FJ8vZrfLvbidD7nVL5+2FtfkcmJiwqiIwtdYiQu4bHEdt26F47b6na6
-        40bHki3Rs0TPaXq9htfGOsUgrLBnmCR/GLguRQNGisD99XFNEVTCNNdedlydgTRRTKthJJMztLa0
-        Gl3uNmy73RHdDvByLMYdC8t7XHpdceleqFlOWoOT5g3emZwx5wtd+BlG1hSbaWw8whBG06SK0szi
-        kCxlhJzHZCjIK6Tnsxg/r4aGZYYLIhy2mfb3r/E2Vf/+Nd6m+t+7xsAhN2OtNSN0BddnQ+55qRC+
-        CiAq6zIOOUOxh2BBAz+lURDKswcAjyAGVUca/dWE3iJ0aQX9B9tuGskuA1W7jF22C3Y50uD+TBj5
-        AwAA//8aLUYoTzCDsRgBAAAA//8i5OLRYoTWLqZLMYJeDOBqppnAW2PwxgrQO+mQTFkNmhOHsg2A
-        LskvSYTO6KObgqs9ZoCrXDIwwl7A4ZocMsDpAZztNVztTFARglXCGKcEvIWXmleWWZSfB2niQYRS
-        SqHLSSBcYkKvLL+EetOaEMPghgJtykgsDssHT/nA5laBWQDi5GoYE1q/kO0A8NIbfZi5Okq5iRVB
-        qcWlOSCDkTwLnqwpKnEsgXgcNGkMmtABeR0ujqrZCEU3VAPYtbW1tQAAAAD//wMA8J2/kr0kAAA=
-    headers:
-      Atl-Request-Id:
-      - 3cc35569-6f2d-4086-bd5e-98c2ae7ac736
-      Atl-Traceid:
-      - 3cc355696f2d4086bd5e98c2ae7ac736
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:08 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=295,atl-edge-internal;dur=20,atl-edge-upstream;dur=271,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - 0f0eef7a1b7269f374fbb67e7e133e71
+      - 728fc706b4414d9373d9986f89db0411
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4016,7 +4354,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       112, "url_ui": "http://localhost:8080/test/112", "url_api": "http://localhost:8080/api/v2/tests/112/"},
       "finding_count": 0, "findings": {"new": [], "reactivated": [], "mitigated":
-      [], "untouched": []}}'
+      [], "untouched": [{"id": 295, "title": "Regular Expression Denial of Service
+      - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/295",
+      "url_api": "http://localhost:8080/api/v2/findings/295/"}, {"id": 296, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/296", "url_api": "http://localhost:8080/api/v2/findings/296/"},
+      {"id": 297, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/297",
+      "url_api": "http://localhost:8080/api/v2/findings/297/"}, {"id": 298, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/298", "url_api": "http://localhost:8080/api/v2/findings/298/"},
+      {"id": 299, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/299",
+      "url_api": "http://localhost:8080/api/v2/findings/299/"}]}}'
     headers:
       Accept:
       - application/json
@@ -4027,11 +4381,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '967'
+      - '2378'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added_empty
       X-DefectDojo-Instance:
@@ -4043,12 +4397,12 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"967\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2378\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added_empty\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
         \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
-        \"172.18.0.2:49184\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \"172.18.0.9:47798\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
         \ \"data\": \"{\\\"description\\\": \\\"Event scan_added_empty has occurred.\\\",
         \\\"title\\\": \\\"Created/Updated 0 findings for Security How-to: 1st Quarter
         Engagement: NPM Audit Scan\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/112\\\",
@@ -4062,16 +4416,58 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 112, \\\"url_ui\\\": \\\"http://localhost:8080/test/112\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/112/\\\"}, \\\"finding_count\\\":
         0, \\\"findings\\\": {\\\"new\\\": [], \\\"reactivated\\\": [], \\\"mitigated\\\":
-        [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n  \"form\": {},\n  \"json\":
-        {\n    \"description\": \"Event scan_added_empty has occurred.\",\n    \"engagement\":
-        {\n      \"id\": 1,\n      \"name\": \"1st Quarter Engagement\",\n      \"url_api\":
-        \"http://localhost:8080/api/v2/engagements/1/\",\n      \"url_ui\": \"http://localhost:8080/engagement/1\"\n
-        \   },\n    \"finding_count\": 0,\n    \"findings\": {\n      \"mitigated\":
-        [],\n      \"new\": [],\n      \"reactivated\": [],\n      \"untouched\":
-        []\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\": \"Security
-        How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
+        [], \\\"untouched\\\": [{\\\"id\\\": 295, \\\"title\\\": \\\"Regular Expression
+        Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/295\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/295/\\\"}, {\\\"id\\\": 296, \\\"title\\\":
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
+        \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/296\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/296/\\\"}, {\\\"id\\\":
+        297, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/297\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/297/\\\"}, {\\\"id\\\": 298, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/298\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/298/\\\"}, {\\\"id\\\": 299, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/299\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/299/\\\"}]}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added_empty has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n
+        \     \"name\": \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        0,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [],\n      \"reactivated\":
+        [],\n      \"untouched\": [\n        {\n          \"id\": 295,\n          \"severity\":
+        \"High\",\n          \"title\": \"Regular Expression Denial of Service - (Negotiator,
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/295/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/295\"\n        },\n
+        \       {\n          \"id\": 296,\n          \"severity\": \"High\",\n          \"title\":
+        \"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/296/\",\n          \"url_ui\": \"http://localhost:8080/finding/296\"\n
+        \       },\n        {\n          \"id\": 297,\n          \"severity\": \"High\",\n
+        \         \"title\": \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 <
+        3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+        < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >=
+        7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/297/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/297\"\n        },\n
+        \       {\n          \"id\": 298,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/298/\",\n          \"url_ui\": \"http://localhost:8080/finding/298\"\n
+        \       },\n        {\n          \"id\": 299,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/299/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/299\"\n        }\n      ]\n
+        \   },\n    \"product\": {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/2\"\n    },\n    \"product_type\": {\n      \"id\":
+        2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
         \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
         {\n      \"id\": 112,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/112/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/112\"\n    },\n    \"title\":
@@ -4087,7 +4483,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:08 GMT
+      - Wed, 30 Apr 2025 16:27:25 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -4112,26 +4508,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1m1d3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLDF4tS8EiGBDNhsDHQMy4oxnk95HsUAFxDhmPfxD9hXuj1nKVQMOC04FNmS0W9W
-        tjdWuQjmdF5IAThDJel0gSJXKlcgFVtOZ0Wt5jmyuQJ2JggmGW51L9ILUYnBhDsnRWofiDlVBO3r
-        tiTH88OenE2T6/uKHD8BAAD//wMAIJmmzCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:26.449+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - dcea8cd5-45de-465f-85d1-a62ebc82fd4c
+      - e5c65114-da4a-4193-bdd9-616b1e4e9a8b
       Atl-Traceid:
-      - dcea8cd545de465f85d1a62ebc82fd4c
+      - e5c65114da4a4193bdd9616b1e4e9a8b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:08 GMT
+      - Wed, 30 Apr 2025 16:27:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4141,7 +4533,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=281,atl-edge-internal;dur=17,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="buuLxxdgse-rjbvjYtC_HEAWAAYzJmQvH80vhlfTL6mfTgofOQaO9A==",cdn-downstream-fbl;dur=377,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=375,atl-edge;dur=297,atl-edge-internal;dur=17,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4150,10 +4542,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 087e16218fcf1ccb7472a2c9f6a4cbe2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - buuLxxdgse-rjbvjYtC_HEAWAAYzJmQvH80vhlfTL6mfTgofOQaO9A==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 0b07bd2d7831e038f65cc811b245e91e
+      - 312d483ab1a69c8a004ba92086400db2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4177,134 +4577,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16115
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18237
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX6VPbRhT/V3b0MbV12RBHM50OBSehpZQaJ/lAGGaRnqUN0q6yu/LRkP+97+ly
-        OJwpdBr4oL3e/XuHvziwLrlMnMjRIBPQkLwWkCdmIHkBZmDiDAo+UCVoboWSZgCJsAVYPogzLlPI
-        VTpYgjZ4B8kMSg0GpG3fxpWxqlgQw6vA9wPf1fC5AmPnmxLONI+tiMEZOILkB/tBsIcbA/kCt5m1
-        pYk8L4EFxDZRn5TLbc6NEVy6EqyHkqzHS+GFnjCmAq9jcAMbpD+dT8/nw2B/FOBRrYJxoi+OQd0q
-        E3MLqdKbxoYEd0gR+uHe0A+GgT8P/Sh4Ge2N3Mn41U+ot09KkhCLitdsnqkk0XvIzw97s9tNAibW
-        oiTH4ekBMwXP8wFLhLFCxpaVAmJgasFWSt+4RB0r+U7nT9SikoLCxfMrvuSWa28pYOXVam0VbK8C
-        fxRMfjHib/i5wLBXBUolWKDIOTc3FKvq2tIqWvDcwMBpCI/Rrpp24GQCgaPjbHMCS0Bd/a8DxwpE
-        VokocSJZoY3OPZiM/O6i1OoTWvRMh7fUtbvrAHbups03INla9U4Ka5GBcXrZhNTf67dGLeyKa8Kr
-        EUWZC1Q4uWc5xqNG2XiyHk+eqO53ItNZ0sdl7L9ENcLxOhz/v1Ka6NdYRIHB/jrY/xEC153EUbge
-        hT9CYgvwr18fwjHYhdOwu1iI9fumBmL0Ly4fvhx1L3maakix3jxIAjRA5VWT/o+L29t1sb/r4uWO
-        i3DnxWTXxauHejZlszmlolR3CCcaBm2tpJBoETcmfXlwRomC3jaZqvLkSJgy55s2nfB4xS22nqZk
-        Pz31m4awbQFew05TYtfLQ1WR62tVP9CBkKkTWV2RbGRq3yNmKL1bb2hAY6l+PNYkxq/2uyZx3219
-        Kbt/sQtUYQ+qUgulhd080wUduVd3mn/fK0TBUzAeUZiOicCDTKSZa5bptlq+xZOurIbOw8QJe9Tn
-        /BqoMD6SGlRPHnVEsAujwYQ8knEzLUV8IuTNa7o5gpLmFxl3GKqRtarv+hOp5BTHF36dwwy4aXCp
-        25VzdvLuzfHp1cnx4fT0fHo1nc3+nKF9mKcGXYIP5hmwM+wA0jKSy4RhSuYbhtVE5MSUWcV+E5qz
-        Mw0FlhNWGcSc+1hVCTChHP9W+H65HEVO0xUxeuj+bVbdqRYYiFRInt9/1E5frXtr5OeoXbunyKYS
-        +tdVSWm7C8l7k3GH5GZQeib4GuK+896dbZ6Gxy3efuXxDY6bHeQ65o2sw3ai+08Kd2NhkzMoJOwG
-        BQkrym6VK33aaHOdVzBMNdas7VCk2JFqgq2KEgdiaR8H/V5fFr4X2PtEfcm4686P8tv/A5ZqVZU0
-        KL4WMsGyZhjmCrsGkKysTAZJjdLj2QF9r4EJuSTJBLOE4U8Bht0MkoiYZaHL3hC7j/JF/X0RsYue
-        rZARk+gvK7hVOvLdPXd0S05Hn+cq5nmmjI0m/sT3Fg3NVa0bzZWXSM0uziGuqEaxt2o1tGoHMTbt
-        pMKmHV4yj10ExrK/Kq4taDaVKWZmgX7eQQr9Ay+oqU/P/mAHFdYAdh5zuYOKRkAvCMLLxqW3t+wc
-        p9daUVwfvp/Wnw/Np4s0bdohgJZzYbEeEGmNLFwhI0Ylk92yC+QxDLEGYPKNwqBWg5Aql4krceB3
-        U7X0llUuEbsWa4t39/0lsRj5fk8Xr8AthNXgKp16mOCcQC9wmqXC4OFTN7NFTnTbgOGmDhkxC/Fv
-        BmmVc3Tqmn7E1XYcgRQ8Jyz9AwAA///sWW1v2jAQ/ivWpFaASBog4a2qOtSuUqVRTau2D90XjONA
-        JiBRXqgm7cfvOccJLyXQUbXqpAkExPbZ5/Pdc76HexktUasxg1Xuihnq7HSWnF9gmrZpVUuMqY/+
-        rNlr0/oD5P6lrJOp1AWa7bJLG/t0Wr1n20WPV3axn28X+6BdXt0mTplNEHG50/Vryj7UxmrXqWTX
-        CFU03sixyXp1RkDONlEgf00bZgED6rllvtlhYwfXCnkBij8DRjkJSh+UYxV8VHdtf9/mWQ3xiOYf
-        +DKOCg2sCG9SU7wsODdPoHYfpBFseePPJNBTZvY+nSTnXAgZJurnyvnWBK9XKF8DGhdqBIB/jZum
-        H5xxd+nHSCGS0m0HCcAjm8OJ8nsBnehotcKI4QbDSH9U5vrOEmlv0NqRN7iFN8TaG3iSIAHHdfY4
-        9cWU4Ro/mQCDU8AfCznWWkwYZ6hpBARxKxIR90iP0UBt1PjMF5MUaDxiU8ldSC45UqiZ7ZZ9Xyk0
-        BNzP5Hpu2ezPS63+ukdiyBd1x3fzfnRP8u7G5gwYOYU4GuHjKtj7hw+GEL9PH+RfeKRtxZglTMcz
-        X+hDG/oqk+oz+6YuW2RhfRiZMgwgM0NHpDcPudt5yEVCMncB89UDQ95b+q50N9zpK0IKN1As/TdO
-        oUXDgNIm+XiFu3N/UWWV6u85fDgJ+oXf7sSMV8cL50i8cAgvnJfhxVEp4wleHJu01o/3rfGi/R8v
-        3gAv7H8LL9qF6AG8eMp3OEXJv13ulhEhDXu9FEoiuIyiYoga2h5aRoBZZR12wVptSxSsQ26FsoFl
-        LIRVxpRZxZoqAKZUfOhSfL2a3y724nQ+51S+fthbX5HJiYsKoiMLXWIkLuGxxH/duheO2+p2uuNG
-        x5It0bNEz2l6vYbXxjrFIKywZ5gkfxi4LkUDRorA/fVxTRFUwjTXXnZcnYE0UUyrYSSTM7S2tBpd
-        7jZsu90R3Q7wcizGHQvLe1x6XXHpXqhZTlqDk+YN3pmcMecLXfgZRtYUm2lsPMIQRtOkitLM4pAs
-        ZYScx2QoyCuk57MYP6+GhmWGCyIctpn296/xNlX//jXepvrfu8YAKDdjrTUjdAXXZ0PueakQvgog
-        KusyVjmDt4dgQQM/pVEQyrMHAI8gBlVHGv3VhN4idGkF/QfbbhrJLgNVu4xdtgt2OdLg/kwY+QMA
-        AP//Gi1GKE8wg7EYAQAAAP//IuTi0WKE1i6mSzGCXgzgaqaZwFtj8MYK0DvpkExZDZoTh7INgC7J
-        L0mEzuijm4KrPWaAq1wyMMJewOGaHDLA6QGc7TW4z9B14GrIGeOUgLfwUvPKMovy8yBNPIhQSil0
-        OQmES0zoleWXUG+iE2IY3FCgTRmJxWH54Ckf2NwqMAtAnFwNY0LrF7IdAF56ow8zV0cpN7EiKLW4
-        NAdkMJJnwZM1RSWOJRCPgyaNQRM6IK/DxVE1G6HohmoAu7a2thYAAAD//wMA76x2QL0kAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18237","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237","key":"NTEST-1871","fields":{"statuscategorychangedate":"2025-04-30T18:27:07.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:07.681+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t67:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:07.763+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
+        (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
+        Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 909f87dd-2971-4c1a-835c-8060e690796b
+      - f565d004-5a60-40c9-a44c-02e12aaa56db
       Atl-Traceid:
-      - 909f87dd29714c1a835c8060e690796b
+      - f565d0045a6040c9a44c02e12aaa56db
       Cache-Control:
       - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:09 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=284,atl-edge-internal;dur=16,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - db7aa21d89a34e552b81ecea51027133
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1nVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLD5/NS8EiGBDNhsDHQMy4oxnk95HsUAFxDhmPfxD9hXuj1nKVQMOF1wWGYF0G9W
-        tjdWuQjmtFhIAThDJel0jiJXKlcgFVtOZ4taFTmyQgE7EwSTDLe6F+mFqMRgwp2TIrUPxJwqgvZ1
-        W5Lj+WFPzqbJ9X1Fjp8AAAD//wMAa2EeYyACAAA=
-    headers:
-      Atl-Request-Id:
-      - 920ccbda-5184-4e60-b7c0-2a4b78cb99eb
-      Atl-Traceid:
-      - 920ccbda51844e60b7c02a4b78cb99eb
-      Cache-Control:
-      - no-cache, no-store, no-transform
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:09 GMT
+      - Wed, 30 Apr 2025 16:27:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4314,7 +4647,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=169,atl-edge-internal;dur=15,atl-edge-upstream;dur=154,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="qK90YnCC2Zsm50VYxNbF6YhEesPI1LV-ApvHQ16dFCaRyFCRP3gy9w==",cdn-downstream-fbl;dur=344,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=341,atl-edge;dur=258,atl-edge-internal;dur=18,atl-edge-upstream;dur=239,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4323,127 +4656,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e111150962050a0e90ab08053c0f9778.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qK90YnCC2Zsm50VYxNbF6YhEesPI1LV-ApvHQ16dFCaRyFCRP3gy9w==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - afb7fc91c54f93f0c61d7799d8fed246
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16116
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf6kOmktt4wYJTJdChxElpKqTHJB8IwZ2ktXZDu1LuTXwr89+5K
-        lh1MnBY6Dcwg6e725XaffXa5dWBecpk4kaNBJqAheSsgT0xH8gJMx8QZFLyjStDcCiVNBxJhC7C8
-        E2dcppCrtDMFbXAPkiGUGgxIuzwbV8aqYkIKrwPfD3xXw58VGDtalHCmeWxFDE7HEWQ/2AuCPfww
-        kE/wM7O2NJHnJTCB2Cbqs3K5zbkxgktXgvXQkvV4KbzQE8ZU4LUKbmCB8qejwfmoG+zthLhUu2Cc
-        6NYx6FtlYm4hVXrR3CHBL5QI/XC36wfdwB+FfhTsR7t7btDr/4h+++QkGbHoeK3mmU6SvIf6fPKq
-        ufbyIwETa1FS4HD1kJmC53mHJcJYIWPLSgExMDVhM6VvXJKOlbzQ+RO9qKSgdPH8mk+55dqbCph5
-        tVtrB5dbgb8T9H8y4i94XWDaqwKtEizQ5IibG8pVNbb0Fk14bqDjNILHeK9atuNkAoGj42xxAlNA
-        X/37jmMFIqtElDiRrPCOzgZMdvx2o9TqM97omQFfStfhrhPYhps+vgDJ+lYXUliLCoyzsk1I/bU+
-        a9TEzrgmvBpRlLlAh5ONm2M+apT1+vNe/4nufiMz7U1Ween5++hG2JuHvf/XSpP9GotoMNibY4V9
-        B4Pz1uJOOMcC/g4WlwC/v38Mx2AbTsNtGzvtxkTMPzTkiLC4vEKYpKmGFPnmH4tgt93Am6m8anjh
-        60f3tm3sb9kIt270t20cPHanoc1mlUip7hBO1A3wk1tsHA3hPr1wGzpfE7jXqNNUlvXrkaoocAGR
-        8kdaEDJ1IqsruF/yNGnTIm6idvtojTzDoyZTVZ68EabM+WJZyriMbtkPiBkq72U0NOBliT8eN4ld
-        d7/vt01iM2wrKtvc2AaqcAWqUgulhV08M4ituFd3mn/fK0TBUzAeSZhWicCFTKSZa6bpmi3f40pL
-        q6HzuHDCVRnkfAxEjFQBmzPBNvAG2zAa9CkiGTeDUsQnQt68pZ03UNL8IuM2j3V2Z/XeakUqOcDx
-        hY9zGAI3DTb08s05O7l4d3x6fXJ8NDg9H1wPhsPfh3g/rFODIcEDowzYGXYAaRnZZcIwJfMFQzYR
-        OSllVrFfhObsTEOBdMIqg6h1v8YqARaU498J3y+n48hpuiJmD8O/rqoHbIGJSIXk+eah5fS1DG+N
-        9By9awkHM5tKWJ2uSirbbUju98MWyc2g9EzwNcKrzvtwtnkaHtd4+5nHNzhutpBrlTe2jpYT3X9y
-        uB0Lm5pBI2E7KEiYUXWrXOnTxptxXkE31cgb66FIsTeqSbYqShyIpf066HdXtPCtxG4KrSjjYTg/
-        yS9/D1mqVVXSoPhWyASJ0TCsFTYGkKysTAZJjdLj4SE9x8CEnJJlglnC8F8Bhk0LkoiUZaHL3pG6
-        T/Jl/XwZscuVWiEjVqbRrhu4/h0FG2Odq5jnmTI26vt935s0Z69rn6jdXqEUuzyHuCJuYu/VrGvV
-        FmFs1kmFzTq8Yh67DIxlf1RcW9BsIFOsyALju0UUVge8oJY+PfuNHVZY++w85nKLFI1+XhCEV00o
-        7+7YOU6ttaP4fvRhUD8+No82w/Sx7PH0OhIWeYBEa0ThGypiRJXsjl2ijm6ItY9tze+HtRuEUDlN
-        XImDvpuqqTetcomYtcgp3sPzV6TioLcSi2fgFsJqcJVOPaxrTlgXOMQSH3gHPTezRU5SZYp/6kSR
-        ihB/hlAoC3iNBNhgjvkgGdZlP5ylHfYit69Y6AaBGzL2IrWvXv8NAAD//+xYUW/bOAz+KwQKDI4v
-        Va5O0qAZ+lC0O+CA2zCs214uB8R11MWbY6eW3XXY9t/3UZJluYk3rNu9tS1ShxQl6iNFfjKNxZ8w
-        1oqxOBYTahSTVjER6IWNfNrKpwJzNfLjVs6P01bO3ln5kThu5VErj/zx41Y+FuNWPmnlk3YDs3Zd
-        fvTkbl1+jAY9yWFTeRSdnDCiZ+ARt3LIodcXAdoX59lPxtmO/11xfozxg2M864sxKmFTFOahjjfL
-        KLyoJV2ghEL4l7wSdDIkbrDUrc7N7/pIuPKsv4/F47H8xZCdoGyHF7rXow2/L4hZEMLxQzsK8DHY
-        F9jvhZVCdAKI/8W/wwccVqyHU68n+LWm0M2s8LKoy0QiuzIZcn8+RBvdpEoyrNt33sCLlkWE6PZu
-        WaSesv1ZpMUoXt2mChQFV4BpFIFgXDPCOAwN72Sqsdy+WxI4HfzLKabSZHHCWSxdFvMeZBlfpRl3
-        1GodV1QkWEjRxzXISQV2bQ0ZtatYSSpKusHF7RPhqpzwGVSYPSnja3YAbKze5MTkS+hzBn5eSgJB
-        p+pj0ZgkpBKZx7jIMGPBUmmyJvAAkPcs/SBB36+xSgy3t9ssTfSbS8uMGoczCXxwYpn/+6PM1uBT
-        nav4GoWC6f6hqnkI/FM3mV3OIqNoE8M4LcALPOeVWOTR7uwwyoG0YmfgHm68JQgh5nXoMFlzPsQW
-        qVJWdZkjtfGk6qxidD0fMG6vE4IBPDjAzaVAPPF3XuSJ3FaLfLlcLnK+DVb0mc6xM3Cer3RK/Co3
-        LWXw5OAumiG1zP9BMzYxI08J1NmaBazUT8JujiWNAcN1SsvLZ/88O39NR3R2SU9u6qJ6usCPmXwU
-        GgkO4T51OFrgXP7BW1VFJgUuCwGyP8EFTsj8dvAfewMGDZN8NDLWS+2AcUoDGMCPIQWyLIeM4IBO
-        +eTQZ8xs94S5Vuz414EFh966RKHn4KzIF+Kj5sub10DzThUHT+yp49D0VXJntFPLnWanmnuae/Xc
-        09yr6J7mXk33NPequtPs1HVP063swOmlfr+zakCa25EWJIsK5vPgYowsJryQDxdjZEGxqgYuxsiB
-        4mmajteg0lExSA6VjoZBcqh0NAySQ6WjYZAcKp7GgORQ6WgMSF4yAa81MolT8tDQvfluoeebypw/
-        0J3w7Szhc4DErK9w/G0PeJ7qi59tAaG7yETiTtzN6Y1+WcAFyBb7JiSomBk0pfCNxn1GJlp7bSZ9
-        NiaMe22mfTYmwHttjvtsTEScDQX0gjuQ7k6uw+kkGJqID3XZNSHmVhNnqqCtSWBBTCPcorO+RXVI
-        v7+oTQh0qZ0FbOz+3mzjpOK4vSgo1V8IKXCbruSqbfMY+AqcqJSo5upn+rw13RZ842aaEsSrTZoP
-        KBh82YCGVMXcUY+9dPaRynoH2C94P6ayswdS2RlT2dn/QWW/AQAA//8irSlLbr8XOdnSuilrONqU
-        BaoCAAAA///smtFqgzAUhl9lDHoZF2ucelG6MjbYRV+gd/FEtzGsRSujb79zjIaaNR2sN14EelGa
-        E3M4mJ+//J+3st7Keit7UdUn1myi6xNrdq7s3sqO8/JW1lvZeVjZ0Gz9w8r+Tu9jE2Db4a0r1g+F
-        a8HgHJT4HRsJXz2zQBSCVSoMamEtcPMMe8GVoXOToY/jcRW6uA9umplk0XZUKY9HCR+Ut+m8s+2q
-        SlIYe38xLaRRE1FRN/+Ma8mdrCUAcSBvahWrKE3SPEx4EUHGIYuXZRaWBAOaIjzhSllB78FGKTyj
-        xUq0e6ens0agJvbtOuPVj7gI3htdRntGzkgUPEylCoV4TCBN4ijLIU84Hl/KokxhrVb9UxbRZrF8
-        xY/exyq5H2JMxvRPbdC17BsHwZYB5aOB1kCaFDtI2dKgcH/v0fG24dfnLePBYU+xuc2Lzb9jGzib
-        f8c2sDb3jlF/lOafBq4B/6+f7rayLDuAz/4CUQim6SqtXrt6T4UvXVMfiocd6goQBzTcNAImcdVc
-        XTphwEQvwxDCJabCxUgJF3gnjGA3g9p7fbntTfoBAAD//yIhJY2WL/Rw8Wj5gqV8QS8G4K0weKMF
-        6Op0SN6rBq3shrINgBbmlyRC16Wjm4KzuYWzXMLZDjPCXvLhWuJogKvhCSoQsEoY4Gp4GuPSYQxv
-        2aXmlWUW5edBWm8QoZRS6KYICJeo0MvPhZhQDWNCi3syil+k/Rz6MHN1lHITK4Ig40AodoNXABaV
-        OJZA3FEG7H6Qu2wRY+ExxDC4oUC7MhKLw/LBCyhhq4VBS59ByxJBVsIdgupaIxTnQjWAg6e2thYA
-        AAD//wMAG0BdqoMzAAA=
-    headers:
-      Atl-Request-Id:
-      - 17aa81ad-76c6-40d2-860c-c64f4221c7d8
-      Atl-Traceid:
-      - 17aa81ad76c640d2860cc64f4221c7d8
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:09 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=273,atl-edge-internal;dur=23,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - b2f237c0d0cd85d6ca3cc7b63ad2dc35
+      - 6aa5c2c0580c26cb0b2c003d1bc28eba
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4470,26 +4694,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTUsDMRCG/0uudreTNP3KTSpYRauw24siks1OMJpNlk22UEr/u1kstEf1Nsw8
-        7zzDHEglA247SwT5iLENYjyuUaOKtf/0uYxWhmCkyx1GMiK1Ca2V+3/wBXY7o7DG8LVG267QRez+
-        umTlnbY9OoW/S+6wC8a7BFMAmkMOWbG5fi7WT+V5uumbKlVEvA7QCEbwlpzYWr9v0pXlvh1sK+v7
-        OoWq3tj6J0JECrD5/NS8kXEAGbBpBjSDZcmY4BPBkxjgChKc8iH9AbvSNJcshZKBoIu0MGf8zKrm
-        zmmfQE5nCyUBp6gVncxRcq25BqXZcjJdVHrGkc00sAtBtIPh3nRyeCFq2dv44JUc2gdiTxVB974t
-        yPHysBfvhsntY0mO3wAAAP//AwB0aLBQIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:27.258+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 91ec3fb8-32fe-4069-b0f4-0f12df444748
+      - 5eb758e5-4ba1-4970-b4e9-920493ec3dd1
       Atl-Traceid:
-      - 91ec3fb832fe4069b0f40f12df444748
+      - 5eb758e54ba14970b4e9920493ec3dd1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:10 GMT
+      - Wed, 30 Apr 2025 16:27:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4499,7 +4719,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=152,atl-edge-internal;dur=21,atl-edge-upstream;dur=131,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="0wN-N5CtXlHy9pYvFzhS8nCQkil-h_GRgACRkltp_ZtPd2lFNgeIOw==",cdn-downstream-fbl;dur=244,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=241,atl-edge;dur=155,atl-edge-internal;dur=14,atl-edge-upstream;dur=142,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4508,10 +4728,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 51e6f466f192ce588105b138cebcc0d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0wN-N5CtXlHy9pYvFzhS8nCQkil-h_GRgACRkltp_ZtPd2lFNgeIOw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 3a106be45847d5c50fc81b99e3131f93
+      - 9655fcee1f1c51f776daa341ab67f60a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4535,132 +4763,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16117
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18239
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX23LbNhD9FQyfOqnEmyRb4Uyn49py4tZ1XVlJHhyPByZXJGISYAFQl8b59+6S
-        ohRfmKndaUYPJAHsBbtnz64+O7AquUycyNEgE9CQHAvIE9OTvADTM3EGBe+pEjS3QknTg0TYAizv
-        xRmXKeQq7S1AG9yDZAqlBgPSbs7GlbGqmJPC68D3A9/V8FcFxs7WJZxrHlsRg9NzBNkP9oJgHz8M
-        5HP8zKwtTeR5Ccwhton6pFxuc26M4NKVYD20ZD1eCi/0hDEVeK2CW1ij/NlscjHrB3uDAS7VLhgn
-        +uwY9K0yMbeQKr1u7pDgF0qEfjjq+0E/8GehHwX70WjsDveDH9Fvn5wkIxYdr9W80EmS91CfH26v
-        vflIwMRalBQ4XD1gpuB53mOJMFbI2LJSQAxMzdlS6VuXpGMl3+n8mV5UUlC6eH7NF9xy7S0ELL3a
-        rZ2Dm63AHwTjn434G34qMO1VgVYJFmhyxs0t5aq6sfQWzXluoOc0gid4r1q252QCgaPjbH0KC0Bf
-        /S89xwpEVokocSJZ4R2dBzAZ+O1GqdUnvNELA76RrsNdJ7ANN318BZLdrd5JYS0qMM7WNiH1t/qs
-        UXO75JrwakRR5gIdTh7cHPNRo2w4Xg3Hz3T3G5lpb7LNy9AnoIfDVTj8f6002a+xiAaDvVWw9z0M
-        rlqLg3A1CL+HxQ3Av3x5DMegC6dh18ag3ZiL1fuGHBEWl1cIkzTVkCLfPCoCvIDKq6b8n9Y66trY
-        69rY79gIOzfGXRuvH/vZ0GazSqRUdwgn6gcbrqSUaBE3V/r8aI0KBaNtMlXlyZEwZc7Xm3LC5SW3
-        2Hoayn5+6TcNYdcCvEadpsKuXw9VRaGvXf1AC0KmTmR1RbZRqX2PmKHy3kRDA16W+OOpJhGMRm2T
-        eBi2LZU93OgCVbgFVamF0sKuXxiCVtyrO82/7xWi4CkYjyRMq0TgQibSzDWLdMeWb3GlpdXQeVw4
-        4bYMcn4DRIxUAQ9ngi7wBl0YDcYUkYybSSniUyFvj2nnCEqaX2TcYqhG1rLe265IJSc4vvCbHKbA
-        TYNLvXlzzk/fvTk5uz49OZycXUyuJ9PpH1O8H9apwZDggVkG7Bw7gLSM7DJhmJL5miGbiJyUMqvY
-        r0Jzdq6hQDphlUHMuU+xSoAF5fh3wvfLxafIaboiZg/Dv6uqe2yBiUiF5PnDQ5vpaxPeGvk5etcS
-        DmY2lbA9XZVUtl1IDgd+i+RmUHoh+Brhbee9P9s8D487vP3C41scN1vItcobW4ebie4/OdyOhU3N
-        oJGwHRQkLKm6Va70WePNTV5BP9XIWbuhSLEj1SRbFSUOxNI+DfpRFy2MtrTwrYzfD+dH+fXvgKVa
-        VSUNisdCJkhrhmGtsBsAycrKZJDUKD2ZHtDzBpiQCzJAMEsY/hVg2LQgiUhZFrrsDan7KF/Vz1cR
-        u9yqFTJic4xhFvnuwPXvKN4Y7lzFPM+UsdHYH/vevDl+XbuFiBhdoSC7vIC4Inpib9Wyb1WHMPbr
-        pMJ+HV4xj10GxrI/K64taDaRKRZlgSHuEIXtAS+opc/Of2cHFZY/u4i57JCi6c8LgvCqiebdHbvA
-        wbV2FN8P30/qx4fm0SaZPjZtnl5nwiIVkGgNKnxDRYzYkt2xS9TRD5Hd+vR35XXtBoFULhJX4qzv
-        pmrhLapcImwt0op3//wVqRj6TbBJLl6CWwirwVU69bC2OeFd4CBLnODhUTezRU5yda7wWWeL9Ewh
-        rXKOsVzR37ba/SOQgueEngvQC/x3xvrsh2MN/wAAAP//7FnbbtpAEP2VVaVEAWHHgLlGUYpCI+WB
-        qmrVPqQvWXbXwRVg5AtRlXx8z6yXDThs2qZqlIcIBPbO3jwze+bMOJs12OE8P8Hgjt+qObRnbH3c
-        GvRpwRHi/Fo1SDeaLLN70ml9o9FhXSuF2lh9XCg2hgui8UJNfTZoMAIotuvdm8+s6Vv31vdt/z8/
-        DvY91jiCI/4jYYSw2Opvx7Ej/NT2PfRTj8zqcDE0f8ef9yxrY0U4jp7i3/xtV+/1L0mRQosX8VwB
-        C1Sp6cOb/EQ711bH8QNG1YEldtkE4GWOvh8nx1yu4ww4B4LRaXUBXxHpGK6yiWpku2s9+TVD6GW0
-        VaSUJtimxuRmI2RyaU2eGZPfzgj6OOZb3jBwbgE5orZIeUQrUYwGJK2K3Ifmvz3MPwH2zJXBuF3R
-        htQPt7wIPT5plik3YkihmVMr3poAPWcYjUZ4pD6Qw6oyG1sNGbiNQ5CulUfRKxaPO5bSiK8p3m5Z
-        iRBsSD/kXLgdCYH5hogP03ksjAUnsQ4KxoBfNW8gnRvLlE/FkpTNIUh9a/nLxYqLnMZ8TFisbxhw
-        fB1LJXd86TPOE8gUlv4bDzFDVwmFAXLwIy4X8bLGjmr3CzhwngzhtI+peMey0SoTcwXjZugS2EyM
-        onSegpfo9IHSmUrX0OZNFUHgyuYCFyEOLCHeqMfV0ZXEBXYzPM+5mFFw3JOWVulGViwWnJjVO1fo
-        J21ThpSkz6RfdAbPuBCUlV3K045s93v9abMXqLYYBGLQaUWDZtTFOrYTVniimyJXGElJ5wQ9RSJ/
-        vt/aCPgZzfVkzUZrWfmgeLobjdnUDUKFLITLZhh2e6Lf67QHUzHtBVg+4irqizN5qmc5aI8OWhf4
-        luO8BV8aTuJ5ZVPmF5l3C0V4LZ/Ijl8eQdKUt+I8I0VhvEZ45DC4PJ94gb9aEg2u1n9e/46rBaTX
-        v+NqAeq17xgQJMtaislTzuH6bMKjqBAi1geISFlZ6ygB7AokFh0/FGmyUsdXgBZBeb05aVQAhdQe
-        XVrBlH33JzehC09DV80jdBXSQovZqQH8N3x5MU96w5eX2PEbvuzBlyoMWCJmeQp2fVOevTt6U2Ou
-        AyyY5Ny8Z6rO4mRcTlxyUrHWfuRzlSwDF/ckQNgrCFzcs+0a0bbkTi3XcZosS3ZXNsnCvOQsb/9I
-        e8minOGOLn8BAAD//wIxocU9GcUv0vysPsxcHaXcxIqg1OLSHJDBSHaDR/SKShxLIO4oyy+h3jQA
-        xDC4oUC7MhKLw/LBA6LwmYf8IvAwI8hKuENQXWuE4lyoBnDw1NbWAgAAAP//AwD+cY/4Ux8AAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18239","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239","key":"NTEST-1872","fields":{"statuscategorychangedate":"2025-04-30T18:27:10.705+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:10.389+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:10.491+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
+        Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:*
+        http://localhost:8080/finding/297 (297)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 2019298a-f7b3-4186-b1cf-95dfe4e5752e
+      - 3d858399-0275-44dc-a533-1055681ebb27
       Atl-Traceid:
-      - 2019298af7b34186b1cf95dfe4e5752e
+      - 3d858399027544dca5331055681ebb27
       Cache-Control:
       - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:10 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=273,atl-edge-internal;dur=23,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - 0534aaa7c7592e63e5304075c9ceecc5
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1q1d32SCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUjDHW4HTUry5n3vyum0RYnCt/bdptxr7pziJjXoyYS0yvWa7//BVzjslMAW3ccadb9C43H4
-        65KVNVKPaAT+LrnDwSlrAkwBaAopJNXm8rFaP9Q/083YNaEi5XOEJjCBl+DEXtt9F66s9320rbQd
-        2xBqRqXbrwgpQ4Dl+al5xX0EGbB5AjSBZc1Ymc3KLIgBLiDAIe/CH3CoVXfOUqgZlLQIC9NimX+z
-        orsx0gYwo4tCcMA5SkFnOfJMykyCkGw5mxeNXGTIFhLYmcDraLhVA48vRMlH7e+s4LF9IPpUETSv
-        24oczw97siZOru9rcvwEAAD//wMA7ZQQ1iACAAA=
-    headers:
-      Atl-Request-Id:
-      - bdaedc31-a779-4c93-9c29-d6223cdc6ccf
-      Atl-Traceid:
-      - bdaedc31a7794c939c29d6223cdc6ccf
-      Cache-Control:
-      - no-cache, no-store, no-transform
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:10 GMT
+      - Wed, 30 Apr 2025 16:27:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4670,7 +4879,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=163,atl-edge-internal;dur=14,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=314,atl-edge;dur=281,atl-edge-internal;dur=17,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0Fz_iwxlc7RQLlN1w_6RMj_PpLgtTtsr9jEhEeVDgoG80CLrpBvqXA==",cdn-downstream-fbl;dur=318
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4679,116 +4888,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 cbe94ab27088fc4bb73abf8e3179b3d2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0Fz_iwxlc7RQLlN1w_6RMj_PpLgtTtsr9jEhEeVDgoG80CLrpBvqXA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4db005d127da566f3fe28a4eeed326fe
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*/*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.3
-    method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16115
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbCmU7HtZXEreu6spI8OB4PTK5IxBTAAqCOxv7v3eWl
-        +FBau9PYD8S1B3a//bD64sC64DJxIkeDTEBD8kZAnpie5AswPRNnsOA9VYDmVihpepAIuwDLe3HG
-        ZQq5SntL0Ab3IJlCocGAtM3ZuDRWLeak8Crw/cB3NfxZgrGzTQFnmsdWxOD0HEH2g70gGOHEQD7H
-        aWZtYSLPS2AOsU3UZ+Vym3NjBJeuBOuhJevxQnihJ4wpwWsV3MAG5U9nk/NZP9gbBLhUuWCc6Itj
-        0LfSxNxCqvSmvkOCM5QI/XDU94N+4M9CPwr2o9HAHQ9f/4B+++QkGbHoeKXmhU6SvIf6/LC7djNJ
-        wMRaFBQ4XD1gZsHzvMcSYayQsWWFgBiYmrOV0jcuScdKvtf5M70opaB08fyKL7nl2lsKWHmVW1sH
-        m63AHwTjn4z4C35cYNrLBVolWKDJGTc3lKvy2tIomvPcQM+pBY/xXpVsz8kEAkfH2eYEloC++nc9
-        xwpEVoEocSJZ4h2dBzAZ+O1GodVnvNELA95IV+GuEtiGmyZfgWR7q/dSWIsKjNPZJqT+Wp01am5X
-        XBNejVgUuUCHkwc3x3xUKBuO18PxM939Rmbam3R5Gfr76EY4XIfD/9dKnf0Ki2gw2FsHe9/D4Lq1
-        OAjXg/B7WGwAfnf3GI7BLpyG7cZcrD/UHIjZv7h8fHLQnuRpqiFFvvnHIhi1G3gzlZc1Lzx9dG/X
-        xv6OjXDnxnjXxuvH7tS0Wa8SKVUvhBP1A5xyiw9HTbjPL9yazrcE7tXqNJVlNTxUJQUuIFL+SAtC
-        pk5kdQl3DU+TNi3iOmpfHq2RZ3jUZKrMkyNhipxvmlLGZXTLfkDMUHk30dCAlyX+eOqRGL7eax+J
-        h2HrqOzhxi5QhR2oCi2UFnbzwiC24l710vz7t0IseArGIwnTKhG4kIk0c80y3bLlO1xpaTV0HhdO
-        2KE+59dAxPhEaRCfPBmIYBdGgzFFJONmUoj4RMibN7RzBAX1LzJu81hld1XtdStSyQm2L/w6hylw
-        U2NDNyPn7OT92+PTq5Pjw8np+eRqMp3+PsX7YZ0aDAkemGXAzvAFkJaRXSYMUzLfMGQTkZNSZhX7
-        RWjOzjQskE5YaRC17lOsEmBBOf6t8P1iOYic+lXE7GH4t1V1jy0wEamQPH94qOm+mvBWSM/Ru2ZO
-        mU0ldKfLgsp2F5JH42GL5LpReiH4auHu5b3f2zwPj1u8/czjG2w3W8i1ymtbh01H958cbtvCumbQ
-        SNg2ChJWVN0qV/q09uY6L6GfauSNbVOk2JGqk60WBTbE0j4N+lFHC99K7EOhjjLuh/OT/Pr/gKVa
-        lQU1im+ETJAYDcNaYdcAkhWlySCpUHo8PaDvNTAhl2SZYJYw/CnA8DWDJCJlWeiyt6Tuk3xVfV9F
-        7KJTK2TEJMbLCm6Vjnx35A5uKegY81zFPM+UsdHYH/vevJa5qnyjvvISpdnFOcQlcRR7p1Z9q3YI
-        46OdlPhoh5fMYxeBseyPkmsLmk1kipW5wDjvEIXugBdU0qdnv7GDEjmAncdc7pCiFtALgvCyDunt
-        LTvH7rVyFMeHHybV52P9aTNNk6YJoOFMWOQDEq2QhSNUxIgy2S27QB39EDkAi28QBpUbhFS5TFyJ
-        Db+bqqW3LHOJ2LXILd7985ekYuD7nVy8AnchrAZX6dTDAucEeoHdLBGDh0fdzC5yktsmDCdVykhZ
-        iH9TSMucY1DX9COuuscRSMFzwtLfAAAA///sWW1v2jAQ/ivWpFaASBog4a2qOtSuUqVRTau2D90X
-        jONAJiBRQqgm7cfvOccJkBLoqFp10gQCYvvs8/nuOd/DvYxWqNWYwSp3+Qx1djpbnl9gmrZpVUuM
-        qY/+rNlr0/oD5N+VrJOp1AWa7bJLG/t0Wr1n20WPV3axn28X+6BdXt0mTplNEHGZ0/Vryj7UxmrX
-        iWTXCFU03sixyXp1RkDOtlEge00bZg4D6rllvtlhYwfXCnkBij8DRjkJSh+UYxV8VHdtf9/mWQ3x
-        iOYf+DKOCg2sCG9SU7wsOLdPoHYfJBFseePPJNBTpvY+nSzPuRAyXKqfa+fbELxeo3wNaJyrEQD+
-        NW6afnDG3ZUfI4VISrcdJACPbA4nyu4FdKKj9QojhhsMI/1Rmes7S6S9QWtH3uDm3hBrb+DLJRJw
-        XGePU19MGa7SkwkwOAH8sZBjrcWEcYaaRkAQtyIRcY/0GA3URo3PfDFJgMYjNpXcheSKI4Wa6W7Z
-        97VCQ8D9TG7mlu3+rNTqb3okhnxRVYKb9aN7knU3tmfAyCnE0QgfV8HeP3wwhPh9+iD/wiNtK8Ys
-        YTKe+UIf2tBXmVSf2Td12SIL68NIlWEAmRk6Ir15yN3OQy6WJHMXMF89MOS9le9Kd8udviKkcAPF
-        0n/jFFo0DChtko9XuDv3F1VWqf6ew4eXQT/3252Y8ep44RyJFw7hhfMyvDgqZTzBi2OT1ubxvjVe
-        tP/jxRvghf1v4UU7Fz2AF0/5Dicv+YvlbhkR0rA3S6FlBJdRZA7RM8WhOSVW6LDKOuyctSpK5KxD
-        ZoWygWUshFXGlFn5mlvVe7G4U9ExpcokrRDjZD7nVL5+2FtfkcmJiwqiIwtdYiQu4bHEoN26F47b
-        6na640bHki3Rs0TPaXq9htfGOvkgrLBnmCR/GLguRQNGisD99XFDEVTCNNdedlydgTRRTKthJJMx
-        tLa0Gl3uNmy73RHdDvByLMYdC8t7XHpdceleqFlOWoOT5g3eqZwx5wtd+BlG2hSbSWw8whBG06SK
-        0kzjkCxlhJzHZCjIK6Tnsxg/r4aGZYYLIhyKTPv717hI1b9/jYtU/3vXGADlpsyxZoSu4PpsyD0v
-        EcJXAURlXcpLp/D2ECxo4KckCkJ59gDgEcSg6kijv5rQm4curaD/YNtNI9lloGqXsct2zi5HGtyf
-        CSN/AAAA//8aLUYoTzCDsRgBAAAA//8i5OLRYoTWLqZLMYJeDOBqppnAW2PwxgvQO+mQTFkNmhOH
-        sg2ALskvSYTO6KObgqs9ZoCrXDIwwl7A4ZocMsDpAZztNbjP0HXgasgZ45SAt/BS88oyi/LzIK04
-        iFBKKXQ5CYRLTOiV5ZdQb6oUYhjcUKBNGYnFYfngKR/Y/CYwC0CcXA1jQusXsh0AXnqjDzNXRyk3
-        sSIotbg0B2QwkmfBkzVFJY4lEI+DJo1BEzogr8PFUTUboeiGagC7tra2FgAAAP//AwD+xNENvSQA
-        AA==
-    headers:
-      Atl-Request-Id:
-      - b93c0659-40bb-4093-9749-effdc96e7f84
-      Atl-Traceid:
-      - b93c065940bb40939749effdc96e7f84
-      Cache-Control:
-      - no-cache, no-store, no-transform
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 10 Jan 2025 19:18:11 GMT
-      Nel:
-      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
-        "endpoint-1"}'
-      Report-To:
-      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
-        "endpoint-1", "include_subdomains": true, "max_age": 600}'
-      Server:
-      - AtlassianEdge
-      Server-Timing:
-      - atl-edge;dur=335,atl-edge-internal;dur=13,atl-edge-upstream;dur=323,atl-edge-pop;desc="aws-us-east-1"
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-      Timing-Allow-Origin:
-      - '*'
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Aaccountid:
-      - 5d3878b170e3c90c952f91f6
-      X-Arequestid:
-      - 77738059f5c3c2229267d9c36471e481
+      - a480c371cdeb1be333aea05315b9da00
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4815,26 +4926,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1nVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLD5/NS8EiGBDNhsDHQMy4oxnk95HsUAFxDhmPfxD9hXuj1nKVQMOF1wSrOCLb9Z
-        2d5Y5SKY02IhBeAMlaTTOYpcqVyBVGw5nS1qVeTICgXsTBBMMtzqXqQXohKDCXdOitQ+EHOqCNrX
-        bUmO54c9OZsm1/cVOX4CAAD//wMAPLUPKCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:28.034+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 2c1ce554-4ed2-4198-95b1-fcd81c87c36f
+      - 121f2864-7c0c-44f8-90db-6125cefb6ead
       Atl-Traceid:
-      - 2c1ce5544ed2419895b1fcd81c87c36f
+      - 121f28647c0c44f890db6125cefb6ead
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:11 GMT
+      - Wed, 30 Apr 2025 16:27:28 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4844,7 +4951,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=178,atl-edge-internal;dur=25,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="Yktfh4aUOyH1zG1A9WiQc4atVxkMFw66wLkVAIsgH_GsSX2OMKD5uw==",cdn-downstream-fbl;dur=246,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=244,atl-edge;dur=157,atl-edge-internal;dur=14,atl-edge-upstream;dur=144,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4853,10 +4960,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c973663b623c0e82cd366d5ae7837bf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Yktfh4aUOyH1zG1A9WiQc4atVxkMFw66wLkVAIsgH_GsSX2OMKD5uw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 238d4bcf462e14ff54b690fe814df925
+      - 877b1ba61a646df40b21e70841af1ae3
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -4880,78 +4995,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16116
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18241
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbVPbRhD+Kzf6kOmktt4w4CiT6VDiJLSUUuMkHwjDnKW1dEG6U+9OfmnIf++u
-        ZMnBxGmh08AMku5uX2732WeXTw4sSy4TJ3I0yAQ0JK8E5InpSV6A6Zk4g4L3VAmaW6Gk6UEibAGW
-        9+KMyxRylfbmoA3uQTKGUoMBaddn48pYVcxI4XXg+4HvavizAmMnqxLONY+tiMHpOYLsBwdBcIAf
-        BvIZfmbWlibyvARmENtEfVQutzk3RnDpSrAeWrIeL4UXesKYCrxWwQ2sUP5sMrqY9IODvRCXaheM
-        E31yDPpWmZhbSJVeNXdI8AslQj/c7/tBP/AnoR8Fh9H+gRsMhj+i3z45SUYsOl6reaSTJO+hPp+8
-        aq69/kjAxFqUFDhcPWKm4HneY4kwVsjYslJADEzN2ELpG5ekYyXf6vyBXlRSULp4fs3n3HLtzQUs
-        vNqtjYPrrcDfC4Y/GfEXvCgw7VWBVgkWaHLCzQ3lqppaeotmPDfQcxrBE7xXLdtzMoHA0XG2OoU5
-        oK/+555jBSKrRJQ4kazwjs4WTPb8dqPU6iPe6JEBX0vX4a4T2IabPr4AyeZWb6WwFhUYp7NNSP21
-        PmvUzC64JrwaUZS5QIeTrZtjPmqUDYbLwfCB7n4jM+1NurwM/EN0Ixwsw8H/a6XJfo1FNBgcLLHC
-        voPBZWtxL1xiAX8Hi2uAf/58H47BLpyGuzb22o2ZWL5ryBFhcXmFMElTDSnyzT8WwX67gTdTedXw
-        wtePHuzaONyxEe7cGO7aeHbfnYY2m1UipbpDOFE/wE9usXE0hPvwwm3ofEPgXqNOU1nWr8eqosAF
-        RMrvaUHI1ImsrgDTh0rtO8w4FWfjXK2P9GsRN3H8dG+NfEVhk6kqT14KU+Z8tS5ugoQGvCzxx/0m
-        se8eDv22SWyHraOy7Y1doAo7UJVaKC3s6pFBbMW9utP8+14hCp6C8UjCtEoELmQizVwzTzds+QZX
-        WloNnfuFE3ZlkPMpEDFSBWzPBLvAG+zCaDCkiGTcjEoRnwp584p2XkJJ84uM26zVuVzUe92KVHKE
-        4wuf5jAGbhok6PWbc3769vXJ2fXpyfHo7GJ0PRqPfx/j/bBODYYED0wyYOfYAaRlZJcJw5TMVwzZ
-        ROSklFnFfhGas3MNBdIJqwyi1v0aqwRYUI5/K3y/nE8jp+mKmD0M/6aq7rAFJiIVkufbh9bT1zq8
-        Na5z9K4lHMxsKqE7XZVUtruQPByGLZKbQemR4GuEu857d7Z5GB43ePuZxzc4braQa5U3to7XE91/
-        crgdC5uaQSNhOyhIWFB1q1zps8abaV5BP9XIEpuhSLGXqkm2KkociKX9Ouj3O1r4VmK3hTrKuBvO
-        D/LL3yOWalWVNCi+EjJBYjQMa4VNASQrK5NBUqP0ZHxEzykwIedkmWCWMPxXgGHTgiQiZVnostek
-        7oN8Wj+fRuyyUytkxMo02ncD17+lYGOscxXzPFPGRkN/6Huz5ux17RO12yuUYpcXEFfETeyNWvSt
-        2iGMzTqpsFmHV8xjl4Gx7I+KawuajWSKFVlgfHeIQnfAC2rps/Pf2FGFtc8uYi53SNHo5wVBeNWE
-        8vaWXeDUWjuK78fvRvXjffNoM0wf6x5PrxNhkQdItEYUvqEiRlTJbtkl6uiHWPvY1vxhWLtBCJXz
-        xJU46LupmnvzKpeIWYuc4t09f0Uqng06sXgBbiGsBlfp1MO65oR1gUMs8YH3bOBmtshJqkzxT50o
-        UhHizxgKZQGvkQAbLTEfJMP67IfztMee5PY5C90gcEPGnqT2+Yu/AQAA///sWFFv2zgM/isECgyO
-        L1WuTtKgGfpQtDvggNswrNteLgfEddTFm2Onlt112Pbf91GSZbmJN6zbvbUtUocUJeojRX4yjcWf
-        MNaKsTgWE2oUk1YxEeiFjXzayqcCczXy41bOj9NWzt5Z+ZE4buVRK4/88eNWPhbjVj5p5ZN2A7N2
-        XX705G5dfowGPclhU3kUnZwwomdgDbdyyKHXFwHaF+fZT8bZjv9dcX6M8YNjPOuLMSphUxTmoY43
-        yyi8qCVdoIRC+Je8EnQyJG6w1K3Oze/6SLjyrL+PxeOx/MWQnaBshxe616MNvy+IWRDC8UM7CvAx
-        2BfY74WVQnQCiP/Fv8MHHFash1OvJ/i1ptDNrPCyqMtEIrsyGXJ/PkQb3aRKMqzbd97Ai5ZFhOj2
-        blmknrL9WaTFKF7dpgoUBVeAaRSBYFwzwjgMDe9kqrHcvlsSOB38yymm0mRxwlksXRbzHmQZX6UZ
-        d9RqHVdUJFhI0cc1yEkFdm0NGbWrWEkqSrrBNe0T4aqc8BlUmD0p42t2AGys3uTE5EvocwZ+XkoC
-        QafqY9GYJKQSmce4yDBjwVJpsibwAJD3LP0gQd+vsUoMt7fbLE30m0vLjBqHMwl8cGKZ//ujzNbg
-        U52r+BqFgun+oap5CPxTN5ldziKjaBPDOC3ACzznlVjk0e7sMMqBtGJn4B5uvCUIIeZ16DBZcz7E
-        FqlSVnWZI7XxpOqsYnQ9HzBurxOCATw4wM2lQDzxd17kidxWi3y5XC5yvg1W9JnOsTNwnq90Svwq
-        Ny1l8OTgLpohtcz/QTM2MSNPCdTZmgWs1E/Cbo4ljQHDdUrLy2f/PDt/TUd0dklPbuqierrAj5l8
-        FBoJDuE+dTha4Fz+wVtVRSYFLgsBsj/BBU7I/HbwH3sDBg2TfDQy1kvtgHFKAxjAjyEFsiyHjOCA
-        Tvnk0GfMbPeEuVbs+NeBBYfeukSh5+CsyBfio+bLm9dA804VB0/sqePQ9FVyZ7RTy51mp5p7mnv1
-        3NPcq+ie5l5N9zT3qrrT7NR1T9Ot7MDppX6/s2pAmtuRFiSLCubz4GKMLCa8kA8XY2RBsaoGLsbI
-        geJpmo7XoNJRMUgOlY6GQXKodDQMkkOlo2GQHCqexoDkUOloDEheMgGvNTKJU/LQ0L35bqHnm8qc
-        P9Cd8O0s4XOAxKyvcPxtD3ie6oufbQGhu8hE4k7czemNflnABcgW+yYkqJgZNKXwjcZ9RiZae20m
-        fTYmjHttpn02JsB7bY77bExEnA0F9II7kO5OrsPpJBiaiA912TUh5lYTZ6qgrUlgQUwj3KKzvkV1
-        SL+/qE0IdKmdBWzs/t5s46TiuL0oKNVfCClwm67kqm3zGPgKnKiUqObqZ/q8Nd0WfONmmhLEq02a
-        DygYfNmAhlTF3FGPvXT2kcp6B9gveD+msrMHUtkZU9nZ/0FlvwEAAP//Iq0pS26/FznZ0ropazja
-        lAWqAgAAAP//7JrRaoMwFIZfZQx6GRdrnHpRujI22EVfoHfxRLcxrEUro2+/c4yGmjUdrDdeBHpR
-        mhNzOJifv/yft7Leynore1HVJ9ZsousTa3au7N7KjvPyVtZb2XlY2dBs/cPK/k7vYxNg2+GtK9YP
-        hWvB4ByU+B0bCV89s0DMgVUqDGphLXDzDHvBlaFzk6GP43EVurgPbpqZZNF2VCmPRwkflLfpvLPt
-        qkpSGHt/MS2kURNRUTf/jGvJnawlAHEgb2oVqyhN0jxMeBFBxiGLl2UWlgQDmiI84UpZQe/BRik8
-        o8VKtHunp7NGoCb27Trj1Y+4CN4bXUZ7Rs5IFDxMpQqFeEwgTeIoyyFPOB5fyqJMYa1W/VMW0Wax
-        fMWP3scquR9iTMb0T23QtewbB8GWAeWjgdZAmhQ7SNnSoHB/79HxtuHX5y3jwWFPsbnNi82/Yxs4
-        m3/HNrA2945Rf5SmnQauAf+vn+62siw7gM/+AlEIpukqrV67ek+FL11TH4qHHeoKEAc03DQCJnHV
-        XF06YcBEL8MQwiWmwsVICRd4J4xgN4Pae3257U36AQAA//8iISWNli/0cPFo+YKlfEEvBuCtMHij
-        BejqdEjeqwat7IayDYAW5pckQtelo5uCs7mFs1zC2Q4zwl7y4VriaICr4QkqELBKGOBqeBrj0mEM
-        b9ml5pVlFuXnQVpvEKGUUuimCAiXqNDLz4WYUA1jQot7MopfpP0c+jBzdZRyEyuCIONAKHaDVwAW
-        lTiWQNxRBux+kLtsEWPhMcQwuKFAuzISi8PywQsoYWuDQUufQcsSQVbCHYLqWiMU50I1gIOntrYW
-        AAAA//8DADrwuiaDMwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18241","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241","key":"NTEST-1873","fields":{"statuscategorychangedate":"2025-04-30T18:27:13.285+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:12.994+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:13.082+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/15]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/298]\n*Defect
+        Dojo link:* http://localhost:8080/finding/298 (298)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1873/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18241/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 73ababcd-63be-4884-81e3-dec0ed052b01
+      - f80cde24-d863-4741-85a5-08d3dee752f6
       Atl-Traceid:
-      - 73ababcd63be488481e3dec0ed052b01
+      - f80cde24d863474185a508d3dee752f6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:11 GMT
+      - Wed, 30 Apr 2025 16:27:28 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -4961,7 +5049,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=268,atl-edge-internal;dur=14,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=304,atl-edge;dur=271,atl-edge-internal;dur=18,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="58-8504-NblBCsqSn9Zb-SXQxLI0mSM-TcdcpqttnldWhIqlQhrnsg==",cdn-downstream-fbl;dur=308
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -4970,10 +5058,436 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a78d8f4a6ccd81221651cd6112d5330a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 58-8504-NblBCsqSn9Zb-SXQxLI0mSM-TcdcpqttnldWhIqlQhrnsg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 0707299f70aea3b3b03a9c38262e3cb4
+      - ebf45c23f61a8fa4c2a97ddba9987c83
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:28.700+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
+    headers:
+      Atl-Request-Id:
+      - 1bc859ea-1ef6-4152-9db8-3af750f05b47
+      Atl-Traceid:
+      - 1bc859ea1ef641529db83af750f05b47
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:28 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=177,atl-edge;dur=144,atl-edge-internal;dur=15,atl-edge-upstream;dur=128,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="jLwp-D_tacHhXq_5YX2wikREQ1TN59iB_gpEl6SGZtrLMaXcZoVJpg==",cdn-downstream-fbl;dur=182
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - jLwp-D_tacHhXq_5YX2wikREQ1TN59iB_gpEl6SGZtrLMaXcZoVJpg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - bd3b52d51c57d3dd6241c2817427da25
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18237
+  response:
+    body:
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18237","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237","key":"NTEST-1871","fields":{"statuscategorychangedate":"2025-04-30T18:27:07.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:07.681+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t67:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:07.763+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/13]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/296]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/296]\n*Defect Dojo link:* http://localhost:8080/finding/296
+        (296)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/295]\n*Defect
+        Dojo link:* http://localhost:8080/finding/295 (295)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1871/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18237/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
+    headers:
+      Atl-Request-Id:
+      - bfb3a159-1fc7-4d95-b11d-9c606f52f4ea
+      Atl-Traceid:
+      - bfb3a1591fc74d95b11d9c606f52f4ea
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:29 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=299,atl-edge;dur=265,atl-edge-internal;dur=15,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="HKbOInGl_JzwzjX_sXHbFOQZaR3SS04_Qk84PeFBT2AecIV-JGpvig==",cdn-downstream-fbl;dur=303
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 800cba2437ee092ab9e4755c65d34a72.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - HKbOInGl_JzwzjX_sXHbFOQZaR3SS04_Qk84PeFBT2AecIV-JGpvig==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - 6f3489a51d8758a9eec6bef4f4657e4d
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:29.373+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
+    headers:
+      Atl-Request-Id:
+      - b6335578-ae85-4f22-8a97-234d1b8c39f0
+      Atl-Traceid:
+      - b6335578ae854f228a97234d1b8c39f0
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:29 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=202,atl-edge;dur=170,atl-edge-internal;dur=15,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="NVVMKyU7D7QOM2ttFQ860JvTh56lC3WlXgvQKPbFgmPXD4E8-923bw==",cdn-downstream-fbl;dur=206
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - NVVMKyU7D7QOM2ttFQ860JvTh56lC3WlXgvQKPbFgmPXD4E8-923bw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - 167ded9a2df9ca620ddb0df48ed86ed9
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18239
+  response:
+    body:
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18239","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239","key":"NTEST-1872","fields":{"statuscategorychangedate":"2025-04-30T18:27:10.705+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:10.389+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:10.491+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/14]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/112]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/299]\n*Defect
+        Dojo link:* http://localhost:8080/finding/299 (299)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/297]\n*Defect Dojo link:*
+        http://localhost:8080/finding/297 (297)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1872/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18239/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
+    headers:
+      Atl-Request-Id:
+      - decc65e5-3726-42a8-bddc-e8bf9122c756
+      Atl-Traceid:
+      - decc65e5372642a8bddce8bf9122c756
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 30 Apr 2025 16:27:29 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=278,atl-edge;dur=245,atl-edge-internal;dur=15,atl-edge-upstream;dur=230,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0HwgGS4qV7heB2BztwGb2c4yZ_gIWOFpIWJ4GzQHcQHoQhpU9H-eOg==",cdn-downstream-fbl;dur=283
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 a65725dd05dc27eea7ae75a2e122228e.cloudfront.net (CloudFront)
+      X-Aaccountid:
+      - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0HwgGS4qV7heB2BztwGb2c4yZ_gIWOFpIWJ4GzQHcQHoQhpU9H-eOg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
+      X-Arequestid:
+      - 1278e2b61ebbc7b8cb3b6896e0216c2f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_no_push_to_jira_reimport_with_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_no_push_to_jira_reimport_with_push_to_jira.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"849\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:49186\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:35750\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -76,7 +76,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:12 GMT
+      - Wed, 30 Apr 2025 16:27:30 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -94,25 +94,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       113, "url_ui": "http://localhost:8080/test/113", "url_api": "http://localhost:8080/api/v2/tests/113/"},
       "finding_count": 5, "findings": {"new": [{"id": 300, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/300", "url_api": "http://localhost:8080/api/v2/findings/300/"},
-      {"id": 301, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/301",
-      "url_api": "http://localhost:8080/api/v2/findings/301/"}, {"id": 302, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/302", "url_api": "http://localhost:8080/api/v2/findings/302/"},
-      {"id": 303, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/303", "url_api":
-      "http://localhost:8080/api/v2/findings/303/"}, {"id": 304, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/304", "url_api": "http://localhost:8080/api/v2/findings/304/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/300",
+      "url_api": "http://localhost:8080/api/v2/findings/300/"}, {"id": 301, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/301", "url_api": "http://localhost:8080/api/v2/findings/301/"},
+      {"id": 302, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/302",
+      "url_api": "http://localhost:8080/api/v2/findings/302/"}, {"id": 303, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/303", "url_api": "http://localhost:8080/api/v2/findings/303/"},
+      {"id": 304, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/304",
+      "url_api": "http://localhost:8080/api/v2/findings/304/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -123,11 +121,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2507'
+      - '2372'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -139,11 +137,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2507\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2372\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:49196\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:35762\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -158,63 +156,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 113, \\\"url_ui\\\": \\\"http://localhost:8080/test/113\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/113/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 300, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/300\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/300/\\\"}, {\\\"id\\\": 301, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/301\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/301/\\\"}, {\\\"id\\\":
-        302, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/302\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/302/\\\"}, {\\\"id\\\":
-        303, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/303\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/303/\\\"}, {\\\"id\\\":
-        304, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/304\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/304/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        302, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/302\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/302/\\\"}, {\\\"id\\\": 303, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/303\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/303/\\\"}, {\\\"id\\\": 304, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/304\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/304/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 300,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/300/\",\n          \"url_ui\": \"http://localhost:8080/finding/300\"\n
         \       },\n        {\n          \"id\": 301,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/301/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/301/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/301\"\n        },\n
         \       {\n          \"id\": 302,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/302/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/302\"\n        },\n        {\n          \"id\":
-        303,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/303/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/303\"\n        },\n
-        \       {\n          \"id\": 304,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/304/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/304\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 113,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/113/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/302/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/302\"\n        },\n
+        \       {\n          \"id\": 303,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/303/\",\n          \"url_ui\": \"http://localhost:8080/finding/303\"\n
+        \       },\n        {\n          \"id\": 304,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/304/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/304\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        113,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/113/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/113\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/113/\",\n
@@ -228,7 +224,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:12 GMT
+      - Wed, 30 Apr 2025 16:27:30 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -253,26 +249,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1q1b3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLCiODWvREggAzYbAx3DsmKM51OeRzHABUQ45n38A/aVbs9ZChUDThecsqxY0m9W
-        tjdWuQjmdL6QAnCGStJpgSJXKlcgFVtOZ4tazXNkcwXsTBBMMtzqXqQXohKDCXdOitQ+EHOqCNrX
-        bUmO54c9OZsm1/cVOX4CAAD//wMA3wZkgCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:30.634+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 1fc87748-f398-4bcd-a9aa-143f8add53d6
+      - 0037c08c-78a1-491a-bb47-2615f83ab6f7
       Atl-Traceid:
-      - 1fc87748f3984bcda9aa143f8add53d6
+      - 0037c08c78a1491abb472615f83ab6f7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:12 GMT
+      - Wed, 30 Apr 2025 16:27:30 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -282,7 +274,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=167,atl-edge-internal;dur=13,atl-edge-upstream;dur=154,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=20,cdn-upstream-fbl;dur=243,atl-edge;dur=156,atl-edge-internal;dur=16,atl-edge-upstream;dur=141,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="8_zMGqmcIQd7kueNRB7xwv9KBuCDWFsfiX-hCvfXN2EOri_ufr7BRw==",cdn-downstream-fbl;dur=247
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -291,10 +283,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 8_zMGqmcIQd7kueNRB7xwv9KBuCDWFsfiX-hCvfXN2EOri_ufr7BRw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - c99fe8ce379dc4a84828c4a2bc89bd39
+      - 880e4c88fa7c7fcf1204c2577a52b4f2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -321,41 +321,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - abd463cd-0f85-4f2f-91b5-83cbdc244259
+      - eb1017cd-7244-4074-a7b8-f0074eafd760
       Atl-Traceid:
-      - abd463cd0f854f2f91b583cbdc244259
+      - eb1017cd72444074a7b8f0074eafd760
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:13 GMT
+      - Wed, 30 Apr 2025 16:27:31 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -365,7 +352,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=342,atl-edge-internal;dur=14,atl-edge-upstream;dur=329,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=287,atl-edge;dur=255,atl-edge-internal;dur=16,atl-edge-upstream;dur=239,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="F1I9eRe0cZGSJ7JSVSLzGzWu4oK5w87FEd8zc60yp1EjOkrcYCTjDQ==",cdn-downstream-fbl;dur=292
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -374,13 +361,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - F1I9eRe0cZGSJ7JSVSLzGzWu4oK5w87FEd8zc60yp1EjOkrcYCTjDQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3e3269c73d342aaf145300809915df56
+      - a34b2dd7a3e912daa03ddba3d952bdff
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -392,7 +387,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/106]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/16]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/113]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -401,28 +396,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/300]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/301]\n*Defect Dojo link:* http://localhost:8080/finding/301
-      (301)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (301)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/300]\n*Defect
       Dojo link:* http://localhost:8080/finding/300 (300)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -436,7 +431,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3359'
+      - '3334'
       Content-Type:
       - application/json
       User-Agent:
@@ -445,18 +440,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16118","key":"NTEST-1634","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16118"}'
+      string: '{"id":"18243","key":"NTEST-1874","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18243"}'
     headers:
       Atl-Request-Id:
-      - da30ed46-0b71-444d-bdff-cff6cf7b4652
+      - 88fcd2b2-b85c-48fc-92ff-ea28b8eb8548
       Atl-Traceid:
-      - da30ed460b71444dbdffcff6cf7b4652
+      - 88fcd2b2b85c48fc92ffea28b8eb8548
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:14 GMT
+      - Wed, 30 Apr 2025 16:27:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -466,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=751,atl-edge-internal;dur=13,atl-edge-upstream;dur=738,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=742,atl-edge;dur=709,atl-edge-internal;dur=17,atl-edge-upstream;dur=692,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="gNYAcCK-oWJCBLyr-zSbWC5TWFyLeZXjUcKJK6lkIAuTHG5KeT1teg==",cdn-downstream-fbl;dur=746
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -475,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b5141080f2dac9506b5156fa7721b41c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - gNYAcCK-oWJCBLyr-zSbWC5TWFyLeZXjUcKJK6lkIAuTHG5KeT1teg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a9168ecf78a88744c7d4159bad8868a0
+      - 8dc10ae943e79258f37c4f17973d8fa3
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -502,66 +507,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1634
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1874
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvybLCmU7HtZXEreu6spI8OB4PTK5IxBTAAqCOxv7v3eWl
-        +FBau9PYD8S1B3a//bD64sC64DJxIkeDTEBD8kZAnpie5AswPRNnsOA9VYDmVihpepAIuwDLe3HG
-        ZQq5SntL0Ab3IJlCocGAtM3ZuDRWLeak8Crw/cB3NfxZgrGzTQFnmsdWxOD0HEH2g1EQjHFiIJ/j
-        NLO2MJHnJTCH2Cbqs3K5zbkxgktXgvXQkvV4IbzQE8aU4LUKbmCD8qezyfmsH4wGQ1yqXDBO9MUx
-        6FtpYm4hVXpT3yHBGUqEfrjX94N+4M9CPwrGUTB0/ZH/A/rtk5NkxKLjlZoXOknyHurzw+7azSQB
-        E2tRUOBw9YCZBc/zHkuEsULGlhUCYmBqzlZK37gkHSv5XufP9KKUgtLF8yu+5JZrbylg5VVubR1s
-        tgJ/EIx/MuIv+HGBaS8XaJVggSZn3NxQrsprS6NoznMDPacWPMZ7VbI9JxMIHB1nmxNYAvrq3/Uc
-        KxBZBaLEiWSJd3QewGTgtxuFVp/xRi8MeCNdhbtKYBtumnwFku2t3kthLSowTmebkPprddaouV1x
-        TXg1YlHkAh1OHtwc81GhbDheD8fPdPcbmWlv0uVl6O+jG+FwHQ7/Xyt19issosFgtA5G38PgurU4
-        CNeD8HtYbAB+d/cYjsEunIbtxlysP9QciNm/uHx8ctCe5GmqIUW++cci2Gs38GYqL2teeProaNfG
-        /o6NcOfGeNfG68fu1LRZrxIpVS+EE/UDnHKLD0dNuM8v3JrOtwTu1eo0lWU1PFQlBS4gUv5IC0Km
-        TmR1CXcNT5M2LeI6al8erZFneNRkqsyTI2GKnG+aUsZldMt+QMxQeTfR0ICXJf54/EgM3P1g2D4S
-        D8PWUdnDjV2gCjtQFVooLezmhUFsxb3qpfn3b4VY8BSMRxKmVSJwIRNp5pplumXLd7jS0mroPC6c
-        sEN9zq+BiPGJ0iA+eTIQwS6M4huPEcm4mRQiPhHy5g3tHEFB/YuM2zxW2V1Ve92KVHKC7Qu/zmEK
-        3NTY0M3IOTt5//b49Ork+HByej65mkynv0/xflinBkOCB2YZsDN8AaRlZJcJw5TMNwzZROSklFnF
-        fhGaszMNC6QTVhpErfsUqwRYUI5/K3y/WOrIqV9FzB6Gf1tV99gCE5EKyfOHh5ruqwlvhfQcvWvm
-        lNlUQne6LKhsdyL59esWyXWj9ELw1cLdy3u/t3keHrd4+5nHN9hutpBrlde2DpuO7j853LaFdc2g
-        kbBtFCSsqLpVrvRp7c11XkI/1cgb26ZIsSNVJ1stCmyIpX0a9HsdLXwrsQ+FOsq4H85P8uv/A5Zq
-        VRbUKL4RMkFiNAxrhV0DSFaUJoOkQunx9IC+18CEXJJlglnC8KcAw9cMkoiUZaHL3pK6T/JV9X0V
-        sYtOrZARkxgvK7hVOvLdPXdwS0HHmOcq5nmmjI3G/tj35rXMVeUbwmJ0idLs4hzikjiKvVOrvlU7
-        hPHRTkp8tMNL5rGLwFj2R8m1Bc0mMsXKXGCcd4hCd8ALKunTs9/YQYkcwM5jLndIUQvoBcHgsg7p
-        7S07x+61chTHhx8m1edj/WkzTZOmCaDhTFjkAxKtkIUjVMSIMtktu0Ad/RA5AItvEAaVG4RUuUxc
-        iQ2/m6qltyxzidi1yC3e/fOXpGLg+51cvAJ3IawGV+nUwwLnBHqB3SwRg4dH3cwucpLbJgwnVcpI
-        WYh/U0jLnGNQ1/QjrrrHEUjBc8LS3wAAAP//7Fltb9owEP4r1qRWgEgaSnitqg6VVao0qmnV9qH7
-        gnEcyAQkygvVpP34Pec4AVICHVWrTppAQGyffT7fPed7uJfhCrUaM1jlLp+hzk7n8cUlpmmbVrXE
-        mProoYTSe4D8u5J1MpW6QLNddmljn61m79l20eOVXezn28U+aJdXt4lVZhNEXOZ0/ZqyD7Wx2jCR
-        bIhQReONnJisV2cE5GwbBbLXrGHmMKCem+abHTZ2MFTIC1D86TPKSVD6oByr4KO6a/v7Ns9qiEc0
-        /8CXcVRoYEV4k5riZcG5fQK1ez8JYcsbby6BnjK19+k0vuBCyCBWP9fOtyE4XKN8DWicq+ED/jVu
-        mp5/xp2VFyGFSEq3HSQAl2wOJ8ruBXSi4/UKY4YbDCP9UZnrO0uovUFrR97g5N4QaW/gcYwEHNXZ
-        48wTM4ar9HQKDE4AfyzgWGs5ZZyhphEQxK1IhNwlPcYDtVHjM19OE6DxmM0kdyC54kihZrpb9n2t
-        0AhwP5ebuWW7Pyu1+pseiSFfVJXgZP3onmbdje0ZMHIGcTTCx1Ww9w8fDCF+nz7Iv/BI24owS5BM
-        5p7QhzbyVCbVZ/ZNXbbIwvowUmUYQGaOjlBvHnK3i4CLmGTufOapB4a8t/Ic6Wy501eEFG6gWPpv
-        nEKLBj6lTfLxCncW3rLKKtXfC/hw7Pdzv92JGa+OF9aReGERXlgvw4ujUsYTvDg2aW0e71vjRfs/
-        XrwBXtj/Fl60c9EDePGU72jlJX+x3C0jQhr2ZikUh3AZReYQPVMcmlNihQ6rrMPOWauiRM46ZFYo
-        G1jGQlhlTJmVr7lVvReLOxUdM6pM0goxShYLTuXrh731FZmcuCg/PLLQJUbiCh5LDNqtc9lymt1O
-        d9LoWLIpepbotc7dXsNtY518EFbYM0ySPwwch6IBI4Xv/Pq4oQgqYZprLzuuzkCaKKbVMJLJGFpb
-        Wo0udxq23e6Ibgd4ORGTjoXlXS7drrhyLtUsJ83ByfkN3qmcseBLXfgZRtoUmUlkPMIQxrlJFaWZ
-        xiFZygg4j8hQkFdIz+cRfl6PDMsMlkQ4FJn2969xkap//xoXqf73rjEAykmZY80IXcP12Yi7biKE
-        pwKIyrqUl07h7cFf0sBPSegH8uwBwCOIQdWRRn81oTcPXVpB/8G2m0ayy0DVLmOX7ZxdDjW4PxNG
-        /gAAAP//Gi1GKE8wg7EYAQAAAP//IuTi0WKE1i6mSzGCXgzgaqaZwFtj8MYL0DvpkExZDZoTh7IN
-        gC7JL0mEzuijm4KrPWaAq1wyMMJewOGaHDLA6QGc7TW4z9B14GrIGeOUgLfwUvPKMovy8yCtOIhQ
-        Sil0OQmES0zoleWXUG+qFGIY3FCgTRmJxWH54Ckf2PwmMAtAnFwNY0LrF7IdAF56ow8zV0cpN7Ei
-        KLW4NAdkMJJnwZM1RSWOJRCPgyaNQRM6IK/DxVE1G6HohmoAu7a2thYAAAD//wMAO1vwOb0kAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18243","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18243","key":"NTEST-1874","fields":{"statuscategorychangedate":"2025-04-30T18:27:32.121+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1874/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:31.799+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:31.892+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/16]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/113]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/301]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/300]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/301]\n*Defect Dojo link:* http://localhost:8080/finding/301
+        (301)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/300]\n*Defect
+        Dojo link:* http://localhost:8080/finding/300 (300)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1874/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18243/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 4d158447-c83a-4121-9abf-b8c7bc4960ae
+      - 870058af-ff81-4c71-b148-21bcd81b7174
       Atl-Traceid:
-      - 4d158447c83a41219abfb8c7bc4960ae
+      - 870058afff814c71b14821bcd81b7174
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:14 GMT
+      - Wed, 30 Apr 2025 16:27:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -571,7 +577,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=349,atl-edge-internal;dur=13,atl-edge-upstream;dur=336,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="R5mwmhps7NJa8NtlLkH_vfchE6qaRfcWvZ0kaLmsVo6FPua3V8zXcw==",cdn-downstream-fbl;dur=370,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=77,cdn-upstream-fbl;dur=368,atl-edge;dur=269,atl-edge-internal;dur=16,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -580,10 +586,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c8780798b589dc6b55523ca0a9bc3c02.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - R5mwmhps7NJa8NtlLkH_vfchE6qaRfcWvZ0kaLmsVo6FPua3V8zXcw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 5c56ea0592021155319f19b63a8bcce4
+      - 7058fa37c3a8782281d74797a2d4faf4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -607,66 +621,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16118
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18243
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXW1PbRhT+Kzt6TG3dbBxHM50OBSehpZQaJ3kgDLNIx9IGeVfZXfnSkP/ec3Rz
-        wDhT6DTwoL2d+3cu/uLAuuAycSJHg0xAQ/JaQJ6YnuQLMD0TZ7DgPVWA5lYoaXqQCLsAy3txxmUK
-        uUp7S9AG7yCZQqHBgLTN27g0Vi3mxPA68P3AdzV8LsHY2aaAc81jK2Jweo4g+cEoCMa4MZDPcZtZ
-        W5jI8xKYQ2wT9Um53ObcGMGlK8F6KMl6vBBe6AljSvBaBrewQfqz2eRi1g9GgyEeVSoYJ/riGNSt
-        NDG3kCq9qW1IcIcUoR8e9P2gH/iz0I+CcRQMXX/k/4R6+6QkCbGoeMXmmUoSvYf8/LAzu9kkYGIt
-        CnIcnh4ys+B53mOJMFbI2LJCQAxMzdlK6VuXqGMl3+n8iVqUUlC4eH7Nl9xy7S0FrLxKra2CzVXg
-        D4LxL0b8DT8vMOzlAqUSLFDkjJtbilV5Y2kVzXluoOfUhCdoV0XbczKBwNFxtjmFJaCu/teeYwUi
-        q0CUOJEs0UbnAUwGfntRaPUJLXqmwxvqyt1VAFt30+YbkGyteieFtcjAOJ1sQurv1Vuj5nbFNeHV
-        iEWRC1Q4eWA5xqNC2XC8Ho6fqO53ItNa0sVl6L9ENcLhOhz+v1Lq6FdYRIHBaB2MfoTAdStxEK4H
-        4Y+Q2AD869ddOAb7cBq2F3Oxfl/XQIz+5dXuy0H7kqephhTrzU4SoAEqL+v0f1zcwb6L0b6Ll3su
-        wr0X430Xr3b1rMtmfUpFqeoQTtQPmlpJIdEirk36snNGiYLeNpkq8+RYmCLnmyad8HjFLbaeumQ/
-        PfXrhrBtAV7NTlNiV8sjVZLrK1U/0IGQqRNZXZJsZGrfI2YovRtvaEBjqX7sNomB+zIYtk3iodu6
-        UvbwYh+owg5UhRZKC7t5pgtacq/qNP++V4gFT8F4RGFaJgIPMpFmrlmm22r5Fk/asho6u4kTdqjP
-        +Q1QYXwkNaiePOqIYB9GscejRzJuJoWIT4W8fU03x1DQ/CLjFkMVslbVXXcilZzg+MJvcpgCNzUu
-        dbNyzk/fvTk5uz49OZqcXUyuJ9Ppn1O0D/PUoEvwwSwDdo4dQFpGcpkwTMl8w7CaiJyYMqvYb0Jz
-        dq5hgeWElQYx5z5WVQJMKMe/E75fLHXk1F0Ro4fu32bVvWqBgUiF5PnDR8301bi3Qn6O2jV7imwq
-        oXtdFpS2e5H86lWL5HpQeib4auKu896fbZ6Gxy3efuXxLY6bLeRa5rWso2ai+08Kt2NhnTMoJGwH
-        BQkrym6VK31Wa3OTl9BPNdas7VCk2LGqg60WBQ7E0j4O+oOuLHwvsA+JupJx350f5bf/hyzVqixo
-        UHwtZIJlzTDMFXYDIFlRmgySCqUn00P63gATckmSCWYJw58CDLsZJBExy0KXvSF2H+WL6vsiYpcd
-        WyEjJtFfVnCrdOS7B+7gjpyOPs9VzPNMGRuN/bHvzWua60o3hMXoCqnZ5QXEJdUo9lat+lbtIcam
-        nZTYtMMr5rHLwFj2V8m1Bc0mMsXMXKCf95BC98ALKuqz8z/YYYk1gF3EXO6hohHQC4LBVe3Suzt2
-        gdNrpSiuj95Pqs+H+tNGmjbNEEDLmbBYD4i0QhaukBGjksnu2CXy6IdYAzD5BmFQqUFIlcvElTjw
-        u6laessyl4hdi7XFu//+ilgMfL+ji1fgLoTV4CqdepjgnEAvcJqlwuDhUzezi5zotgHDTRUyYhbi
-        3xTSMufo1DX9iKvsOAYpeE5Y+gcAAP//7Fltb9owEP4r1qRWgEgaSnitqg6VVao0qmnV9qH7gnEc
-        yAQkygvVpP34Pec4IVACHVWrTppAQGyffT7fPed7uJfhCrUaM1jlLp+hzk7n8cUlpmmbVrXEmPro
-        oYTSe4Dcv5J1MpW6QLNddmljn61m79l20eOVXezn28U+aJdXt4lVZhNEXOZ0/ZqyD7Wx2jCRbIhQ
-        ReONnJisV2cE5GwTBbLXrGHmMKCem+abHTZ2MFTIC1D86TPKSVD6oByr4KO6a/v7Ns9qiEc0/8CX
-        cVRoYEV4k5riZcG5eQK1ez8JYcsbby6BnjK19+k0vuBCyCBWP9fOVxAcrlG+BjTO1fAB/xo3Tc8/
-        487Ki5BCJKXbDhKASzaHE2X3AjrR8XqFMcMNhpH+qMz1nSXU3qC1I29wcm+ItDfwOEYCjursceaJ
-        GcM1fjoFBieAPxZwrLWcMs5Q0wgI4lYkQu6SHuOB2qjxmS+nCdB4zGaSO5BccaRQM90t+75WaAS4
-        n8tibtnsz0qtftEjMeSLuuM7WT+6p1l3Y3MGjJxBHI3wcRXs/cMHQ4jfpw/yLzzStiLMEiSTuSf0
-        oY08lUn1mX1Tly2ysD6MVBkGkJmjI9Sbh9ztIuAiJpk7n3nqgSHvrTxHOhvu9BUhhRsolv4bp9Ci
-        gU9pk3y8wp2Ft6yySvX3Aj4c+/3cb3dixqvjhXUkXliEF9bL8OKolPEEL45NWsXjfWu8aP/HizfA
-        C/vfwot2LnoAL57yHa285N8ud8uIkIZdLIXiEC6jqBiihraHlhFgVlmHnbNW2xI565BZoWxgGQth
-        lTFlVr6mCoAZFR+6FC9W89vFXpQsFpzK1w976ysyOXFRfnhkoUuMxBU8lvivW+ey5TS7ne6k0bFk
-        U/Qs0Wudu72G28Y6+SCssGeYJH8YOA5FA0YK3/n1saAIKmGaay87rs5Amiim1TCSyRhaW1qNLnca
-        tt3uiG4HeDkRk46F5V0u3a64ci7VLCfNwcn5Dd6pnLHgS134GUbaFJlJZDzCEMa5SRWlmcYhWcoI
-        OI/IUJBXSM/nEX5ejwzLDJZEOGwz7e9f422q/v1rvE31v3eNAVBOylprRugars9G3HUTITwVQFTW
-        paxyCm8P/pIGfkpCP5BnDwAeQQyqjjT6qwm9eejSCvoPtt00kl0GqnYZu2zn7HKowf2ZMPIHAAD/
-        /xotRihPMIOxGAEAAAD//yLk4tFihNYupksxgl4M4GqmmcBbY/DGCtA76ZBMWQ2aE4eyDYAuyS9J
-        hM7oo5uCqz1mgKtcMjDCXsDhmhwywOkBnO01uM/QdeBqyBnjlIC38FLzyjKL8vMgTTyIUEopdDkJ
-        hEtM6JXll1BvohNiGNxQoE0ZicVh+eApH9jcKjALQJxcDWNC6xeyHQBeeqMPM1dHKTexIii1uDQH
-        ZDCSZ8GTNUUljiUQj4MmjUETOiCvw8VRNRuh6IZqALu2trYWAAAA//8DAEycWma9JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18243","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18243","key":"NTEST-1874","fields":{"statuscategorychangedate":"2025-04-30T18:27:32.121+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1874/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:31.799+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t6v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:31.892+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/16]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/113]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/301]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/300]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/301]\n*Defect Dojo link:* http://localhost:8080/finding/301
+        (301)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/300]\n*Defect
+        Dojo link:* http://localhost:8080/finding/300 (300)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1874/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18243/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 4b995f5d-17a1-4fcc-8368-a4f502d0216a
+      - c182a12a-5bc6-4c80-bd48-a26e74f5e970
       Atl-Traceid:
-      - 4b995f5d17a14fcc8368a4f502d0216a
+      - c182a12a5bc64c80bd48a26e74f5e970
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:14 GMT
+      - Wed, 30 Apr 2025 16:27:33 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -676,7 +691,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=267,atl-edge-internal;dur=14,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="YHnjelKvzCyr4LdIq760kV_vAbTMOK0VAn2iUUetHMLQEVbVDzxucQ==",cdn-downstream-fbl;dur=337,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=334,atl-edge;dur=251,atl-edge-internal;dur=16,atl-edge-upstream;dur=234,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -685,10 +700,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8dac9acbf37a4821f35529f7cc336eba.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - YHnjelKvzCyr4LdIq760kV_vAbTMOK0VAn2iUUetHMLQEVbVDzxucQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 2b8e4e3b58556d9006b306bc8dae255e
+      - e548d54cd516a25ade3ac7a1669bd5e7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -715,26 +738,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1nZb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwCbz0/NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4HTBaZ7SIvtm
-        ZXdjlA1gRouFFIA5KklncxSZUpkCqdhyli9qVWTICgXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAiFvGXSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:33.474+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 997ddd06-b9f2-4010-a5c1-662a45adfc0d
+      - 5dafffe6-0547-4ba7-8a3c-f24c657431db
       Atl-Traceid:
-      - 997ddd06b9f24010a5c1662a45adfc0d
+      - 5dafffe605474ba78a3cf24c657431db
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:15 GMT
+      - Wed, 30 Apr 2025 16:27:33 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -744,7 +763,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=161,atl-edge-internal;dur=14,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="I_atcKYzKE-cK_jyGNKkhvJbqj7cDMiGhTZcVD-XMdxbbmM9ZhVs4w==",cdn-downstream-fbl;dur=234,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=232,atl-edge;dur=158,atl-edge-internal;dur=14,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -753,10 +772,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 603f7fca6e96da4aaee2b5219f231c92.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - I_atcKYzKE-cK_jyGNKkhvJbqj7cDMiGhTZcVD-XMdxbbmM9ZhVs4w==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 25ff25bacce54cc3b6b2a30c3fa9aeda
+      - 3cac7ae920db2a16900d386909498a5d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -783,41 +810,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 6e556412-ee5f-4572-9cae-6d775097f153
+      - a1e1283f-e98b-4d6d-bae3-937e0976310c
       Atl-Traceid:
-      - 6e556412ee5f45729cae6d775097f153
+      - a1e1283fe98b4d6dbae3937e0976310c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:15 GMT
+      - Wed, 30 Apr 2025 16:27:34 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -827,7 +841,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=279,atl-edge-internal;dur=13,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="tEhyPP6uC4F14S0o7RrkFfXNPILFJE4mzVOZH3CZ7W79CpPTbjDPTg==",cdn-downstream-fbl;dur=403,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=400,atl-edge;dur=312,atl-edge-internal;dur=18,atl-edge-upstream;dur=295,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -836,13 +850,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 6bddabf0adf0131ec8169647c939d30c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - tEhyPP6uC4F14S0o7RrkFfXNPILFJE4mzVOZH3CZ7W79CpPTbjDPTg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 4a710a368068b81c1a5731eca046c3f6
+      - 110b5c232b1bf776affc77b9f0d73e18
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -854,7 +876,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/107] in [Security
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/17] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/113]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
@@ -869,13 +891,13 @@ interactions:
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/302] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/304]\n*Defect
       Dojo link:* http://localhost:8080/finding/304 (304)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -884,31 +906,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/302]\n*Defect Dojo link:* http://localhost:8080/finding/302
-      (302)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (302)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -917,25 +937,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
     headers:
       Accept:
@@ -947,7 +965,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7141'
+      - '6804'
       Content-Type:
       - application/json
       User-Agent:
@@ -956,18 +974,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16119","key":"NTEST-1635","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16119"}'
+      string: '{"id":"18245","key":"NTEST-1875","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18245"}'
     headers:
       Atl-Request-Id:
-      - ad8b9fca-0104-439d-87ec-aead892ea9aa
+      - 182c5f75-47b8-4b3b-bcf8-c4c5c4ec16fc
       Atl-Traceid:
-      - ad8b9fca0104439d87ecaead892ea9aa
+      - 182c5f7547b84b3bbcf8c4c5c4ec16fc
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:16 GMT
+      - Wed, 30 Apr 2025 16:27:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -977,7 +997,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=677,atl-edge-internal;dur=14,atl-edge-upstream;dur=663,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=795,atl-edge;dur=761,atl-edge-internal;dur=15,atl-edge-upstream;dur=747,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="g5n1YhJwNk_J5x3Ut11XG38kJ7xXtsBUlkZ_URnphEOLxygrMPUb2Q==",cdn-downstream-fbl;dur=800
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -986,10 +1006,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 edb5724c2fa0963fde9c6c5089b747ce.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - g5n1YhJwNk_J5x3Ut11XG38kJ7xXtsBUlkZ_URnphEOLxygrMPUb2Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c70826a8b825fcc8a43c51658f3ebf83
+      - 03cf72a0652aee65d7b7bc0f5c4c5f3b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1013,78 +1041,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1635
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1875
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+ZDqpxEtHZGYyHddREreu68pK8uB4PDC5ohCTAAOAOhLnv3eX
-        hxQfSmt3GnvGJAHsgd1vv11/cWBVcJk4kaNBJqAheSUgS0xH8hxMx8RzyHlHFaC5FUqaDiTC5mB5
-        J55zmUKm0s4CtME9SCZQaDAgbXM2Lo1V+YwUXgS+H/iuhk8lGDtdF3CieWxFDE7HEWQ/GAbBHn4Y
-        yGb4Obe2MJHnJTCD2Cbqo3K5zbgxgktXgvXQkvV4IbzQE8aU4LUKrmCN8sfT8em0Gwx7A1yqXDBO
-        9MUx6FtpYm4hVXpd3yHBL5QI/XDQ9YNu4E9DPwpGUTB0w1H4M/rtk5NkxKLjlZpHOknyHurzw821
-        m48ETKxFQYHD1X1mcp5lHZYIY4WMLSsExMDUjC2VvnJJOlbyrc4e6EUpBaWLZxd8wS3X3kLA0qvc
-        2jrYbAV+Lxj9YsRneJFj2sscrRIs0OSUmyvKVXlp6S2a8cxAx6kFD/FelWzHmQsEjo7n6yNYAPrq
-        f+04ViCyCkSJE8kS7+jcgknP37URtBuFVh/xqo/MRCNd5aHKbJsH+vgGPdvrvpXCWlRgnI1tgvDv
-        1VmjZnbJNQHZiLzIBDqc3AoJJqqCX3+06o8e6O53UtbeZJOwvv8M3Qj7q7D//1qpYVGBFA0Gw1Uw
-        /BEGV63FXrjqhT/CYoP8r1/vwjFs4TgTq3c1B2KSz87vnuy1J3maakiRb/6xCAbtBl5AZWXNC/cf
-        He7aeLZjI9y5Mdq1sXfXnZo261UipapDOFE3aLiSIq9FXHv+5c4a1QMG1cxVmSUvhSkyvm6qBpcx
-        hfYdpocqqTHBLTajmsQfXvN1i9g2Ba9Wp6miq9cDVVIyKuff04KQqRNZXZI3sQa8LNHE3SYxcPd6
-        g7ZJ3A7bLioLN1R2e2MDqkILpYVdP/LCrbhXdZp/3ytEzlMwHkmYVonAhblI565ZpFtSfIMrLXuG
-        zt36CDeoz/glEP/dUxpEG/cGItiF0WBEEZlzMy5EfCTk1SvaeQkFzS8ybjFUIWtZ7W1WpJJjHF/4
-        ZQYT4KbGpW7enJOjt68Pjy+ODg/Gx6fji/Fk8ucE74d1ajAkeGA6B3aCRC8tI7tMGKZktmZIGiIj
-        pcwq9pvQnJ1oyJE1WGkQYe595IGTSuT418L3i8XnyKm7ImYPw7+tqhtsgYlIheTZ7UPN9NWEt8J5
-        ht4135TZVMLmdFlQ2d6P5KGLdd4iuR6UHgm+WnjTYG/ONg/D4xZvv/L4CsfNFnKt8trWQTPR/SeH
-        27Gwrhk0ErbzgIQlVbfKlD6uvbnMSuimGjlrOxQp9lLVyVZ5gQOxtPeDfrCLFgYbWvhexm+G84P8
-        9nefpVqVBQ2Kr4RMkMQMw1phlwCSFaWZQ1Kh9HCyT89LYEIuyADBLGH4rwDDbgZJRMrmoctek7oP
-        8mn1fBqxs41aISNWpNHADVz/moKNsc5UzLO5MjYa+SPfm9VnLyqfEA7PzlGKnZ1CXBI3sTdq2bVq
-        hzD25KTEnhyeM4+dBcayv0quLWg2lilWZI7x3SEKmwNeUEkfn/zB9kusfXYac7lDiiY8Lwh653Uo
-        r6/ZKU6tlaP4fvBuXD3e1482w/TRNH96nQqLPECiFaLwDRUxokp2zc5QRzfE2scW5I/Cyg1CqFwk
-        rsRB303VwluUmUTMWuQU7+b5c1Kx19+IxUtwc2E1uEqnHtY1J6wLnFWJD7y9vju3eUZSRYp/qkSR
-        ihB/JpArC3iNBNh4hfkgGdZlP52kHfYks89Z6AaBGzL2JLXPX/wNAAD//+xYUW/bOAz+KwQKDI4v
-        VVYnabAMfSjaHXDAbRiuu3tZBsR11MWbY6eW3XbY7b/voyTLcuNsWLe9tS1ShxQl6iNFfjKNxVMY
-        a8VYHIsJNYpJq5iIqZg18mkrnwrM1ciPWzk/Tls5e2flR+K4lUetPPLHj1v5WIxb+aSVT9oNzNp1
-        +dGTu3X5MRrsSQ6byqPx0wkjegoOcyOHHHrN96kvzrMfjLMd/6vi/BjjB8dYx6AvxqiETVGYhzre
-        LKPwvJZ0jhIK4Z/yUtCzIXGDpW51bn7XR8KVZ/19LB6P5U+GbIKyHZ7rXo82/KEgZkEIx3ftKMDH
-        oC+w3worhegEEL/Fv8MHHFash1OvJ/i5ptDNrPCiqMtEIrsyGXJ/PkQb3aRKMqzb997A85ZFhOj2
-        blmknrL9WaTFKF7dpApMBFeAaRSBYFwxwjgMDe9kqrHcvl8SOB38yymm0mRxwlksXRbzHmQZX6YZ
-        d9RqHVdUJFhI0e0a5KQCu7aGjNplrCQVJV3j0viJcFVO+AwqzJ6U8RU7ADZWb3Ji8iX0OQM/LyWB
-        oFN1WzQmCalE5jEuMsxYsFSarAk8AOQ9Sz9K0PcrrBLD7e02SxP95tIyo8bhTAIfnFjm//4oszX4
-        VOcqvkKhYLp/qGoeAv/UdWaXs8go2sQwTgvwAs95JRZ5tDs7jHIgrdgZuIfbaQmyiHkdOkzWnA+x
-        RaqUVV3mSG08qTqrGF3PB4zrdUIwgAcHuLkUiCf+zoo8kdtqkS+Xy0XOt8GKPtMZdgbO84VOiF/l
-        pqUMnhzcRTOklvk/aMYmZuQJgTpbs4CV+knYzbGkMWC4Tmh58eLvF2dv6IhOL+jJdV1Uzxf4MZOP
-        QiPBIexTh6MFzuUfvFVVZFLgshAg+xNc4ITMbwbv2BswaJjko5GxXmoHjFMawAB+DCmQZTlkBAd0
-        wieHPmNmuyfMtWLHvwwsOPSfSxR6Cc6KfCE+ar68eT8071Rx8MQ9dRyafZXcGe3UcqfZqeae5l49
-        9zT3KrqnuVfTPc29qu40O3Xd03QrO3B6rd/FrBqQ5nakBcmigvk8uBgjiwkv5MPFGFlQrKqBizFy
-        oHiapuM1qHRUDJJDpaNhkBwqHQ2D5FDpaBgkh4qnMSA5VDoaA5KXTMBrjUzilDw0dG++W+j5pjLn
-        D3QnfDtN+BwgMetLHH/bA16m+uJnW0DoLjKRuBN3c/pXvyzgAmSLfRMSVMwMmlL4RuN9RiZavTaT
-        fTYmjL020302JsC9Nsf7bExEnA0F9Io7kO5OrsPpJBiaiA912TUh5lYTZ6qgrUlgQUwj3KKzfYvq
-        kH57UZsQ6FI7C9jY/bXZxknFcXtVUKq/EFLgJl3JVdvmMfAfcKJSopqrH+nz1nRb8I2baUoQrzZp
-        PqBg8P8GNKQq5o569NLZRyrrHWC/4H2fyjKpewiVjZjKRr+Dyn4FAAD//yKtKUtuvxc52dK6KWs4
-        2pQFqgIAAAD//+yaz2rDMAzGX2UMenTmNE6THEpXxgY79AV6c+VkGyNNyB9G335SnJrUqzsYDHIw
-        9BBqqRIiFl/5fl7KeinrpezVrX4hzS72+oU0m252L2XP8/JS1kvZeUjZ0KT+ImV/uvexMbBt89bl
-        34Vi6t91jYTPASMg0MEONYCHdSAMamEdcFcGNx76eQquQJenzl3cBzfNyK6T8E6W2mgsT71p26Fs
-        +7KUZMbeX3ULadREVFTNH+1aUicbCUDMxqtaxypKk/QQJjyPIOOQxcsiC4sV1jFBWOFGWE7vwVYp
-        rNFiJMq90+OkEaiIfbuNcg2zz4O3RodRzhknEjkPU6lCIVYJpEkcZQc4JBzLFzIvUtio9fAri2i7
-        WL7gR+exUh5HG5Mx/VUb9C37wkGwZUD+aKB3IE2K1VK2NCjMHzQ63jZ8fNoxHtRHss1tLGz+Hdtc
-        2fw7trm0uXeMi0lp9mrkGvD/+uluJ4uiB/gYLhCZYJqE0mttXx0p8Llvqjp/2OPCAeKAxptGXCSe
-        mqtLFUZM9DoMIVzLVLgYKWEYqWZc6n6N/NML8w0AAP//wkwwo8UIPVw8WoxgKUbQiwFczTMTeCsM
-        3kgBeicdkimrQQu4oWwDoEvySxKh69LRTcHZ3MJZLuFay2hghL3kw9kcw+kznO00uJfRJIxx6TCG
-        t+xS88oyi/LzIE07iFBKKXRTBIRLTOiVAZv95C4XxFicCzEMbijQpozE4rB88MJF2AphYBaAOLka
-        xoTWL2Q7ALyBRB9mro5SbmJFEGTgCcWz4CWHRSWOJRCPg5Y+g5YlgrwOF0fVbISiG6oB7Nra2loA
-        AAAA//8DAMtirXaDMwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18245","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18245","key":"NTEST-1875","fields":{"statuscategorychangedate":"2025-04-30T18:27:35.017+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1875/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:34.699+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t73:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:34.802+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/17]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/113]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/304] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/302] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/304]\n*Defect
+        Dojo link:* http://localhost:8080/finding/304 (304)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/302]\n*Defect Dojo link:*
+        http://localhost:8080/finding/302 (302)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1875/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18245/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f2c5f31e-c3bc-4dbf-b435-1240f6b91c06
+      - bc3bd91e-7e1d-481c-b81d-0f4a6aa73e4c
       Atl-Traceid:
-      - f2c5f31ec3bc4dbfb4351240f6b91c06
+      - bc3bd91e7e1d481cb81d0f4a6aa73e4c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:16 GMT
+      - Wed, 30 Apr 2025 16:27:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1094,7 +1157,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=279,atl-edge-internal;dur=13,atl-edge-upstream;dur=266,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=288,atl-edge;dur=255,atl-edge-internal;dur=15,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="HgDDDid2g2ZaPeisolkaeNd2cNffQe0kHds_oh_L3HdI-ZIbi7j_pg==",cdn-downstream-fbl;dur=292
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1103,10 +1166,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 de5b26aba33b480d2b740b96a34fe916.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - HgDDDid2g2ZaPeisolkaeNd2cNffQe0kHds_oh_L3HdI-ZIbi7j_pg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 223fc35827b658e2cea83bff59cf3e3c
+      - bceb78bdc96d08f4822d2fbfc11276a6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1130,78 +1201,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16119
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18245
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWW/bRhD+Kws+BEUq8dIRmUFQuI6SuHVdV1aSB8cw1uSI2pjcZXeXOhL7v3eG
-        hxQfCmoXjQ2Ye82xM998O/7qwKrgMnEiR4NMQEPyRkCWmI7kOZiOieeQ844qQHMrlDQdSITNwfJO
-        POcyhUylnQVog3uQTKDQYEDa5mxcGqvyGSm8CHw/8F0Nf5dg7HRdwInmsRUxOB1HkP1gGAR7ODGQ
-        zXA6t7YwkeclMIPYJuqzcrnNuDGCS1eC9dCS9XghvNATxpTgtQquYI3yx9Px6bQbDHsDXKpcME70
-        1THoW2libiFVel3fIcEZSoR+OOj6QTfwp6EfBaMoGLrhKPwZ/fbJSTJi0fFKzROdJHkP9fnh5trN
-        JAETa1FQ4HB1n5mcZ1mHJcJYIWPLCgExMDVjS6WvXJKOlXyvs0d6UUpB6eLZBV9wy7W3ELD0Kre2
-        DjZbgd8LRr8Y8QVe5Zj2MkerBAs0OeXminJVXloaRTOeGeg4teAh3quS7ThzgcDR8Xx9BAtAX/2b
-        jmMFIqtAlDiRLPGOzh2Y9Px2o9DqM97oiQFvpKtwVwlsw02Tb0CyvdV7KaxFBcbZ2Cak/l6dNWpm
-        l1wTXo3Ii0ygw8mdm2M+KpT1R6v+6JHuficz7U02een7L9CNsL8K+/+vlTr7FRbRYDBcBcMfYXDV
-        WuyFq174Iyw2AL+5uQ/HYBdOw3ZjJlYfag7E7J+d3z/Za0/yNNWQIt/cKwK8gMrKuvwfNjfYtTHc
-        tfFix0a4c2O0a2Pvvp81bdarRErVC+FE3QCn3OLDURPu4wu3pvMtgXu1Ok1lWQ0PVEmBC4iUP9KC
-        kKkTWV3CTcPTpE2LuA7n13tr5BkeNXNVZslrYYqMr5tSxmV0y35AzFB5N9HQgJcl/rj/SAzcvd6g
-        fSTuhm1DZXc3doEq3ICq0EJpYddPDGIr7lUvzb9/K0TOUzAeSZhWicCFuUjnrlmkW7Z8hystrYbO
-        /cIJN6jP+CUQMT5QGsQnDwYi2IXRYEQRmXMzLkR8JOTVG9p5DQX1LzJu81hld1ntbVakkmNsX/hl
-        BhPgpsaGbkbOydH7t4fHF0eHB+Pj0/HFeDL5c4L3wzo1GBI8MJ0DO8EXQFpGdpkwTMlszZBNREZK
-        mVXsN6E5O9GQI52w0iBq3YdYBTuVyPGvhe8Xiy+RU7+KmD0M/7aqbrEFJiIVkmd3DzXdVxPeCukZ
-        etfMKbOphM3psqCyfRjJQxfrvEVy3Sg9EXy18Oblvd3bPA6PW7z9yuMrbDdbyLXKa1sHTUf3nxxu
-        28K6ZtBI2DYKEpZU3SpT+rj25jIroZtq5I1tU6TYa1UnW+UFNsTSPgz6wS5aGGxo4XsZvx3OT/Lb
-        332WalUW1Ci+ETJBYjQMa4VdAkhWlGYOSYXSw8k+fS+BCbkgAwSzhOG/AgxfM0giUjYPXfaW1H2S
-        z6vv84idbdQKGbEijQZu4PrXFGyMdaZins2VsdHIH/nerD57UfmEcHhxjlLs7BTikriJvVPLrlU7
-        hPGxTkp8rMNz5rGzwFj2V8m1Bc3GMsWKzDG+O0Rhc8ALKunjkz/Yfom1z05jLndIUevnBUHvvA7l
-        9TU7xa61chTHBx/G1edj/WkzTJPm8afhVFjkARKtEIUjVMSIKtk1O0Md3RBrH581fxRWbhBC5SJx
-        JTb6bqoW3qLMJGLWIqd4t8+fk4q9/kYsXoKbC6vBVTr1sK45YV1gE0t84O313bnNM5IqUvxTJYpU
-        hPgzgVxZwGskwMYrzAfJsC776STtsGeZfclCNwjckLFnqX356h8AAAD//+xYUW/bOAz+KwQKDI4v
-        VVYnabAMfSjaHXDAbRiuu3tZBsR11MWbY6eW3XbY7b/voyTLcuNsWLe9tS1ShxQl6iNFfjKNxVMY
-        a8VYHIsJNYpJq5iIqZg18mkrnwrM1ciPWzk/Tls5e2flR+K4lUetPPLHj1v5WIxb+aSVT9oNzNp1
-        +dGTu3X5MRrsSQ6byqPx0wkjegoecSOHHHp9EaC+OM9+MM52/K+K82OMHxxjHYO+GKMSNkVhHup4
-        s4zC81rSOUoohH/KS0HPhsQNlrrVufldHwlXnvX3sXg8lj8ZsgnKdniuez3a8IeCmAUhHN+1owAf
-        g77AfiusFKITQPwW/w4fcFixHk69nuDnmkI3s8KLoi4TiezKZMj9+RBtdJMqybBu33sDz1sWEaLb
-        u2WResr2Z5EWo3h1kyowEVwBplEEgnHFCOMwNLyTqcZy+35J4HTwL6eYSpPFCWexdFnMe5BlfJlm
-        3FGrdVxRkWAhRbdrkJMK7NoaMmqXsZJUlHSNi9snwlU54TOoMHtSxlfsANhYvcmJyZfQ5wz8vJQE
-        gk7VbdGYJKQSmce4yDBjwVJpsibwAJD3LP0oQd+vsEoMt7fbLE30m0vLjBqHMwl8cGKZ//ujzNbg
-        U52r+AqFgun+oap5CPxT15ldziKjaBPDOC3ACzznlVjk0e7sMMqBtGJn4B5uvCXIIuZ16DBZcz7E
-        FqlSVnWZI7XxpOqsYnQ9HzCu1wnBAB4c4OZSIJ74OyvyRG6rRb5cLhc53wYr+kxn2Bk4zxc6IX6V
-        m5YyeHJwF82QWub/oBmbmJEnBOpszQJW6idhN8eSxoDhOqHlxYu/X5y9oSM6vaAn13VRPV/gx0w+
-        Co0Eh7BPHY4WOJd/8FZVkUmBy0KA7E9wgRMyvxm8Y2/AoGGSj0bGeqkdME5pAAP4MaRAluWQERzQ
-        CZ8c+oyZ7Z4w14od/zKw4NB/LlHoJTgr8oX4qPny5v3QvFPFwRP31HFo9lVyZ7RTy51mp5p7mnv1
-        3NPcq+ie5l5N9zT3qrrT7NR1T9Ot7MDptX6/s2pAmtuRFiSLCubz4GKMLCa8kA8XY2RBsaoGLsbI
-        geJpmo7XoNJRMUgOlY6GQXKodDQMkkOlo2GQHCqexoDkUOloDEheMgGvNTKJU/LQ0L35bqHnm8qc
-        P9Cd8O004XOAxKwvcfxtD3iZ6oufbQGhu8hE4k7czelf/bKAC5At9k1IUDEzaErhG433GZlo9dpM
-        9tmYMPbaTPfZmAD32hzvszERcTYU0CvuQLo7uQ6nk2BoIj7UZdeEmFtNnKmCtiaBBTGNcIvO9i2q
-        Q/rtRW1CoEvtLGBj99dmGycVx+1VQan+QkiBm3QlV22bx8B/wIlKiWqufqTPW9NtwTdupilBvNqk
-        +YCCwf8b0JCqmDvq0UtnH6msd4D9gvd9Ksuk7iFUNmIqG/0OKvsVAAD//yKtKUtuvxc52dK6KWs4
-        2pQFqgIAAAD//+ya0WqDMBSGX2UMehkXNVa9KF0ZG+yiL9C79ES3MdSildG33znGhpo1HWw3XgR6
-        Ic1JTziYn7/8n7ey3sp6K3tV1SfWbKLrE2t2qezeyp7n5a2st7LzsLKh2fqLlf2Z3icmwLbDW1d+
-        FwrXgoE3KNg7thI+B2aBKASrVBjUwlrgLgCEuzJ0bjL083hchS7ug5vDTLJoO5GUx6OEd8rbdN7Z
-        9VUlKYy9v5oW0qiJqGjaP8a15E7WEoA4kFe1SlScpdk+THkRQ84hT6IyD8sl9jFF2OFGWUHvwUYp
-        7NFhJdq90+PFQaAh9u024zWMuAjeWl1Ge86ckSh4mEkVCrFMIUuTON/DPuXYvpRFmcFarYZfWcSb
-        RfSCH72PVbIeY0zG9Fdd0HfsCwfBooDy0UBrIE2KHaTsaFC4f/DoeNvw8WnLeHCoKTa3ebH5n9gG
-        zuZ/YhtYm/uJUX+U5p9GrgH/r5/utrIse4CP4QJRCKbpKq1eu6amwue+bQ7Fww51BYgDGm8aAZO4
-        aq4udRgx0eswhHCJqXAxUsIwUvaCEex2VHuvL/97k74BAAD//yIhJY2WL/Rw8Wj5gqV8QS8G4K0w
-        eKMF6Op0SN6rBq3shrINgBbmlyRC16Wjm4KzuYWzXMLZDjPCXvLhWuJogKvhCSoQsEoY4Gp4GuPS
-        YQxv2aXmlWUW5edBWm8QoZRS6KYICJeo0MvPhZhQDWNCi3syil+k/Rz6MHN1lHITK4Ig40AodoNX
-        ABaVOJZA3FEG7H6Qu2wRY+ExxDC4oUC7MhKLw/LBCyhhq4VBS59ByxJBVsIdgupaIxTnQjWAg6e2
-        thYAAAD//wMAcwsUsoMzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18245","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18245","key":"NTEST-1875","fields":{"statuscategorychangedate":"2025-04-30T18:27:35.017+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1875/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:34.699+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t73:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:34.802+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/17]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/113]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/304] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/302] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/304]\n*Defect
+        Dojo link:* http://localhost:8080/finding/304 (304)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/302]\n*Defect Dojo link:*
+        http://localhost:8080/finding/302 (302)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1875/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18245/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - bcd41f00-c923-40ab-9021-2027a676959b
+      - b41e56f1-8b6c-4165-a34a-ab769db876f9
       Atl-Traceid:
-      - bcd41f00c92340ab90212027a676959b
+      - b41e56f18b6c4165a34aab769db876f9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:17 GMT
+      - Wed, 30 Apr 2025 16:27:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1211,7 +1317,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=313,atl-edge-internal;dur=15,atl-edge-upstream;dur=299,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="w1-JJZnbFW-2RtQ0Td6dzqG0JDf3W3dcA8HK92VElQwcTY2vuuPxOQ==",cdn-downstream-fbl;dur=353,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=350,atl-edge;dur=265,atl-edge-internal;dur=16,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1220,10 +1326,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 48f2e5da4dd7651bfa3bfd0054610cf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - w1-JJZnbFW-2RtQ0Td6dzqG0JDf3W3dcA8HK92VElQwcTY2vuuPxOQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 09e8d86325cecebdaeb253f6badd8855
+      - 7ce8a965d50fc8d970836eca165cfa92
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1250,26 +1364,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2q1d3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwGW56fmlfARZMDmU6BTWFaM8SzlWRADXECAQ96FP+BQtd05S6FiwGnBaZ6kafHN
-        yu7GKBvAjC4KKQDnqCRNcxSZUpkCqdgynRe1WmTIFgrYmcDraLhtBxFfiEqM2t9ZKWL7QPSpImhe
-        tyU5nh/2ZE2cXN9X5PgJAAD//wMAlaS+vyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:36.361+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 53744adc-0902-4b28-9135-39ce732c15a3
+      - 9ed5d0be-3c7f-4c1f-9ffc-5dd4a24c5ef4
       Atl-Traceid:
-      - 53744adc09024b28913539ce732c15a3
+      - 9ed5d0be3c7f4c1f9ffc5dd4a24c5ef4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:17 GMT
+      - Wed, 30 Apr 2025 16:27:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1279,7 +1389,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=152,atl-edge-internal;dur=27,atl-edge-upstream;dur=125,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=178,atl-edge;dur=146,atl-edge-internal;dur=14,atl-edge-upstream;dur=131,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="EE9pqCEB9qboGN7XPtAx6IWHCrtILBPOpYY4DoXGmDu_V0WVKfzOgg==",cdn-downstream-fbl;dur=182
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1288,10 +1398,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9fe7d47ea2a815113a41181f1d63f69e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - EE9pqCEB9qboGN7XPtAx6IWHCrtILBPOpYY4DoXGmDu_V0WVKfzOgg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 71763312b093a6bf136040b528991598
+      - 54b675481d07fed9918125775e218323
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1318,41 +1436,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 0a2283e5-726f-4411-a52a-46e94565d30a
+      - bdc682c2-28ea-4bec-9915-f7b9959d342e
       Atl-Traceid:
-      - 0a2283e5726f4411a52a46e94565d30a
+      - bdc682c228ea4bec9915f7b9959d342e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:17 GMT
+      - Wed, 30 Apr 2025 16:27:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1362,7 +1467,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=335,atl-edge-internal;dur=14,atl-edge-upstream;dur=321,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="E_QLL7dGDF9_uslHbuL1mS_ASJNOhLBFS_JGgUbfY3JOKDZDqXCvoQ==",cdn-downstream-fbl;dur=436,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=78,cdn-upstream-fbl;dur=433,atl-edge;dur=332,atl-edge-internal;dur=16,atl-edge-upstream;dur=316,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1371,13 +1476,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b376080c70ff0aef5ae83cd4d75e16d0.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - E_QLL7dGDF9_uslHbuL1mS_ASJNOhLBFS_JGgUbfY3JOKDZDqXCvoQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 34bd6fba306a4a6901f4676534a4fd61
+      - d99f2d1490d026bae8c74ea57ae000cd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1389,22 +1502,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/108] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/18] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/113]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/303]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/303]\n*Defect
       Dojo link:* http://localhost:8080/finding/303 (303)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -1418,7 +1530,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1973'
+      - '1945'
       Content-Type:
       - application/json
       User-Agent:
@@ -1427,18 +1539,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16120","key":"NTEST-1636","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16120"}'
+      string: '{"id":"18247","key":"NTEST-1876","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18247"}'
     headers:
       Atl-Request-Id:
-      - a3846917-4e53-4382-9fc4-8fd213f9161f
+      - 0aa8d30f-d83d-413f-99cc-85b50659953a
       Atl-Traceid:
-      - a38469174e5343829fc48fd213f9161f
+      - 0aa8d30fd83d413f99cc85b50659953a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:18 GMT
+      - Wed, 30 Apr 2025 16:27:37 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1448,7 +1562,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=672,atl-edge-internal;dur=20,atl-edge-upstream;dur=651,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Hr64e59qbEpYbac__zivnASyO8IjrakkJPyFvI1QjoEko9Jp3fT_BA==",cdn-downstream-fbl;dur=850,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=94,cdn-upstream-fbl;dur=846,atl-edge;dur=720,atl-edge-internal;dur=18,atl-edge-upstream;dur=701,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1457,10 +1571,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Hr64e59qbEpYbac__zivnASyO8IjrakkJPyFvI1QjoEko9Jp3fT_BA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 60585db7afc0f05f7a0d8f9b1f643bd3
+      - a356cc2986ba40d1ba69f6ffd7ac7396
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1484,64 +1606,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1636
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1876
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+DZ2tNzuuK2AYssTpsmVZ5rjthzQIGOkssaFIjaT8sqb/fUfK
-        shcnKpYMKxJAEsl74d1zz50/e7CqqMi8xFMgMlCQnTDgme4JWoLu6bSAkvZkBYoaJoXuQcZMCYb2
-        0oKKHLjMewtQGvcgm0KlQIMwm7NprY0s51bhTRSGUegr+LMGbWbrCi4UTQ1Lwet5zNqPRlEc4ocG
-        PsfPwphKJ0GQwRxSk8lP0qeGU60ZFb4AE6AlE9CKBXHAtK4haBXcwRrlz2eTy1k/Gg1GuORc0F7y
-        2dPoW61TaiCXat3cIcMvlIjD+KAfRv0onMVhEo3x3x++GXyPflu1zohBx52aFzpp5QPUF8bba28+
-        MtCpYpUNHK4eEl1SznskY9owkRpSMUiByDlZSnXnW+lUineKP9OLWjCbLspv6IIaqoIFg2Xg3No5
-        uNmKwkE0/lGzv+CHEtNel2jVwgJNzqi+s7mqb419S+aUa+h5jeAp3svJ9ryCIXBUWqzPYAHoa/il
-        5xmGyKoQJV4iaryjtweTQdhuVEp+whu9MOAbaRdul8A23Hsg2d3qnWDGoALtbW1bpP7qzmo5N0uq
-        LF41KyvO0OFs7+aYD4ey4Xg1HD/T3a9kpr3JNi/D8DW6EQ9X8fD/tdJk32ERDUajVTT6FgZXrcVB
-        vBrE38LiBuBfvjyGY9SF07hrY9BuzNnqfUOOCIura4RJnivIkW8eFQFeQPK6Kf+ntR50bYy6Nl53
-        bMSdG+OujTeP/Wxos1m1pOQ6hJf0ow1X2pQoljZX+vxozRYKRlsXsubZMdMVp+tNOeHykhpsPQ1l
-        P7/0m4awawFBo07ZwnavR7K2oXeufrALTOReYlRtbaNS8x4xY8t7Ew0FeFnLH081iWg0bJvEfti2
-        VLa/0QWqeAuqSjGpmFm/MASteOA6zb/vFaykOejASuhWCcOFguWFrxf5ji1/xpWWVmPvceHE2zLg
-        9BYsMdoK2J8JusAbdWE0GtuIFFRPKpaeMXF3YneOobLzi0hbDDlkLd3edkVIMcHxhd5ymALVDS7V
-        5s27OHv39vT85uz0aHJ+ObmZTKe/T/F+WKcaQ4IHZgWQC+wAwhBrlzBNpOBrgmzCuFVKjCS/MEXJ
-        hYIS6YTUGjHnP8UqERaUF96zMKyWrxOv6YqYPQz/rqoesAUmImeC8v1Dm+lrE16HfI7etYSDmc0F
-        bE/XlS3bLiTHw6hFcjMovRB8jfC28z6cbZ6Hxx3efqLpHY6bLeRa5Y2to81E958cbsfCpmbQSNwO
-        CgKWtroll+q88eaW19DPFXLWbiiS5Fg2yZZlhQOxME+D/qCLFg62tPC1jD8M50fxz79DkitZV3ZQ
-        PGEiQ1rTBGuF3AIIUtW6gMyh9HR6aJ+3QJhYWAMWZhnBnwIEmxZkiVVWxD55a9V9FK/c81VCrrZq
-        mUjIHGNYJKE/8MN7G28MN5cp5YXUJhmH4zCYN8dvnFuIiPE1CpKrS0hrS0/kZ7nsG9khjP06q7Ff
-        x9ckIFeRNuSPmioDikxEjkVZYog7RGF7IIic9PnFb+SwxvInlykVHVJ2+guiaHDdRPP+nlzi4Ooc
-        xfej9xP3+NA82iTbj02bt68zZpAKrKgDFb6hImLZktyTK9TRj5HdsC9F0RvnhgWpWGS+wFnfz+Ui
-        WNRcIGwN0krw8Py1VTEMm2BbuXQJfsmMAl+qPMDaphbvDAdZywkBHvULU3Ir53KFT5ctq2cKec0p
-        xnJlf7Y5949BMMotei5BLfDXGemT704U/A0AAP//7FnbTttAEP2VVSUQiWLjxA65IEQjKBIPqapW
-        7QN9YbO7Jq6SOPIlqIKP75n1ZklMlrZURTygRIm9szfPzJ45M86nLbY/K44xuOt3Gg7tGVsfhkFI
-        C44Q51eqRbrRZJndk06ba40Om1op1Maa56Vi53BBNF6oic8GLUYAxba9e/2Ztn3r3vo+9P/z42Df
-        5xpHcMR/pIwQFlv97Th2gJ/Grod+6pFZEy6G5u/4855lbawIx9FT/Ju/beu9+SUtM2jxIpkpYIGq
-        NL1/Uxxr59roeP6AUU1giV02BXiZo+8n6SGXqyQHzoFgdDtHgK+YdAxXWUc1st21nvyaIfQy2ipS
-        ShNsM2NysxEyubQmz43Jb6cEfRzzLW4YOLeAHFFbZDymlShGA5KWZeFD898e5h8De2bKYNy2aE3q
-        hxtehB6fNMuUazGk0MyJFW9MgJ5TjEYjPFIfyGFdma2NhhzcxiHIVsqj6JWIxx0racxXFG83rEQI
-        NqQfci7cjoTAfEPEh8ksEcaC40QHBWPAr5o3kM6NZaqnYmnGZhBkvrX85XzJRUFjPqYs0TcMOL5K
-        pJJbvvQZ5wlkCkv/jYeYocuUwgA5+AGX82TRYAeN+zkcuEiHcNrHVLxr2WidibmCcTtyCWwmRlG6
-        yMBLdPpA6Uyta2TzppogcGVzgYsQB5YQr9Xj6uhK4gK7GV4UXEwpOO5IS+t0Iy/nc07M6p0r9JO2
-        KUNKs2fSLzqDp1wIysou5UlXhv1ef9LuBSoUg0AMup140I6pkmc7YYUnuilyhZGUdE7QU6Ty5/uN
-        jYCf0VxP1my0lpUPiqe70Zh13SBSyEK4bEfRUU/0e91wMBGTXoDlY67ivjiVJ3qWvXC017nAtxrn
-        zfnCcBLPq5pyv8y9WyjC6/hEdvzqCJKmvCXnOSkK4zXCI4fB5dnYC/zlgmhwvf7z+ndcLyC9/h3X
-        C1CvfceAIFnVUkyecgbXZ2Mex6UQiT5ARMqqWkcFYFcgsej4oczSpTq8ArQIyuvNSaMCKKT26NIK
-        puy7O7mJXHgauWoekauQFlnMzgzgv+HLi3nSG768xI7f8GUHvtRhwBIxy1Ow65vq7N3RmxpzHWDB
-        tODmPVN9FifjcuKSk4p1diOfq2QZuLgnAcJOQeDinqFrRGjJnVqskixdVOyuapKleclZ3f6R9tJ5
-        NcMdXf4CAAD//wIxocU9GcUv0vysPsxcHaXcxIqg1OLSHJDBSHaDR/SKShxLIO4oyy+h3jQAxDC4
-        oUC7MhKLw/LBA6LwmYf8IvAwI8hKuENQXWuE4lyoBnDw1NbWAgAAAP//AwAoIR11Ux8AAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18247","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18247","key":"NTEST-1876","fields":{"statuscategorychangedate":"2025-04-30T18:27:37.802+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1876/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:37.513+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t7b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:37.600+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/18]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/113]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/303]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/303]\n*Defect
+        Dojo link:* http://localhost:8080/finding/303 (303)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1876/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18247/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 14e98bb4-1885-445f-808b-72bfb498862b
+      - 31b7b112-a7ee-4a1d-b50d-fb09a3e4b719
       Atl-Traceid:
-      - 14e98bb41885445f808b72bfb498862b
+      - 31b7b112a7ee4a1db50dfb09a3e4b719
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:18 GMT
+      - Wed, 30 Apr 2025 16:27:38 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1551,7 +1660,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=323,atl-edge-internal;dur=16,atl-edge-upstream;dur=308,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=358,atl-edge;dur=325,atl-edge-internal;dur=30,atl-edge-upstream;dur=293,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="WtJ5N-ptg8QzYkXWBqEN7b8_jrnvk7JOWieIjqKsSIZcKTEsAYISRQ==",cdn-downstream-fbl;dur=362
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1560,10 +1669,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e665d09233240df4d3172e59222e0ba2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - WtJ5N-ptg8QzYkXWBqEN7b8_jrnvk7JOWieIjqKsSIZcKTEsAYISRQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 0978e554d06fb99bfde278fcfb2aeb92
+      - f1b89f051b97500b6158dd3008e91180
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1587,65 +1704,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16120
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18247
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+DZ2tN7uOK2AYssRps2VZ5rjthzQIGOkssaFIjaT8sib/fUdK
-        spcXd0uGFQkgieS98O65585fPFhVVGRe4ikQGSjIjhjwTPcELUH3dFpASXuyAkUNk0L3IGOmBEN7
-        aUFFDlzmvQUojXuQTaFSoEGY9mxaayPLuVV4FYVhFPoK/qhBm9m6gjNFU8NS8Hoes/ajURSH+KGB
-        z/GzMKbSSRBkMIfUZPKz9KnhVGtGhS/ABGjJBLRiQRwwrWsIOgU3sEb509nkfNaPRoMRLjkXtJd8
-        8TT6VuuUGsilWjd3yPALJeIwft0Po34UzuIwicb47w/fDL5Hv61aZ8Sg407NC5208gHqC+PNtduP
-        DHSqWGUDh6v7RJeU8x7JmDZMpIZUDFIgck6WUt34VjqV4r3iz/SiFsymi/IruqCGqmDBYBk4t7YO
-        tltROIjGP2r2J/xQYtrrEq1aWKDJGdU3Nlf1tbFvyZxyDT2vETzGeznZnlcwBI5Ki/UJLAB9De96
-        nmGIrApR4iWixjt6D2AyCLuNSsnPeKMXBryVduF2CezC/QAk21u9F8wYVKC9jW2L1F/cWS3nZkmV
-        xatmZcUZOpw9uDnmw6FsOF4Nx8909yuZ6W6yycsw3EM34uEqHv6/VprsOyyiwWi0ikbfwuCqsziI
-        V4P4W1hsAX539xiO0S6cxt3GnK0+NByI2b+4fHxy0J2kea4gR775xyJ43W3gzSSvG154+uho18be
-        jo1458Z418abx+40tNmsWlJyHcJL+hF+UoONoyHc5xduQ+dbAg8adcqWpXs9kLUNXGRJ+aNdYCL3
-        EqNquGt52mpTLG2i9uXRmvUMj+pC1jw7ZLridN2WMi6jW+YDYsaWdxsNBXhZyx9PNYloNOyaxMOw
-        bajs4cYuUMUbUFWKScXM+oVB7MQD12n+fa9gJc1BB1ZCd0oYLhQsL3y9yLds+Q5XOlqNvceFE29Q
-        z+k1WGJ8ojQsnzwZiGgXRqOxjUhB9aRi6QkTN0d25xAqO7+ItMujy+7S7W1WhBQTHF/oNYcpUN1g
-        Q7Vv3tnJ+7fHp1cnxweT0/PJ1WQ6/W2K98M61RgSPDArgJxhBxCGWLuEaSIFXxNkE8atUmIk+Zkp
-        Ss4UlEgnpNaIWv8pVomwoLzwloVhtdxLvKYrYvYw/NuquscWmIicCcofHmqnrza8DukcvWu/bWZz
-        AZvTdWXLdheS42HUIbkZlF4IvkZ403nvzzbPw+MWbz/R9AbHzQ5ynfLG1kE70f0nh7uxsKkZNBJ3
-        g4KApa1uyaU6bby55jX0c4W8sR2KJDmUTbJlWeFALMzToH+9oYWvJfah0IYy7ofzk/j73z7Jlawr
-        OygeMZEhMWqCtUKuAQSpal1A5lB6PN23z2sgTCysZQuzjOBPAYLdDLLEKitin7y16j6JV+75KiEX
-        G7VMJGSOMSyS0B/44a2NN4aby5TyQmqTjMNxGMyb41fOLUTE+BIFycU5pLWlJ/JOLvtG7hDGfp3V
-        2K/jSxKQi0gb8ntNlQFFJiLHoiwxxDtEYXMgiJz06dmvZL/G8ifnKRU7pOz0F0TR4LKJ5u0tOcfB
-        1TmK7wcfJu7xsXl0SbYfbf+3rzNmkAqsqAMVvqEiYtmS3JIL1NGPkd2ws0XRG+eGBalYZL7AWd/P
-        5SJY1FwgbA3SSnD//KVVMQybYFu5dAl+yYwCX6o8wNqmFu8MB1nLCQEe9QtTcivncoVPly2rZwp5
-        zSnGcmV/tjn3D0Ewyi16zkEt8NcZ6ZPvjhT8BQAA///sWdtO20AQ/ZVVpSISxcaJHXJBiEakSDyk
-        qlq1D/SFzXpNXCVx5EtQVT6+Z9brxTFZ2lIV8YBASbyz15nZM2fG2aLDDpb5CQb33V7Loj1t6yPf
-        82nBCWLtVnZIN4osszvSabvS6LitlEJtrD0tJJvCBdF4IecuG3UYARTb9e7qb9F1jXurZ9/9z8fB
-        vqcKR3DFvyeMEBZb/e04doiP1r5DP3Zk1oaLofkbvpwnWRsrwnHUFP/mb7t6b39OihRavIiXElgg
-        S00f3OQnyrlqHaf3GNUGlphlE4CXvvpunBzxcBtnAEAQjH7vGPAVkY7hKlVUI9tdq8mvGUIvo60i
-        pdTBNtUm1xshk4fG5Jk2+e2CoI9jvvUNA+cWkCNqi5RHtBLFaEDSpshdaP7r/fwzYM9SaozbFVVs
-        f1zzIvT4qHhqWIkhhWZOjbg2AXouMBqN8Eh1IcdNZXZqDRm4jUWQbqVD0SsWDzuW0ohvKd7WrEQI
-        NqYPci48ToTAfGPEh/kyFtqCs1gFBW3AL4o3kM61ZcpTsSRlSwhS11j+crXhIqcxHxIWqwcGHN/G
-        oQx3fOkT7hPIFJb+Gw/RQzcJhQFy8EMeruJ1ix227lZw4DwZw2kfUvG+YaNNJmbj6N2gHqXzFPRD
-        5RmUOTS7mmytIfBsgsAkVM0RhhBXWrB1tBFkz5bEeWbNHWLZ5B08z7lYUOQsyUtWrFacmNUbW+gn
-        bVOGlKRPpF90B8+4EJTXXYan/dAfDobz7sCTvhh5YtTvRaNuRJU80wkrPNJNkitMwpDuCXqKJPzx
-        rrYR8DOa69GajVK/dEHxVDcaU9UNAokshIfdIDgeiOGg74/mYj7wsHzEZTQUZ+GpmuWtP3nbu8B/
-        Oc5Z8bXmJI5TNmVukTm3UITTc4nsuOUVJE05G84zUhTGK4RHDoOf5zPHczdrosHN+s/L33GzgPTy
-        d9wsQL30HQObwrKeofOUc7g+m/EoKoSI1QUiUlZWS0pkuwKJRcf3RZps5NEVMEdQXq9vGhVAITVX
-        l1bQZd/9yU1gw9PAVvMITM0j1bj+CiPP5jCvMPIcO36FkT0w0oQBG0MLDBEzvAXHuSkv5U96U6N/
-        e9hJknP9nqk5i42KeTZc8nr7Ac5WsvSsB7BSNXOy5ggbh/OtAkPu5Hobp8m6JHBlU1jol5zl459o
-        b5vktQL+LwAAAP//Iq0cxhjAhxgGNxRoU0ZicVg+eCASNuoOzAIQJ1fDmND6hWwHgCeE9WHm6ijl
-        JlYEpRaX5oAMRvIseAixqMSxBOJx0FQGaJgR5HW4OKpmIxTdUA1g19bW1gIAAAD//wMAhDvkZ1Mf
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18247","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18247","key":"NTEST-1876","fields":{"statuscategorychangedate":"2025-04-30T18:27:37.802+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1876/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:37.513+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t7b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:37.600+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/18]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/113]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/303]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/303]\n*Defect
+        Dojo link:* http://localhost:8080/finding/303 (303)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1876/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18247/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a7ad9f38-96ad-4090-8f57-b62da1d466c5
+      - 9c98cc3f-6dba-49aa-9c63-ab6bf306c3ff
       Atl-Traceid:
-      - a7ad9f3896ad40908f57b62da1d466c5
+      - 9c98cc3f6dba49aa9c63ab6bf306c3ff
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:19 GMT
+      - Wed, 30 Apr 2025 16:27:38 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1655,7 +1758,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=264,atl-edge-internal;dur=15,atl-edge-upstream;dur=250,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="tKxZ9TAbnt_DXTEpngro8iDybGCka0m2nsNT8hsPWA5lu5g9YyERsA==",cdn-downstream-fbl;dur=402,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=399,atl-edge;dur=315,atl-edge-internal;dur=26,atl-edge-upstream;dur=290,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1664,10 +1767,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 41e9e91568ab5e34cd26bd32ceb4035e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - tKxZ9TAbnt_DXTEpngro8iDybGCka0m2nsNT8hsPWA5lu5g9YyERsA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 67114588fd80b93aa93f585e362a8ca3
+      - bfb4ea49bf33b943d56527381720b51a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1687,7 +1798,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       113, "url_ui": "http://localhost:8080/test/113", "url_api": "http://localhost:8080/api/v2/tests/113/"},
       "finding_count": 0, "findings": {"new": [], "reactivated": [], "mitigated":
-      [], "untouched": []}}'
+      [], "untouched": [{"id": 304, "title": "2222Remote Code Execution - (Pg, < 2.11.2
+      || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5
+      || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+      || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/304",
+      "url_api": "http://localhost:8080/api/v2/findings/304/"}, {"id": 300, "title":
+      "Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/300", "url_api": "http://localhost:8080/api/v2/findings/300/"},
+      {"id": 301, "title": "2222Regular Expression Denial of Service - (Negotiator,
+      <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/301",
+      "url_api": "http://localhost:8080/api/v2/findings/301/"}, {"id": 302, "title":
+      "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7
+      || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5
+      || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)",
+      "severity": "High", "url_ui": "http://localhost:8080/finding/302", "url_api":
+      "http://localhost:8080/api/v2/findings/302/"}, {"id": 303, "title": "Regular
+      Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High", "url_ui":
+      "http://localhost:8080/finding/303", "url_api": "http://localhost:8080/api/v2/findings/303/"}]}}'
     headers:
       Accept:
       - application/json
@@ -1698,11 +1825,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '967'
+      - '2378'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added_empty
       X-DefectDojo-Instance:
@@ -1714,12 +1841,12 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"967\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2378\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added_empty\"\n    ],\n    \"X-Defectdojo-Instance\": [\n
         \     \"http://localhost:8080\"\n    ]\n  },\n  \"method\": \"POST\",\n  \"origin\":
-        \"172.18.0.2:34446\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
+        \"172.18.0.9:35094\",\n  \"url\": \"http://webhook.endpoint:8080/post\",\n
         \ \"data\": \"{\\\"description\\\": \\\"Event scan_added_empty has occurred.\\\",
         \\\"title\\\": \\\"Created/Updated 0 findings for Security How-to: 1st Quarter
         Engagement: NPM Audit Scan\\\", \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/113\\\",
@@ -1733,14 +1860,56 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 113, \\\"url_ui\\\": \\\"http://localhost:8080/test/113\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/113/\\\"}, \\\"finding_count\\\":
         0, \\\"findings\\\": {\\\"new\\\": [], \\\"reactivated\\\": [], \\\"mitigated\\\":
-        [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n  \"form\": {},\n  \"json\":
-        {\n    \"description\": \"Event scan_added_empty has occurred.\",\n    \"engagement\":
-        {\n      \"id\": 1,\n      \"name\": \"1st Quarter Engagement\",\n      \"url_api\":
-        \"http://localhost:8080/api/v2/engagements/1/\",\n      \"url_ui\": \"http://localhost:8080/engagement/1\"\n
-        \   },\n    \"finding_count\": 0,\n    \"findings\": {\n      \"mitigated\":
-        [],\n      \"new\": [],\n      \"reactivated\": [],\n      \"untouched\":
-        []\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\": \"Security
-        How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
+        [], \\\"untouched\\\": [{\\\"id\\\": 304, \\\"title\\\": \\\"2222Remote Code
+        Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0
+        < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >=
+        6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\",
+        \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/304\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/304/\\\"}, {\\\"id\\\":
+        300, \\\"title\\\": \\\"Regular Expression Denial of Service - (Negotiator,
+        <= 0.6.0)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/300\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/300/\\\"}, {\\\"id\\\":
+        301, \\\"title\\\": \\\"2222Regular Expression Denial of Service - (Negotiator,
+        <= 0.6.0)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/301\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/301/\\\"}, {\\\"id\\\":
+        302, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/302\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/302/\\\"}, {\\\"id\\\": 303, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/303\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/303/\\\"}]}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added_empty
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        0,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [],\n      \"reactivated\":
+        [],\n      \"untouched\": [\n        {\n          \"id\": 304,\n          \"severity\":
+        \"High\",\n          \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2
+        || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 <
+        6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0
+        < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/304/\",\n          \"url_ui\": \"http://localhost:8080/finding/304\"\n
+        \       },\n        {\n          \"id\": 300,\n          \"severity\": \"High\",\n
+        \         \"title\": \"Regular Expression Denial of Service - (Negotiator,
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/300/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/300\"\n        },\n
+        \       {\n          \"id\": 301,\n          \"severity\": \"High\",\n          \"title\":
+        \"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/301/\",\n          \"url_ui\": \"http://localhost:8080/finding/301\"\n
+        \       },\n        {\n          \"id\": 302,\n          \"severity\": \"High\",\n
+        \         \"title\": \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 <
+        3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+        < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >=
+        7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/302/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/302\"\n        },\n
+        \       {\n          \"id\": 303,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/303/\",\n          \"url_ui\": \"http://localhost:8080/finding/303\"\n
+        \       }\n      ]\n    },\n    \"product\": {\n      \"id\": 2,\n      \"name\":
+        \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
         \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
         {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
         \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
@@ -1758,7 +1927,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:19 GMT
+      - Wed, 30 Apr 2025 16:27:39 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_push_to_jira.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1m5d3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwBbLE7NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4LTgdJkWRf7N
-        yu7GKBvAjM4LKQBzVJLOFigypTIFUrHlLC9qNc+QzRWwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAv0S8OiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:39.547+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 5866335c-f0d3-48c9-90f2-904c785f065f
+      - 22e569f7-385b-4f6e-9a5b-03e5f1362960
       Atl-Traceid:
-      - 5866335cf0d348c990f2904c785f065f
+      - 22e569f7385b4f6e9a5b03e5f1362960
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:19 GMT
+      - Wed, 30 Apr 2025 16:27:39 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=159,atl-edge-internal;dur=13,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="mPdu8bp4MdMyha7V2FJl-ZNt-5W4zTarTUtmyiF1scM6qrfOCspumQ==",cdn-downstream-fbl;dur=238,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=235,atl-edge;dur=162,atl-edge-internal;dur=12,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 51e6f466f192ce588105b138cebcc0d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - mPdu8bp4MdMyha7V2FJl-ZNt-5W4zTarTUtmyiF1scM6qrfOCspumQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - ec8f0dc7f6e38b2802bbf2c3dd1a1bed
+      - 6ec127ca5a30dfa52f009cc3578e0e09
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 38c1e756-36a7-4fca-bd0c-87ddb43c8b3f
+      - 0aeb5128-29ed-41c8-a67a-734c0091c63b
       Atl-Traceid:
-      - 38c1e75636a74fcabd0c87ddb43c8b3f
+      - 0aeb512829ed41c8a67a734c0091c63b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:20 GMT
+      - Wed, 30 Apr 2025 16:27:40 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=306,atl-edge-internal;dur=15,atl-edge-upstream;dur=292,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="acF3SD5Vhs2pY6M39XCoTbQbkSYS07DaiZ82zrNEd2y7azvml2Ii0w==",cdn-downstream-fbl;dur=407,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=404,atl-edge;dur=320,atl-edge-internal;dur=15,atl-edge-upstream;dur=305,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 64d5385c423c2207e3680beec4636de8.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - acF3SD5Vhs2pY6M39XCoTbQbkSYS07DaiZ82zrNEd2y7azvml2Ii0w==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 63c9d651f1db97188f7572cdb8f95d52
+      - f9661197886284abcd5a57e72b171ba4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -157,7 +156,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/109]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/19]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/114]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -166,28 +165,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/305]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/306]\n*Defect Dojo link:* http://localhost:8080/finding/306
-      (306)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (306)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/305]\n*Defect
       Dojo link:* http://localhost:8080/finding/305 (305)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -201,7 +200,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3359'
+      - '3334'
       Content-Type:
       - application/json
       User-Agent:
@@ -210,18 +209,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16121","key":"NTEST-1637","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16121"}'
+      string: '{"id":"18249","key":"NTEST-1877","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18249"}'
     headers:
       Atl-Request-Id:
-      - aef950b4-c695-4fb9-bc47-4b8a31cb3f41
+      - f54c7f7c-4655-41f2-b4cc-0354edb2fb06
       Atl-Traceid:
-      - aef950b4c6954fb9bc474b8a31cb3f41
+      - f54c7f7c465541f2b4cc0354edb2fb06
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:21 GMT
+      - Wed, 30 Apr 2025 16:27:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -231,7 +232,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=798,atl-edge-internal;dur=15,atl-edge-upstream;dur=775,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="-cI6Gs3UUJFSsVyeXYh_Mql-8IT-jMnqpt9tCAYG1Vwd5ELLpvvNYQ==",cdn-downstream-fbl;dur=821,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=817,atl-edge;dur=741,atl-edge-internal;dur=17,atl-edge-upstream;dur=725,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -240,10 +241,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2bdfafaaaec33c116889588ecd9de280.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -cI6Gs3UUJFSsVyeXYh_Mql-8IT-jMnqpt9tCAYG1Vwd5ELLpvvNYQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 719e06138215a96291c73f45f3471d10
+      - 47a4dd8e1868ed95d9543a04826e4a17
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -267,66 +276,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1637
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1877
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWVPjRhD+K1N63Ni6bMCrqlSKgNklIYQYL/vAUtQgtaVZpBllZuQjsP893Trs
-        5fAmkMrCg+bqY7q//qZ958Cy5DJxIkeDTEBDciQgT0xP8gJMz8QZFLynStDcCiVNDxJhC7C8F2dc
-        ppCrtDcHbXAPkgmUGgxI256NK2NVMSOF14HvB76r4c8KjJ2uSjjTPLYiBqfnCLIf7AZhgBMD+Qyn
-        mbWliTwvgRnENlGflcttzo0RXLoSrIeWrMdL4YWeMKYCr1NwCyuUP52Oz6f9YHewh0u1C8aJ7hyD
-        vlUm5hZSpVfNHRKcoUTohzt9P+gH/jT0o2AUhYHr7+79gH775CQZseh4reaVTpK8h/r8cH3tdpKA
-        ibUoKXC4us9MwfO8xxJhrJCxZaWAGJiasYXSty5Jx0p+0PkLvaikoHTx/JrPueXamwtYeLVbGwfb
-        rcAfBKOfjPgLfiww7VWBVgkWaHLKzS3lqrqxNIpmPDfQcxrBY7xXLdtzMoHA0XG2OoE5oK/+l55j
-        BSKrRJQ4kazwjs4jmAz8bqPU6jPe6JUBb6XrcNcJ7MJNk69AsrnVBymsRQXGWdsmpP5anzVqZhdc
-        E16NKMpcoMPJo5tjPmqUDUfL4eiF7n4jM91N1nkZ+oTqcLgMh/+vlSb7NRbRYLC7DHa/h8FlZ3EQ
-        Lgfh97DYAvzLl6dwDLbhNOw2ZmJ50XAgZv/y6unJQXeSp6mGFPnmH4tgp9vAm6m8anjh+aO72zb2
-        tmyEWzdG2zbePnWnoc1mlUipfiGcqB+0XEkp0SJuPL97skaFgtE2mary5FCYMuertpxwecEtPj0N
-        Zb+89JsHYfMEeI06TYVdDw9URaGvXf1IC0KmTmR1RbZRqb1AzFB5t9HQgJcl/nj6SPju3nDUPRKP
-        w7amsscb20AVrkFVaqG0sKtXhqAT9+qX5t+/FaLgKRiPJEynROBCJtLMNfN0w5bvcaWj1dB5Wjjh
-        GvU5vwEixmdKg/jk2UAE2zAajCgiGTfjUsQnQt4e0c4hlNS/yLjDUI2sRb23XpFKjrF94Tc5TICb
-        Bpe6HTlnJx/eHZ9enxwfjE/Px9fjyeT3Cd4P69RgSPDANAN2hi+AtIzsMmGYkvmKIZuInJQyq9gv
-        QnN2pqFAOmGVQcy5z7FKgAXl+PfC98vFLHKaVxGzh+HfVNUDtsBEpELy/PGhtvtqw1sjP0fv2jll
-        NpWwPl2VVLbbkDzydzokN43SK8HXCK9f3oe9zcvwuMHbzzy+xXazg1ynvLF10HZ0/8nhri1sagaN
-        hF2jIGFB1a1ypU8bb27yCvqpRs7aNEWKHaom2aoosSGW9nnQ72yjhZ01LXwr4w/D+Ul+/b/PUq2q
-        khrFIyETpDXDsFbYDYBkZWUySGqUHk/26XsDTMg5GSCYJQx/CjB8zSCJSFkWuuwdqfsk39TfNxG7
-        XKsVMmIS42UFt0pHvrvjDu4p6BjzXMU8z5Sx0cgf+d6skbmufUNYvL1CaXZ5DnFFHMXeq0Xfqi3C
-        +GgnFT7a4RXz2GVgLPuj4tqCZmOZYmUWGOctorA+4AW19OnZb2y/Qg5g5zGXW6SoBfSCYHjVhPT+
-        np1j91o7iuODi3H9+dh8ukzTpG0CaDgVFvmARGtk4QgVMaJMds8uUUc/RA7A4huEQe0GIVXOE1di
-        w++mau7Nq1widi1yi/fw/BWpGPj+Wi5egFsIq8FVOvWwwDmBXmA3S8Tg4VE3s0VOcpuE4aROGSkL
-        8W8CaZVzDOqSfsTV9zgEKXhOWPobAAD//+xZbW/aMBD+K9akVoBIGkrCW1V1qKxSpVFNq7YP3ReM
-        40AmIFFCqCbtx+85xwmQEuioWnXSBAJi++zz+e4538O9jFao1ZjBKnf5DHV2OlteXGKalmlVS4yp
-        jx5KtGj9PnL/StbJVOoCzXbZpYV9Os3us+2ixyu72M+3i33QLq9uE6fMJoi4zOl6NWUfamO1QSLZ
-        AKGKxhs5Nlm3zgjI2TYKZK9pw8xhQD03zTc7bOxgoJAXoPgzYJSToPRBOVbBR3XX9vdtntUQj2j+
-        gS/jqNDAivAmNcXLgnP7BGr3QRLBljf+TAI9ZWrv08nyggshw6X6uXa+DcHBGuVrQONcjQDwr3HT
-        9IMz7q78GJlCUrptIwF4ZHM4UXYvoBMdrVcYMdxgGOmPylzfWSLtDVo78gY394ZYewNfLpGA4zp7
-        nPpiynCNn0yAwQngj4Ucay0mjDPUNAKCuBWJiHukx6ivNmp85otJAjQesankLiRXHCnUTHfLvq8V
-        GgLuZ3Izt2z3Z6VWb9MjMeSLuuO7WT+6J1l3Y3sGjJxCHI3wcRXsvcMHQ4jfow/yLzzStmLMEibj
-        mS/0oQ19lUn1mX1Tly2ysD6MVBkGkJmhI9Kbh9ztPORiSTJ3AfPVA0PeW/mudLfc6StCCjdQLP03
-        TqFFw4DSJvl4hbtzf1FllervOXx4GfRyv92JGa+OF86ReOEQXjgvw4ujUsYTvDg2aW0e71vjRes/
-        XrwBXtj/Fl60ctEDePGU73Dykr9Y7pZVPA17s+JZRnAZRcUQNVQcmlNihQ47J6cKHVaZhJWzDpkV
-        ygaWsRBWGVNm5cqoAJhS8aFL8c1qvljTxcl8zql8/bC3viKTExcVREcWusRIXMFjif+6dS8dt9lp
-        d8aNtiWbomuJrnPudRteC+vkg7DCnmGS/KHvuhQNGCkC99fHDUVQCdNce9lxdQbSRDGthpFMxtDa
-        0mp0uNuw7VZbdNrAy7EYty0s73HpdcSVe6lmOWn2T85v8E7ljDlf6MLPMNKm2Exi4xGGMM5NqijN
-        NA7JUkbIeUyGgrxCej6L8fN6aFhmuCDCoci0v3+Ni1T9+9e4SPW/d40BUG7KWmtG6Bquz4bc8xIh
-        fBVAVNalrHIKbw/BggZ+SqIglGcPAB5BDKqONPqrCb156NIK+g+23TSSXQaqdhm7bOfscqTB/Zkw
-        8gcAAP//Gi1GKE8wg7EYAQAAAP//IuTi0WKE1i6mSzGCXgzgaqaZwFtj8MYK0DvpkExZDZoTh7IN
-        gC7JL0mEzuijm4Kz2YWzXMI1C2RghL3kw9ksw+kznO01uJfRJIxx6TCGt/BS88oyi/LzIE08iFBK
-        KXQ5CYRLTOiV5ZdQb6ITYhjcUKBNGYnFYfngKR/Y3CowC0CcXA1jQusXsh0AXnqjDzNXRyk3sSIo
-        tbg0B2QwkmfBkzVFJY4lEI+DJo1BEzogr8PFUTUboeiGagC7tra2FgAAAP//AwBNQPkDvSQAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18249","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18249","key":"NTEST-1877","fields":{"statuscategorychangedate":"2025-04-30T18:27:41.112+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1877/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:40.779+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t7j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:40.868+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/19]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/114]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/306]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/305]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/306]\n*Defect Dojo link:* http://localhost:8080/finding/306
+        (306)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/305]\n*Defect
+        Dojo link:* http://localhost:8080/finding/305 (305)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1877/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18249/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - cc7363f5-fc14-44c9-b8b6-4eae7c1e1178
+      - 48eec609-0952-4ecc-889b-d6bb1787740e
       Atl-Traceid:
-      - cc7363f5fc1444c9b8b64eae7c1e1178
+      - 48eec60909524ecc889bd6bb1787740e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:21 GMT
+      - Wed, 30 Apr 2025 16:27:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -336,7 +346,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=277,atl-edge-internal;dur=13,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=312,atl-edge;dur=279,atl-edge-internal;dur=16,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="obgnaWbQq2z4NLJsfNGBeCyDVf-zV-wZDhBgrE4E38JU7rSoO4w6nQ==",cdn-downstream-fbl;dur=316
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -345,10 +355,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8139bc666c011a53bdc5037ba6d5931e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - obgnaWbQq2z4NLJsfNGBeCyDVf-zV-wZDhBgrE4E38JU7rSoO4w6nQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 11c6f5103c3264b6db05400b4eaeb197
+      - 08b8a9b9e4d1a6407596bd021d72edf7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,66 +390,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16121
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18249
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIv+VA40+m4tpK4dV1XVpIHx+OByRWJmARYANTR2P+9u7wU
-        H0prdxr7gbj2wO63H1ZfHFiVXCZO5GiQCWhI3gjIEzOQvAAzMHEGBR+oEjS3QkkzgETYAiwfxBmX
-        KeQqHSxAG9yDZAqlBgPStmfjylhVzEnhVeD7ge9q+LMCY2frEs40j62IwRk4guwHe0EY4MRAPsdp
-        Zm1pIs9LYA6xTdRn5XKbc2MEl64E66El6/FSeKEnjKnA6xTcwBrlT2eT89kw2Bvt41LtgnGiL45B
-        3yoTcwup0uvmDgnOUCL0w92hHwwDfxb6UTCOwsD19/Z/QL99cpKMWHS8VvNCJ0neQ31+2F+7nSRg
-        Yi1KChyuHjBT8DwfsEQYK2RsWSkgBqbmbKn0jUvSsZLvdf5MLyopKF08v+ILbrn2FgKWXu3WxsF2
-        K/BHwfgnI/6CHwtMe1WgVYIFmpxxc0O5qq4tjaI5zw0MnEbwGO9Vyw6cTCBwdJytT2AB6Kt/N3Cs
-        QGSViBInkhXe0XkAk5HfbZRafcYbvTDgrXQd7jqBXbhp8hVINrd6L4W1qMA4vW1C6q/1WaPmdsk1
-        4dWIoswFOpw8uDnmo0bZzni1M36mu9/ITHeTPi87PqE63FmFO/+vlSb7NRbRYLC3Cva+h8FVZ3EU
-        rkbh97DYAvzu7jEcg204DbuNuVh9aDgQs39x+fjkqDvJ01RDinzzj0Ww223gzVReNbzw9NG9bRv7
-        WzbCrRvjbRuvH7vT0GazSqRUvxBONAxwyi0+HA3hPr9wGzrfELjXqNNUlvXwUFUUuIBI+SMtCJk6
-        kdUV3LU8Tdq0iJuofXm0Rp7hUZOpKk+OhClzvm5LGZfRLfsBMUPl3UZDA16W+OPxI+G7+zvj7pF4
-        GLaeyh5ubANV2IOq1EJpYdcvDGIn7tUvzb9/K0TBUzAeSZhOicCFTKSZaxbphi3f4UpHq6HzuHDC
-        HvU5vwYixidKg/jkyUAE2zAajCkiGTeTUsQnQt68oZ0jKKl/kXGXxzq7y3qvX5FKTrB94dc5TIGb
-        Bhu6HTlnJ+/fHp9enRwfTk7PJ1eT6fT3Kd4P69RgSPDALAN2hi+AtIzsMmGYkvmaIZuInJQyq9gv
-        QnN2pqFAOmGVQdS6T7FKgAXl+LfC98vlPHKaVxGzh+HfVNU9tsBEpELy/OGhtvtqw1sjPUfv2jll
-        NpXQn65KKtttSB77ux2Sm0bpheBrhPuX935v8zw8bvD2M49vsN3sINcpb2wdth3df3K4awubmkEj
-        YdcoSFhSdatc6dPGm+u8gmGqkTc2TZFiR6pJtipKbIilfRr0uz0tfCuxD4V6yrgfzk/y6/8DlmpV
-        ldQovhEyQWI0DGuFXQNIVlYmg6RG6fH0gL7XwIRckGWCWcLwpwDD1wySiJRlocvekrpP8lX9fRWx
-        i16tkBGTGC8ruFU68t1dd3RLQceY5yrmeaaMjcb+2PfmjcxV7RvC4vUlSrOLc4gr4ij2Ti2HVm0R
-        xkc7qfDRDi+Zxy4CY9kfFdcWNJvIFCuzwDhvEYX+gBfU0qdnv7GDCjmAncdcbpGiFtALgp3LJqS3
-        t+wcu9faURwffpjUn4/Np8s0TdomgIYzYZEPSLRGFo5QESPKZLfsAnUMQ+QALL5RGNRuEFLlInEl
-        NvxuqhbeosolYtcit3j3z1+SipHv93LxEtxCWA2u0qmHBc4J9AK7WSIGD4+6mS1yktskDCd1ykhZ
-        iH9TSKucY1BX9COuvscRSMFzwtLfAAAA///sWW1v2jAQ/ivWpFaASBpKwltVdaisUqVRTau2D90X
-        jONAJiBRQqgm7cfvOccJkBLoqFp10gQCYvvs8/nuOd/DvYxWqNWYwSp3+Qx1djpbXlximpZpVUuM
-        qY8eSrRo/T7y70rWyVTqAs122aWFfTrN7rPtoscru9jPt4t90C6vbhOnzCaIuMzpejVlH2pjtUEi
-        2QChisYbOTZZt84IyNk2CmSvacPMYUA9N803O2zsYKCQF6D4M2CUk6D0QTlWwUd11/b3bZ7VEI9o
-        /oEv46jQwIrwJjXFy4Jz+wRq90ESwZY3/kwCPWVq79PJ8oILIcOl+rl2vg3BwRrla0DjXI0A8K9x
-        0/SDM+6u/BgpRFK6bSMBeGRzOFF2L6ATHa1XGDHcYBjpj8pc31ki7Q1aO/IGN/eGWHsDXy6RgOM6
-        e5z6YspwlZ5MgMEJ4I+FHGstJowz1DQCgrgViYh7pMeorzZqfOaLSQI0HrGp5C4kVxwp1Ex3y76v
-        FRoC7mdyM7ds92elVm/TIzHki6oS3Kwf3ZOsu7E9A0ZOIY5G+LgK9t7hgyHE79EH+RceaVsxZgmT
-        8cwX+tCGvsqk+sy+qcsWWVgfRqoMA8jM0BHpzUPudh5ysSSZu4D56oEh7618V7pb7vQVIYUbKJb+
-        G6fQomFAaZN8vMLdub+oskr19xw+vAx6ud/uxIxXxwvnSLxwCC+cl+HFUSnjCV4cm7Q2j/et8aL1
-        Hy/eAC/sfwsvWrnoAbx4ync4eclfLHfLiJCGvVkKLSO4jCJziJ4pDs0psUKHVdZh56xVUSJnHTIr
-        lA0sYyGsMqbMytfcqt6LxZ2KjilVJmmFGCfzOafy9cPe+opMTlxUEB1Z6BIjcQWPJQbt1r103Gan
-        3Rk32pZsiq4lus651214LayTD8IKe4ZJ8oe+61I0YKQI3F8fNxRBJUxz7WXH1RlIE8W0GkYyGUNr
-        S6vR4W7Dtltt0WkDL8di3LawvMel1xFX7qWa5aTZPzm/wTuVM+Z8oQs/w0ibYjOJjUcYwjg3qaI0
-        0zgkSxkh5zEZCvIK6fksxs/roWGZ4YIIhyLT/v41LlL171/jItX/3jUGQLkpc6wZoWu4Phtyz0uE
-        8FUAUVmX8tIpvD0ECxr4KYmCUJ49AHgEMag60uivJvTmoUsr6D/YdtNIdhmo2mXssp2zy5EG92fC
-        yB8AAAD//xotRihPMIOxGAEAAAD//yLk4tFihNYupksxgl4M4GqmmcBbY/DGC9A76ZBMWQ2aE4ey
-        DYAuyS9JhM7oo5uCqz1mgKtcMjDCXsDhmhwywOkBnO01uM/QdeBqyBnjlIC38FLzyjKL8vMgrTiI
-        UEopdDkJhEtM6JXll1BvqhRiGNxQoE0ZicVh+eApH9j8JjALQJxcDWNC6xeyHQBeeqMPM1dHKTex
-        Iii1uDQHZDCSZ8GTNUUljiUQj4MmjUETOiCvw8VRNRuh6IZqALu2trYWAAAA//8DAMZkAzy9JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18249","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18249","key":"NTEST-1877","fields":{"statuscategorychangedate":"2025-04-30T18:27:41.112+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1877/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:40.779+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t7j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:40.868+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/19]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/114]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/306]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/305]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/306]\n*Defect Dojo link:* http://localhost:8080/finding/306
+        (306)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/305]\n*Defect
+        Dojo link:* http://localhost:8080/finding/305 (305)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1877/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18249/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 8ffd1ccb-e3f7-4836-8300-1a1390b270c1
+      - 9851bcff-002d-49d8-aaf1-7c35a97c6c44
       Atl-Traceid:
-      - 8ffd1ccbe3f7483683001a1390b270c1
+      - 9851bcff002d49d8aaf17c35a97c6c44
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:21 GMT
+      - Wed, 30 Apr 2025 16:27:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -441,7 +460,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=287,atl-edge-internal;dur=12,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=23,cdn-upstream-fbl;dur=362,atl-edge;dur=266,atl-edge-internal;dur=21,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="pi-juRiGU0V9yuhgRvBY7p-feFuUUmk9ifR1csfYnp5uvpwtQwydRw==",cdn-downstream-fbl;dur=365
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -450,10 +469,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ed78483d37e5338746e5a4b545e5818e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - pi-juRiGU0V9yuhgRvBY7p-feFuUUmk9ifR1csfYnp5uvpwtQwydRw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - dae939744bfb96925deefb3694a1d80a
+      - 653d6f8369b3d73e348a3829dd3fd2ff
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -480,26 +507,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2Tdl+5oSExEAykdhcQQmnqiECaVE06aZr230nEBDsCN8t+
-        Xj+WD6QWHre9IZy8hdB5Ppk0qFCGxr27TAQjvNfCZhYDGZFG+86I/T/4Evudltig/1ij6VZoA/Z/
-        XbJyVpkBrcTfJXfYe+1shCkAzSCDcbm5fCzXD9XPdDO0dawIf07QCEbwEp3YGbdv45XVvku2lXFD
-        E0P1oE3zFSE8Bth8fmpeiZBABmw6BjqGZcUYL3JeRDHABUQ45n38A/aVbs9ZChUDThecsYwu829W
-        tjdWuQgWdLaQAnCKStJ8jqJQqlAgFVvm00WtZgWymQJ2JggmGW51L9ILUYnBhDsnRWofiDlVBO3r
-        tiTH88OenE2T6/uKHD8BAAD//wMAefUGmSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:42.646+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 4466077f-df10-4b30-a11d-3322ce005005
+      - 2eff8508-6ef1-4286-8a3d-d0e026deaea9
       Atl-Traceid:
-      - 4466077fdf104b30a11d3322ce005005
+      - 2eff85086ef142868a3dd0e026deaea9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:22 GMT
+      - Wed, 30 Apr 2025 16:27:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -509,7 +532,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=170,atl-edge-internal;dur=13,atl-edge-upstream;dur=158,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="id--yAbDe91lnYitZtH6HTqj_9DlGheB48sRCToJQ3gA1JF31irYxQ==",cdn-downstream-fbl;dur=247,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=245,atl-edge;dur=167,atl-edge-internal;dur=17,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -518,10 +541,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c4fd63432996b55c90ff4db02c11a616.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - id--yAbDe91lnYitZtH6HTqj_9DlGheB48sRCToJQ3gA1JF31irYxQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - f9e57d89ca6389011419cb4d08b4214d
+      - b5575a54bf9165a972bafdc613f45089
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -548,41 +579,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 9416a231-2fda-41fb-9e20-49e8037c52fa
+      - 09b098a7-8e58-4859-a7d5-ed9369e63b0a
       Atl-Traceid:
-      - 9416a2312fda41fb9e2049e8037c52fa
+      - 09b098a78e584859a7d5ed9369e63b0a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:22 GMT
+      - Wed, 30 Apr 2025 16:27:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -592,7 +610,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=15,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="jdLPkODPw2YOWWu4Vwz8KO0mqjxa0AoUk8-KJsh2CrgxcdA6mZQdXw==",cdn-downstream-fbl;dur=426,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=423,atl-edge;dur=338,atl-edge-internal;dur=17,atl-edge-upstream;dur=321,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -601,13 +619,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 603f7fca6e96da4aaee2b5219f231c92.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - jdLPkODPw2YOWWu4Vwz8KO0mqjxa0AoUk8-KJsh2CrgxcdA6mZQdXw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 33556884ed6fc607aeed670c7414c2b7
+      - 9efb1380b51343144c42ba56c399da3f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -619,7 +645,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/110] in [Security
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/20] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/114]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
@@ -634,13 +660,13 @@ interactions:
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/307] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/309]\n*Defect
       Dojo link:* http://localhost:8080/finding/309 (309)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -649,31 +675,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/307]\n*Defect Dojo link:* http://localhost:8080/finding/307
-      (307)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (307)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -682,25 +706,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
     headers:
       Accept:
@@ -712,7 +734,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7141'
+      - '6804'
       Content-Type:
       - application/json
       User-Agent:
@@ -721,18 +743,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16122","key":"NTEST-1638","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16122"}'
+      string: '{"id":"18251","key":"NTEST-1878","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18251"}'
     headers:
       Atl-Request-Id:
-      - d0697559-cb8d-4550-97ef-320438d487e2
+      - e184f67e-39d3-4f60-9f9a-64881dbd5d8d
       Atl-Traceid:
-      - d0697559cb8d455097ef320438d487e2
+      - e184f67e39d34f609f9a64881dbd5d8d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:23 GMT
+      - Wed, 30 Apr 2025 16:27:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -742,7 +766,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=673,atl-edge-internal;dur=14,atl-edge-upstream;dur=659,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=743,atl-edge;dur=709,atl-edge-internal;dur=17,atl-edge-upstream;dur=692,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="XODfq1_-A9in8WcSh5o2A0VvzoamNc22KeUj7bLFP4zQgOQLeedI9A==",cdn-downstream-fbl;dur=748
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -751,10 +775,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a78d8f4a6ccd81221651cd6112d5330a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - XODfq1_-A9in8WcSh5o2A0VvzoamNc22KeUj7bLFP4zQgOQLeedI9A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a2ce2580ed32d34114a6cca137924a09
+      - 6358a132d750b22fa388d1c15e29de61
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -778,78 +810,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1638
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1878
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWVMbRxD+K1P74Eo50l4SWKzLlSJYtkkIIUK2HzBFDbut1Zjdmc3MrI4Y/nu6
-        95I55ARSMVSxc/Ux3V9/03xxYFVwmTiRo0EmoCF5IyBLTE/yHEzPxHPIeU8VoLkVSpoeJMLmYHkv
-        nnOZQqbS3gK0wT1IJlBoMCBtczYujVX5jBReBL4f+K6GP0swdrou4ETz2IoYnJ4jyH6wG4QhTgxk
-        M5zOrS1M5HkJzCC2ifqsXG4zbozg0pVgPbRkPV4IL/SEMSV4rYIrWKP88XR8Ou0Hu4MRLlUuGCf6
-        4hj0rTQxt5Aqva7vkOAMJUI/3On7QT/wp6EfBaMoHLjhaPgj+u2Tk2TEouOVmic6SfIe6vPJ0fra
-        zSQBE2tRUOBwdZ+ZnGdZjyXCWCFjywoBMTA1Y0ulr1ySjpV8r7NHelFKQeni2QVfcMu1txCw9Cq3
-        Ng42W4E/CEY/GfEXvMox7WWOVgkWaHLKzRXlqry0NIpmPDPQc2rBQ7xXJdtz5gKBo+P5+ggWgL76
-        Nz3HCkRWgShxIlniHZ07MBn42zaCdqPQ6jNe9YmZaKSrPFSZbfNAk6/Qs7nueymsRQXG6WwThH+t
-        zho1s0uuCchG5EUm0OHkTkgwURX8hqPVcPRId7+RsvYmXcKG/gt0IxyuwuH/a6WGRQVSNBjsroLd
-        72Fw1VochKtB+D0sNsi/ubkPx7CF40ysPtQciEk+O79/ctCe5GmqIUW++cci2Gk38AIqK2teePjo
-        7raNF1s2wq0bo20be/fdqWmzXiVSql4IJ+oHOOUWH46acB9fnzWdbwjcq9Vpqr5qeKBKClxApPyR
-        FoRMncjqEm4aniZtWsR11L7cWyPP8KiZqzJLXgtTZHzdVCwuo1v2A0KDqriJhga8LNHE/UcidPfC
-        UftI3A3bNioLOyq7u9GBqtBCaWHXTwxiK+5VL82/fytEzlMwHkmYVonAhblI565ZpBtSfIcrLXuG
-        zv36CDvUZ/wSiP8eKA2ijQcDEWzDaDCiiMy5GRciPhLy6g3tvIaC+hcZt3mssrus9roVqeQY2xd+
-        mcEEuKmxoZuRc3L0/u3h8cXR4cH4+HR8MZ5Mfp/g/bBODYYED0znwE6Q6KVlZJcJw5TM1gxJQ2Sk
-        lFnFfhGasxMNObIGKw2i1n2IPAIsKMe/Fr5fLGXk1K8iZg/Dv6mqW2yBiUiF5NndQ0331YS3QnqG
-        3jVzymwqoTtdFlS2DyN54PpB1+7UjdITwVcLdw/s7d7mcXjc4O1nHl9hu9lCrlVe2zpoOrr/5HDb
-        FtY1g0bCth+QsKTqVpnSx7U3l1kJ/VQjb2yaIsVeqzrZKi+wIZb2YdDvdLTwrcTeFeoo43Y4P8mv
-        f/dZqlVZUKP4RsgEidEwrBV2CSBZUZo5JBVKDyf79L0EJuSCLBPMEob/CjB8zSCJSNk8dNlbUvdJ
-        Pq++zyN21qkVMmJFGu24getfU7Ax1pmKeTZXxkYjf+R7s/rsReWTFwT+OUqxs1OIS+Im9k4t+1Zt
-        EcY3OSnxTQ7PmcfOAmPZHyXXFjQbyxQrMsf4bhGF7oAXVNLHJ7+x/RJrn53GXG6Rog4PnRye16G8
-        vman2LVWjuL44MO4+nysP22GadI8/jScCos8QKIVonCEihhRJbtmZ6ijH2Lt47Pmj8LKDUKoXCSu
-        xEbfTdXCW5SZRMxa5BTv9vlzUrE37MTiJbi5sBpcpVMP65oT1gX2qsQH3t7Qnds8I6kixT9VokhF
-        iD8TyJUFvEYCbLzCfJAM67MfTtIee5bZlyx0g8ANGXuW2pev/gYAAP//7Fhtb9s4DP4rBAoMji9V
-        rnmp0Qz9ULQ74IDbMKzbvlwOiOuoizfHTi2767Dtv++hJMtyE29Yt/vWtkgdUpSohxT5yITaAGOt
-        mIhjMaVGMW0VUzETUSOftfKZwFyN/LiV8+OslbN3Vn4kjlv5uJWP/fGTVj4Rk1Y+beXTdgNRuy4/
-        enK3Lj+OBz3JYVN5NPnzhBE9A4+4lUMOveb7tC/O0U/G2Y7/XXF+jPGDYxz1xRiVsCkK81DHm2UU
-        XtSSLlBCIfxLXgk6GRI3WOpW5+Z3fSRcedbfJ+LxWP5iyE5QtsML3evRht8XxCwI4fihHQX4GOwL
-        7PfCSiE6AcT/4t/hAw4r1sOp1xP8WlPoZlZ4WdRlIpFdmQy5Px+ijW5SJRnW7Ttv4EXLIkJ0e7cs
-        Uk/Z/izSYhSvblMFioIrwGw8BsG4ZoRxGBreyVRjuX23JHA6+JdTTKXJ4oSzWLos5j3IMr5KM+6o
-        1TquqEiwkKKPa5CTCuzaGjJqV7GSVJR0g4vbJ8JVOeEzqDB7UsbX7ADYWL3JicmX0OcM/LyUBIJO
-        1ceiMUlIJTKPcZFhxoKl0mRN4AEg71n6QYK+X2OVGG5vt1ma6DeXlhk1DmcS+ODEMv/3R5mtwac6
-        V/E1CgXT/UNV8xD4p24yu5xFRtEmhnFagBd4ziuxyMe7s8MoB9KKnYF7uPGWIISY16HDZM35EFuk
-        SlnVZY7UxpOqs4rR9XzAuL1OCAbw4AA3lwLxxN95kSdyWy3y5XK5yPk2WNFnOsfOwHm+0inxq9y0
-        lMGTg7txhNQy/wfN2MSMPCVQZ2sWsFI/Cbs5ljQGDNcpLS+f/fPs/DUd0dklPbmpi+rpAj9m8lFo
-        JDiE+9ThaIFz+QdvVRWZFLgsBMj+BBc4IfPbwX/sDRg0TPLRyFgvtQPGKQ1gAD+GFMiyHDKCAzrl
-        k0OfMbPdE+ZaseNfBxYceusShZ6DsyJfiI+aL2/eD807VRw8saeOQ9NXyZ3RTi13mp1q7mnu1XNP
-        c6+ie5p7Nd3T3KvqTrNT1z1Nt7IDp5f6/c6qAWluR1qQLCqYz4OLMbKY8EI+XIyRBcWqGrgYIweK
-        p2k6XoNKR8UgOVQ6GgbJodLRMEgOlY6GQXKoeBoDkkOlozEgeckEvNbIJE7JQ0P35ruFnm8qc/5A
-        d8K3s4TPARKzvsLxtz3geaovfrYFhO4iMxZ34m5Ob/TLAi5Attg3IUHFzKAphW806TMy0dprM+2z
-        MWHcazPrszEB3mtz3GdjIuJsKKAX3IF0d3IdTifB0ER8qMuuCTG3mjhTBW1NAgtiGuEWjfoW1SH9
-        /qI2IdCldhawsft7s42TiuP2oqBUfyGkwG26kqu2zWPgK3CiUqKaq5/p89Z0W/CNm2lKEK82aT6g
-        YPBlAxpSFXNHPfbS2Ucq6x1gv+D9mMpGD6SyEVPZ6P+gst8AAAD//yKtKUtuvxc52dK6KWs42pQF
-        qgIAAAD//+yaTWrDMBCFr1IKWcqVYzm2FyENpYUucoHslJHdluLY+IeS23fGckSsRikUCl4IsjDR
-        KCMG6/HC+7yV9VbWW9mrqj6xZhNdn1izS2X3VvY8L29lvZWdh5UNzdZfrOzP9D42AbYd3rpi/VBc
-        BntdI+FzQBMINrBLDeBhLXDXgjAMhr3DZOjnKbgKXZk6d3Ef3PScZNF2VCm7TsI75W0672z7spQU
-        xt5fTQtp1ERUVM0f41pyJxsJQBzIq1rHKkqT9BAmPI8g45DFyyILixX2MUXY4UZZTu/BVins0WIl
-        2r3T48VBoCL27TbKNcw+D94aXUZ7zjiRyHmYShUKsUogTeIoO8Ah4di+kHmRwkath19ZRNvF8gU/
-        eh8r5XGMMRnTX7VB37IvHARbBpSPBloDaVKslrKlQeH+waPjbcPHpx3jQX2k2NzGwuZ/Ypsrm/+J
-        bS5t7idGYVKafxq5Bvy/frrbyaLoAT6GC0QhmKartKztqyMVPvdNVecPexQcIA5ovGnEReKqubrU
-        YcREr8MQwiWmwsVICcNINaOoexn5pxfmGwAA///CTDCjxQg9XDxajGApRtCLAVzNMxN4KwzeaAF6
-        Jx2SKatBC7ihbAOgS/JLEqHr0tFNwdUOM8BVLhkYYS/gcC1xNMDpAZztNLjP0HXgasAZ45SAt+xS
-        88oyi/LzIK03iFBKKXRTBIRLTOiVAZv95C4XxFjwCzEMbijQpozE4rB88MJF2CpdYBaAOLkaxoTW
-        L2Q7ALyBRB9mro5SbmJFEGTgCcWz4CWHRSWOJRCPg5Y+g5YlgrwOF0fVbISiG6oB7Nra2loAAAAA
-        //8DAOQvWW6DMwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18251","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18251","key":"NTEST-1878","fields":{"statuscategorychangedate":"2025-04-30T18:27:43.985+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1878/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:43.679+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t7r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:43.808+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/20]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/114]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/309] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/307] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/309]\n*Defect
+        Dojo link:* http://localhost:8080/finding/309 (309)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/307]\n*Defect Dojo link:*
+        http://localhost:8080/finding/307 (307)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1878/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18251/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 8c713252-fec7-4707-9cb5-eeafc69aef68
+      - 5a292f05-f8cf-45ed-8bdf-fc6e13f95e84
       Atl-Traceid:
-      - 8c713252fec747079cb5eeafc69aef68
+      - 5a292f05f8cf45ed8bdffc6e13f95e84
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:23 GMT
+      - Wed, 30 Apr 2025 16:27:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -859,7 +926,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=329,atl-edge-internal;dur=19,atl-edge-upstream;dur=309,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=313,atl-edge;dur=280,atl-edge-internal;dur=15,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Af98SSyZgcPXljGD_WCXltE2HL1S89VcF3Bp6gfDADcV_HkoFeKB9g==",cdn-downstream-fbl;dur=317
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -868,10 +935,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Af98SSyZgcPXljGD_WCXltE2HL1S89VcF3Bp6gfDADcV_HkoFeKB9g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3e46d57d74667d25abb92017e6496fc2
+      - b2af81dda0c0b05357632f11dc8be033
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -895,78 +970,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16122
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18251
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61PbRhD/V270IdNJbb1siFEm06HESWgppcZJPhCGOaS1dEG6U+9OfhTyv3dX
-        Dzs8nBY6Dcwg6e72cbu//e1y7cCy5DJxIkeDTEBD8kZAnpie5AWYnokzKHhPlaC5FUqaHiTCFmB5
-        L864TCFXaW8O2uAeJBMoNRiQtj0bV8aqYkYKLwLfD3xXw58VGDtdlXCieWxFDE7PEWQ/2A3CED8M
-        5DP8zKwtTeR5Ccwgton6rFxuc26M4NKVYD20ZD1eCi/0hDEVeJ2CK1ih/PF0fDrtB7uDES7VLhgn
-        unYM+laZmFtIlV41d0jwCyVCP9zp+0E/8KehHwWjKBy44Wj4I/rtk5NkxKLjtZonOknyHurzydHm
-        2u1HAibWoqTA4eo+MwXP8x5LhLFCxpaVAmJgasYWSl+5JB0r+V7nj/SikoLSxfMLPueWa28uYOHV
-        bm0cbLcCfxCMfjLiL3hVYNqrAq0SLNDklJsrylV1aektmvHcQM9pBA/xXrVsz8kEAkfH2eoI5oC+
-        +l96jhWIrBJR4kSywjs6d2Ay8LuNUqvPeKMnBryVrsNdJ7ALN318BZLNrd5LYS0qMM7aNiH11/qs
-        UTO74JrwakRR5gIdTu7cHPNRo2w4Wg5Hj3T3G5npbrLOy9B/gW6Ew2U4/H+tNNmvsYgGg91lsPs9
-        DC47i4NwOQi/h8UW4F++3IdjsA2nYbcxE8sPDQdi9s/O758cdCd5mmpIkW/+sQh2ug28mcqrhhce
-        Prq7bePFlo1w68Zo28befXca2mxWiZTqDuFE/aDlSkqJFnHj+fW9NSoUjLbJVJUnr4Upc75qywmX
-        F9xi62ko+/Gl3zSETQvwGnWaCrt+PVAVhb529SMtCJk6kdUV2Ual9gNihsq7jYYGvCzxx/0mEbp7
-        4ahrEnfDtqayuxvbQBWuQVVqobSwqyeGoBP36k7z73uFKHgKxiMJ0ykRuJCJNHPNPN2w5Ttc6Wg1
-        dO4XTrhGfc4vgYjxgdIgPnkwEME2jAYjikjGzbgU8ZGQV29o5zWUNL/IuMNQjaxFvbdekUqOcXzh
-        lzlMgJsGl7p9c06O3r89PL44OjwYH5+OL8aTye8TvB/WqcGQ4IFpBuwEO4C0jOwyYZiS+Yohm4ic
-        lDKr2C9Cc3aioUA6YZVBzLkPsUqABeX4N8L3y4WMnKYrYvYw/JuqusUWmIhUSJ7fPdROX214a+Tn
-        6F37TZlNJaxPVyWV7cNIHrh+sB53mkHpieBrhNed9/Zs8zg8bvD2M4+vcNzsINcpb2wdtBPdf3K4
-        GwubmkEjYTcoSFhQdatc6ePGm8u8gn6qkbM2Q5Fir1WTbFWUOBBL+zDod7bRws6aFr6V8dvh/CS/
-        /t1nqVZVSYPiGyETpDXDsFbYJYBkZWUySGqUHk726XkJTMg5GSCYJQz/FWDYzSCJSFkWuuwtqfsk
-        n9fP5xE7W6sVMmJlGu24gevfULAx1rmKeZ4pY6ORP/K9WXP2ovbJCwL/HKXY2SnEFXETe6cWfau2
-        CGOzTips1uE589hZYCz7o+LagmZjmWJFFhjfLaKwPuAFtfTxyW9sv8LaZ6cxl1ukaPRDJ4fnTShv
-        btgpTq21o/h+8GFcPz42jy7D9NE2f3qdCos8QKI1ovANFTGiSnbDzlBHP8Tax6bkj8LaDUKonCeu
-        xEHfTdXcm1e5RMxa5BTv9vlzUrE3XIvFC3ALYTW4Sqce1jUnrAscYokPvL2hm9kiJ6kyxT91okhF
-        iD8TKJQFvEYCbLzEfJAM67MfTtIee5bblyx0g8ANGXuW2pev/gYAAP//7Fhtb9s4DP4rBAoMji9V
-        rnmp0Qz9ULQ74IDbMKzbvlwOiOuoizfHTi2767Dtv++hJMtyE29Yt/vWtkgdUpSohxT5yITaAGOt
-        mIhjMaVGMW0VUzETUSOftfKZwFyN/LiV8+OslbN3Vn4kjlv5uJWP/fGTVj4Rk1Y+beXTdgNRuy4/
-        enK3Lj+OBz3JYVN5NPnzhBE9A4e5lUMOvb4I0L44Rz8ZZzv+d8X5McYPjnHUF2NUwqYozEMdb5ZR
-        eFFLukAJhfAveSXoZEjcYKlbnZvf9ZFw5Vl/n4jHY/mLITtB2Q4vdK9HG35fELMghOOHdhTgY7Av
-        sN8LK4XoBBD/i3+HDzisWA+nXk/wa02hm1nhZVGXiUR2ZTLk/nyINrpJlWRYt++8gRctiwjR7d2y
-        SD1l+7NIi1G8uk0VmAiuALPxGATjmhHGYWh4J1ON5fbdksDp4F9OMZUmixPOYumymPcgy/gqzbij
-        Vuu4oiLBQoo+rkFOKrBra8ioXcVKUlHSDS6NnwhX5YTPoMLsSRlfswNgY/UmJyZfQp8z8PNSEgg6
-        VR+LxiQhlcg8xkWGGQuWSpM1gQeAvGfpBwn6fo1VYri93WZpot9cWmbUOJxJ4IMTy/zfH2W2Bp/q
-        XMXXKBRM9w9VzUPgn7rJ7HIWGUWbGMZpAV7gOa/EIh/vzg6jHEgrdgbu4b5agixiXocOkzXnQ2yR
-        KmVVlzlSG0+qzipG1/MB4/Y6IRjAgwPcXArEE3/nRZ7IbbXIl8vlIufbYEWf6Rw7A+f5SqfEr3LT
-        UgZPDu7GEVLL/B80YxMz8pRAna1ZwEr9JOzmWNIYMFyntLx89s+z89d0RGeX9OSmLqqnC/yYyUeh
-        keAQ7lOHowXO5R+8VVVkUuCyECD7E1zghMxvB/+xN2DQMMlHI2O91A4YpzSAAfwYUiDLcsgIDuiU
-        Tw59xsx2T5hrxY5/HVhw6K1LFHoOzop8IT5qvrx5PzTvVHHwxJ46Dk1fJXdGO7XcaXaquae5V889
-        zb2K7mnu1XRPc6+qO81OXfc03coOnF7qtzOrBqS5HWlBsqhgPg8uxshiwgv5cDFGFhSrauBijBwo
-        nqbpeA0qHRWD5FDpaBgkh0pHwyA5VDoaBsmh4mkMSA6VjsaA5CUT8FojkzglDw3dm+8Wer6pzPkD
-        3QnfzhI+B0jM+grH3/aA56m++NkWELqLzFjcibs5vdEvC7gA2WLfhAQVM4OmFL7RpM/IRGuvzbTP
-        xoRxr82sz8YEeK/NcZ+NiYizoYBecAfS3cl1OJ0EQxPxoS67JsTcauJMFbQ1CSyIaYRbNOpbVIf0
-        +4vahECX2lnAxu7vzTZOKo7bi4JS/YWQArfpSq7aNo+Br8CJSolqrn6mz1vTbcE3bqYpQbzapPmA
-        gsGXDWhIVcwd9dhLZx+prHeA/YL3YyobPZDKRkxlo/+Dyn4DAAD//yKtKUtuvxc52dK6KWs42pQF
-        qgIAAAD//+yaz2rDMAzGX2UMenTmNE6THEpXxgY79AV6c+VkGyNNyB9G335SnJrUqzsYDHIw9BBq
-        qRIiFl/5fl7KeinrpezVrX4hzS72+oU0m252L2XP8/JS1kvZeUjZ0KT+ImV/uvexMbBt89bl34Vi
-        6t91jYTPASwg0MEONYCHdSAMamEdcFcGNx76eQquQJenzl3cBzfNyK6T8E6W2mgsT71p26Fs+7KU
-        ZMbeX3ULadREVFTNH+1aUicbCUAUx6taxypKk/QQJjyPIOOQxcsiC4sV1jFBWOFGWE7vwVYprNFi
-        JMq90+OkEaiIfbvNeA2zz4O3RodRzpkzEjkPU6lCIVYJpEkcZQc4JBzLFzIvUtio9fAri2i7WL7g
-        R+exUh5HG5Mx/VUb9C37wkGwZUD+aKB3IE2K1VK2NCjMHzQ63jZ8fNoxHtRHss1tXmz+HdvA2fw7
-        toG1uXeMi0lp9mrkGvD/+uluJ4uiB/gYLhCZYJqN0mttXx0p8Llvqjp/2OPCAeKAxptGwCSemqtL
-        FUZM9DoMIVzLVLgYKWEYqWZc6n6N/NML8w0AAP//wkwwo8UIPVw8WoxgKUbQiwFczTMTeCsM3kgB
-        eicdkimrQSu7oWwDoEvySxKh69LRTcHZ3MJZLuFay2hghL3kw9kcw+kznO00uJfRJIxx6TCGt+xS
-        88oyi/LzIE07iFBKKXRTBIRLTOiVAZv95C4XxFiuCzEMbijQpozE4rB88MJF2AphYBaAOLkaxoTW
-        L2Q7ALyBRB9mro5SbmJFEGTgCcWz4CWHRSWOJRCPg5Y+g5YlgrwOF0fVbISiG6oB7Nra2loAAAAA
-        //8DAFJG3X+DMwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18251","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18251","key":"NTEST-1878","fields":{"statuscategorychangedate":"2025-04-30T18:27:43.985+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1878/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:43.679+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t7r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:43.808+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/20]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/114]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/309] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/307] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/309]\n*Defect
+        Dojo link:* http://localhost:8080/finding/309 (309)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/307]\n*Defect Dojo link:*
+        http://localhost:8080/finding/307 (307)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1878/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18251/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 07895630-4e75-4b62-b273-8b6c40eb852f
+      - 545565c1-3209-48e4-92ff-6ed501fe3de0
       Atl-Traceid:
-      - 078956304e754b62b2738b6c40eb852f
+      - 545565c1320948e492ff6ed501fe3de0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:24 GMT
+      - Wed, 30 Apr 2025 16:27:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -976,7 +1086,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=293,atl-edge-internal;dur=15,atl-edge-upstream;dur=279,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="RxVF8tHAoXsQP8qQVU_cXsYayQY0Yt9oGpGb9JDcLTv_cnepZF2mwA==",cdn-downstream-fbl;dur=389,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=387,atl-edge;dur=301,atl-edge-internal;dur=18,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -985,10 +1095,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f82a4020c8fc9b14a403737c65661074.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - RxVF8tHAoXsQP8qQVU_cXsYayQY0Yt9oGpGb9JDcLTv_cnepZF2mwA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - c79bd829017e0aa1b6b37c9e7c93bfd4
+      - bc5e0d5d7467b2b8b29f46c91b1d2d38
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1015,26 +1133,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrmm1d3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDptUKEMjXt3qQhGeK+FTS0GMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCGcAWQopJOXm8rFcP1Q/083Q1rEi/HmEJjCBl+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0XxHCY4AuFqfmlQgjSIHOEsgSWFaUcpZzFsUAFxDhmPfxD9hXuj1nM6go8KzglKV5sfxm
-        ZXtjlYsgy+aFFIAzVDLLFyiYUkyBVHSZz4pazRnSuQJ6JghmNNzqXowvRCUGE+6cFGP7QMypImhf
-        tyU5nh/25Ow4ub6vyPETAAD//wMAVeNrHSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:45.538+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 6b84d82b-cd51-4eed-beba-5a1e42e8fae6
+      - 8b47a52d-2a03-4feb-9a48-f9b46a0a2c10
       Atl-Traceid:
-      - 6b84d82bcd514eedbeba5a1e42e8fae6
+      - 8b47a52d2a034feb9a48f9b46a0a2c10
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:24 GMT
+      - Wed, 30 Apr 2025 16:27:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1044,7 +1158,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=14,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=188,atl-edge;dur=154,atl-edge-internal;dur=16,atl-edge-upstream;dur=140,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="qqoTjaWIR-SJxObpq-93g685GesKJLWayrGC5b_SCIdIqGFg9Dim3w==",cdn-downstream-fbl;dur=192
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1053,10 +1167,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qqoTjaWIR-SJxObpq-93g685GesKJLWayrGC5b_SCIdIqGFg9Dim3w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 6cbf4d2d4fd8f398ecc4c972b7aa24d7
+      - 805763e00b0d71c4efc67fb17392c8d6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1083,41 +1205,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - a39c57d9-dfc4-424c-939f-b3bfbf0c8a61
+      - f23aad1f-a8cb-48ab-9132-472db66de853
       Atl-Traceid:
-      - a39c57d9dfc4424c939fb3bfbf0c8a61
+      - f23aad1fa8cb48ab9132472db66de853
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:24 GMT
+      - Wed, 30 Apr 2025 16:27:46 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1127,7 +1236,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=312,atl-edge-internal;dur=16,atl-edge-upstream;dur=299,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=302,atl-edge;dur=269,atl-edge-internal;dur=14,atl-edge-upstream;dur=256,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="fb-sU3oHIvB8IC2HHhLHkbncSm0kgzXYxip4MHBmTaqtbiuQUzzkAw==",cdn-downstream-fbl;dur=306
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1136,13 +1245,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - fb-sU3oHIvB8IC2HHhLHkbncSm0kgzXYxip4MHBmTaqtbiuQUzzkAw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 8b99d84cd60b409ea52e95eb315c6361
+      - f651c21f2d6f16911fcd342d8d81ce3c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1154,22 +1271,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/111] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/21] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/114]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/308]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/308]\n*Defect
       Dojo link:* http://localhost:8080/finding/308 (308)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -1183,7 +1299,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1973'
+      - '1945'
       Content-Type:
       - application/json
       User-Agent:
@@ -1192,18 +1308,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16123","key":"NTEST-1639","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16123"}'
+      string: '{"id":"18253","key":"NTEST-1879","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18253"}'
     headers:
       Atl-Request-Id:
-      - 4107a348-0a0f-4c98-8231-37f29e407fd4
+      - 0d94027a-ead9-4c4a-b69a-1b6aa251fcf1
       Atl-Traceid:
-      - 4107a3480a0f4c98823137f29e407fd4
+      - 0d94027aead94c4ab69a1b6aa251fcf1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:25 GMT
+      - Wed, 30 Apr 2025 16:27:46 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1213,7 +1331,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=739,atl-edge-internal;dur=15,atl-edge-upstream;dur=724,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=748,atl-edge;dur=716,atl-edge-internal;dur=14,atl-edge-upstream;dur=702,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="nWsH_t3p5vK8uCJ0jDHv35Wqmoqk9QIWUTT5bkOUj1v0j1qar1UD_w==",cdn-downstream-fbl;dur=754
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1222,10 +1340,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - nWsH_t3p5vK8uCJ0jDHv35Wqmoqk9QIWUTT5bkOUj1v0j1qar1UD_w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 50a1d473a4b3fef4fa1b8c4708125409
+      - cb3a421346b1546cbf9b0466fb3d9560
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1249,65 +1375,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1639
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1879
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX23LbNhD9FQyfOqnEm2RH5kyn49py4tR1XVlJHhyPByZXJGISYAFQl8b+9+6S
-        ohRfmNbuNKMHkgD2gt2zZ1dfHFiWXCZO5GiQCWhIjgTkielJXoDpmTiDgvdUCZpboaTpQSJsAZb3
-        4ozLFHKV9uagDe5BMoFSgwFp12fjylhVzEjhVeD7ge9q+LMCY6erEs40j62Iwek5guwHu0E4wA8D
-        +Qw/M2tLE3leAjOIbaI+K5fbnBsjuHQlWA8tWY+Xwgs9YUwFXqvgBlYofzodn0/7we5gD5dqF4wT
-        fXEM+laZmFtIlV41d0jwCyVCP9zp+0E/8KehHwWjKNxxd0aDH9Fvn5wkIxYdr9W80EmS91CfH26u
-        vf5IwMRalBQ4XN1npuB53mOJMFbI2LJSQAxMzdhC6RuXpGMl3+v8mV5UUlC6eH7F59xy7c0FLLza
-        ra2D663AHwSjn434C34qMO1VgVYJFmhyys0N5aq6tvQWzXhuoOc0gsd4r1q252QCgaPjbHUCc0Bf
-        /bueYwUiq0SUOJGs8I7OA5gM/Haj1Ooz3uiFAV9L1+GuE9iGmz6+Asn2Vu+lsBYVGGdjm5D6a33W
-        qJldcE14NaIoc4EOJw9ujvmoUTYcLYejZ7r7jcy0N9nkZei/RjfC4TIc/r9WmuzXWESDwe4y2P0e
-        BpetxUG4HITfw+Ia4Hd3j+EYdOE07NoYtBszsfzQkCPC4uISYZKmGlLkm38sgp12A2+m8qrhhaeP
-        7nZtvO7YCDs3Rl0be4/daWizWSVSqjuEE/UD/OQWG0dDuM8v3IbOtwTuNeo0lWX9eqAqClxApPyR
-        FoRMncjqCu7WPE3atIibqH15tEae4VGTqSpPDoUpc75alzIuo1v2A2KGynsdDQ14WeKPp5pEOPTb
-        JvEwbBsqe7jRBapwA6pSC6WFXb0wiK24V3eaf98rRMFTMB5JmFaJwIVMpJlr5umWLd/iSkurofO4
-        cMJNGeT8GogYqQIezgRd4A26MBqMKCIZN+NSxCdC3hzRziGUNL/IuM1jnd1FvbdZkUqOcXzh1zlM
-        gJsGG3r95pydvH9zfHp1cnwwPj0fX40nk98neD+sU4MhwQPTDNgZdgBpGdllwjAl8xVDNhE5KWVW
-        sXdCc3amoUA6YZVB1LpPsUqABeX4t8L3y8U8cpquiNnD8G+r6h5bYCJSIXn+8NB6+lqHt0Z6jt61
-        hIOZTSVsTlcllW0XkgfBXovkZlB6Ifga4U3nvT/bPA+PW7z9wuMbHDdbyLXKG1sH64nuPzncjoVN
-        zaCRsB0UJCyoulWu9GnjzXVeQT/VyBvboUixQ9UkWxUlDsTSPg36nS5a2NnQwrcyfj+cn+TXv32W
-        alWVNCgeCZkgMRqGtcKuASQrK5NBUqP0eLJPz2tgQs7JAMEsYfhXgGHTgiQiZVnosjek7pN8VT9f
-        Rexio1bIiM0whlnkuwPXv6V4Y7hzFfM8U8ZGI3/ke7Pm+FXtlhcEwSUKsotziCuiJ/ZWLfpWdQhj
-        v04q7NfhJfPYRWAs+6Pi2oJmY5liURYY4g5R2Bzwglr69Ow3tl9h+bPzmMsOKZr+0MnhZRPN21t2
-        joNr7Si+H3wY14+PzaNNMn2s2zy9ToVFKiDRGlT4hooYsSW7ZReoox8iu2FnC4K92g0CqZwnrsRZ
-        303V3JtXuUTYWqQV7/75S1Ix9Jtgk1y8ALcQVoOrdOphbXPCu8BBljjBw6NuZouc5Opc4bPOFumZ
-        QFrlHGO5pL9ttfuHIAXPCT3noOf474z12Q9HGv4GAAD//+xZ207bQBD9lVUlEIli48QOuSBEIygS
-        D6mqVu0DfWGzuyaukjjyJaiCj++Z9WZJTJa2VEU8oESJvbM3z8yeOTPOpy22PyuOMRjxruHQnrH1
-        YRj0acERYu1KtUg3miyze9Jpc63RYVMrhdpY87xU7BwuiMYLNfHZoMUIoNi2d68/07Zv3Vvfh/5/
-        fhzs+1zjCI74j5QRwmKrvx3HDvDT2PXQTz0ya8LF0Pwdf96zrI0V4Th6in/zt229N7+kZQYtXiQz
-        BSxQlab3b4pj7VwbHc8fMKoJLLHLpgAvc/T9JD3kcpXkwDkQjG7nCPAVk47hKuuoRra71pNfM4Re
-        RltFSmmCbWZMbjZCJpfW5Lkx+e2UoI9jvsUNA+cWkCNqi4zHtBLFaEDSsix8aP7bw/xjYM9MGYzb
-        Fq1J/XDDi9Djk+apci2GFJo5seKNCdBzitFohEfqAzmsK7O10ZCD2zgE2Up5FL0S8bhjJY35iuLt
-        hpUIwYb0Q86F25EQmG+I+DCZJcJYcJzooGAM+FXzBtK5sUz1VCzN2AyCzLeWv5wvuShozMeUJfqG
-        AcdXiVRyy5c+4zyBTGHpv/EQM3SZUhggBz/gcp4sGuygcT+HAxfpEE77mIp3LRutMzFXMG5HLoHN
-        zShKFxl4iU5AKKWodY1s3lQTBHaOusBFiANLiNfqcXV0JXGB3cwWsazTC14UXEwpclbkJS/nc07M
-        6p0r9JO2KUNKs2fSLzqDp1wIyusu5UlXhv1ef9LuBSoUg0AMup140I6PsI7thBWe6KbIFUZS0jlB
-        T5HKn+83NgJ+RnM9WbPRWlY+KJ7uRmPWdYNIIQvhsh1FRz3R73XDwURMegGWj7mK++JUnuhZ9sLR
-        XucC32qcN+cLw0k8r2rK/TL3bqEIr+MT2fGrI0ia8pac56QojNcIjxwGl2djL/CXC6LB9frP699x
-        vYD0+ndcL0C99h0DgmRVzzB5yhlcn415HJdCJPoAESmrqiUVgF2BxKLjhzJLl+rwCtAiKK83J40K
-        oJDao0srmLLv7uQmcuFp5Kp5RK5CWmQxOzOA/4YvL+ZJb/jyEjt+w5cd+FKHAUvELG/Brm+qs3dH
-        b2rMdYAF04Kb90z1WZyMy4lLTirW2Y18rpJl4OKeBAg7BYGLe4auEaEld2qxSrJ0URG4qkmW5iVn
-        dftH2kvn1Qx3dPkLAAD//wIxocU9GcUv0vysPsxcHaXcxIqg1OLSHJDBSHaDR/SKShxLIO4oyy+h
-        3kQCxDC4oUC7MhKLw/LBA6Kw0X/QVAZomBFkJdwhqK41QnEuVAM4eGprawEAAAD//wMAIKNkqVMf
-        AAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18253","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18253","key":"NTEST-1879","fields":{"statuscategorychangedate":"2025-04-30T18:27:46.833+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1879/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:46.534+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t7z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:46.617+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/21]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/114]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/308]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/308]\n*Defect
+        Dojo link:* http://localhost:8080/finding/308 (308)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1879/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18253/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 88655af1-6983-4a96-808b-3826759ebf46
+      - 779fba62-15d6-41fe-82b9-da335634ef14
       Atl-Traceid:
-      - 88655af169834a96808b3826759ebf46
+      - 779fba6215d641fe82b9da335634ef14
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:26 GMT
+      - Wed, 30 Apr 2025 16:27:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1317,7 +1429,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=305,atl-edge-internal;dur=13,atl-edge-upstream;dur=292,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="brSw7iU4H4Hw5YoPVHdakBRx5M3mdFDO6kXJoYJkSz-s8OWMcCh80Q==",cdn-downstream-fbl;dur=340,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=337,atl-edge;dur=264,atl-edge-internal;dur=14,atl-edge-upstream;dur=250,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1326,10 +1438,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2ac235acced332a2c079b041387a4918.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - brSw7iU4H4Hw5YoPVHdakBRx5M3mdFDO6kXJoYJkSz-s8OWMcCh80Q==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 007d6da06561fca3ae150efd917cb74f
+      - 2d5401527e5b1acc2e1d63283b634370
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1353,65 +1473,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16123
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18253
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJl2RH5kyn49py4tZ1XVl2HhyPByZXJGISYAFQR+P89+7y
-        kOJDmdqdZvRAEsAe2P3229VnB5Yll4kTORpkAhqSIwF5YnqSF2B6Js6g4D1VguZWKGl6kAhbgOW9
-        OOMyhVylvTlog3uQTKDUYEDa9mxcGauKGSm8CXw/8F0Nf1Vg7HRVwpnmsRUxOD1HkP1gNwgH+GEg
-        n+FnZm1pIs9LYAaxTdQn5XKbc2MEl64E66El6/FSeKEnjKnA6xTcwQrlT6fj82k/2B3s4VLtgnGi
-        z45B3yoTcwup0qvmDgl+oUTohzt9P+gH/jT0o2AUhTvuzmjwI/rtk5NkxKLjtZpXOknyHurzw/W1
-        248ETKxFSYHD1X1mCp7nPZYIY4WMLSsFxMDUjC2UvnNJOlbyQucv9KKSgtLF8xs+55Zrby5g4dVu
-        bRxstwJ/EIx+NuJv+KnAtFcFWiVYoMkpN3eUq+rW0ls047mBntMIHuO9atmekwkEjo6z1QnMAX31
-        v/QcKxBZJaLEiWSFd3QewWTgb9sIuo1Sq0941VdmopWu81BntssDfXyFns11L6SwFhUYZ22bIPxb
-        fdaomV1wTUA2oihzgQ4nj0KCiarhNxwth6MXuvuNlHU3WSds6L9FN8LhMhz+v1YaWNQgRYPB7jLY
-        /R4Gl53FQbgchN/DYov8L1+ewjHs4DgTy8uGAzHJV9dPTw66kzxNNaTIN0+KAP1UedWU//Po39m2
-        sbtt4+2WjXDrxmjbxt5TPxvabFaJlOoO4UT9oOVKirwWcXOlz0/WqB4wqCZTVZ4cClPmfNVWDS5j
-        Cu0lpocqqTXBLTajhsRfXvNNi9g0Ba9Rp6mi69cDVVEyauc/0IKQqRNZXZE3sQa8LNHEc00iHPpd
-        k3gctm1UFq6p7PHGGlSlFkoLu3rlhTtxr+40/75XiIKnYDySMJ0SgQuZSDPXzNMNKb7HlY49Q+dp
-        fYRr1Of8Foj/nikNoo1nAxFsw2gwoohk3IxLEZ8IeXdEO4dQ0vwi4w5DNbIW9d56RSo5xvGF3+Yw
-        AW4aXOr2zTk7uXh3fHpzcnwwPj0f34wnkz8meD+sU4MhwQPTDNgZEr20jOwyYZiS+YohaYiclDKr
-        2K9Cc3amoUDWYJVBhLnPkUeABeX498L3y8U8cpquiNnD8G+q6gFbYCJSIXn++FA7fbXhrXGeo3ft
-        N2U2lbA+XZVUttuQPAj2OiQ3g9IrwdcIrxvsw9nmZXjc4O0XHt/huNlBrlPe2DpoJ7r/5HA3FjY1
-        g0bCbh6QsKDqVrnSp403t3kF/VQjZ22GIsUOVZNsVZQ4EEv7POh31rTwrcQ+FlpTxsNwfpRf//ZZ
-        qlVV0qB4JGSCJGYY1gq7BZCsrEwGSY3S48k+PW+BCTknywSzhOFfAYbdDJKIlGWhy96Ruo/yTf18
-        E7GrtVohIzbDGGaR7w5c/57ijeHOVczzTBkbjfyR782a4ze1W14QBNcoyK7OIa6Inth7tehbtUUY
-        23JSYVsOr5nHrgJj2Z8V1xY0G8sUi7LAEG8RhfUBL6ilT89+Z/sVlj87j7ncIkVDHjo5vG6ieX/P
-        znFwrR3F94PLcf340Dy6JNNH2//pdSosUgGJ1qDCN1TEiC3ZPbtCHf0Q2Q27UBDs1W4QSOU8cSXO
-        +m6q5t68yiXC1iKteA/PX5OKod8Em+TiBbiFsBpcpVMPa5sT3gXOq8QJHh51M1vkJFfnCp91tkjP
-        BNIq5xjLJf1tq90/BCl4Tug5Bz3Hf2esz3440vAPAAAA///sWdtO20AQ/ZVVpSISxcZJHHJBiEak
-        SDykqlq1D/SFze6auEriyJegqnx8z6w3i2OytKUq4gGBknhnrzOzZ86Ms3mLHSzyEwxGvGs4tGds
-        fdQNBrTgGHF+o1qkG82J2R3ptLnV6KiplUJtrDkpFJvABdF4oWY+G7YYARTb9e7t37ztW/fWz13/
-        Px8H+55oHMEV/54wQlhs9bfj2CE+GvsO/diRWRMuhuZv+PKeZG2sCMfRU/ybv+3qvfk5KVJo8SJe
-        KGCBKjV9cJOfaOeqdJzcY1QTWGKXTQBe5ur7cXLE5SbOAIAgGL3OMeArIh3DVbZRjWx3rSe/Zgi9
-        jLaKlNIE29SY3GyETC6tyTNj8ts5QR/HfKsbBs4tIEfUFimPaCWK0YCkdZH70PzX+/mnwJ6FMhi3
-        K9qy/VHFi9Djo+aUciuGFJo5teLKBOg5x2g0wiP1hRzVldmqNGTgNg5BulEeRa9YPOxYSiO+oXhb
-        sRIh2Ig+yLnwOBYC840QH2aLWBgLTmMdFIwBv2jeQDo3lilPxZKULSBIfWv5y+Wai5zGfEhYrB8Y
-        cHwTSyV3fOkT7hPIFJb+Gw8xQ9cJhQFy8EMul/GqwQ4bd0s4cJ6M4LQPqXjPstE6E3Nx9HZYjdJ5
-        CvqhcwLKWupdXblZ4BKENqGqj7CEeKsFV0cXQQ5cSVxg1+R5zsWcgqNhiVWiWechWbFccmJWb1yh
-        n7RNGVKSPpF+0R0840JQDnYpT3uyO+gPZu1+oLpiGIhhrxMN29Ex1rGdsMIj3RS5wlhKuifoKRL5
-        411lI+BnNNejpRmtfuWD4uluNGZbHggVshAu22F43BeDfq87nIlZP8DyEVfRQJzJUz3L2+74becC
-        /+U4b8lXhpN4XtmU+UXm3UIRXscnsuOXV5A05a05z0hRGK8RHjkMfp5PvcBfr4gG18s8L3/H9TrR
-        y99xvc700ncMbJJlLcXkKedwfTblUVQIEesLRKSsrGyUyHYFEouO74s0WaujK2COoLze3DSqc0Jq
-        ry6tYMq++5Ob0IWnoavmEdqaR2pw/RVGns1hXmHkOXb8CiN7YKQOAy6GFloiZnkKjnNTXsqf9ELG
-        /A6wkyTn5j1TfRYXFQtcuBR09gOcq2QZOA/gpGr2ZPURLg7XdQosuVOrTZwmq5LdlU2yMC85y8c/
-        0d4mySvF9l8AAAD//yKtHMYYbIcYBjcUaFNGYnFYPnggEjbiD8wCECdXw5jQ+oVsB4AnhPVh5uoo
-        5SZWBKUWl+aADEbyLHgIsajEsQTicdBUBmiYEeR1uDiqZiMU3VANYNfW1tYCAAAA//8DAAM9OzNT
-        HwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18253","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18253","key":"NTEST-1879","fields":{"statuscategorychangedate":"2025-04-30T18:27:46.833+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1879/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:46.534+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t7z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:46.617+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/21]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/114]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/308]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/308]\n*Defect
+        Dojo link:* http://localhost:8080/finding/308 (308)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1879/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18253/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 471806e2-d139-4493-87d1-bd95857ae52a
+      - 09e99309-817d-4e8b-a54c-26f2850cb9bd
       Atl-Traceid:
-      - 471806e2d139449387d1bd95857ae52a
+      - 09e99309817d4e8ba54c26f2850cb9bd
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:26 GMT
+      - Wed, 30 Apr 2025 16:27:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1421,7 +1527,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=283,atl-edge-internal;dur=15,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=313,atl-edge;dur=280,atl-edge-internal;dur=18,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="eKcNWI6yYLmAdlVQ3Nt12jhjTfiRdO-zb1_LH3quhhH2fu47NhQCPg==",cdn-downstream-fbl;dur=317
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1430,10 +1536,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 71ab92edd02bc8ec941d842529d753d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - eKcNWI6yYLmAdlVQ3Nt12jhjTfiRdO-zb1_LH3quhhH2fu47NhQCPg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 673b0b8ed0af2d1704a256f5399cdd43
+      - 77334081b1060d632f7a1d5720a88bbd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1466,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1480,9 +1594,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"849\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:34460\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:53206\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -1518,7 +1632,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:26 GMT
+      - Wed, 30 Apr 2025 16:27:48 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1536,25 +1650,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       114, "url_ui": "http://localhost:8080/test/114", "url_api": "http://localhost:8080/api/v2/tests/114/"},
       "finding_count": 5, "findings": {"new": [{"id": 305, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/305", "url_api": "http://localhost:8080/api/v2/findings/305/"},
-      {"id": 306, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/306",
-      "url_api": "http://localhost:8080/api/v2/findings/306/"}, {"id": 307, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/307", "url_api": "http://localhost:8080/api/v2/findings/307/"},
-      {"id": 308, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/308", "url_api":
-      "http://localhost:8080/api/v2/findings/308/"}, {"id": 309, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/309", "url_api": "http://localhost:8080/api/v2/findings/309/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/305",
+      "url_api": "http://localhost:8080/api/v2/findings/305/"}, {"id": 306, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/306", "url_api": "http://localhost:8080/api/v2/findings/306/"},
+      {"id": 307, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/307",
+      "url_api": "http://localhost:8080/api/v2/findings/307/"}, {"id": 308, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/308", "url_api": "http://localhost:8080/api/v2/findings/308/"},
+      {"id": 309, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/309",
+      "url_api": "http://localhost:8080/api/v2/findings/309/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -1565,11 +1677,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2507'
+      - '2372'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -1581,11 +1693,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2507\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2372\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:34472\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:53208\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -1600,63 +1712,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 114, \\\"url_ui\\\": \\\"http://localhost:8080/test/114\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/114/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 305, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/305\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/305/\\\"}, {\\\"id\\\": 306, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/306\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/306/\\\"}, {\\\"id\\\":
-        307, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/307\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/307/\\\"}, {\\\"id\\\":
-        308, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/308\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/308/\\\"}, {\\\"id\\\":
-        309, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/309\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/309/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        307, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/307\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/307/\\\"}, {\\\"id\\\": 308, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/308\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/308/\\\"}, {\\\"id\\\": 309, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/309\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/309/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 305,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/305/\",\n          \"url_ui\": \"http://localhost:8080/finding/305\"\n
         \       },\n        {\n          \"id\": 306,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/306/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/306/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/306\"\n        },\n
         \       {\n          \"id\": 307,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/307/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/307\"\n        },\n        {\n          \"id\":
-        308,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/308/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/308\"\n        },\n
-        \       {\n          \"id\": 309,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/309/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/309\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 114,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/114/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/307/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/307\"\n        },\n
+        \       {\n          \"id\": 308,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/308/\",\n          \"url_ui\": \"http://localhost:8080/finding/308\"\n
+        \       },\n        {\n          \"id\": 309,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/309/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/309\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        114,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/114/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/114\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/114/\",\n
@@ -1670,7 +1780,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:26 GMT
+      - Wed, 30 Apr 2025 16:27:48 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_twice_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_twice_push_to_jira.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL2q1b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmCzBGgCy4oxnmc8D2KACwhwyLvwBxyqtjtnKVQMOF1wVqTAsm9W
-        djdG2QDmdL6QAnCGStKsQJErlSuQii2z2aJW8xzZXAE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMAXkT9PiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:48.500+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - dd4fe1d7-1306-483a-b51c-a4f495c90614
+      - c7d04e52-6319-4450-9f68-aa4893cd88cc
       Atl-Traceid:
-      - dd4fe1d71306483ab51ca4f495c90614
+      - c7d04e52631944509f68aa4893cd88cc
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:27 GMT
+      - Wed, 30 Apr 2025 16:27:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=165,atl-edge-internal;dur=16,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=194,atl-edge;dur=161,atl-edge-internal;dur=15,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="QiTB1-k01kkBixAuH01YFdbTyd4AxnMBboU0PrVhpQoeSv3-B92-ZA==",cdn-downstream-fbl;dur=198
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 7d27498ef63e76e5a81975299a76fae4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QiTB1-k01kkBixAuH01YFdbTyd4AxnMBboU0PrVhpQoeSv3-B92-ZA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - de11d9aeeda1937edfd76157c03241d6
+      - 1b12e9a025979e8aa079ac000d2f1b31
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 83738a16-5b73-4fbd-87e6-56210cbb78e1
+      - 5721ed45-124b-41a4-8601-18dbed5d2209
       Atl-Traceid:
-      - 83738a165b734fbd87e656210cbb78e1
+      - 5721ed45124b41a4860118dbed5d2209
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:27 GMT
+      - Wed, 30 Apr 2025 16:27:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=317,atl-edge-internal;dur=15,atl-edge-upstream;dur=302,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=320,atl-edge;dur=288,atl-edge-internal;dur=15,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="QyF82sss6Bz72tXMqtgfUmew43qppi3kq2EIJIvErJD_IuneUjPB2w==",cdn-downstream-fbl;dur=325
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QyF82sss6Bz72tXMqtgfUmew43qppi3kq2EIJIvErJD_IuneUjPB2w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 887c2c258ad9aabdb081ee70a68b020f
+      - 84118f91b1ae19e59c9ce46beda15953
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -157,7 +156,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/112]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/22]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/115]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -166,28 +165,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/310]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/311]\n*Defect Dojo link:* http://localhost:8080/finding/311
-      (311)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (311)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/310]\n*Defect
       Dojo link:* http://localhost:8080/finding/310 (310)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -201,7 +200,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3359'
+      - '3334'
       Content-Type:
       - application/json
       User-Agent:
@@ -210,18 +209,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16124","key":"NTEST-1640","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16124"}'
+      string: '{"id":"18255","key":"NTEST-1880","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18255"}'
     headers:
       Atl-Request-Id:
-      - 3e4b2769-43c9-40eb-96db-48913f2e3c77
+      - cf10f118-fda6-40d1-a485-e8d54f93022b
       Atl-Traceid:
-      - 3e4b276943c940eb96db48913f2e3c77
+      - cf10f118fda640d1a485e8d54f93022b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:28 GMT
+      - Wed, 30 Apr 2025 16:27:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -231,7 +232,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=775,atl-edge-internal;dur=13,atl-edge-upstream;dur=763,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=681,atl-edge;dur=649,atl-edge-internal;dur=25,atl-edge-upstream;dur=624,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ePSbOk7WRZ-Wcin6Kvh06FcGDqo4Y5V0PIRVLB8SxSaXaxe1wwFfeA==",cdn-downstream-fbl;dur=685
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -240,10 +241,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ePSbOk7WRZ-Wcin6Kvh06FcGDqo4Y5V0PIRVLB8SxSaXaxe1wwFfeA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 6b6a8ebd1c834732de30c5c2d5fd5f11
+      - 18bdfc6bd86d7a548824170057dcae71
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -267,66 +276,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1640
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1880
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIv+VA40+m4tpK4dV1XVpIHx+OByRWJmARYANTR2P+9u7wU
-        H0prdxr7gbj2wO63H1ZfHFiVXCZO5GiQCWhI3gjIEzOQvAAzMHEGBR+oEjS3QkkzgETYAiwfxBmX
-        KeQqHSxAG9yDZAqlBgPStmfjylhVzEnhVeD7ge9q+LMCY2frEs40j62IwRk4guwHe0G4gxMD+Ryn
-        mbWliTwvgTnENlGflcttzo0RXLoSrIeWrMdL4YWeMKYCr1NwA2uUP51NzmfDYG/Hx6XaBeNEXxyD
-        vlUm5hZSpdfNHRKcoUToh7tDPxgG/iz0o2AchWM33Bv9gH6TjtqIRcdrNS90kuQ91OeH/bXbSQIm
-        1qKkwOHqATMFz/MBS4SxQsaWlQJiYGrOlkrfuCQdK/le58/0opKC0sXzK77glmtvIWDp1W5tHGy3
-        An8UjH8y4i/4scC0VwVaJVigyRk3N5Sr6trSKJrz3MDAaQSP8V617MDJBAJHx9n6BBaAvvp3A8cK
-        RFaJKHEiWeEdnQcwGfnbNoJuo9TqM171hZlopes81Jnt8kCTr9Czue57KaxFBcbpbROEf63PGjW3
-        S64JyEYUZS7Q4eRBSDBRNfx2xqud8TPd/UbKupv0Cdvx99GNcGeFlfC/WmlgUYMUDQZ7q2Dvexhc
-        dRZH4WoUfg+LLfLv7h7DMezgOBerDw0HYpIvLh+fHHUneZpqSJFv/rEIdrsNvIDKq4YXnj66t21j
-        f8tGuHVjvG3j9WN3GtpsVomU6hfCiYYBTrnFh6Mh3OfXZ0PnGwL3GnWaqq8eHqqKAhcQKX+kBSFT
-        J7K6gruWp0mbFnETtS+P1sgzPGoyVeXJkTBlztdtxeIyumU/IDSoittoaMDLEk08fiT23fHrve6R
-        eBi2bVQW9lT2cKMHVamF0sKuXxjETtyrX5p//1aIgqdgPJIwnRKBC5lIM9cs0g0pvsOVjj1D53F9
-        hD3qc34NxH9PlAbRxpOBCLZhNBhTRDJuJqWIT4S8eUM7R1BS/yLjLo91dpf1Xr8ilZxg+8Kvc5gC
-        Nw02dDtyzk7evz0+vTo5Ppycnk+uJtPp71O8H9apwZDggVkG7AyJXlpGdpkwTMl8zZA0RE5KmVXs
-        F6E5O9NQIGuwyiBq3afII8CCcvxb4fvlahQ5zauI2cPwb6rqHltgIlIhef7wUNt9teGtkZ6jd+2c
-        MptK6E9XJZXtNiS/Hu92SG4apReCrxHuH9j7vc3z8LjB2888vsF2s4Ncp7yxddh2dP/J4a4tbGoG
-        jYRdPyBhSdWtcqVPG2+u8wqGqUbe2DRFih2pJtmqKLEhlvZp0O/2tPCtxD4U6injfjg/ya//D1iq
-        VVVSo/hGyASJ0TCsFXYNIFlZmQySGqXH0wP6XgMTckGWCWYJw58CDF8zSCJSloUue0vqPslX9fdV
-        xC56tUJGTGK8rOBW6ch3d93RLQUdY56rmOeZMjYa+2PfmzcyV7VvXhCElyjNLs4hroij2Du1HFq1
-        RRjf5qTCtxmFPHYRGMv+qLi2oNlEpliZBcZ5iyj0B7yglj49+40dVMgB7DzmcosUdXro5O5lE9Lb
-        W3aO3WvtKI4PP0zqz8fm02WaJm0TQMOZsMgHJFojC0eoiBFlslt2gTqGIXIAFt8oDGo3CKlykbgS
-        G343VQtvUeUSsWuRW7z75y9Jxcj3e7l4CW4hrAZX6dTDAucEeoFNKxGDh0fdzBY5yW0ShpM6ZaQs
-        xL8ppFXOMagr+hFX3+MIpOA5YelvAAAA///sWW1v2jAQ/ivWpFaASJqU8FpVHSqrVGlU06rtQ/cF
-        4ziQCUiUEKpJ+/F7znECpAQ6qladNIGA2D77fL57zvdwL6MVajVmsMpdPkOdnc6WF5eYpmVa1RJj
-        6qM/a9hK7z7y70rWyVTqnsx22aWFfTYb3WfbRY9XdnGebxfnoF1e3SZWmU0QcZnT9WrKPtTGaoNE
-        sgFCFY03cmyybp0RkLNtFMheU9vMYUA9N8w3O2zsYKCQF6D4M2CUk6D0QTlWwUd11/b3bZ7VEI9o
-        /oEv46jQwIrwJjXFy4Jz+wRq90ESwZY3/kwCPWVq79PJ8oILIcOl+rl2vg3BwRrla0DjXI0A8K9x
-        0/SDM+6u/BgpRFK6bSMBeGRzOFF2L6ATHa1XGDHcYBjpj8pc31ki7Q1aO/IGN/eGWHsDXy6RgOM6
-        e5z6YspwlZ5MgMEJ4I+FHGstJowz1DQCgrgViYh7pMeorzZqfOaLSQI0HrGp5C4kVxwp1Ex3y76v
-        FRoC7mdyM7ds92elVm/TIzHki6oS3Kwf3ZOs296eASOnEEcjfFwFe+/wwRDi9+iD/AuPtK0Ys4TJ
-        eOYLfWhDX2VSfWbf1GWLLKwPI1WGAWRm6Ij05iF3Ow+5WJLMXcB89cCQ91a+K90td/qKkMINFEv/
-        jVNo0TCgtEk+XuHu3F9UWaX6ew4fXga93G93Ysar44V1JF5YhBfWy/DiqJTxBC+OTVqbx/vWeNH6
-        jxdvgBfOv4UXrVz0AF485TuaeclfLHfLiBDb2SyFlhFcRpE5RM8Uh+aUWKHDKutwctaqKJGzDpkV
-        ygaWsRBWGVNm5WtuVe/F4k5Fx5Qqk7RCjJP5nFP5+mFvfUUmJy4qiI4sdImRuILHEoN261423Uan
-        3RnbbUs2RNcS3ea517W9FtbJB2GFPcMk+UPfdSkaMFIE7q+PG4qgEqa59pLg6gykiWJaDSOZjIh1
-        pGV3uGs7TqstOm3g5ViM2xaW97j0OuLKvVSznDT6J+c3eKdyxpwvdOFnGGlTbCax8QhDGOcmVZRm
-        GodkKSPkPCZDQV4hPZ/F+Hk9NCwzXBDhUCTU37/GRUb+/WtcZPTfu8YAKDdljjUjdA3XZ0PueYkQ
-        vgogKutSXjqFt4dgQQM/JVEQyrMHAI8gBlVHGv2jhN48dGkF/QfbbhrJKQNVp4xddnJ2OdLg/kwY
-        +QMAAP//Gi1GKE8wg7EYAQAAAP//IuTi0WKE1i6mSzGCXgzgaqaZwFtj8MYL0DvpkExZDZr6hrIN
-        gC7JL0mEzuijm4KrPWaAq1wyMMJewOGaHDLA6QGc7TW4z9B14GrIGeOUgLfwUvPKMovy8yCtOIhQ
-        Sil0OQmES0zoleWXUG+qFGIY3FCgTRmJxWH54Ckf2PwmMAtAnFwNY0LrF7IdAF56ow8zV0cpN7Ei
-        KLW4NAdkMJJnwZM1RSWOJRCPgyaNQRM6IK/DxVE1G6HohmoAu7a2thYAAAD//wMAnswDOL0kAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18255","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18255","key":"NTEST-1880","fields":{"statuscategorychangedate":"2025-04-30T18:27:49.767+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1880/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:49.496+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t87:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:49.570+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/22]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/115]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/311]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/310]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/311]\n*Defect Dojo link:* http://localhost:8080/finding/311
+        (311)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/310]\n*Defect
+        Dojo link:* http://localhost:8080/finding/310 (310)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1880/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18255/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3681b087-e23d-4a56-82fc-266cf3d3cc3a
+      - 5696b45b-466f-4a7c-9ee7-d1a0604df30a
       Atl-Traceid:
-      - 3681b087e23d4a5682fc266cf3d3cc3a
+      - 5696b45b466f4a7c9ee7d1a0604df30a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:28 GMT
+      - Wed, 30 Apr 2025 16:27:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -336,7 +346,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=272,atl-edge-internal;dur=21,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=32,cdn-upstream-fbl;dur=392,atl-edge;dur=264,atl-edge-internal;dur=16,atl-edge-upstream;dur=248,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="UHr5BmLYRxNdRyq4q-JjccgLS_TUdk6kuzyLiDen4K9ZOURRnOIMsQ==",cdn-downstream-fbl;dur=395
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -345,10 +355,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - UHr5BmLYRxNdRyq4q-JjccgLS_TUdk6kuzyLiDen4K9ZOURRnOIMsQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d2ab19a03aa695dd00536933fc48d69f
+      - eedf1a9701d7f16409dcd4643920b56e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,66 +390,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16124
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18255
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXW1MbNxT+K5p9TO29GYizM50OBSehpZQaJ3kgDCN2j3cVtNJG0vrSkP/eI+3F
-        AeNModPAw+p27t+5+IsHq4qKzEs8BSIDBdlrBjzTA0FL0AOdFlDSgaxAUcOk0APImCnB0EFaUJED
-        l/lgAUrjHWRTqBRoEKZ9m9bayHJuGV5HYRiFvoLPNWgzW1dwrmhqWArewGNWfnQQxXu40cDnuC2M
-        qXQSBBnMITWZ/CR9ajjVmlHhCzABSjIBrVgQB0zrGoKOwS2skf5sNrmYDaODvRCPnAraS754GnWr
-        dUoN5FKtGxsy3CFFHMb7wzAaRuEsDpNonMRjPz4Y/YR6Wx5OiEHFHZtnKmnpA+QXxr3Z7SYDnSpW
-        Wcfh6SHRJeV8QDKmDROpIRWDFIick6VUt76lTqV4p/gTtagFs+Gi/JouqKEqWDBYBk6tjYLtVRSO
-        ovEvmv0NP5cY9rpEqRYWKHJG9a2NVX1j7CqZU65h4DWEJ2iXox14BUPgqLRYn8ICUNfw68AzDJFV
-        IUq8RNRoo/cAJqOwu6iU/IQWPdPhLbVztwtg5267+QYkG6veCWYMMtBeL9si9Xf3Vsu5WVJl8apZ
-        WXGGCmcPLMd4OJTtjVd74yeq+53IdJb0cdkLX6Ia8d4KAf+/Smmi77CIAqODVXTwIwSuOomjeDWK
-        f4TEFuBfv27DMdqF07i7mLPV+6YGYvQvr7ZfjrqXNM8V5FhvtpIADZC8btL/cXH7uy4Odl283HER
-        77wY77p4ta1nUzabU1uUXIfwkmHU1kobEsXSxqQvW2c2UdDbupA1z46Zrjhdt+mExxhb8x7jZlOs
-        FUENNqOmiD+9GDQtYtMUgoadsqnulkeytsFwyn+wB0zkXmJUbbVJFaCxtn5sN4mX/vjVQdckHrqt
-        L2UPL3aBKu5BVSkmFTPrZxrckQeu0/z7XsFKmoMOLIXumDA8KFhe+HqRb6rlWzzpymrsbSdO3KOe
-        0xuwhfGR1LD15FFHRLswGo2tRwqqJxVLT5m4fW1vjqGy84tIOww5ZC3dXX8ipJjg+EJvOEyB6gaX
-        ql1556fv3pycXZ+eHE3OLibXk+n0zynah3mq0SX4YFYAOccOIAyxcgnTRAq+JlhNGLdMiZHkN6Yo
-        OVdQYjkhtUaE+Y9VlQgTygvvWBhWq1HiNV0Ro4fu32TVvWqBgciZoPzho3b6at3rcM5Ru3ZvI5sL
-        6F/XlU3bXUh+Nd7vkNwMSs8EX0Pcd977s83T8LjB2680vcVxs4Ncx7yRddROdP9J4W4sbHIGhcTd
-        oCBgabNbcqnOGm1ueA3DXGHN2gxFkhzLJtiyrHAgFuZx0O/3ZeF7gX1I1JeM++78KL79PyS5knVl
-        B8XXTGRYxDTBXCE3AIJUtS4gcyg9mR7a7w0QJhZWsoVZRvCnAMFuBllimRWxT95Ydh/FC/d9kZDL
-        ni0TCRHoL8OokSoJ/X1/dGedjj7nMqW8kNok43AcBvOG5trpFkRRfIXU5PIC0trWKPJWLodG7iDG
-        pp3V2LSRKCCXkTbkr5oqA4pMRI6ZWaKfd5BC/yCIHPXZ+R/ksMYaQC5SKnZQ2REQldy/alx6d0cu
-        cHp1iuL66P3EfT40ny7SdtMOAXY5YwbrgSV1yMIVMiK2ZJI7cok8hjHWAEy+URw5NSxSxSLzBQ78
-        fi4XwaLmArFrsLYE999fWRajMOzp0iX4JTMKfKnyABOcWtAznGZtYQjwqV+Yklu6TcBw40JmmcX4
-        N4W85hSdurI/4pwdxyAY5RZL/wAAAP//7Fltb9owEP4r1qRWgEialPBaVR0qq1RpVNOq7UP3BeM4
-        kAlIlBeqSfvxe85xwksJdFStOmkCAbF99vl895zv4V5GS9RqzGCVu2KGOjudJReXmKZlWtUSY+qj
-        P2vYSu8+cv9S1slU6gLNdtmlhX02G91n20WPV3Zxnm8X56BdXt0mVplNEHG50/Vqyj7UxmqDVLIB
-        QhWNN3Jssm6dEZCzTRTIX1PbLGBAPTfMNzts7GCgkBeg+DNglJOg9EE5VsFHddf2922e1RCPaP6B
-        L+Oo0MCK8CY1xcuCc/MEavdBGsGWN/5MAj1lZu/TSXLBhZBhon6unG9NcLBC+RrQuFAjAPxr3DT9
-        4Iy7Sz9GCpGUbttIAB7ZHE6U3wvoREerFUYMNxhG+qMy13eWSHuD1o68wS28IdbewJMECTius8ep
-        L6YM1/jJBBicAv5YyLHWYsI4Q00jIIhbkYi4R3qM+mqjxme+mKRA4xGbSu5CcsmRQs1st+z7SqEh
-        4H4m13PLZn9eavXWPRJDvqgbvZv3o3uSd9ubM2DkFOJohI+rYO8dPhhC/B59kH/hkbYVY5YwHc98
-        oQ9t6KtMqs/sm7pskYX1YWTKMIDMDB2R3jzkbuchFwnJ3AXMVw8MeW/pu9LdcKevCCncQLH03ziF
-        Fg0DSpvk4xXuzv1FlVWqv+fw4SToFX67EzNeHS+sI/HCIrywXoYXR6WMJ3hxbNJaP963xovWf7x4
-        A7xw/i28aBWiB/DiKd/RLEr+7XK3jAixnbKOgu6iGimJ4EuKkSHOaGuoVcaMOQVrtS1RsA65FcoG
-        lrEQVhlTZhVrqgCYUvGhS/H1an672IvT+ZxT+fphb31FJicuKoiOLHSJkbiCxxLbdeteNt1Gp90Z
-        221LNkTXEt3mude1vRbWKQZhhT3DJPlD33UpGjBSBO6vj2uKoBKmufay4+oMpIliWg0jmZyhdaRl
-        d7hrO06rLTpt4OVYjNsWlve49Driyr1Us5w0+ifnN3hncsacL3ThZxhZU2ymsfEIQxjnJlWUZhaH
-        ZCkj5DwmQ0FeIT2fxfh5PTQsM1wQ4bDNtL9/jbep+vev8TbV/941Bg65GWutGaFruD4bcs9LhfBV
-        AFFZl3HIGYo9BAsa+CmNglCePQB4BDGoOtLoryb0FqFLK+g/2HbTSE4ZqDpl7LJTsMuRBvdnwsgf
-        AAAA//8aLUYoTzCDsRgBAAAA//8i5OLRYoTWLqZLMYJeDOBqppnAW2PwxgrQO+mQTFkNmhOHsg2A
-        LskvSYTO6KObgqs9ZoCrXDIwwl7A4ZocMsDpAZztNVztTFARglXCGKcEvIWXmleWWZSfB2niQYRS
-        SqHLSSBcYkKvLL+EetOaEMPghgJtykgsDssHT/nA5laBWQDi5GoYE1q/kO0A8NIbfZi5Okq5iRVB
-        qcWlOSCDkTwLnqwpKnEsgXgcNGkMmtABeR0ujqrZCEU3VAPYtbW1tQAAAAD//wMAANt0z70kAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18255","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18255","key":"NTEST-1880","fields":{"statuscategorychangedate":"2025-04-30T18:27:49.767+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1880/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:49.496+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t87:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:49.570+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/22]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/115]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/311]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/310]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/311]\n*Defect Dojo link:* http://localhost:8080/finding/311
+        (311)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/310]\n*Defect
+        Dojo link:* http://localhost:8080/finding/310 (310)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1880/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18255/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - baa7d1d8-d2d0-43b3-b015-76a98cfa1c8b
+      - 128803b3-b48e-45d4-94ae-97fa33f6e0f3
       Atl-Traceid:
-      - baa7d1d8d2d043b3b01576a98cfa1c8b
+      - 128803b3b48e45d494ae97fa33f6e0f3
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:28 GMT
+      - Wed, 30 Apr 2025 16:27:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -441,7 +460,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=278,atl-edge-internal;dur=14,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="YMl7tw7NQ1ghrR3VYkiUgrbuKTqP45Cb7OXPV5NVUueDhzP6XF-EEQ==",cdn-downstream-fbl;dur=333,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=53,cdn-upstream-fbl;dur=331,atl-edge;dur=259,atl-edge-internal;dur=15,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -450,10 +469,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c6aa039b46ee567794869d726acc308a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - YMl7tw7NQ1ghrR3VYkiUgrbuKTqP45Cb7OXPV5NVUueDhzP6XF-EEQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - fd55c1fc76696f67d2137cff03e36b11
+      - fda53ae3ee5a59147b3e84eb86dc13e3
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -480,26 +507,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2Tdl+5oSExEAykdhcQQmnqiECaVE06aZr230nEBDsCN8t+
-        Xj+WD6QWHre9IZy8hdB5Ppk0qFCGxr27TAQjvNfCZhYDGZFG+86I/T/4Evudltig/1ij6VZoA/Z/
-        XbJyVpkBrcTfJXfYe+1shCkAzSCDcbm5fCzXD9XPdDO0dawIf07QCEbwEp3YGbdv45XVvku2lXFD
-        E0P1oE3zFSE8Bth8fmpeiZBABmw6BjqGZcUYL3JeRDHABUQ45n38A/aVbs9ZChUDThecLbOcFt+s
-        bG+schEs6GwhBeAUlaT5HEWhVKFAKrbMp4tazQpkMwXsTBBMMtzqXqQXohKDCXdOitQ+EHOqCNrX
-        bUmO54c9OZsm1/cVOX4CAAD//wMAU7uR/yACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:51.156+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - a43e018a-aeb5-4119-a875-e2f0ba7b1a3e
+      - b66990e8-2fb3-4553-94fd-f96b183a55d6
       Atl-Traceid:
-      - a43e018aaeb54119a875e2f0ba7b1a3e
+      - b66990e82fb3455394fdf96b183a55d6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:29 GMT
+      - Wed, 30 Apr 2025 16:27:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -509,7 +532,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=159,atl-edge-internal;dur=14,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=185,atl-edge;dur=152,atl-edge-internal;dur=15,atl-edge-upstream;dur=135,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="JHL5J0lchE0JjBmmBiqYkD6wG_JT3iwnjIzEqLwOF8DD9RIry8F5rQ==",cdn-downstream-fbl;dur=189
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -518,10 +541,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e9bcf307d6ed54e3e501e39bc538dcfc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JHL5J0lchE0JjBmmBiqYkD6wG_JT3iwnjIzEqLwOF8DD9RIry8F5rQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e9687a53f1e7d37860ff1d5bcb620aaa
+      - 97b6b5c6e05383bcf97909176c74e415
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -548,41 +579,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - dcdc47cf-e704-4716-a8dd-50f3e385b1f2
+      - 8ccba03d-4de0-4d7f-99da-910dde6aa9b8
       Atl-Traceid:
-      - dcdc47cfe7044716a8dd50f3e385b1f2
+      - 8ccba03d4de04d7f99da910dde6aa9b8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:29 GMT
+      - Wed, 30 Apr 2025 16:27:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -592,7 +610,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=241,atl-edge-internal;dur=13,atl-edge-upstream;dur=228,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=365,atl-edge;dur=333,atl-edge-internal;dur=15,atl-edge-upstream;dur=318,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="W73afSOU-a05RlH80lOkSY963ICs-8vhSfrbbo81A3L11grFOrOKOw==",cdn-downstream-fbl;dur=369
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -601,13 +619,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 4bbf91f2f9edc22eb68408b6405ae452.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - W73afSOU-a05RlH80lOkSY963ICs-8vhSfrbbo81A3L11grFOrOKOw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - be8a253fc30045a31167318e1e8d31e2
+      - abd6c3e275334c9b08eb5d6fd670fe32
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -619,7 +645,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/113] in [Security
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/23] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/115]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
@@ -634,13 +660,13 @@ interactions:
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/312] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/314]\n*Defect
       Dojo link:* http://localhost:8080/finding/314 (314)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -649,31 +675,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/312]\n*Defect Dojo link:* http://localhost:8080/finding/312
-      (312)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (312)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -682,25 +706,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
     headers:
       Accept:
@@ -712,7 +734,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7141'
+      - '6804'
       Content-Type:
       - application/json
       User-Agent:
@@ -721,18 +743,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16125","key":"NTEST-1641","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16125"}'
+      string: '{"id":"18257","key":"NTEST-1881","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18257"}'
     headers:
       Atl-Request-Id:
-      - 07e0c8cb-690f-4d21-84c5-d361dd2a0041
+      - c40cd50c-e8bf-4049-a1f0-a2dcdd2b954c
       Atl-Traceid:
-      - 07e0c8cb690f4d2184c5d361dd2a0041
+      - c40cd50ce8bf4049a1f0a2dcdd2b954c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:30 GMT
+      - Wed, 30 Apr 2025 16:27:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -742,7 +766,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=652,atl-edge-internal;dur=13,atl-edge-upstream;dur=639,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="f4k3Fts5YIYx6L2xUtg4yCS91biyggJ3uQdZlrnsRuAMZ-hRAPbJjA==",cdn-downstream-fbl;dur=841,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=838,atl-edge;dur=753,atl-edge-internal;dur=16,atl-edge-upstream;dur=737,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -751,10 +775,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c6aa039b46ee567794869d726acc308a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - f4k3Fts5YIYx6L2xUtg4yCS91biyggJ3uQdZlrnsRuAMZ-hRAPbJjA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 90d14c3fd1e5c4a566abcab8bd187c41
+      - 7c0e37d4a851220a5fd32585d7c1ebb4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -778,78 +810,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1641
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1881
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXbW/bNhD+K4Q+FENnS6JsJ46KYshSt82WZZnjth/SIKCls8RGIjWS8sua/vcd
-        JUtuXtQtGdYEiCSS98K75567fHZgXTARO6GjQMSgIH7NIYt1T7AcdE9HKeSsJwtQzHApdA9ibnIw
-        rBelTCSQyaS3BKVxD+IpFAo0CLM9G5XayHxhFV5R36e+q+DPErSZbQo4UywyPAKn53Brn+7RYIQf
-        GrIFfqbGFDr0vBgWEJlYfpIuMxnTmjPhCjAeWjIeK7gXeFzrErxGwTVsUP50Njmf9enekOJS5YJ2
-        ws+ORt9KHTEDiVSb+g4xfqFE4Aejvk/71J8FfkjH4cB3B/v7P6LfvnXSGjHoeKXmiU5aeQ/1+UF7
-        7e1HDDpSvLCBw9VDonOWZT0Sc224iAwpOERA5IKspLp2rXQkxTuVPdKLUnCbLpZdsSUzTHlLDiuv
-        cmvn4HaL+gM6/knzv+Bljmkvc7RqYYEmZ0xf21yVc2PfwgXLNPScWvAY71XJ9pyUI3BUlG5OYAno
-        q/+l5xiOyCoQJU4oSryjcwcmA7/ZKJT8hDd6YsC30lW4qwQ24bYfX4Fkd6t3ghuDCrTT2rZI/bU6
-        q+XCrJiyeNU8LzKODsd3bo75qFA2HK+H40e6+43MNDdp8zL099GNYLgOhv+vlTr7FRbRIN1b073v
-        YXDdWBwE60HwPSxuAf7ly3040i6cBl0bg2Zjwdfva3JEWFxcIkySREGCfPOPRTBqNvBmMitrXnj4
-        6F7Xxn7HRtC5Me7aOLjvTk2b9aolpapDOGGf4icz2Dhqwn184dZ0viNwr1anbFlWr0eytIGjlpQ/
-        2AUuEic0qgRMHyo17zHjtjhr5yp9Vr/iUR3Hz/fWrK8orFNZZvErrouMbbbFbSGhAC9r+eOhJuEf
-        jJsmcTdsLZXd3egCVdCCqlBcKm42TwxiI+5Vnebf9wqeswS0ZyV0o4TjQsqT1NXLZMeWb3GlodXA
-        uV84QVsGGZuDJUZbAXdngi7w0i6M0rGNSMr0pODRCRfXr+3OKyjs/CKiJmtVLlfVXrsipJjg+MLm
-        GUyB6RoJavvmnJ28e3N8enVyfDQ5PZ9cTabT36d4P6xTjSHBA7MUyBl2AGGItUu4JlJkG4JswjOr
-        lBhJfuGKkTMFOdIJKTWi1n2IVSgWlOPfcN8v1vPQqbsiZg/Dv6uqW2yBiUi4YNndQ9vpaxveCtcZ
-        etcQDmY2EdCeLgtbtl1IpvstkutB6Yngq4Xbznt7tnkcHnd4+5lF1zhuNpBrlNe2jrYT3X9yuBkL
-        65pBI0EzKAhY2eqWmVSntTfzrIR+opAldkORJK9knWyZFzgQC/Mw6EddtDBqaeFbGb8dzo/i699D
-        kihZFnZQfM1FjMSoCdYKmQMIUpQ6hbhC6fH00D7nQLhYWgMWZjHBfwUINi2IQ6ssDVzyxqr7KJ5X
-        z+chuWjVchGSIglHLnX9GxtsjHUmI5alUptw7I99b1Gfvap88igdXKIUuTiHqLTcRN7KVd/IDmFs
-        1nGJzTq4JB65oNqQP0qmDCgyEQlWZI7x7RCF9oBHK+nTs9/IYYm1T84jJjqk7OiHTo4u61De3JBz
-        nForR/H96P2kenyoH02G7ce2x9vXGTfIA1a0QhS+oSJiqZLckAvU0Q+w9rGt+eOgcsMiVCxjV+Cg
-        7yZy6S3LTCBmDXKKd/v8pVVxMGzFohW4OTcKXKkSD+uaWaxzHGItH3gHQzc1eWaligT/VImyKgL8
-        mUIuDeA1YiCTNebDypA++eEs6ZFnmXlBApdSNyDkWWJevPwbAAD//+xYUW/bOAz+KwQKDI6XKqiT
-        NLgc+lC0GzBgG4b1tpfLAXEddfGdY6eW3XXY9t/voyTLcuOsaLe9tS1ShxQl6iNFfjKNBfqcUYzF
-        sZhQo5i0iomYilkjn7byqcBcjfy4lfPjtJWzd1Z+JI5bedTKI3/8uJWPxbiVT1r5pN3ArF2XHz25
-        W5cfo8Ge5LCpPBofTRjRU7CGGznk0OuLAPXFefbAONvxvyrOTzF+dIx1DPpijErYFIV5qOPNMgrP
-        a0nnKKEQvpSXgv4YEjdY6lbn5nd9JFx51t/H4ulY/mTIJijb4bnu9WjD/xbELAjhuNeOAnwM+gL7
-        o7BSiE4A8d/4d/iIw4r1cOr1BD/XFLqZFV4UdZlIZFcmQ+7Ph2ijm1RJhnX7yRt43rKIEN3eLYvU
-        U7Y/i7QYxaubVIGJ4AowjSIQjCtGGIeh4Z1MNZbbT0sCp4N/OcVUmixOOIuly2LegyzjyzTjjlqt
-        44qKBAsp+rwGOanArq0ho3YZK0lFSde4pn0hXJUTPoMKsydlfMUOgI3Vm5yYfAl9zsDPS0kg6FR9
-        LhqThFQi8xgXGWYsWCpN1gQeAPKepf9J0PcrrBLD7e02SxP95tIyo8bhTAIfnFjm//4oszX4VOcq
-        vkKhYLp/qGoeAv/UdWaXs8go2sQwTgvwAs95JRZ5tDs7jHIgrdgZuIcbbwmyiHkdOkzWnA+xRaqU
-        VV3mSG08qTqrGF3PB4zrdUIwgAcHuLkUiCf+zoo8kdtqkS+Xy0XOt8GKvtIZdgbO851OiF/lpqUM
-        nh3cRjOklvk/aMYmZuQJgTpbs4CV+knYzbGkMWC4Tmh58eL1i7O/6IhOL+jZdV1Ufy7wYyYfhUaC
-        Q9inDkcLnMvnvFVVZFLgshAg+xNc4ITMbwb/sDdg0DDJRyNjvdQOGKc0gAH8GFIgy3LICA7ohE8O
-        fcXMdk+Ya8WOfx9YcOijSxR6A86KfCE+ar68eQ0071Rx8MQ9dRyafZXcGe3UcqfZqeae5k499zR3
-        KrqnuVPTPc2dqu40O3Xd03QrO3B6p9/vrBqQ5nakBcmigvk8uBgjiwkv5MPFGFlQrKqBizFyoHia
-        puM1qHRUDJJDpaNhkBwqHQ2D5FDpaBgkh4qnMSA5VDoaA5KXTMBrjUzilDw0dG++W+j5pjLnD3Qn
-        fDtN+BwgMetLHH/bA96k+uJnW0DoLjKRuBW3c/qgXxZwAbLFvgkJKmYGTSl8o/E+IxOtXpvJPhsT
-        xl6b6T4bE+Bem+N9NiYizoYCessdSHcn1+F0EgxNxIe67JoQc6uJM1XQ1iSwIKYRbtHZvkV1SH+8
-        qE0IdKmdBWzsXm22cVJx3N4WlOovhBS4SVdy1bZ5DHwPTlRKVHP1kD5vTbcF37iZpgTxapPmAwoG
-        3zagIVUxd9Sjl84+UVnvAPsF734qy6TuMVQ2Yiob/Q4q+z8AAAD//yKtKUtuvxc52dK6KWs42pQF
-        qgIAAAD//+ya0WqDMBSGX2UMehkXNVa9KF0ZG+yiL9C79ES3MdSildG33znGhpo1HWw3XgR6UZoT
-        TziYn7/8n7ey3sp6K3tV1SfWbKLrE2t2qezeyp7n5a2st7LzsLKh2fqLlf2Z3icmwLbDW1d+FwrX
-        gsE5KNg7thI+B2aBmAOrVBjUwlrg5hn2gitD5yZDP4/HVejiPrg5zCSLthNJeTxKeKe8TeedXV9V
-        ksLY+6tpIY2aiIqm/WNcS+5kLQGIA3lVq0TFWZrtw5QXMeQc8iQq87BcYh9ThB1ulBX0HmyUwh4d
-        VqLdOz1eHAQaYt9uM17DiIvgrdVltOfMGYmCh5lUoRDLFLI0ifM97FOO7UtZlBms1Wp4yiLeLKIX
-        /Oh9rJL1GGMypn/qgr5jXzgIFgWUjwZaA2lS7CBlR4PC/YNHx9uGX5+2jAeHmmJzmxeb/4lt4Gz+
-        J7aBtbmfGPVHadpp5Brw//rpbivLsgf4GC4QhWCartLqtWtqKnzu2+ZQPOxQV4A4oPGmETCJq+bq
-        UocRE70OQwiXmAoXIyVc4J0wgt2Oau/15X9v0jcAAAD//yIhJY2WL/Rw8Wj5gqV8QS8G4K0weKMF
-        6Op0SN6rBq3shrINgBbmlyRC16Wjm4KzuYWzXMLZDjPCXvLhWuJogKvhCSoQsEoY4Gp4GuPSYQxv
-        2aXmlWUW5edBWm8QoZRS6KYICJeo0MvPhZhQDWNCi3syil+k/Rz6MHN1lHITK4Ig40AodoNXABaV
-        OJZA3FEG7H6Qu2wRY+ExxDC4oUC7MhKLw/LBCyhha4NBS59ByxJBVsIdgupaIxTnQjWAg6e2thYA
-        AAD//wMAyB5BboMzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18257","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18257","key":"NTEST-1881","fields":{"statuscategorychangedate":"2025-04-30T18:27:52.607+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1881/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:52.249+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t8f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:52.345+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/23]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/115]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/314] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/312] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/314]\n*Defect
+        Dojo link:* http://localhost:8080/finding/314 (314)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/312]\n*Defect Dojo link:*
+        http://localhost:8080/finding/312 (312)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1881/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18257/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - fb119411-5a33-4cb1-af0a-7d4125a867ac
+      - e23c394e-cf37-4901-8b90-e143f6916b1a
       Atl-Traceid:
-      - fb1194115a334cb1af0a7d4125a867ac
+      - e23c394ecf3749018b90e143f6916b1a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:30 GMT
+      - Wed, 30 Apr 2025 16:27:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -859,7 +926,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=316,atl-edge-internal;dur=17,atl-edge-upstream;dur=300,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=319,atl-edge;dur=298,atl-edge-internal;dur=14,atl-edge-upstream;dur=284,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="lCJwRywK7GTWXCYcgIfRUsCCOLH24sKgb_oLEeOXbCha-l0J4lD_ag==",cdn-downstream-fbl;dur=322
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -868,10 +935,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f497fa2422d5b3ba3b34ed87ffef89a6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - lCJwRywK7GTWXCYcgIfRUsCCOLH24sKgb_oLEeOXbCha-l0J4lD_ag==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 164ec2642158e043ed78cd6acec9e300
+      - eb96016493159640dccbc030dabe3afe
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -895,78 +970,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16125
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18257
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX6VPbRhT/V3b0IdNJbV02YJTJdChxElpKqXGSD4RhFulZ3iDtKrsrHw353/ue
-        LofDmUKngRm017t/7+CLA6uCy8SJHA0yAQ3JawFZYnqS52B6Jp5DznuqAM2tUNL0IBE2B8t78ZzL
-        FDKV9hagDd5BMoFCgwFpm7dxaazKZ8TwMvD9wHc1fC7B2Om6gFPNYyticHqOIPnBbhDu4MZANsPt
-        3NrCRJ6XwAxim6hPyuU248YILl0J1kNJ1uOF8EJPGFOC1zK4hjXSn0zHZ9N+sDsM8KhSwTjRF8eg
-        bqWJuYVU6XVtQ4I7pAj9cKfvB/3An4Z+FIyige8O9vZ+Rr19UpKEWFS8YvNEJYneQ35+2JndbBIw
-        sRYFOQ5PD5jJeZb1WCKMFTK2rBAQA1MztlT62iXqWMl3OnukFqUUFC6eXfIFt1x7CwFLr1Jro2Bz
-        FfiDYPSLEX/DyxzDXuYolWCBIqfcXFOsyitLq2jGMwM9pyY8Qrsq2p4zFwgcHc/Xx7AA1NX/2nOs
-        QGQViBInkiXa6NyBycBvLwqtPqFFT3R4Q125uwpg627afAOSjVXvpLAWGRink01I/b16a9TMLrkm
-        vBqRF5lAhZM7lmM8KpQNR6vh6JHqficyrSVdXIb+HqoRDlfh8P+VUke/wiIKDHZXwe6PELhqJQ7C
-        1SD8ERIbgH/9eh+OwTachu3FTKze1zUQo39+cf/loH3J01RDivXmXhKgASor6/R/WNzOtovdbRd7
-        Wy7CrRejbRf79/Wsy2Z9SkWp6hBO1A+aWkkh0SKuTfpy74wSBb1t5qrMklfCFBlfN+mEx0tusfXU
-        JfvxqV83hE0L8Gp2mhK7Wh6qklxfqfqBDoRMncjqkmQjU/seMUPp3XhDAxpL9eOhJuHvj9omcddt
-        XSm7e7ENVGEHqkILpYVdP9EFLblXdZp/3ytEzlMwHlGYlonAg7lI565ZpJtq+RZP2rIaOvcTJ+xQ
-        n/EroML4QGpQPXnQEcE2jAYj8sicm3Eh4mMhr1/TzSsoaH6RcYuhClnL6q47kUqOcXzhVxlMgJsa
-        l7pZOafH794cnVweHx2OT87Gl+PJ5M8J2od5atAl+GA6B3aKHUBaRnKZMEzJbM2wmoiMmDKr2G9C
-        c3aqIcdywkqDmHMfqioBJpTj3wjfL1ZXkVN3RYweun+TVbeqBQYiFZJndx8101fj3gr5GWrX7Cmy
-        qYTudVlQ2m5DcrDXIbkelJ4Ivpq467y3Z5vH4XGDt195fI3jZgu5lnkt67CZ6P6Twu1YWOcMCgnb
-        QUHCkrJbZUqf1NpcZSX0U401azMUKfZK1cFWeYEDsbQPg36nKwvfC+xdoq5k3HbnR/nt7wFLtSoL
-        GhRfC5lgWTMMc4VdAUhWlGYOSYXSo8kBfa+ACbkgyQSzhOG/Agy7GSQRMZuHLntD7D7K59X3ecTO
-        O7ZCRqxIox03cP0bcjb6OlMxz+bK2Gjkj3xvVr+9rHTygmBwgVTs/AzikmoTe6uWfau2EGOzTkps
-        1uEF89h5YCz7q+TagmZjmWJG5ujfLaTQPfCCivrk9A92UGLus7OYyy1UNPqhkjsXtStvbtgZTq2V
-        org+fD+uPh/qTxth2jTNn5ZTYbEOEGmFKFwhI0alkt2wc+TRDzH3sSn5o7BSgxAqF4krcdB3U7Xw
-        FmUmEbMWa4p3+/0FsdgfdmTxEtxcWA2u0qmHec0J6wKHWKoH3v7Qnds8I6oixT9VoIhFiD8TyJUF
-        NCMBNl5hPIiG9dlPp2mPPcvsCxa6QeCGjD1L7YuX/wAAAP//7FhRb9s4DP4rBAoMjpcqqJM0uBz6
-        ULQbMGAbhvW2l8sBcR118Z1jp5bdddj23++jJMty46xot721LVKHFCXqI0V+Mo0F+pxRjMWxmFCj
-        mLSKiZiKWSOftvKpwFyN/LiV8+O0lbN3Vn4kjlt51Mojf/y4lY/FuJVPWvmk3cCsXZcfPblblx+j
-        wZ7ksKk8Gh9NGNFTcJgbOeTQ64sA9cV59sA42/G/Ks5PMX50jHUM+mKMStgUhXmo480yCs9rSeco
-        oRC+lJeC/hgSN1jqVufmd30kXHnW38fi6Vj+ZMgmKNvhue71aMP/FsQsCOG4144CfAz6AvujsFKI
-        TgDx3/h3+IjDivVw6vUEP9cUupkVXhR1mUhkVyZD7s+HaKObVEmGdfvJG3jesogQ3d4ti9RTtj+L
-        tBjFq5tUgaLgCjCNIhCMK0YYh6HhnUw1lttPSwKng385xVSaLE44i6XLYt6DLOPLNOOOWq3jiooE
-        Cyn6vAY5qcCurSGjdhkrSUVJ17g0fiFclRM+gwqzJ2V8xQ6AjdWbnJh8CX3OwM9LSSDoVH0uGpOE
-        VCLzGBcZZixYKk3WBB4A8p6l/0nQ9yusEsPt7TZLE/3m0jKjxuFMAh+cWOb//iizNfhU5yq+QqFg
-        un+oah4C/9R1ZpezyCjaxDBOC/ACz3klFnm0OzuMciCt2Bm4h/tqCUKIeR06TNacD7FFqpRVXeZI
-        bTypOqsYXc8HjOt1QjCABwe4uRSIJ/7OijyR22qRL5fLRc63wYq+0hl2Bs7znU6IX+WmpQyeHdxG
-        M6SW+T9oxiZm5AmBOluzgJX6SdjNsaQxYLhOaHnx4vWLs7/oiE4v6Nl1XVR/LvBjJh+FRoJD2KcO
-        Rwucy+e8VVVkUuCyECD7E1zghMxvBv+wN2DQMMlHI2O91A4YpzSAAfwYUiDLcsgIDuiETw59xcx2
-        T5hrxY5/H1hw6KNLFHoDzop8IT5qvrx5PzTvVHHwxD11HJp9ldwZ7dRyp9mp5p7mTj33NHcquqe5
-        U9M9zZ2q7jQ7dd3TdCs7cHqn386sGpDmdqQFyaKC+Ty4GCOLCS/kw8UYWVCsqoGLMXKgeJqm4zWo
-        dFQMkkOlo2GQHCodDYPkUOloGCSHiqcxIDlUOhoDkpdMwGuNTOKUPDR0b75b6PmmMucPdCd8O034
-        HCAx60scf9sD3qT64mdbQOguMpG4Fbdz+qBfFnABssW+CQkqZgZNKXyj8T4jE61em8k+GxPGXpvp
-        PhsT4F6b4302JiLOhgJ6yx1IdyfX4XQSDE3Eh7rsmhBzq4kzVdDWJLAgphFu0dm+RXVIf7yoTQh0
-        qZ0FbOxebbZxUnHc3haU6i+EFLhJV3LVtnkMfA9OVEpUc/WQPm9NtwXfuJmmBPFqk+YDCgbfNqAh
-        VTF31KOXzj5RWe8A+wXvfirLpO4xVDZiKhv9Dir7PwAAAP//Iq0pS26/FznZ0ropazjalAWqAgAA
-        AP//7JrRaoMwFIZfZQx6GRdrrHpRujI22EVfoHfpiW5jqEUro2+/c4wNmjUdDAZeBHoh9cQTDubn
-        l//zVtZbWW9lr6r6xJpNdH1izcbK7q3sZV7eynorOw8rG5qlv1jZn+l9bAJsO7x1xfqhcN0w8AYl
-        fqdGwmdPHBABYZVyF+chDINhrzAZ+mUKrkJXps5d3Ac3PeXpJOGdIrUhWB5n03Z02XZlKSmMvb+a
-        FtKoiaiomz/GteRONhKAKI5XtY5VlCbpIUx4HkHGIYuXRRYWK+xjirDDjbKc3oOtUtijxUq0e+fH
-        0UagJvbtNuPVzz4P3hpdRmsunJHIeZhKFQqxSiBN4ig7wCHh2L6QeZHCRq37pyyi7WL5gj+9jpWy
-        GmJMxvRfbdC17AsHwZYB5aOB1kCaFDtK2dKgcH3v0fG04eXTjvHgWFFsbvNi89+xDZzNf8c2sDb3
-        HaP+KM1eDVwDfq+f73ayKDqAj/4AUQim2SitXvu6osLnrqmP+cMeBQeIAxpOGgGTeNccXeowYKLX
-        YQjhElPhYqSEYaSaQdS9jPzTC/MNAAD//8JMMKPFCD1cPFqMYClG0IsBXM0zE3grDN5IAXonHZIp
-        q0Eru6FsA6BL8ksSoevS0U3B1Q4zwFUuGRhhL+BwLXE0wOkBnO00XO1LUBGCVcIYpwS8ZZeaV5ZZ
-        lJ8HadpBhFJKoZsiIFxiQq8M2Ownd7kgxnJdiGFwQ4E2ZSQWh+WDFy7CVggDswDEydUwJrR+IdsB
-        4A0k+jBzdZRyEyuCIANPKJ4FLzksKnEsgXgctPQZtCwR5HW4OKpmIxTdUA1g19bW1gIAAAD//wMA
-        AGOiF4MzAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18257","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18257","key":"NTEST-1881","fields":{"statuscategorychangedate":"2025-04-30T18:27:52.607+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1881/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:52.249+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t8f:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:52.345+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/23]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/115]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/314] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/312] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/314]\n*Defect
+        Dojo link:* http://localhost:8080/finding/314 (314)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/312]\n*Defect Dojo link:*
+        http://localhost:8080/finding/312 (312)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1881/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18257/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 0765bd8b-da9e-4742-b0e7-55fcee253576
+      - 63343298-392f-4b33-ba15-5fde44fa0c68
       Atl-Traceid:
-      - 0765bd8bda9e4742b0e755fcee253576
+      - 63343298392f4b33ba155fde44fa0c68
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:31 GMT
+      - Wed, 30 Apr 2025 16:27:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -976,7 +1086,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=234,atl-edge-internal;dur=14,atl-edge-upstream;dur=220,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="UJwvW2vnM4QRf06NgdfS9MOK7t0AKAud9kIdh5wiRbJdqiszZ6babQ==",cdn-downstream-fbl;dur=342,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=61,cdn-upstream-fbl;dur=339,atl-edge;dur=256,atl-edge-internal;dur=17,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -985,10 +1095,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 48f2e5da4dd7651bfa3bfd0054610cf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - UJwvW2vnM4QRf06NgdfS9MOK7t0AKAud9kIdh5wiRbJdqiszZ6babQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 45545672d765965611df85aac0c0d150
+      - 091ceb3031880331df2ceef6961c8116
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1015,26 +1133,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TZl+5oSExEAykdhcQQmnqiEKaVE06aZr230nEBDsCN8t+
-        Xj+WD6SSHre9IYK8hdB5MZnUqFGF2r27TAYjvW+kzSwGMiJ14zsj9//gC+x3jcIa/ccaTbdCG7D/
-        65KVs9oMaBX+LrnD3jfORpgC0AwyGBeby8di/VD+TDdDW8WKiOcEjWAEL9GJnXH7Nl5Z7rtkWxk3
-        1DFUDY2pvyJExACbz0/NKxkSyIBNx0DHsCwZEzwXPIoBLiDCMe/jH7Avm/acpVAyEHQhcppx4N+s
-        am+sdhHkdLZQEnCKWtF8jpJrzTUozZb5dFHpGUc208DOBMEkw23Ty/RC1HIw4c4pmdoHYk4VQfu6
-        Lcjx/LAnZ9Pk+r4kx08AAAD//wMAN7XiyyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:54.055+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 5bfa91a4-6b8e-4198-9dcb-2b42bfe73acc
+      - c22e7639-669f-44ff-b8a5-e0dcf94e5614
       Atl-Traceid:
-      - 5bfa91a46b8e41989dcb2b42bfe73acc
+      - c22e7639669f44ffb8a5e0dcf94e5614
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:31 GMT
+      - Wed, 30 Apr 2025 16:27:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1044,7 +1158,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=150,atl-edge-internal;dur=18,atl-edge-upstream;dur=133,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=204,atl-edge;dur=170,atl-edge-internal;dur=22,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="vAJ1ReUb2K1oW5GfhZn4nFJTS3IIFbpG9Y6jN-OTnSOA9NSqH6h6Hg==",cdn-downstream-fbl;dur=208
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1053,10 +1167,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5538280951642fc71308aa997730220e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - vAJ1ReUb2K1oW5GfhZn4nFJTS3IIFbpG9Y6jN-OTnSOA9NSqH6h6Hg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4dbcbd2b38935f5c6035de13bd83c8d0
+      - 181bc8baafbfcc9a3be93f4cb7affa33
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1083,41 +1205,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 77cc25ed-9cb3-444b-a29e-3fcd422f9082
+      - e1d7a7a8-cf87-4e39-8e8b-5bd373591b25
       Atl-Traceid:
-      - 77cc25ed9cb3444ba29e3fcd422f9082
+      - e1d7a7a8cf874e398e8b5bd373591b25
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:31 GMT
+      - Wed, 30 Apr 2025 16:27:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1127,7 +1236,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=272,atl-edge-internal;dur=30,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=405,atl-edge;dur=318,atl-edge-internal;dur=15,atl-edge-upstream;dur=304,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="82vE17HX36JPkxDCMgcT7oRO9Bd37fubmg45M02jDYAjvoby0AfJ0Q==",cdn-downstream-fbl;dur=409
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1136,13 +1245,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a4888bfa57444daa340ca8dc53629170.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 82vE17HX36JPkxDCMgcT7oRO9Bd37fubmg45M02jDYAjvoby0AfJ0Q==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - eefe2096c5cedce26cd2eea586d0f8ee
+      - b68c97136a9750e63598dd87321caa4b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1154,22 +1271,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/114] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/24] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/115]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/313]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/313]\n*Defect
       Dojo link:* http://localhost:8080/finding/313 (313)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -1183,7 +1299,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1973'
+      - '1945'
       Content-Type:
       - application/json
       User-Agent:
@@ -1192,18 +1308,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16126","key":"NTEST-1642","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16126"}'
+      string: '{"id":"18259","key":"NTEST-1882","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18259"}'
     headers:
       Atl-Request-Id:
-      - ea6e5207-c445-465c-ac16-d78a39709d42
+      - 46975e66-32c1-4b4e-a93a-b5d650074f1f
       Atl-Traceid:
-      - ea6e5207c445465cac16d78a39709d42
+      - 46975e6632c14b4ea93ab5d650074f1f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:32 GMT
+      - Wed, 30 Apr 2025 16:27:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1213,7 +1331,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=724,atl-edge-internal;dur=15,atl-edge-upstream;dur=708,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="ym0_v6KmfoeQmf05HDLzxqvM9jlyzCLLpJu4iGI-G9dozs9ZZwnDyw==",cdn-downstream-fbl;dur=777,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=773,atl-edge;dur=694,atl-edge-internal;dur=22,atl-edge-upstream;dur=671,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1222,10 +1340,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f266ac47d4aee3a84c8fc38a6ef92022.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ym0_v6KmfoeQmf05HDLzxqvM9jlyzCLLpJu4iGI-G9dozs9ZZwnDyw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - de884b390c30fe9b0f6e20cbde3bee76
+      - da67dc0efebd7ef302bc7810f1dde013
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1249,65 +1375,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1642
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1882
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJlyRb4Uyn49py4tZ1XVlJHhyPByZXJGISYAFQR+P89+7y
-        kOJDmdqdZvRAEsAe2P3229VnB1Yll4kTORpkAhqSYwF5YnqSF2B6Js6g4D1VguZWKGl6kAhbgOW9
-        OOMyhVylvQVog3uQTKHUYEDa9mxcGauKOSm8Dnw/8F0Nf1Vg7GxdwrnmsRUxOD1HkP1gLwj38MNA
-        PsfPzNrSRJ6XwBxim6hPyuU258YILl0J1kNL1uOl8EJPGFOB1ym4hTXKn80mF7N+sDcMcal2wTjR
-        Z8egb5WJuYVU6XVzhwS/UCL0w1HfD/qBPwv9KBhHg9AdjUY/ot8+OUlGLDpeq3mhkyTvoT6fvGqu
-        3X4kYGItSgocrh4wU/A877FEGCtkbFkpIAam5myp9K1L0rGS73T+TC8qKShdPL/mC2659hYCll7t
-        1tbBdivwB8H4ZyP+hp8KTHtVoFWCBZqccXNLuapuLL1Fc54b6DmN4Aneq5btOZlA4Og4W5/CAtBX
-        /0vPsQKRVSJKnEhWeEfnAUwGfrdRavUJb/TCgLfSdbjrBHbhpo+vQLK91TsprEUFxtnYJqT+Vp81
-        am6XXBNejSjKXKDDyYObYz5qlA3Hq+H4me5+IzPdTTZ5Gfr76EY4XIXD/9dKk/0ai2gw2FsFe9/D
-        4KqzOAhXg/B7WGwB/uXLYzgGu3AadhtzsXrfcCBm//Lq8clBd5KnqYYU+eZREeAFVF415f+0udGu
-        jb1dG/s7NsKdG+NdG68f+9nQZrNKpFR3CCfqBy1XUkq0iJsrfX60RoWC0TaZqvLkSJgy5+u2nHB5
-        yS22noayn1/6TUPYtgCvUaepsOvXQ1VR6GtXP9CCkKkTWV2RbVRq3yNmqLzbaGjAyxJ/PNUkwn2/
-        axIPw7ahsocbu0AVbkBVaqG0sOsXhqAT9+pO8+97hSh4CsYjCdMpEbiQiTRzzSLdsuVbXOloNXQe
-        F064QX3Ob4CI8YnSID55MhDBLowGY4pIxs2kFPGpkLfHtHMEJc0vMu4wVCNrWe9tVqSSExxf+E0O
-        U+CmwaVu35zz03dvTs6uT08OJ2cXk+vJdPrHFO+HdWowJHhglgE7xw4gLSO7TBimZL5myCYiJ6XM
-        Kvar0JydayiQTlhlEHPuU6wSYEE5/p3w/XL1KXKarojZw/Bvq+oeW2AiUiF5/vBQO3214a2Rn6N3
-        7TdlNpWwOV2VVLa7kDwYbMadZlB6Ifga4U3nvT/bPA+PW7z9wuNbHDc7yHXKG1uH7UT3nxzuxsKm
-        ZtBI2A0KEpZU3SpX+qzx5iavoJ9q5KztUKTYkWqSrYoSB2Jpnwb9aEML30rsQ6ENZdwP50f59e+A
-        pVpVJQ2Kx0ImSGuGYa2wGwDJyspkkNQoPZke0PMGmJALskwwSxj+FWDYzSCJSFkWuuwNqfsoX9XP
-        VxG73KgVMmJzjGEW+e7A9e8o3hjuXMU8z5Sx0dgf+968OX5du+UFwfAKBdnlBcQV0RN7q5Z9q3YI
-        Y79OKuzX4RXz2GVgLPuz4tqCZhOZYlEWGOIdorA54AW19Nn57+ygwvJnFzGXO6Ro+kMnR1dNNO/u
-        2AUOrrWj+H74flI/PjSPLsn00fZ/ep0Ji1RAojWo8A0VMWJLdscuUUc/RHbDvhQEr2s3CKRykbgS
-        Z303VQtvUeUSYWuRVrz7569IxdBvgk1y8RLcQlgNrtKph7XNCe8CB1niBA+PupktcpKrc4XPOluk
-        ZwpplXOM5Yr+ttXuH4EUPCf0XIBe4L8z1mc/HGv4BwAA///sWdtO20AQ/ZVVpSISxcaJHXJBiEak
-        SDykqlq1D/SFzXpNXCVx5EtQVT6+Z9brxTFZ2lIV8YBASbyz15nZM2fG2aLDDpb5CQb33V7Loj1t
-        6yO/69OCE8T5reyQbhRZZnek03al0XFbKYXaWHtaSDaFC6LxQs5dNuowAii2693V36LrGvdWz777
-        n4+DfU8VjuCKf08YISy2+ttx7BAfrX2HfuzIrA0XQ/M3fDlPsjZWhOOoKf7N33b13v6cFCm0eBEv
-        JbBAlpo+uMlPlHPVOk7vMaoNLDHLJgAvffXdODni4TbOAIAgGP3eMeArIh3DVaqoRra7VpNfM4Re
-        RltFSqmDbapNrjdCJg+NyTNt8tsFQR/HfOsbBs4tIEfUFimPaCWK0YCkTZG70PzX+/lnwJ6l1Bi3
-        K6rY/rjmRejxUbHMsBJDCs2cGnFtAvRcYDQa4ZHqQo6byuzUGjJwG4sg3UqHolcsHnYspRHfUryt
-        WYkQbEwf5Fx4nAiB+caID/NlLLQFZ7EKCtqAXxRvIJ1ry5SnYknKlhCkrrH85WrDRU5jPiQsVg8M
-        OL6NQxnu+NIn3CeQKSz9Nx6ih24SCgPk4Ic8XMXrFjts3a3gwHkyhtM+pOJ9w0abTMzG0buBTWAy
-        MQrfeQpeotIHSmcaXT1b0haYhKo5whDiSgu2jjaC7NmSOM+syfOciwUFR80S60SzyUOyYrXixKze
-        2EI/aZsypCR9Iv2iO3jGhaCs7DI87Yf+cDCcdwee9MXIE6N+Lxp1IyrumU5Y4ZFuklxhEoZ0T9BT
-        JOGPd7WNgJ/RXI/WbJT6pQuKp7rRmKpuEEhkITzsBsHxQAwHfX80F/OBh+UjLqOhOAtP1Sxv/cnb
-        3gX+y3HOiq81J3Gcsilzi8y5hSKcnktkxy2vIGnK2XCekaIwXiE8chj8PJ85nrtZEw1u1n9e/o6b
-        BaSXv+NmAeql7xgQFJa1FJ2nnMP12YxHUSFErC4QkbKy1lEC2BVILDq+L9JkI4+ugDmC8np906gA
-        Cqm5urSCLvvuT24CG54GtppHYGoeqcb1Vxh5Nod5hZHn2PErjOyBkSYM2BhaYIiY4Sk4zk15KX/S
-        mxr928NOkpzr90zNWWxUzLPhktfbD3C2kqVnPYCVqtkoJkHIXoFvFRhyJ9fbOE3WJbsrm8JCv+Qs
-        H/9Ee9skr5XffwEAAP//Iq0cxhh+hxgGNxRoU0ZicVg+eCASNuIPzAIQJ1fDmND6hWwHgCeE9WHm
-        6ijlJlYEpRaX5oAMRvIseAixqMSxBOJx0FQGaJgR5HW4OKpmIxTdUA1g19bW1gIAAAD//wMAjfUq
-        MVMfAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18259","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18259","key":"NTEST-1882","fields":{"statuscategorychangedate":"2025-04-30T18:27:55.488+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1882/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:55.202+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t8n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:55.284+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/24]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/115]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/313]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/313]\n*Defect
+        Dojo link:* http://localhost:8080/finding/313 (313)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1882/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18259/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 7c4f4d6c-04c1-40cd-a501-403d2b909a8c
+      - 90d207f0-59ea-418f-9198-21cb0ac4c8b6
       Atl-Traceid:
-      - 7c4f4d6c04c140cda501403d2b909a8c
+      - 90d207f059ea418f919821cb0ac4c8b6
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:32 GMT
+      - Wed, 30 Apr 2025 16:27:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1317,7 +1429,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=265,atl-edge-internal;dur=15,atl-edge-upstream;dur=250,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="m-VJZhvF9gnIMNxU4o0u4hY6YI5uKFpGuh-OygIkWhotJRxjaECHxw==",cdn-downstream-fbl;dur=357,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=60,cdn-upstream-fbl;dur=355,atl-edge;dur=275,atl-edge-internal;dur=16,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1326,10 +1438,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8913ce09707cf3a865704b4fbd2875de.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - m-VJZhvF9gnIMNxU4o0u4hY6YI5uKFpGuh-OygIkWhotJRxjaECHxw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 0af60a5dd338a24fefaf660e54d11837
+      - 1f2150b7a46a46f9e116125fb9be80ab
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1353,65 +1473,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16126
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18259
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX23LbNhD9FQyfOqnEmyRH4Uyn49py4tR1XVlJHhyPByZXJGISYAFQl8b59+6S
-        ohRfmNbuNKMHkgD2gt2zZ1efHViVXCZO5GiQCWhIjgTkielJXoDpmTiDgvdUCZpboaTpQSJsAZb3
-        4ozLFHKV9hagDe5BMoVSgwFpN2fjylhVzEnhVeD7ge9q+LMCY2frEs40j62Iwek5guwHe0G4hx8G
-        8jl+ZtaWJvK8BOYQ20R9Ui63OTdGcOlKsB5ash4vhRd6wpgKvFbBDaxR/nQ2OZ/1g71hiEu1C8aJ
-        PjsGfatMzC2kSq+bOyT4hRKhH476ftAP/FnoR8E4GoTuaDT6Ef32yUkyYtHxWs0znSR5D/X55FVz
-        7c1HAibWoqTA4eo+MwXP8x5LhLFCxpaVAmJgas6WSt+4JB0r+U7nT/SikoLSxfMrvuCWa28hYOnV
-        bu0c3GwF/iAY/2zEX/BTgWmvCrRKsECTM25uKFfVtaW3aM5zAz2nETzGe9WyPScTCBwdZ+sTWAD6
-        6n/pOVYgskpEiRPJCu/o3IPJwG83Sq0+4Y2eGfCNdB3uOoFtuOnjK5DsbvVOCmtRgXG2tgmpv9Zn
-        jZrbJdeEVyOKMhfocHLv5piPGmXD8Wo4fqK738hMe5NtXob+S3QjHK7C4f9rpcl+jUU0GOytgr3v
-        YXDVWhyEq0H4PSxuAP7ly0M4Bl04Dbs2Bu3GXKzeN+SIsLi4RJikqYYU+eYfi2DUbuDNVF41vPD4
-        0b2ujZcdG2Hnxrhr49VDdxrabFaJlOoO4UT9AD+5xcbREO7TC7eh8x2Be406TWVZvx6oigIXECl/
-        oAUhUyeyugJMHyq17zHjVJyNc7U+0q9F3MTx84M18hWFTaaqPDkUpsz5elPcBAkNeFnij8eaRPjS
-        b5vE/bBtqez+Rheowi2oSi2UFnb9zCC24l7daf59rxAFT8F4JGFaJQIXMpFmrlmkO7Z8gystrYbO
-        w8IJt2WQ82sgYqQKuD8TdIE36MJoMKaIZNxMShGfCHlzRDuHUNL8IuM2a3Uul/XedkUqOcHxhV/n
-        MAVuGiTozZtzdvLu9fHp1cnxweT0fHI1mU5/n+L9sE4NhgQPzDJgZ9gBpGVklwnDlMzXDNlE5KSU
-        WcXeCs3ZmYYC6YRVBlHrPsYqARaU498K3y9XnyKn6YqYPQz/rqrusAUmIhWS5/cPbaavTXhrXOfo
-        XUs4mNlUwvZ0VVLZdiF5MNiOO82g9EzwNcLbznt3tnkaHnd4+4XHNzhutpBrlTe2DjYT3X9yuB0L
-        m5pBI2E7KEhYUnWrXOnTxpvrvIJ+qpEldkORYoeqSbYqShyIpX0c9KMuWhhtaeFbGb8bzo/y698+
-        S7WqShoUj4RMkBgNw1ph1wCSlZXJIKlRejzdp+c1MCEXZIBgljD8K8CwaUESkbIsdNlrUvdRvqif
-        LyJ2sVUrZMTmGMMs8t2B699SvDHcuYp5niljo7E/9r15c/yqdssLguElCrKLc4groif2Ri37VnUI
-        Y79OKuzX4SXz2EVgLPuj4tqCZhOZYlEWGOIOUdge8IJa+vTsN7ZfYfmz85jLDima/tDJ0WUTzdtb
-        do6Da+0ovh+8n9SPD82jTTJ9bNo8vc6ERSog0RpU+IaKGLElu2UXqKMfIrthZwuCV7UbBFK5SFyJ
-        s76bqoW3qHKJsLVIK97d85ekYug3wSa5eAluIawGV+nUw9rmhHeBgyxxgodH3cwWOcnVucJnnS3S
-        M4W0yjnGckV/22r3D0EKnhN6zkEv8N8Z67MfjjT8DQAA///sWdtO20AQ/ZVVJRCJYuPEDrkgRCMo
-        Eg+pqlbtA31hs7smrpI48iWogo/vmfVmSUyWtlRFPKBEib2zN8/Mnjkzzqcttj8rjjG463caDu0Z
-        Wx+G7ZAWHCGyrlSLdKPJMrsnnTbXGh02tVKojTXPS8XO4YJovFATnw1ajACKbXv3+jNt+9a99X3o
-        /+fHwb7PNY7giP9IGSEstvrbcewAP41dD/3UI7MmXAzN3/HnPcvaWBGOo6f4N3/b1nvzS1pm0OJF
-        MlPAAlVpev+mONbOtdHx/AGjmsASu2wK8DJH30/SQy5XSQ6cA8Hodo4AXzHpGK6yjmpku2s9+TVD
-        6GW0VaSUJthmxuRmI2RyaU2eG5PfTgn6OOZb3DBwbgE5orbIeEwrUYwGJC3Lwofmvz3MPwb2zJTB
-        uG3RmtQPN7wIPT5pnirXYkihmRMr3pgAPacYjUZ4pD6Qw7oyWxsNObiNQ5CtlEfRKxGPO1bSmK8o
-        3m5YiRBsSD/kXLgdCYH5hogPk1kijAXHiQ4KxoBfNW8gnRvLVE/F0ozNIMh8a/nL+ZKLgsZ8TFmi
-        bxhwfJVIJbd86TPOE8gUlv4bDzFDlymFAXLwAy7nyaLBDhr3czhwkQ7htI+peNey0ToTcwXjduQS
-        2NyMonSRgZfoBIQSiFrXyOZNNUFg56gLXIQ4sIR4rR5XR1cSF9jNbBHLOr3gRcHFlCJnRV7ycj7n
-        xKzeuUI/aZsypDR7Jv2iM3jKhaC87lKedGXY7/Un7V6gQjEIxKDbiQftmIp7thNWeKKbIlcYSUnn
-        BD1FKn++39gI+BnN9WTNRmtZ+aB4uhuNWdcNIoUshMt2FB31RL/XDQcTMekFWD7mKu6LU3miZ9kL
-        R3udC3yrcd6cLwwn8byqKffL3LuFIryOT2THr44gacpbcp6TojBeIzxyGFyejb3AXy6IBtfrP69/
-        x/UC0uvfcb0A9dp3DAiSVfXC5ClncH025nFcCpHoA0SkrKqWVAB2BRKLjh/KLF2qwytAi6C83pw0
-        KoBCao8urWDKvruTm8iFp5Gr5hG5CmmRxezMAP4bvryYJ73hy0vs+A1fduBLHQYsEbO8Bbu+qc7e
-        Hb2pMdcBFkwLbt4z1WdxMi4nLjmpWGc38rlKloGLexIg7BQELu4ZukaEltypxSrJ0kVF4KomWZqX
-        nNXtH2kvnVcz3NHlLwAAAP//AjGhxT0ZxS/S/Kw+zFwdpdzEiqDU4tIckMFIdoNH9IpKHEsg7ijL
-        L6HeRALEMLihQLsyEovD8sEDorCxftBUBmiYEWQl3CGorjVCcS5UAzh4amtrAQAAAP//AwAb0TCg
-        Ux8AAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18259","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18259","key":"NTEST-1882","fields":{"statuscategorychangedate":"2025-04-30T18:27:55.488+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1882/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:55.202+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t8n:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:55.284+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/24]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/115]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/313]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/313]\n*Defect
+        Dojo link:* http://localhost:8080/finding/313 (313)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1882/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18259/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 882275ef-2c7c-4d1c-bc5f-39ea661fb302
+      - a5e743d0-8d38-45c9-906d-6851ea7e0e3e
       Atl-Traceid:
-      - 882275ef2c7c4d1cbc5f39ea661fb302
+      - a5e743d08d3845c9906d6851ea7e0e3e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:33 GMT
+      - Wed, 30 Apr 2025 16:27:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1421,7 +1527,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=285,atl-edge-internal;dur=15,atl-edge-upstream;dur=270,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=420,atl-edge;dur=387,atl-edge-internal;dur=15,atl-edge-upstream;dur=373,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="JuHBBzHspevxC2SFcr8b3PhSM69MpluXwyi1LNRrIRY46riwoukk5w==",cdn-downstream-fbl;dur=423
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1430,10 +1536,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5538280951642fc71308aa997730220e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JuHBBzHspevxC2SFcr8b3PhSM69MpluXwyi1LNRrIRY46riwoukk5w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 0a18492e27fc234a0dbfdcbcfed04b3f
+      - 14ea9f4085172fa592e3d2eb03a544ec
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1466,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1480,9 +1594,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"849\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:43146\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:53214\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -1518,7 +1632,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:33 GMT
+      - Wed, 30 Apr 2025 16:27:56 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1536,25 +1650,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       115, "url_ui": "http://localhost:8080/test/115", "url_api": "http://localhost:8080/api/v2/tests/115/"},
       "finding_count": 5, "findings": {"new": [{"id": 310, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/310", "url_api": "http://localhost:8080/api/v2/findings/310/"},
-      {"id": 311, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/311",
-      "url_api": "http://localhost:8080/api/v2/findings/311/"}, {"id": 312, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/312", "url_api": "http://localhost:8080/api/v2/findings/312/"},
-      {"id": 313, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/313", "url_api":
-      "http://localhost:8080/api/v2/findings/313/"}, {"id": 314, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/314", "url_api": "http://localhost:8080/api/v2/findings/314/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/310",
+      "url_api": "http://localhost:8080/api/v2/findings/310/"}, {"id": 311, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/311", "url_api": "http://localhost:8080/api/v2/findings/311/"},
+      {"id": 312, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/312",
+      "url_api": "http://localhost:8080/api/v2/findings/312/"}, {"id": 313, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/313", "url_api": "http://localhost:8080/api/v2/findings/313/"},
+      {"id": 314, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/314",
+      "url_api": "http://localhost:8080/api/v2/findings/314/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -1565,11 +1677,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2507'
+      - '2372'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -1581,11 +1693,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2507\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2372\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:43156\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:53218\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -1600,63 +1712,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 115, \\\"url_ui\\\": \\\"http://localhost:8080/test/115\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/115/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 310, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/310\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/310/\\\"}, {\\\"id\\\": 311, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/311\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/311/\\\"}, {\\\"id\\\":
-        312, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/312\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/312/\\\"}, {\\\"id\\\":
-        313, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/313\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/313/\\\"}, {\\\"id\\\":
-        314, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/314\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/314/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        312, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/312\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/312/\\\"}, {\\\"id\\\": 313, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/313\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/313/\\\"}, {\\\"id\\\": 314, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/314\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/314/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 310,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/310/\",\n          \"url_ui\": \"http://localhost:8080/finding/310\"\n
         \       },\n        {\n          \"id\": 311,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/311/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/311/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/311\"\n        },\n
         \       {\n          \"id\": 312,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/312/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/312\"\n        },\n        {\n          \"id\":
-        313,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/313/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/313\"\n        },\n
-        \       {\n          \"id\": 314,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/314/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/314\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 115,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/115/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/312/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/312\"\n        },\n
+        \       {\n          \"id\": 313,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/313/\",\n          \"url_ui\": \"http://localhost:8080/finding/313\"\n
+        \       },\n        {\n          \"id\": 314,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/314/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/314\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        115,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/115/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/115\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/115/\",\n
@@ -1670,7 +1780,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:33 GMT
+      - Wed, 30 Apr 2025 16:27:56 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1701,7 +1811,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1715,9 +1825,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"849\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:43166\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:53232\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -1753,7 +1863,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:33 GMT
+      - Wed, 30 Apr 2025 16:27:56 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1771,25 +1881,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       116, "url_ui": "http://localhost:8080/test/116", "url_api": "http://localhost:8080/api/v2/tests/116/"},
       "finding_count": 5, "findings": {"new": [{"id": 315, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/315", "url_api": "http://localhost:8080/api/v2/findings/315/"},
-      {"id": 316, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/316",
-      "url_api": "http://localhost:8080/api/v2/findings/316/"}, {"id": 317, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/317", "url_api": "http://localhost:8080/api/v2/findings/317/"},
-      {"id": 318, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/318", "url_api":
-      "http://localhost:8080/api/v2/findings/318/"}, {"id": 319, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/319", "url_api": "http://localhost:8080/api/v2/findings/319/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/315",
+      "url_api": "http://localhost:8080/api/v2/findings/315/"}, {"id": 316, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/316", "url_api": "http://localhost:8080/api/v2/findings/316/"},
+      {"id": 317, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/317",
+      "url_api": "http://localhost:8080/api/v2/findings/317/"}, {"id": 318, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/318", "url_api": "http://localhost:8080/api/v2/findings/318/"},
+      {"id": 319, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/319",
+      "url_api": "http://localhost:8080/api/v2/findings/319/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -1800,11 +1908,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2507'
+      - '2372'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -1816,11 +1924,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2507\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2372\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:43178\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:53236\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -1835,63 +1943,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 116, \\\"url_ui\\\": \\\"http://localhost:8080/test/116\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/116/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 315, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/315\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/315/\\\"}, {\\\"id\\\": 316, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/316\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/316/\\\"}, {\\\"id\\\":
-        317, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/317\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/317/\\\"}, {\\\"id\\\":
-        318, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/318\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/318/\\\"}, {\\\"id\\\":
-        319, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/319\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/319/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        317, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/317\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/317/\\\"}, {\\\"id\\\": 318, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/318\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/318/\\\"}, {\\\"id\\\": 319, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/319\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/319/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 315,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/315/\",\n          \"url_ui\": \"http://localhost:8080/finding/315\"\n
         \       },\n        {\n          \"id\": 316,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/316/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/316/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/316\"\n        },\n
         \       {\n          \"id\": 317,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/317/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/317\"\n        },\n        {\n          \"id\":
-        318,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/318/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/318\"\n        },\n
-        \       {\n          \"id\": 319,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/319/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/319\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 116,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/116/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/317/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/317\"\n        },\n
+        \       {\n          \"id\": 318,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/318/\",\n          \"url_ui\": \"http://localhost:8080/finding/318\"\n
+        \       },\n        {\n          \"id\": 319,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/319/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/319\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        116,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/116/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/116\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/116/\",\n
@@ -1905,7 +2011,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:33 GMT
+      - Wed, 30 Apr 2025 16:27:56 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_with_push_to_jira_is_false_but_push_all.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_groups_with_push_to_jira_is_false_but_push_all.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TZl+5oSExEAykdhcQQmnqiEKaVE06aZr230nEBDsCN8t+
-        Xj+WD6SSHre9IYK8hdB5MZnUqFGF2r27TAYjvW+kzSwGMiJ14zsj9//gC+x3jcIa/ccaTbdCG7D/
-        65KVs9oMaBX+LrnD3jfORpgC0AwyGBeby8di/VD+TDdDW8WKiOcEjWAEL9GJnXH7Nl5Z7rtkWxk3
-        1DFUDY2pvyJExACbz0/NKxkSyIBNx0DHsCwZEzwXPIoBLiDCMe/jH7Avm/acpVAyEHQhcp5xWH6z
-        qr2x2kWQ09lCScApakXzOUquNdegNFvm00WlZxzZTAM7EwSTDLdNL9MLUcvBhDunZGofiDlVBO3r
-        tiDH88OenE2T6/uSHD8BAAD//wMASLJiriACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:27:57.546+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 2ffe632a-8171-441a-8c61-665b0aa927de
+      - 57f26753-8e1d-42d9-823e-e1dff8c2ca91
       Atl-Traceid:
-      - 2ffe632a8171441a8c61665b0aa927de
+      - 57f267538e1d42d9823ee1dff8c2ca91
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:34 GMT
+      - Wed, 30 Apr 2025 16:27:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=14,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="T_-QHDjiRU1LVYT4Dhy1SmC_pqtxCljxfPmE3yHsKm04bc_rVPp8EA==",cdn-downstream-fbl;dur=324,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=70,cdn-upstream-fbl;dur=322,atl-edge;dur=228,atl-edge-internal;dur=13,atl-edge-upstream;dur=215,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 51e6f466f192ce588105b138cebcc0d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - T_-QHDjiRU1LVYT4Dhy1SmC_pqtxCljxfPmE3yHsKm04bc_rVPp8EA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 19f1fabf35341708942c0f0a6ac3629e
+      - a7ba8bd322bb7f6f569214edd869cc7b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - c428bd05-ebbd-48d4-9061-1aa8e7a66aad
+      - ffc22c39-4aed-46e5-ad5f-d2e76653a6f5
       Atl-Traceid:
-      - c428bd05ebbd48d490611aa8e7a66aad
+      - ffc22c394aed46e5ad5fd2e76653a6f5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:34 GMT
+      - Wed, 30 Apr 2025 16:27:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=347,atl-edge-internal;dur=19,atl-edge-upstream;dur=332,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="ZujxIZoXiHJon39CoOzffPWX19BVYWBOoemJ2C3B0XF4dd1M-wv3DA==",cdn-downstream-fbl;dur=367,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=364,atl-edge;dur=289,atl-edge-internal;dur=16,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f266ac47d4aee3a84c8fc38a6ef92022.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ZujxIZoXiHJon39CoOzffPWX19BVYWBOoemJ2C3B0XF4dd1M-wv3DA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 706baacaa21918755587bc1cbf762e47
+      - c6b908138d9f4b776c255c1e870d809b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -157,7 +156,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
       group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
-      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/118]
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/28]
       in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/117]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
@@ -166,28 +165,28 @@ interactions:
       | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
       | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/320]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
       0.6.0)|http://localhost:8080/finding/321]\n*Defect Dojo link:* http://localhost:8080/finding/321
-      (321)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      (321)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
       \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
       Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/320]\n*Defect
       Dojo link:* http://localhost:8080/finding/320 (320)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
       File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
       versions of `negotiator` are vulnerable to regular expression denial of service
       attacks, which trigger upon parsing a specially crafted `Accept-Language` header
-      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
-      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <= 0.6.0\n
+      Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -201,7 +200,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3359'
+      - '3334'
       Content-Type:
       - application/json
       User-Agent:
@@ -210,18 +209,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16127","key":"NTEST-1643","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16127"}'
+      string: '{"id":"18261","key":"NTEST-1883","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18261"}'
     headers:
       Atl-Request-Id:
-      - a17de581-3b17-485d-a41a-253ef589ca3d
+      - c33005be-1c6e-490d-a5c3-b78b27d9d316
       Atl-Traceid:
-      - a17de5813b17485da41a253ef589ca3d
+      - c33005be1c6e490da5c3b78b27d9d316
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:35 GMT
+      - Wed, 30 Apr 2025 16:27:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -231,7 +232,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=675,atl-edge-internal;dur=16,atl-edge-upstream;dur=660,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="YCv47yDPkedtKNFAeZDkzj4AXEhTbcYhutqMB0CkMJ2JRF8ZGwo6bg==",cdn-downstream-fbl;dur=721,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=60,cdn-upstream-fbl;dur=719,atl-edge;dur=638,atl-edge-internal;dur=18,atl-edge-upstream;dur=620,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -240,10 +241,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b1383a69c949c8987c982636bd26b4f2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - YCv47yDPkedtKNFAeZDkzj4AXEhTbcYhutqMB0CkMJ2JRF8ZGwo6bg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 27fde3cbbb2fe67335b31f83d7ebfdf2
+      - ebc22e3c92f8ae4d26b9fc643e492537
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -267,66 +276,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1643
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1883
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIv2YrCmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxvnv3eWl
-        +FBau9PYD8S1B3a//bD67MC65DJxIkeDTEBD8lpAnpiB5AWYgYkzKPhAlaC5FUqaASTCFmD5IM64
-        TCFX6WAJ2uAeJDMoNRiQtj0bV8aqYkEKrwLfD3xXw58VGDvflHCmeWxFDM7AEWQ/GAfhS5wYyBc4
-        zawtTeR5CSwgton6pFxuc26M4NKVYD20ZD1eCi/0hDEVeJ2CG9ig/Ol8ej4fBuO9ES7VLhgn+uwY
-        9K0yMbeQKr1p7pDgDCVCP9wf+sEw8OehHwWTaLTvjv3RD+i3T06SEYuO12qe6STJe6jPD/trt5ME
-        TKxFSYHD1QNmCp7nA5YIY4WMLSsFxMDUgq2UvnFJOlbync6f6EUlBaWL51d8yS3X3lLAyqvd2jrY
-        bgX+KJj8ZMRf8GOBaa8KtEqwQJNzbm4oV9W1pVG04LmBgdMIHuO9atmBkwkEjo6zzQksAX31vwwc
-        KxBZJaLEiWSFd3TuwWTkdxulVp/wRs8MeCtdh7tOYBdumnwFku2t3klhLSowTm+bkPprfdaohV1x
-        TXg1oihzgQ4n926O+ahRtjdZ702e6O43MtPdpM/Lnk9AD/fW4d7/a6XJfo1FNBiM18H4exhcdxZH
-        4XoUfg+LLcC/fHkIx2AXTsNuYyHW7xsOxOxfXD48OepO8jTVkCLf/GMR7HcbeDOVVw0vPH50vGvj
-        5Y6NcOfGZNfGq4fuNLTZrBIp1S+EEw2DlispJVrEjeefH6xRoWC0TaaqPDkSpsz5pi0nXF5xi09P
-        Q9lPL/3mQdg+AV6jTlNh18NDVVHoa1c/0IKQqRNZXZFtVGrfI2aovNtoaMDLEn889kiErybdI3E/
-        bD2V3d/YBaqwB1WphdLCbp4Zgk7cq1+af/9WiIKnYDySMJ0SgQuZSDPXLNMtW77FlY5WQ+dh4YQ9
-        6nN+DUSMj5QG8cmjgQh2YTSYUEQybqaliE+EvHlNO0dQUv8i4w5DNbJW9V6/IpWcYvvCr3OYATcN
-        LnU7cs5O3r05Pr06OT6cnp5Pr6az2e8zvB/WqcGQ4IF5BuwMXwBpGdllwjAl8w1DNhE5KWVWsV+E
-        5uxMQ4F0wiqDmHMfY5UAC8rxb4Xvl2sdOc2riNnD8G+r6g5bYCJSIXl+/1DbfbXhrZGfo3ftnDKb
-        SuhPVyWV7S4kj8avOiQ3jdIzwdcI9y/v3d7maXjc4u1nHt9gu9lBrlPe2DpsO7r/5HDXFjY1g0bC
-        rlGQsKLqVrnSp40313kFw1QjZ22bIsWOVJNsVZTYEEv7OOj3d9HCfk8L38r43XB+lF//H7BUq6qk
-        RvG1kAnSmmFYK+waQLKyMhkkNUqPZwf0vQYm5JIMEMwShj8FGL5mkESkLAtd9obUfZQv6u+LiF30
-        aoWMmMR4WcGt0pHvIn5uKegY81zFPM+UsdHEn/jeopG5qn3zgmByidLs4hziijiKvVWroVU7hPHR
-        Tip8tMNL5rGLwFj2R8W1Bc2mMsXKLDDOO0ShP+AFtfTp2W/soEIOYOcxlzukqAVEJ19eNiG9vWXn
-        2L3WjuL48P20/nxoPl2madI2ATScC4t8QKI1snCEihhRJrtlF6hjGCIHYPGNwqB2g5Aql4krseF3
-        U7X0llUuEbsWucW7e/6SVIx8v5eLV+AWwmpwlU49LHBOoBfYzRIxeHjUzWyRk9w2YTipU0bKQvyb
-        QVrlHIO6ph9x9T2OQAqeE5b+BgAA///sWW1v2jAQ/ivWpFaASBpKeK2qDpVVqjSqadX2ofuCcRzI
-        BCTKC9Wk/fg95zgBUgIdVatOmkBAbJ99Pt8953u4l+EKtRozWOUun6HOTufxxSWmaZtWtcSY+ujP
-        tN4D5P6VrJOp1AWa7bJLG/tsNXvPtoser+xiP98u9kG7vLpNrDKbIOIyp+vXlH2ojdWGiWRDhCoa
-        b+TEZL06IyBn2yiQvWYNM4cB9dw03+ywsYOhQl6A4k+fUU6C0gflWAUf1V3b37d5VkM8ovkHvoyj
-        QgMrwpvUFC8Lzu0TqN37SQhb3nhzCfSUqb1Pp/EFF0IGsfq5dr4NweEa5WtA41wNH/CvcdP0/DPu
-        rLwImUJSuu0gAbhkczhRdi+gEx2vVxgz3GAY6Y/KXN9ZQu0NWjvyBif3hkh7A49jJOCozh5nnpgx
-        XOOnU2BwAvhjAcdayynjDDWNgCBuRSLkLukxHqiNGp/5cpoAjcdsJrkDyRVHCjXT3bLva4VGgPu5
-        3Mwt2/1ZqdXf9EgM+aLu+E7Wj+5p1t3YngEjZxBHI3xcBXv/8MEQ4vfpg/wLj7StCLMEyWTuCX1o
-        I09lUn1m39RliyysDyNVhgFk5ugI9eYhd7sIuIhJ5s5nnnpgyHsrz5HOljt9RUjhBoql/8YptGjg
-        U9okH69wZ+Etq6xS/b2AD8d+P/fbnZjx6nhhHYkXFuGF9TK8OCplPMGLY5PW5vG+NV60/+PFG+CF
-        /W/hRTsXPYAXT/mOVl7yF8vdsoqnYW9WPHEIl1FUDFFDxaE5JVbosHNyqtBhlUlYOeuQWaFsYBkL
-        YZUxZVaujAqAGRUfuhTfrOaLNV2ULBacytcPe+srMjlxUX54ZKFLjMQVPJb4r1vnsuU0u53upNGx
-        ZFP0LNFrnbu9htvGOvkgrLBnmCR/GDgORQNGCt/59XFDEVTCNNdedlydgTRRTKthJJMxtLa0Gl3u
-        NGy73RHdDvByIiYdC8u7XLpdceVcqllOmoOT8xu8UzljwZe68DOMtCkyk8h4hCGMc5MqSjONQ7KU
-        EXAekaEgr5CezyP8vB4ZlhksiXAoMu3vX+MiVf/+NS5S/e9dYwCUk7LWmhG6huuzEXfdRAhPBRCV
-        dSmrnMLbg7+kgZ+S0A/k2QOARxCDqiON/mpCbx66tIL+g203jWSXgapdxi7bObscanB/Joz8AQAA
-        //8aLUYoTzCDsRgBAAAA//8i5OLRYoTWLqZLMYJeDOBqppnAW2PwxgrQO+mQTFkNmhOHsg2ALskv
-        SYTO6KObgrPZhbNcwjULZGCEveTD2SzD6TOc7TW4l9EkjHHpMIa38FLzyjKL8vMgTTyIUEopdDkJ
-        hEtM6JXll1BvohNiGNxQoE0ZicVh+eApH9jcKjALQJxcDWNC6xeyHQBeeqMPM1dHKTexIii1uDQH
-        ZDCSZ8GTNUUljiUQj4MmjUETOiCvw8VRNRuh6IZqALu2trYWAAAA//8DAKY9NGG9JAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18261","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18261","key":"NTEST-1883","fields":{"statuscategorychangedate":"2025-04-30T18:27:58.937+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1883/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:58.673+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t8v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:58.748+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/28]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/117]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/321]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/320]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/321]\n*Defect Dojo link:* http://localhost:8080/finding/321
+        (321)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/320]\n*Defect
+        Dojo link:* http://localhost:8080/finding/320 (320)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1883/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18261/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 93e90f91-4436-4a6b-92bf-49a9e17767e9
+      - bff9ab65-4a52-4c85-a8dc-31123dbcbc5e
       Atl-Traceid:
-      - 93e90f9144364a6b92bf49a9e17767e9
+      - bff9ab654a524c85a8dc31123dbcbc5e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:36 GMT
+      - Wed, 30 Apr 2025 16:27:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -336,7 +346,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=312,atl-edge-internal;dur=15,atl-edge-upstream;dur=298,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="Syi7a3gUEBtqXR1plJzpqamzX6IZg4JYrvF1MUWMr9QL2p3lshFu7A==",cdn-downstream-fbl;dur=363,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=361,atl-edge;dur=273,atl-edge-internal;dur=17,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -345,10 +355,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f6567fa2210130239a3a2c737c9517ac.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Syi7a3gUEBtqXR1plJzpqamzX6IZg4JYrvF1MUWMr9QL2p3lshFu7A==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - d2d1ba1b8a099c0d0300c6723bb01f2f
+      - 068874afa6a276f6d6dba59ef3b001e2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -372,66 +390,67 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16127
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18261
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIv+VA40+m4tpK4dV1XVpIHx+OByRWJmARYANTR2P+9u7wU
-        H0prdxr7gbj2wO63H1ZfHFiVXCZO5GiQCWhI3gjIEzOQvAAzMHEGBR+oEjS3QkkzgETYAiwfxBmX
-        KeQqHSxAG9yDZAqlBgPStmfjylhVzEnhVeD7ge9q+LMCY2frEs40j62IwRk4guwHe0G4jxMD+Ryn
-        mbWliTwvgTnENlGflcttzo0RXLoSrIeWrMdL4YWeMKYCr1NwA2uUP51NzmfDYG9nhEu1C8aJvjgG
-        fatMzC2kSq+bOyQ4Q4nQD3eHfjAM/FnoR8E4Gu26e/7oB/TbJyfJiEXHazUvdJLkPdTnh/2120kC
-        JtaipMDh6gEzBc/zAUuEsULGlpUCYmBqzpZK37gkHSv5XufP9KKSgtLF8yu+4JZrbyFg6dVubRxs
-        twJ/FIx/MuIv+LHAtFcFWiVYoMkZNzeUq+ra0iia89zAwGkEj/FetezAyQQCR8fZ+gQWgL76dwPH
-        CkRWiShxIlnhHZ0HMBn52zaCbqPU6jNe9YWZaKXrPNSZ7fJAk6/Qs7nueymsRQXG6W0ThH+tzxo1
-        t0uuCchGFGUu0OHkQUgwUTX8dsarnfEz3f1Gyrqb9Anb8akCwp1VuPP/WmlgUYMUDQZ7q2Dvexhc
-        dRZH4WoUfg+LLfLv7h7DMezgOBerDw0HYpIvLh+fHHUneZpqSJFv/rEIdrsNvIDKq4YXnj66t21j
-        f8tGuHVjvG3j9WN3GtpsVomU6hfCiYYBTrnFh6Mh3OfXZ0PnGwL3GnWaqq8eHqqKAhcQKX+kBSFT
-        J7K6gruWp0mbFnETtS+P1sgzPGoyVeXJkTBlztdtxeIyumU/IDSoittoaMDLEk089UiEr8fdI/Ew
-        bNuoLOyp7OFGD6pSC6WFXb8wiJ24V780//6tEAVPwXgkYTolAhcykWauWaQbUnyHKx17hs7j+gh7
-        1Of8Goj/nigNoo0nAxFsw2gwpohk3ExKEZ8IefOGdo6gpP5Fxl0e6+wu671+RSo5wfaFX+cwBW4a
-        bOh25JydvH97fHp1cnw4OT2fXE2m09+neD+sU4MhwQOzDNgZEr20jOwyYZiS+ZohaYiclDKr2C9C
-        c3amoUDWYJVB1LpPkUeABeX4t8L3y5WOnOZVxOxh+DdVdY8tMBGpkDx/eKjtvtrw1kjP0bt2TplN
-        JfSnq5LKdhuSR3uvOyQ3jdILwdcI9w/s/d7meXjc4O1nHt9gu9lBrlPe2DpsO7r/5HDXFjY1g0bC
-        rh+QsKTqVrnSp40313kFw1Qjb2yaIsWOVJNsVZTYEEv7NOh3e1r4VmIfCvWUcT+cn+TX/wcs1aoq
-        qVF8I2SCxGgY1gq7BpCsrEwGSY3S4+kBfa+BCbkgywSzhOFPAYavGSQRKctCl70ldZ/kq/r7KmIX
-        vVohIyYxXlZwq3Tku4ifWwo6xjxXMc8zZWw09se+N29krmrfvCAYX6I0uziHuCKOYu/UcmjVFmF8
-        m5MK3+bwknnsIjCW/VFxbUGziUyxMguM8xZR6A94QS19evYbO6iQA9h5zOUWKer00Mn9yyakt7fs
-        HLvX2lEcH36Y1J+PzafLNE3aJoCGM2GRD0i0RhaOUBEjymS37AJ1DEPkACy+URjUbhBS5SJxJTb8
-        bqoW3qLKJWLXIrd4989fkoqR7/dy8RLcQlgNrtKphwXOCfQCm1YiBg+PupktcpLbJAwndcpIWYh/
-        U0irnGNQV/Qjrr7HEUjBc8LS3wAAAP//7Fltb9owEP4r1qRWgEgaSnitqg6VVao0qmnV9qH7gnEc
-        yAQkygvVpP34Pec4AVICHVWrTppAQGyffT7fPed7uJfhCrUaM1jlLp+hzk7n8cUlpmmbVrXEmPro
-        z7TeA+TflayTqdQ9me2ySxv7bDV7z7aLHq/sYj/fLvZBu7y6TawymyDiMqfr15R9qI3VholkQ4Qq
-        Gm/kxGS9OiMgZ9sokL1mDTOHAfXcNN/ssLGDoUJegOJPn1FOgtIH5VgFH9Vd29+3eVZDPKL5B76M
-        o0IDK8Kb1BQvC87tE6jd+0kIW954cwn0lKm9T6fxBRdCBrH6uXa+DcHhGuVrQONcDR/wr3HT9Pwz
-        7qy8CClEUrrtIAG4ZHM4UXYvoBMdr1cYM9xgGOmPylzfWULtDVo78gYn94ZIewOPYyTgqM4eZ56Y
-        MVylp1NgcAL4YwHHWssp4ww1jYAgbkUi5C7pMR6ojRqf+XKaAI3HbCa5A8kVRwo1092y72uFRoD7
-        udzMLdv9WanV3/RIDPmiqgQn60f3NOtubM+AkTOIoxE+roK9f/hgCPH79EH+hUfaVoRZgmQy94Q+
-        tJGnMqk+s2/qskUW1oeRKsMAMnN0hHrzkLtdBFzEJHPnM089MOS9ledIZ8udviKkcAPF0n/jFFo0
-        8Cltko9XuLPwllVWqf5ewIdjv5/77U7MeHW8sI7EC4vwwnoZXhyVMp7gxbFJa/N43xov2v/x4g3w
-        wv638KKdix7Ai6d8Rysv+YvlbhkR0rA3S6E4hMsoMofomeLQnBIrdFhlHXbOWhUlctYhs0LZwDIW
-        wipjyqx8za3qvVjcqeiYUWWSVohRslhwKl8/7K2vyOTERfnhkYUuMRJX8Fhi0G6dy5bT7Ha6k0bH
-        kk3Rs0Svde72Gm4b6+SDsMKeYZL8YeA4FA0YKXzn18cNRVAJ01x7SXB1BtJEMa2GkUxGxNrSanS5
-        07Dtdkd0O8DLiZh0LCzvcul2xZVzqWY5aQ5Ozm/wTuWMBV/qws8w0qbITCLjEYYwzk2qKM00DslS
-        RsB5RIaCvEJ6Po/w83pkWGawJMKhSKi/f42LjPz717jI6L93jQFQTsoca0boGq7PRtx1EyE8FUBU
-        1qW8dApvD/6SBn5KQj+QZw8AHkEMqo40+kcJvXno0gr6D7bdNJJdBqp2Gbts5+xyqMH9mTDyBwAA
-        //8aLUYoTzCDsRgBAAAA//8i5OLRYoTWLqZLMYJeDOBqppnAW2PwxgvQO+mQTFkNmvqGsg2ALskv
-        SYTO6KObgqs9ZoCrXDIwwl7A4ZocMsDpAZztNbjP0HXgasgZ45SAt/BS88oyi/LzIK04iFBKKXQ5
-        CYRLTOiV5ZdQb6oUYhjcUKBNGYnFYfngKR/Y/CYwC0CcXA1jQusXsh0AXnqjDzNXRyk3sSIotbg0
-        B2QwkmfBkzVFJY4lEI+DJo1BEzogr8PFUTUboeiGagC7tra2FgAAAP//AwA5a+7UvSQAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18261","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18261","key":"NTEST-1883","fields":{"statuscategorychangedate":"2025-04-30T18:27:58.937+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1883/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:27:58.673+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t8v:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:27:58.748+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/28]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/117]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+        | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+        | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/321]
+        | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+        | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/320]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+        0.6.0)|http://localhost:8080/finding/321]\n*Defect Dojo link:* http://localhost:8080/finding/321
+        (321)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+        \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+        of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/320]\n*Defect
+        Dojo link:* http://localhost:8080/finding/320 (320)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+        File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+        versions of `negotiator` are vulnerable to regular expression denial of service
+        attacks, which trigger upon parsing a specially crafted `Accept-Language`
+        header value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: <=
+        0.6.0\n Patched Version: >= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express>accepts>negotiator\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: negotiator:0.5.3","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1883/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18261/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 765ee003-15e5-4ae6-9de5-1b5c90e70ffb
+      - e0ad787a-2f77-47fe-9d9a-dbb3130db2cb
       Atl-Traceid:
-      - 765ee00315e54ae69de51b5c90e70ffb
+      - e0ad787a2f7747fe9d9adbb3130db2cb
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:36 GMT
+      - Wed, 30 Apr 2025 16:28:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -441,7 +460,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=273,atl-edge-internal;dur=15,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=334,atl-edge;dur=301,atl-edge-internal;dur=19,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="HMfsflQZXpyeDwZtXIqhwlcn4gwhlTeLHP0LIT1MaFd7rL_4h_ydJA==",cdn-downstream-fbl;dur=339
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -450,10 +469,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - HMfsflQZXpyeDwZtXIqhwlcn4gwhlTeLHP0LIT1MaFd7rL_4h_ydJA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - daff0b79c5cb91ff2b999d3cb593cd69
+      - ab183ae6d8a7902c481bf4401d671d94
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -480,26 +507,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL2nVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwCbz0/NK+EjyIDNEqAJLCvGeJ7xPIgBLiDAIe/CH3Co2u6cpVAx4HTBsyItlvSb
-        ld2NUTaAOS0WUgDOUEmazVHkSuUKpGLLbLaoVZEjKxSwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAhhey/SACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:00.513+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 81779497-37a6-4ae1-92f0-65022d4658a5
+      - 1b85d0f3-c819-496d-a3b9-b91990f17df7
       Atl-Traceid:
-      - 8177949737a64ae192f065022d4658a5
+      - 1b85d0f3c819496da3b9b91990f17df7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:36 GMT
+      - Wed, 30 Apr 2025 16:28:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -509,7 +532,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=168,atl-edge-internal;dur=16,atl-edge-upstream;dur=152,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=210,atl-edge;dur=178,atl-edge-internal;dur=15,atl-edge-upstream;dur=163,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="pt68z7AbRgil3uoUW5ryD8ZcYfiK9GIMeWbh9PAf43x4QrVt99PJ5g==",cdn-downstream-fbl;dur=215
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -518,10 +541,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 995d6494814d695ff2add6899f970080.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - pt68z7AbRgil3uoUW5ryD8ZcYfiK9GIMeWbh9PAf43x4QrVt99PJ5g==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ee721dd9a0b4819688cc977aaf81fff8
+      - ef8d6296f7cbc6d1a275d4e87074425b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -548,41 +579,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 097a1018-9212-4732-8825-81cd1bb69c5e
+      - 1033f50c-2f80-4745-a059-e9d3e66ce1f7
       Atl-Traceid:
-      - 097a101892124732882581cd1bb69c5e
+      - 1033f50c2f804745a059e9d3e66ce1f7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:37 GMT
+      - Wed, 30 Apr 2025 16:28:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -592,7 +610,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=30,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="bEoRGc7X8-4WcNnjo73BXFj_cID4_DeNUk--dsy988mHEkWzGaizvA==",cdn-downstream-fbl;dur=409,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=406,atl-edge;dur=332,atl-edge-internal;dur=15,atl-edge-upstream;dur=316,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -601,13 +619,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c1388c9ad241eb02cd4ddbe69b1a2d34.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - bEoRGc7X8-4WcNnjo73BXFj_cID4_DeNUk--dsy988mHEkWzGaizvA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - bbd5585090aab1d96d2f1bbff73cdc0c
+      - facef41a72b34f4bca32b681a021829d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -619,7 +645,7 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
       Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/119] in [Security
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/29] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/117]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
@@ -634,13 +660,13 @@ interactions:
       4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
       6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
       &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/322] | Active,
-      Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
       3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
       6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
       &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/324]\n*Defect
       Dojo link:* http://localhost:8080/finding/324 (324)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -649,31 +675,29 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
       &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
       5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
       6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
       &lt; 7.1.2)|http://localhost:8080/finding/322]\n*Defect Dojo link:* http://localhost:8080/finding/322
-      (322)\n*Severity:* High\n *Due Date:* Feb. 9, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      (322)\n*Severity:* High\n *Due Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
       \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
       File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
       versions of `pg` contain a remote code execution vulnerability that occurs when
@@ -682,25 +706,23 @@ interactions:
       The application executes unsafe, user-supplied sql which contains malicious
       column names.\n2. The application connects to an untrusted database and executes
       a query returning results which contain a malicious column name.\n\n## Proof
-      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
-      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
-      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
-      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
-      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
-      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
-      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
-      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
-      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
-      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
-      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
-      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
-      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
-      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
-      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
-      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
-      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
-      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
-      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      of Concept\n```\nconst { Client } = require(''pg'')\nconst client = new Client()\nclient.connect()\n\nconst
+      sql = `SELECT 1 AS \"\\\\''/*\", 2 AS \"\\\\''*/\\n + console.log(process.env)]
+      = null;\\n//\"`\n\nclient.query(sql, (err, res) => {\n  client.end()\n})\n```\n
+      Vulnerable Module: pg\n Vulnerable Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >=
+      4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 ||
+      >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2\n Patched Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0
+      ||  >= 4.5.7 < 5.0.0 || >= 5.2.1 < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 <
+      6.2.0 || >= 6.2.5 < 6.3.0 || >= 6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2
+      < 7.1.0 || >= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n
+      Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to version 2.11.2
+      or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n* Version 4.x.x:
+      Update to version 4.5.7 or later.\n* Version 5.x.x: Update to version 5.2.1
+      or later.\n* Version 6.x.x: Update to version 6.4.2 or later. ( Note that versions
+      6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version 7.x.x: Update to version
+      7.1.2 or later. ( Note that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo
+      impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
     headers:
       Accept:
@@ -712,7 +734,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '7141'
+      - '6804'
       Content-Type:
       - application/json
       User-Agent:
@@ -721,18 +743,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16128","key":"NTEST-1644","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16128"}'
+      string: '{"id":"18263","key":"NTEST-1884","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18263"}'
     headers:
       Atl-Request-Id:
-      - 14d21b24-1ef5-4671-842a-fd462721cd72
+      - 0e26c875-2ca2-48f2-84a3-774b837dde4c
       Atl-Traceid:
-      - 14d21b241ef54671842afd462721cd72
+      - 0e26c8752ca248f284a3774b837dde4c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:37 GMT
+      - Wed, 30 Apr 2025 16:28:02 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -742,7 +766,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=672,atl-edge-internal;dur=16,atl-edge-upstream;dur=656,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="QQ81hdEL1X3aAOh9ugwaXSOHwu0zn35eVkvQahr9XQ8FXzvvMzI01Q==",cdn-downstream-fbl;dur=1415,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=1411,atl-edge;dur=1325,atl-edge-internal;dur=15,atl-edge-upstream;dur=1310,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -751,10 +775,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0d9c2d5ae2c28ab89ceaef885af258e6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QQ81hdEL1X3aAOh9ugwaXSOHwu0zn35eVkvQahr9XQ8FXzvvMzI01Q==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - ed05ea47fc2be41adf1dfe675949526f
+      - 1b746d2f5532533ec5702fc8ba0a6563
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -778,78 +810,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1644
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1884
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX61MbNxD/VzT3IdNJ7XvZBnOZTIcSJ6GllBon+UAYRtyt7xR00lXS+RHgf+/q
-        Xg4PZwqdBmY4vfah3d/+tFw7sCqoSJzIUSASUJC8ZcAT3RM0B93TcQY57ckCFDVMCt2DhJkcDO3F
-        GRUpcJn2FqA07kEyhUKBBmGas3GpjcznVuFF4PuB7yr4uwRtZusCThSNDYvB6TnM2g92gnCMEw18
-        jtPMmEJHnpfAHGKTyC/SpYZTrRkVrgDjoSXj0YJ5oce0LsFrFVzBGuWPZ5PTWT/YGQ5xqXJBO9G1
-        o9G3UsfUQCrVur5DgjOUCP1w1PeDfuDPQj8KxtFg1x0Pgp/Rb986aY0YdLxS80wnrbyH+vywu3Yz
-        SUDHihU2cLi6T3ROOe+RhGnDRGxIwSAGIudkKdWVa6VjKT4o/kQvSsFsuii/oAtqqPIWDJZe5dbG
-        wWYr8AfB+BfNvsLrHNNe5mjVwgJNzqi+srkqL40dRXPKNfScWvAQ71XJ9pyMIXBUnK2PYAHoq3/b
-        cwxDZBWIEicSJd7RuQeTgd9uFEp+wRs9M+CNdBXuKoFtuO3kG5BsbvVBMGNQgXY62xapv1dntZyb
-        JVUWr5rlBWfocHLv5piPCmXD8Wo4fqK738lMe5MuL0N/F90Ih6tw+P9aqbNfYRENBjurYOdHGFy1
-        FgfhahD+CIsNwG9vH8Ix2IbTsN2Ys9XHmgMx+2fnD08O2pM0TRWkyDcPigAvIHlZl//j5kbbNna2
-        bexu2Qi3boy3bew99LOmzXrVklL1QjhRP8ApNfhw1IT79MKt6XxD4F6tTtmyrIYHsrSBCywpf7IL
-        TKROZFQJtw1PW22KxXU4rx+sWc/wqM5kyZM3TBecrptSxmV0y3xEzNjybqKhAC9r+eOxR2K4s9s+
-        EvfD1lHZ/Y1toAo7UBWKScXM+plBbMW96qX5928Fy2kK2rMSulXCcCFjaebqRbphy/e40tJq6Dws
-        nLBDPaeXYInxkdKwfPJoIIJtGA3GNiIZ1ZOCxUdMXL21O2+gsP2LiNs8VtldVnvdipBigu0LveQw
-        BaprbKhm5JwcfXh3eHxxdHgwOT6dXEym0z+neD+sU40hwQOzDMgJvgDCEGuXME2k4GuCbMK4VUqM
-        JL8xRcmJghzphJQaUes+xioBFpTj3zDfL1ZfI6d+FTF7GP5NVd1hC0xEygTl9w813VcT3grpHL1r
-        5jazqYDudFnYst2G5NGoQ3LdKD0TfLVw9/Le7W2ehscN3n6l8RW2my3kWuW1rYOmo/tPDrdtYV0z
-        aCRsGwUBS1vdkkt1XHtzyUvopwp5Y9MUSfJG1smWeYENsTCPg360jRZGHS18L+N3w/lZfPu7T1Il
-        y8I2im+ZSJAYNcFaIZcAghSlziCpUHo43bffSyBMLKwBC7OE4L8CBF8zSCKrLAtd8s6q+yxeVt+X
-        ETnr1DIRkSKNRm7g+jc22BhrLmPKM6lNNPbHvjevz15UPnlBsHeOUuTsFOLSchN5L5d9I7cI42Od
-        lPhYh+fEI2eBNuSvkioDikxEihWZY3y3iEJ3wAsq6eOTP8h+ibVPTmMqtkjZ1g+d3D2vQ3lzQ06x
-        a60cxfHBx0n1+VR/2gzbSfP42+GMGeQBK1ohCkeoiFiqJDfkDHX0Q6x9fNb8cVi5YREqFokrsNF3
-        U7nwFiUXiFmDnOLdPX9uVewNO7F4CW7OjAJXqtTDuqYW6wybWMsH3t7QzUzOrVSR4p8qUVZFiD9T
-        yKUBvEYCZLLCfFgZ0ic/naQ98oKbVyR0g8ANCXmRmlev/wEAAP//7FhRb9s4DP4rBAoMji9VVidp
-        sBz6ULQ74IDbcFi3vSwD4jrq4s2xU8tuO+z23/dRkmW5cTasu721LVKHFCXqI0V+Mo3FUxhrxVgc
-        iwk1ikmrmIipmDXyaSufCszVyI9bOT9OWzl7Z+VH4riVR6088sePW/lYjFv5pJVP2g3M2nX50ZO7
-        dfkxGuxJDpvKo3E0YURPwSNu5JBDry8C1Bfn2U/G2Y7/v+L8GOMHx1jHoC/GqIRNUZiHOt4so/C8
-        lnSOEgrhX/JS0LMhcYOlbnVuftdHwpVn/X0sHo/lL4ZsgrIdnutejzb8sSBmQQjHD+0owMegL7Df
-        CyuF6AQQv8O/wwccVqyHU68n+LWm0M2s8KKoy0QiuzIZcn8+RBvdpEoyrNsP3sDzlkWE6PZuWaSe
-        sv1ZpMUoXt2kCkwEV4BpFIFgXDHCOAwN72Sqsdx+WBI4HfzLKabSZHHCWSxdFvMeZBlfphl31God
-        V1QkWEjR7RrkpAK7toaM2mWsJBUlXePi9plwVU74DCrMnpTxFTsANlZvcmLyJfQ5Az8vJYGgU3Vb
-        NCYJqUTmMS4yzFiwVJqsCTwA5D1LP0nQ9yusEsPt7TZLE/3m0jKjxuFMAh+cWOb//iizNfhU5yq+
-        QqFgun+oah4C/9R1ZpezyCjaxDBOC/ACz3klFnm0OzuMciCt2Bm4hxtvCbKIeR06TNacD7FFqpRV
-        XeZIbTypOqsYXc8HjOt1QjCABwe4uRSIJ/7OijyR22qRL5fLRc63wYq+0Bl2Bs7zlU6IX+WmpQye
-        HNxFM6SW+T9oxiZm5AmBOluzgJX6SdjNsaQxYLhOaHnx/J/nZ6/piE4v6Ml1XVR/LvBjJh+FRoJD
-        2KcORwucyz94q6rIpMBlIUD2J7jACZnfDN6zN2DQMMlHI2O91A4YpzSAAfwYUiDLcsgIDuiETw59
-        wcx2T5hrxY5/HVhw6K1LFHoBzop8IT5qvrx5PzTvVHHwxD11HJp9ldwZ7dRyp9mp5p7mXj33NPcq
-        uqe5V9M9zb2q7jQ7dd3TdCs7cPpXv99ZNSDN7UgLkkUF83lwMUYWE17Ih4sxsqBYVQMXY+RA8TRN
-        x2tQ6agYJIdKR8MgOVQ6GgbJodLRMEgOFU9jQHKodDQGJC+ZgNcamcQpeWjo3ny30PNNZc4f6E74
-        dprwOUBi1pc4/rYHvEj1xc+2gNBdZCJxJ+7m9Ea/LOACZIt9ExJUzAyaUvhG431GJlq9NpN9NiaM
-        vTbTfTYmwL02x/tsTEScDQX0kjuQ7k6uw+kkGJqID3XZNSHmVhNnqqCtSWBBTCPcorN9i+qQfn9R
-        mxDoUjsL2Nj9vdnGScVxe1lQqr8QUuAmXclV2+Yx8BU4USlRzdXP9Hlrui34xs00JYhXmzQfUDD4
-        bwMaUhVzRz166ewjlfUOsF/wfkxlmdQ9hMpGTGWj30FlvwEAAP//Iq0pS26/FznZ0ropazjalAWq
-        AgAAAP//7JrRaoMwFIZfZQx6GRc1Vr0oXRkb7KIv0Lv0RLcx1KKV0bffOcaGmjUdbDdeBHohzUlP
-        OJifv/yft7Leynore1XVJ9ZsousTa3ap7N7Knuflray3svOwsqHZ+ouV/ZneJybAtsNbV34XCteC
-        gTco2Du2Ej4HZoEoBKtUGNTCWuAuAIS7MnRuMvTzeFyFLu6Dm8NMsmg7kZTHo4R3ytt03tn1VSUp
-        jL2/mhbSqImoaNo/xrXkTtYSgDiQV7VKVJyl2T5MeRFDziFPojIPyyX2MUXY4UZZQe/BRins0WEl
-        2r3T48VBoCH27TbjNYy4CN5aXUZ7zpyRKHiYSRUKsUwhS5M438M+5di+lEWZwVqthl9ZxJtF9IIf
-        vY9Vsh5jTMb0V13Qd+wLB8GigPLRQGsgTYodpOxoULh/8Oh42/Dxact4cKgpNrd5sfmf2AbO5n9i
-        G1ib+4lRf5Tmn0auAf+vn+62six7gI/hAlEIpukqrV67pqbC575tDsXDDnUFiAMabxoBk7hqri51
-        GDHR6zCEcImpcDFSwjBS9oIR7HZUe68v/3uTvgEAAP//IiEljZYv9HDxaPmCpXxBLwbgrTB4owXo
-        6nRI3qsGreyGsg2AFuaXJELXpaObgrO5hbNcwtkOM8Je8uFa4miAq+EJKhCwShjganga49JhDG/Z
-        peaVZRbl50FabxChlFLopggIl6jQy8+FmFANY0KLezKKX6T9HPowc3WUchMrgiDjQCh2g1cAFpU4
-        lkDcUQbsfpC7bBFj4THEMLihQLsyEovD8sELKGGrhUFLn0HLEkFWwh2C6lojFOdCNYCDp7a2FgAA
-        AP//AwDy0OPXgzMAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18263","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18263","key":"NTEST-1884","fields":{"statuscategorychangedate":"2025-04-30T18:28:02.566+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1884/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:01.611+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t93:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:02.390+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/29]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/117]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/324] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/322] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/324]\n*Defect
+        Dojo link:* http://localhost:8080/finding/324 (324)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/322]\n*Defect Dojo link:*
+        http://localhost:8080/finding/322 (322)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1884/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18263/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 95b5ffde-7401-4a23-8951-ce7f4eea10f3
+      - d7b0b2a1-06a3-489f-91a7-954e55f6340b
       Atl-Traceid:
-      - 95b5ffde74014a238951ce7f4eea10f3
+      - d7b0b2a106a3489f91a7954e55f6340b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:38 GMT
+      - Wed, 30 Apr 2025 16:28:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -859,7 +926,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=311,atl-edge-internal;dur=13,atl-edge-upstream;dur=299,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=284,atl-edge;dur=251,atl-edge-internal;dur=16,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="H6Gq_Pnwa7KNf7e4BaLwUbXgv6mJsF40lxX5S03W8ltMdCR04VyNJA==",cdn-downstream-fbl;dur=287
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -868,10 +935,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - H6Gq_Pnwa7KNf7e4BaLwUbXgv6mJsF40lxX5S03W8ltMdCR04VyNJA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ecfa9022e9585defb40a7db9e34eb4ec
+      - 85d2ae8cd1ac59e7fe8de0c2150809b0
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -895,78 +970,113 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16128
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18263
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXW1PbRhT+Kzt6yHRSWzfbYJTJdChxElpKqTHkgTDMIh1LG1a76u7Kl4T8956V
-        LDlclCl0GphB0p499+9c+OLAqqAicSJHgUhAQfKWAU90T9AcdE/HGeS0JwtQ1DApdA8SZnIwtBdn
-        VKTAZdpbgNJIg2QKhQINwmzuxqU2Mp9bgVeB7we+q+DvErSZrQs4UTQ2LAan5zCrP9gJwjF+aOBz
-        /MyMKXTkeQnMITaJ/CRdajjVmlHhCjAeajIeLZgXekzrErxGwA2skf94Njmd9YOd4RCPKhO0E31x
-        NNpW6pgaSKVa1z4k+IUcoR+O+n7QD/xZ6EfBOBrsuuNB8DPa7VsjrRKDhldinmmk5fdQnh+2bm8+
-        EtCxYoUNHJ7uE51TznskYdowERtSMIiByDlZSnXjWu5YijPFn2hFKZhNF+VXdEENVd6CwdKrzNoa
-        uCEF/iAY/6LZZ3idY9rLHLVaWKDKGdU3NlfltbFv0ZxyDT2nZjxEvyrenpMxBI6Ks/URLABt9b/2
-        HMMQWQWixIlEiT4692Ay8BtCoeQn9OiZAd9wV+GuEtiE2358A5KtV2eCGYMCtNPqtkj9vbqr5dws
-        qbJ41SwvOEODk3ueYz4qlA3Hq+H4ieZ+JzONJ21ehv4umhEOV+Hw/9VSZ7/CIioMdlbBzo9QuGo0
-        DsLVIPwRGjcA//r1IRyDLpyGXYRBQ5iz1XndHBEWF5cIkzRVkGK/eVAE6IDkZV3+j0sddRF2ugi7
-        HYSwkzDuIuw9tLNum/WpbUrVhHCifrDplTYlisW1S18enNlCwWjrTJY8ecN0wel6U054vKQGR0/d
-        sp9e+vVA2I4ArxanbGFXrweytKGvTP1gD5hIncio0upGoeYcMWPLexMNBeis7R+PDYnhzm4zJO6H
-        rW1l9wldoApbUBWKScXM+pkhaNi9atL8+1nBcpqC9iyHboQwPMhYmrl6kW675Xs8adpq6DwsnLAt
-        A06vwTZGWwH3d4Iu8AZdGA3GNiIZ1ZOCxUdM3Ly1lDdQ2P1FxA2GKmQtK1p7IqSY4PpCrzlMgeoa
-        l2rz5pwcnb07PL46OjyYHJ9OribT6Z9T9A/rVGNI8MIsA3KCE0AYYvUSpokUfE2wmzBuhRIjyW9M
-        UXKiIMd2QkqNmHMf6yoBFpTj3zLfL1afI6eeipg9DP+2qu50C0xEygTl9y9ttq9NeCvkc7SuaTiY
-        2VRAe7ssbNl2IXk0apFcL0rPBF/N3E7eu7vN0/C4xduvNL7BdbOBXCO81nWw2ej+k8HNWljXDCoJ
-        m0VBwNJWt+RSHdfWXPMS+qnCnrVdiiR5I+tky7zAhViYx0E/6moLo7YtfC/jd8P5UXz7u09SJcvC
-        LopvmUiwrWmCtUKuAQQpSp1BUqH0cLpvn9dAmFhYBRZmCcF/BQgOLUgiKywLXfLOivsoXlbPlxG5
-        aMUyEZEijUZu4Pq3NtgYay5jyjOpTTT2x743r+9eVTZ5QbB3iVzk4hTi0vYm8l4u+0Z2MOOwTkoc
-        1uEl8chFoA35q6TKgCITkWJF5hjfDlZoL3hBxX188gfZL7H2yWlMRQeXXf3QyN3LOpS3t+QUt9bK
-        UHw/OJ9Ujw/1o8mw/djMePs6Ywb7gGWtEIVvKIjYVkluyQXK6IdY+ziU/HFYmWERKhaJK3DRd1O5
-        8BYlF4hZgz3Fu3v/0orYG7Zs8RLcnBkFrlSph3VNLdYZLrG2H3h7QzczObdcRYp/qkRZESH+TCGX
-        BtCNBMhkhfmwPKRPfjpJe+QFN69I6AaBGxLyIjWvXv8DAAD//+xYUW/bOAz+KwQKDI4vVVYnabAc
-        +lC0O+CA23BYt70sA+I66uLNsVPLbjvs9t/3UZJluXE2rLu9tS1ShxQl6iNFfjKNxVMYa8VYHIsJ
-        NYpJq5iIqZg18mkrnwrM1ciPWzk/Tls5e2flR+K4lUetPPLHj1v5WIxb+aSVT9oNzNp1+dGTu3X5
-        MRrsSQ6byqNxNGFET8FhbuSQQ68vAtQX59lPxtmO/7/i/BjjB8dYx6AvxqiETVGYhzreLKPwvJZ0
-        jhIK4V/yUtCzIXGDpW51bn7XR8KVZ/19LB6P5S+GbIKyHZ7rXo82/LEgZkEIxw/tKMDHoC+w3wsr
-        hegEEL/Dv8MHHFash1OvJ/i1ptDNrPCiqMtEIrsyGXJ/PkQb3aRKMqzbD97A85ZFhOj2blmknrL9
-        WaTFKF7dpApMBFeAaRSBYFwxwjgMDe9kqrHcflgSOB38yymm0mRxwlksXRbzHmQZX6YZd9RqHVdU
-        JFhI0e0a5KQCu7aGjNplrCQVJV3j0viZcFVO+AwqzJ6U8RU7ADZWb3Ji8iX0OQM/LyWBoFN1WzQm
-        CalE5jEuMsxYsFSarAk8AOQ9Sz9J0PcrrBLD7e02SxP95tIyo8bhTAIfnFjm//4oszX4VOcqvkKh
-        YLp/qGoeAv/UdWaXs8go2sQwTgvwAs95JRZ5tDs7jHIgrdgZuIf7agmyiHkdOkzWnA+xRaqUVV3m
-        SG08qTqrGF3PB4zrdUIwgAcHuLkUiCf+zoo8kdtqkS+Xy0XOt8GKvtAZdgbO85VOiF/lpqUMnhzc
-        RTOklvk/aMYmZuQJgTpbs4CV+knYzbGkMWC4Tmh58fyf52ev6YhOL+jJdV1Ufy7wYyYfhUaCQ9in
-        DkcLnMs/eKuqyKTAZSFA9ie4wAmZ3wzeszdg0DDJRyNjvdQOGKc0gAH8GFIgy3LICA7ohE8OfcHM
-        dk+Ya8WOfx1YcOitSxR6Ac6KfCE+ar68eQ0071Rx8MQ9dRyafZXcGe3UcqfZqeae5l499zT3Krqn
-        uVfTPc29qu40O3Xd03QrO3D6V7+dWTUgze1IC5JFBfN5cDFGFhNeyIeLMbKgWFUDF2PkQPE0Tcdr
-        UOmoGCSHSkfDIDlUOhoGyaHS0TBIDhVPY0ByqHQ0BiQvmYDXGpnEKXlo6N58t9DzTWXOH+hO+Haa
-        8DlAYtaXOP62B7xI9cXPtoDQXWQicSfu5vRGvyzgAmSLfRMSVMwMmlL4RuN9RiZavTaTfTYmjL02
-        0302JsC9Nsf7bExEnA0F9JI7kO5OrsPpJBiaiA912TUh5lYTZ6qgrUlgQUwj3KKzfYvqkH5/UZsQ
-        6FI7C9jY/b3ZxknFcXtZUKq/EFLgJl3JVdvmMfAVOFEpUc3Vz/R5a7ot+MbNNCWIV5s0H1Aw+G8D
-        GlIVc0c9eunsI5X1DrBf8H5MZZnUPYTKRkxlo99BZb8BAAD//yKtKUtuvxc52dK6KWs42pQFqgIA
-        AAD//+ya0WqDMBSGX2UMehkXNVa9KF0ZG+yiL9C79ES3MdSildG33znGhjYzHWw3XgR6Ic1JTziY
-        n7/8n7ey3sp6Kzup6lfW7ErXr6zZpbJ7K3uel7ey3srOw8qGZusvVvZnep+YANsOb135XShcCwbe
-        oGDv2Er4HIgDIiCsUmFQC2uBuwAQ7srQucnQz+NxFbq4D24OI49HCe8UqU2QLHZC2fVVJSmMvZ9M
-        C2nURFQ07R/jWnInawlAFMerWiUqztJsH6a8iCHnkCdRmYflEvuYIuxwo6yg92CjFPbosBLt3unx
-        4iDQEPt2m/EaRlwEb60uoz1nzkgUPMykCoVYppClSZzvYZ9ybF/KosxgrVbDryzizSJ6wY/exypZ
-        jzEmY/qrLug79oWDYFFA+WigNZAmxQ5SdjQo3D94dLxt+Pi0ZTw41BSb27zY/E9sA2fzP7ENrM39
-        xKg/SrNXI9eA/9dPd1tZlj3Ax3CBKATTbJRWr11TU+Fz3zaH4mGHugLEAY03jYBJXDVXlzqMmOg0
-        DCFcYipcjJRwgXfCCHY7qr3Xl/+9Sd8AAAD//yIhJY2WL/Rw8Wj5gqV8QS8G4K0weCMF6Op0SN6r
-        Bq3shrINgBbmlyRC16Wjm4KzuYWzXMLZDjPCXvLhWuJogKvhCSoQsEoY4Gp4GuPSYQxv2aXmlWUW
-        5edBmnYQoZRS6KYICJeo0MvPhZhQDWNCi3syil+k/Rz6MHN1lHITK4Ig40AodoNXABaVOJZA3FEG
-        7H6Qu2wRY9kwxDC4oUC7MhKLw/LBCyjhK5Xzi8DLEkFWwh2C6lojFOdCNYCDp7a2FgAAAP//AwCn
-        B36/gzMAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18263","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18263","key":"NTEST-1884","fields":{"statuscategorychangedate":"2025-04-30T18:28:02.566+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1884/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:01.611+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t93:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:02.390+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: pg:5.1.0|http://localhost:8080/finding_group/29]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/117]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/324] | Active,
+        Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+        | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+        Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+        4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+        6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+        &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/322] | Active,
+        Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0
+        &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt;
+        6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;=
+        6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/324]\n*Defect
+        Dojo link:* http://localhost:8080/finding/324 (324)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+        &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0
+        &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt;
+        6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;=
+        7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/322]\n*Defect Dojo link:*
+        http://localhost:8080/finding/322 (322)\n*Severity:* High\n *Due Date:* May
+        30, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+        \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+        File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+        versions of `pg` contain a remote code execution vulnerability that occurs
+        when the remote database or query specifies a crafted column name. \n\nThere
+        are two specific scenarios in which it is likely for an application to be
+        vulnerable:\n1. The application executes unsafe, user-supplied sql which contains
+        malicious column names.\n2. The application connects to an untrusted database
+        and executes a query returning results which contain a malicious column name.\n\n##
+        Proof of Concept\n```\nconst { Client } = require(''pg'')\nconst client =
+        new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS \"\\\\''/*\", 2
+        AS \"\\\\''*/\\n + console.log(process.env)] = null;\\n//\"`\n\nclient.query(sql,
+        (err, res) => {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+        Versions: < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 <
+        5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0
+        < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2\n Patched
+        Version: >= 2.11.2 < 3.0.0|| >= 3.6.4 < 4.0.0 ||  >= 4.5.7 < 5.0.0 || >= 5.2.1
+        < 6.0.0 || >= 6.0.5  < 6.1.0 || >= 6.1.6 < 6.2.0 || >= 6.2.5 < 6.3.0 || >=
+        6.3.3 < 6.4.0 || >= 6.4.2 < 7.0.0 || >= 7.0.2 < 7.1.0 || >= 7.1.2\n Vulnerable
+        Paths: \n  - 5.1.0:pg-promise>pg\n CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n*
+        Version 2.x.x: Update to version 2.11.2 or later.\n* Version 3.x.x: Update
+        to version 3.6.4 or later.\n* Version 4.x.x: Update to version 4.5.7 or later.\n*
+        Version 5.x.x: Update to version 5.2.1 or later.\n* Version 6.x.x: Update
+        to version 6.4.2 or later. ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are
+        also patched. )\n* Version 7.x.x: Update to version 7.1.2 or later. ( Note
+        that version 7.0.2 is also patched. )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: pg:5.1.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1884/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18263/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 35e19075-4a4c-4f6b-aad1-934cb97490c9
+      - edc9b52a-f253-40cf-a742-0092b4f5bc00
       Atl-Traceid:
-      - 35e190754a4c4f6baad1934cb97490c9
+      - edc9b52af25340cfa7420092b4f5bc00
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:38 GMT
+      - Wed, 30 Apr 2025 16:28:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -976,7 +1086,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=300,atl-edge-internal;dur=22,atl-edge-upstream;dur=276,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=289,atl-edge;dur=256,atl-edge-internal;dur=14,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="jvRnhWcON13IvUFVWTMvhTCX2v0sCDQsaYjR7e9gyFCghkGRyQbGxA==",cdn-downstream-fbl;dur=294
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -985,10 +1095,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - jvRnhWcON13IvUFVWTMvhTCX2v0sCDQsaYjR7e9gyFCghkGRyQbGxA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 955f88b4113505fe53e66f92291a04c0
+      - 9e938f43e7f87b94b07f64eae44040a7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1015,26 +1133,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2nVd3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwG2WJyaV8JHkAGbT4FOYVkxxrOUZ0EMcAEBDnkX/oBD1XbnLIWKAacFT4tkyfJv
-        VnY3RtkAZjQvpACco5I0XaDIlMoUSMWW6byoVZ4hyxWwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMASYwM/iACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:03.685+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - f77f8c4d-0fcf-4e77-9f30-9dc58c7b3a26
+      - 494e0b76-8774-41bd-89e5-289415ed2a56
       Atl-Traceid:
-      - f77f8c4d0fcf4e779f309dc58c7b3a26
+      - 494e0b76877441bd89e5289415ed2a56
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:38 GMT
+      - Wed, 30 Apr 2025 16:28:03 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1044,7 +1158,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=16,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=196,atl-edge;dur=163,atl-edge-internal;dur=14,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="fakDGwARJqZEy54i7B1hanICwTc9BgmJKMScei_JRKacoTDFfq8nig==",cdn-downstream-fbl;dur=200
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1053,10 +1167,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - fakDGwARJqZEy54i7B1hanICwTc9BgmJKMScei_JRKacoTDFfq8nig==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e77567f4e1cc7bcf19f62db5acf16f3a
+      - 55949cf8f90ec1c1e08c7beead6557b8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1083,41 +1205,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 2df506ec-27f1-45b0-b175-b6c440be726f
+      - ebc8bfcc-cec0-4bad-8130-91b91d43beea
       Atl-Traceid:
-      - 2df506ec27f145b0b175b6c440be726f
+      - ebc8bfcccec04bad813091b91d43beea
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:39 GMT
+      - Wed, 30 Apr 2025 16:28:04 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1127,7 +1236,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=313,atl-edge-internal;dur=17,atl-edge-upstream;dur=296,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=311,atl-edge;dur=279,atl-edge-internal;dur=17,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="IfbrCog3aawWYGj4o9JE0eBkaddY6QzgacHkMxMPykL1dH67Pi7Y5Q==",cdn-downstream-fbl;dur=316
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1136,13 +1245,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2918cacbb3dda2d143059f9b5f341e32.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - IfbrCog3aawWYGj4o9JE0eBkaddY6QzgacHkMxMPykL1dH67Pi7Y5Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 27dcb8ccac6fd7a04b5f773d4ad79364
+      - 53622d815eadde30a981eed76147c1cd
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1154,22 +1271,21 @@ interactions:
     body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
       "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
       of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
-      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/120] in [Security
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/30] in [Security
       How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
       / [NPM Audit Scan|http://localhost:8080/test/117]\n\n\n|| Severity || CVE ||
       CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
       | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
       Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/323]
-      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Feb. 9, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
       Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/323]\n*Defect
       Dojo link:* http://localhost:8080/finding/323 (323)\n*Severity:* High\n *Due
-      Date:* Feb. 9, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
       \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
       File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
       versions of `fresh` are vulnerable to regular expression denial of service when
       parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
-      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
-      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
       CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
       later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
@@ -1183,7 +1299,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1973'
+      - '1945'
       Content-Type:
       - application/json
       User-Agent:
@@ -1192,18 +1308,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16129","key":"NTEST-1645","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16129"}'
+      string: '{"id":"18265","key":"NTEST-1885","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18265"}'
     headers:
       Atl-Request-Id:
-      - e4d7837b-3540-48a8-b92d-2708a2baaed2
+      - 2483fd2f-d1d8-491d-a681-f57ecf5434b9
       Atl-Traceid:
-      - e4d7837b354048a8b92d2708a2baaed2
+      - 2483fd2fd1d8491da681f57ecf5434b9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:40 GMT
+      - Wed, 30 Apr 2025 16:28:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1213,7 +1331,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=594,atl-edge-internal;dur=16,atl-edge-upstream;dur=579,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="RhbOPvd9jJIjPUj7htreWouE07nJpCVc-IQZv2Zf3X2TE1NGmYf9TA==",cdn-downstream-fbl;dur=806,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=803,atl-edge;dur=714,atl-edge-internal;dur=15,atl-edge-upstream;dur=699,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1222,10 +1340,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a4888bfa57444daa340ca8dc53629170.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - RhbOPvd9jJIjPUj7htreWouE07nJpCVc-IQZv2Zf3X2TE1NGmYf9TA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - f00b48b178d22b95dcc86f2be51c5968
+      - 798ab030b4cac8b810a47260d73b414b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1249,65 +1375,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1645
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1885
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWVPjRhD+K1N6Sm1sXTZgVJVKETAbEkKI8e4+sBQ1SG1pFmlGmRn5yMJ/T7cO
-        ezm8CaSy5QfN1cd0f/1N+7MDy5LLxIkcDTIBDcmxgDwxPckLMD0TZ1DwnipBcyuUND1IhC3A8l6c
-        cZlCrtLeHLTBPUgmUGowIG17Nq6MVcWMFF4Hvh/4roY/KzB2uirhXPPYihicniPIfrAbhPs4MZDP
-        cJpZW5rI8xKYQWwT9Um53ObcGMGlK8F6aMl6vBRe6AljKvA6BbewQvmz6fhi2g92hzu4VLtgnOiz
-        Y9C3ysTcQqr0qrlDgjOUCP1wp+8H/cCfhn4UjKLBvru/t/89+u2Tk2TEouO1mlc6SfIe6vPD9bXb
-        SQIm1qKkwOHqATMFz/MeS4SxQsaWlQJiYGrGFkrfuiQdK/lO5y/0opKC0sXzaz7nlmtvLmDh1W5t
-        HGy3An8QjH404i/4ocC0VwVaJVigySk3t5Sr6sbSKJrx3EDPaQRP8F61bM/JBAJHx9nqFOaAvvr3
-        PccKRFaJKHEiWeEdnUcwGfjdRqnVJ7zRKwPeStfhrhPYhZsmX4Bkc6t3UliLCoyztk1I/bU+a9TM
-        LrgmvBpRlLlAh5NHN8d81CgbjpbD0Qvd/Upmupus8zL099CNcLgMh/+vlSb7NRbRYLC7DHa/hcFl
-        Z3EQLgfht7DYAvz+/ikcg204DbuNmVi+bzgQs3959fTkoDvJ01RDinzzj0Ww023gzVReNbzw/NHd
-        bRt7WzbCrRujbRv7T91paLNZJVKqXwgn6gc45RYfjoZwX164DZ1vCNxr1Gkqy3p4qCoKXECk/IEW
-        hEydyOoK7lueJm1axE3UPj9ZI8/wqMlUlSdHwpQ5X7WljMvoln2PmKHybqOhAS9L/PHcI7E7CrpH
-        4nHY1lT2eGMbqMI1qEotlBZ29cogduJe/dL8+7dCFDwF45GE6ZQIXMhEmrlmnm7Y8mdc6Wg1dJ4W
-        TrhGfc5vgIjxmdIgPnk2EME2jAYjikjGzbgU8amQt8e0cwQl9S8y7vJYZ3dR761XpJJjbF/4TQ4T
-        4KbBhm5Hzvnpu7cnZ9enJ4fjs4vx9Xgy+X2C98M6NRgSPDDNgJ3jCyAtI7tMGKZkvmLIJiInpcwq
-        9ovQnJ1rKJBOWGUQte5zrBJgQTn+nfD9crUXOc2riNnD8G+q6gFbYCJSIXn++FDbfbXhrZGeo3ft
-        nDKbSlifrkoq221I3tsZdUhuGqVXgq8RXr+8D3ubl+Fxg7efeHyL7WYHuU55Y+uw7ej+k8NdW9jU
-        DBoJu0ZBwoKqW+VKnzXe3OQV9FONvLFpihQ7Uk2yVVFiQyzt86DfWdPC1xL7WGhNGQ/D+VF++Ttg
-        qVZVSY3isZAJEqNhWCvsBkCysjIZJDVKTyYH9L0BJuScLBPMEoZ/BRi+ZpBEpCwLXfaW1H2Ub+rv
-        m4hdrtUKGbEZxjCLfHfg+ncUbwx3rmKeZ8rYaOSPfG/WHL+u3fKC0L9CQXZ5AXFF9MR+Vou+VVuE
-        8b1OKnyvwyvmscvAWPZHxbUFzcYyxaIsMMRbRGF9wAtq6bPz39hBheXPLmIut0hR9+cFwd5VE827
-        O3aBjWvtKI4P34/rz4fm0yWZJu37T8OpsEgFJFqDCkeoiBFbsjt2iTr6IbIbvmxBsF+7QSCV88SV
-        2Ou7qZp78yqXCFuLtOI9PH9FKoZ+E2ySixfgFsJqcJVOPaxtTngX2MgSJ3h41M1skZNcnSv81tki
-        PRNIq5xjLJf0t612/wik4Dmh5wL0HP+dsT777ljD3wAAAP//7FnbTttAEP2VVaUiEsXGiR1yQYhG
-        pEg8pKpatQ/0hc16TVwlceRLUFU+vmfW68UxWdpSFfGAQEm8s9eZ2TNnxtmiww6W+QkG991ey6I9
-        besjv+fTghPE2q3skG4UWWZ3pNN2pdFxWymF2lh7Wkg2hQui8ULOXTbqMAIotuvd1d+i6xr3Vs++
-        +5+Pg31PFY7gin9PGCEstvrbcewQH619h37syKwNF0PzN3w5T7I2VoTjqCn+zd929d7+nBQptHgR
-        LyWwQJaaPrjJT5Rz1TpO7zGqDSwxyyYAL3313Tg54uE2zgCAIBj93jHgKyIdw1WqqEa2u1aTXzOE
-        XkZbRUqpg22qTa43QiYPjckzbfLbBUEfx3zrGwbOLSBH1BYpj2glitGApE2Ru9D81/v5Z8CepdQY
-        tyuq2P645kXo8VHx1LASQwrNnBpxbQL0XGA0GuGR6kKOm8rs1BoycBuLIN1Kh6JXLB52LKUR31K8
-        rVmJEGxMH+RceJwIgfnGiA/zZSy0BWexCgragF8UbyCda8uUp2JJypYQpK6x/OVqw0VOYz4kLFYP
-        DDi+jUMZ7vjSJ9wnkCks/TceooduEgoD5OCHPFzF6xY7bN2t4MB5MobTPqTifcNGm0zMxtG7QT1K
-        5ynoh8ozKHNodjXZWkPg2QSBSaiaIwwhrrRg62gjyJ4tifPMmjvEssk7eJ5zsaDIWZKXrFitODGr
-        N7bQT9qmDClJn0i/6A6ecSEor7sMT/uhPxwM592BJ30x8sSo34tG3egY65hOWOGRbpJcYRKGdE/Q
-        UyThj3e1jYCf0VyP1myU+qULiqe60ZiqbhBIZCE87AbB8UAMB31/NBfzgYflIy6joTgLT9Usb/3J
-        294F/stxzoqvNSdxnLIpc4vMuYUinJ5LZMctryBpytlwnpGiMF4hPHIY/DyfOZ67WRMNbtZ/Xv6O
-        mwWkl7/jZgHqpe8Y2BSW9Qydp5zD9dmMR1EhRKwuEJGyslpSItsVSCw6vi/SZCOProA5gvJ6fdOo
-        AAqpubq0gi777k9uAhueBraaR2BqHqnG9VcYeTaHeYWR59jxK4zsgZEmDNgYWmCImOEtOM5NeSl/
-        0psa/dvDTpKc6/dMzVlsVMyz4ZLX2w9wtpKlZz2AlaqZkzVH2DicbxUYcifX2zhN1iWBK5vCQr/k
-        LB//RHvbJK8V8H8BAAD//yKtHMYYwIcYBjcUaFNGYnFYPnggEjbqDswCECdXw5jQ+oVsB4AnhPVh
-        5uoo5SZWBKUWl+aADEbyLHgIsajEsQTicdBUBmiYEeR1uDiqZiMU3VANYNfW1tYCAAAA//8DAOCg
-        Gv9THwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18265","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18265","key":"NTEST-1885","fields":{"statuscategorychangedate":"2025-04-30T18:28:05.050+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1885/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:04.742+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:04.830+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/30]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/117]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/323]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/323]\n*Defect
+        Dojo link:* http://localhost:8080/finding/323 (323)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1885/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18265/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 260a59ea-b9d5-4a46-9ac2-13d6266e842d
+      - 38379104-744e-4768-80de-8cbd4e93ea43
       Atl-Traceid:
-      - 260a59eab9d54a469ac213d6266e842d
+      - 38379104744e476880de8cbd4e93ea43
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:40 GMT
+      - Wed, 30 Apr 2025 16:28:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1317,7 +1429,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=258,atl-edge-internal;dur=19,atl-edge-upstream;dur=239,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=310,atl-edge;dur=277,atl-edge-internal;dur=19,atl-edge-upstream;dur=258,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ZG8nZSiPDgHRKpcCKr9Q3X4g7RRuiJygTkOQBsYM5hFlKN34euAJqA==",cdn-downstream-fbl;dur=314
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1326,10 +1438,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a65725dd05dc27eea7ae75a2e122228e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ZG8nZSiPDgHRKpcCKr9Q3X4g7RRuiJygTkOQBsYM5hFlKN34euAJqA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 5c95ec046a48e9465ff84acf95cda922
+      - 42e9cd0dca7d6312d1e64c73b6d3df46
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1353,65 +1473,51 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16129
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18265
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xXWVPjRhD+K1N6Sm1sXTZgVJVKETAbEkKI8e4+sBQ1SG1pFmlGmRn5yMJ/T7cO
-        ezm8CaSy5QfN1cd0f/1N+7MDy5LLxIkcDTIBDcmxgDwxPckLMD0TZ1DwnipBcyuUND1IhC3A8l6c
-        cZlCrtLeHLTBPUgmUGowIG17Nq6MVcWMFF4Hvh/4roY/KzB2uirhXPPYihicniPIfrAbhPs4MZDP
-        cJpZW5rI8xKYQWwT9Um53ObcGMGlK8F6aMl6vBRe6AljKvA6BbewQvmz6fhi2g92hzu4VLtgnOiz
-        Y9C3ysTcQqr0qrlDgjOUCP1wp+8H/cCfhn4UjKLBvru/t/89+u2Tk2TEouO1mlc6SfIe6vPD9bXb
-        SQIm1qKkwOHqATMFz/MeS4SxQsaWlQJiYGrGFkrfuiQdK/lO5y/0opKC0sXzaz7nlmtvLmDh1W5t
-        HGy3An8QjH404i/4ocC0VwVaJVigySk3t5Sr6sbSKJrx3EDPaQRP8F61bM/JBAJHx9nqFOaAvvr3
-        PccKRFaJKHEiWeEdnUcwGfjbNoJuo9TqE171lZlopes81Jnt8kCTL9Czue47KaxFBcZZ2yYI/1qf
-        NWpmF1wTkI0oylygw8mjkGCiavgNR8vh6IXufiVl3U3WCRv6e+hGOFyGw//XSgOLGqRoMNhdBrvf
-        wuCyszgIl4PwW1hskX9//xSOYQfHmVi+bzgQk3x59fTkoDvJ01RDinzzj0Ww023gBVReNbzw/NHd
-        bRt7WzbCrRujbRv7T91paLNZJVKqXwgn6gc45RYfjoZwX16fDZ1vCNxr1Gmqvnp4qCoKXECk/IEW
-        hEydyOoK7lueJm1axE3UPj9ZI8/wqMlUlSdHwpQ5X7UVi8voln2P0KAqbqOhAS9LNPHcI7E7CrpH
-        4nHYtlFZuKayxxtrUJVaKC3s6pVB7MS9+qX592+FKHgKxiMJ0ykRuJCJNHPNPN2Q4s+40rFn6Dyt
-        j3CN+pzfAPHfM6VBtPFsIIJtGA1GFJGMm3Ep4lMhb49p5whK6l9k3OWxzu6i3luvSCXH2L7wmxwm
-        wE2DDd2OnPPTd29Pzq5PTw7HZxfj6/Fk8vsE74d1ajAkeGCaATtHopeWkV0mDFMyXzEkDZGTUmYV
-        +0Vozs41FMgarDKIWvc58giwoBz/Tvh+udqLnOZVxOxh+DdV9YAtMBGpkDx/fKjtvtrw1kjP0bt2
-        TplNJaxPVyWV7TYk7+2MOiQ3jdIrwdcIrx/Yh73Ny/C4wdtPPL7FdrODXKe8sXXYdnT/yeGuLWxq
-        Bo2EXT8gYUHVrXKlzxpvbvIK+qlG3tg0RYodqSbZqiixIZb2edDvrGnha4l9LLSmjIfh/Ci//B2w
-        VKuqpEbxWMgEidEwrBV2AyBZWZkMkhqlJ5MD+t4AE3JOlglmCcO/AgxfM0giUpaFLntL6j7KN/X3
-        TcQu12qFjNgMY5hFvjtw/TuKN4Y7VzHPM2VsNPJHvjdrjl/XbnlB6F+hILu8gLgiemI/q0Xfqi3C
-        +CwnFT7L4RXz2GVgLPuj4tqCZmOZYlEWGOItorA+4AW19Nn5b+ygwvJnFzGXW6SoyfOCYO+qiebd
-        HbvAxrV2FMeH78f150Pz6ZJMk/b9p+FUWKQCEq1BhSNUxIgt2R27RB39ENkNX7Yg2K/dIJDKeeJK
-        7PXdVM29eZVLhK1FWvEenr8iFUO/CTbJxQtwC2E1uEqnHtY2J7wL7FeJEzw86ma2yEmuzhV+62yR
-        ngmkVc4xlkv621a7fwRS8JzQcwF6jv/OWJ99d6zhbwAAAP//7FnbTttAEP2VVaUiEsXGiR1yQYhG
-        pEg8pKpatQ/0hc16TVwlceRLUFU+vmfW68UxWdpSFfGAQEm8s9eZ2TNnxtmiww6W+QkG991ey6I9
-        besjv+fTghPE2q3skG4UJ2Z3pNN2pdFxWymF2lh7Wkg2hQui8ULOXTbqMAIotuvd1d+i6xr3Vs++
-        +5+Pg31PFY7gin9PGCEstvrbcewQH619h37syKwNF0PzN3w5T7I2VoTjqCn+zd929d7+nBQptHgR
-        LyWwQJaaPrjJT5Rz1TpO7zGqDSwxyyYAL3313Tg54uE2zgCAIBj93jHgKyIdw1WqqEa2u1aTXzOE
-        XkZbRUqpg22qTa43QiYPjckzbfLbBUEfx3zrGwbOLSBH1BYpj2glitGApE2Ru9D81/v5Z8CepdQY
-        tyuq2P645kXo8VHx1LASQwrNnBpxbQL0XGA0GuGR6kKOm8rs1BoycBuLIN1Kh6JXLB52LKUR31K8
-        rVmJEGxMH+RceJwIgfnGiA/zZSy0BWexCgragF8UbyCda8uUp2JJypYQpK6x/OVqw0VOYz4kLFYP
-        DDi+jUMZ7vjSJ9wnkCks/TceooduEgoD5OCHPFzF6xY7bN2t4MB5MobTPqTifcNGm0zMxtG7QT1K
-        5ynoh8ozKHNodjXZWkPg2QSBSaiaIwwhrrRg62gjyJ4tifPMmjvEssk7eJ5zsaDIWZKXrFitODGr
-        N7bQT9qmDClJn0i/6A6ecSEor7sMT/uhPxwM592BJ30x8sSo34tG3egY65hOWOGRbpJcYRKGdE/Q
-        UyThj3e1jYCf0VyPlmaU+qULiqe60ZiqPBBIZCE87AbB8UAMB31/NBfzgYflIy6joTgLT9Usb/3J
-        294F/stxzoqvNSdxnLIpc4vMuYUinJ5LZMctryBpytlwnpGiMF4hPHIY/DyfOZ67WRMNbpZ5Xv6O
-        m3Wil7/jZp3ppe8Y2BSW9Qydp5zD9dmMR1EhRKwuEJGyslpSItsVSCw6vi/SZCOProA5gvJ6fdOo
-        zgmpubq0gi777k9uAhueBraaR2BqHqnG9VcYeTaHeYWR59jxK4zsgZEmDNgYWmCImOEtOM5NeSl/
-        0gsZ/dvDTpKc6/dMzVlsVMyz4ZLX2w9wtpKlZz2AlaqZkzVH2DicbxUYcifX2zhN1iWBK5vCQr/k
-        LB//RHvbJK8V8H8BAAD//yKtHMYYwIcYBjcUaFNGYnFYPnggEjbqDswCECdXw5jQ+oVsB4AnhPVh
-        5uoo5SZWBKUWl+aADEbyLHgIsajEsQTicdBUBmiYEeR1uDiqZiMU3VANYNfW1tYCAAAA//8DACP3
-        lp9THwAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18265","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18265","key":"NTEST-1885","fields":{"statuscategorychangedate":"2025-04-30T18:28:05.050+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1885/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:04.742+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9b:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:04.830+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n\nA
+        group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+        Group\n*Group*: [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/30]
+        in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+        / [NPM Audit Scan|http://localhost:8080/test/117]\n\n\n|| Severity || CVE
+        || CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+        | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 |
+        [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/323]
+        | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* May 30, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+        Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/323]\n*Defect
+        Dojo link:* http://localhost:8080/finding/323 (323)\n*Severity:* High\n *Due
+        Date:* May 30, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+        \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+        File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+        versions of `fresh` are vulnerable to regular expression denial of service
+        when parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+        Versions: < 0.5.2\n Patched Version: >= 0.5.2\n Vulnerable Paths: \n  - 0.3.0:express>fresh,express>send>fresh,express>serve-static>send>fresh,serve-favicon>fresh\n
+        CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2
+        or later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Findings
+        in: fresh:0.3.0","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1885/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18265/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 35d1446f-83eb-4e2a-97d4-7c77c2174a0f
+      - 554c16df-c1b0-415e-9737-7f26c156cc8d
       Atl-Traceid:
-      - 35d1446f83eb4e2a97d47c77c2174a0f
+      - 554c16dfc1b0415e97377f26c156cc8d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:40 GMT
+      - Wed, 30 Apr 2025 16:28:05 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1421,7 +1527,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=222,atl-edge-internal;dur=17,atl-edge-upstream;dur=208,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=307,atl-edge;dur=275,atl-edge-internal;dur=16,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="XnI7iuLlZguK5YsGwpTxv75XMbZC8lBtDas6vtFPjxp2fHYQpVEiiQ==",cdn-downstream-fbl;dur=312
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1430,10 +1536,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5ea7f8bcbac3004590a821cdd0466e1c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - XnI7iuLlZguK5YsGwpTxv75XMbZC8lBtDas6vtFPjxp2fHYQpVEiiQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3d44e9ac07eba6e16f59fee6053e5a56
+      - 8eb67de3c24549233261895a97010117
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1466,7 +1580,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -1480,9 +1594,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"849\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33656\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:38538\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
@@ -1518,7 +1632,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:40 GMT
+      - Wed, 30 Apr 2025 16:28:06 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -1536,25 +1650,23 @@ interactions:
       "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
       117, "url_ui": "http://localhost:8080/test/117", "url_api": "http://localhost:8080/api/v2/tests/117/"},
       "finding_count": 5, "findings": {"new": [{"id": 320, "title": "Regular Expression
-      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
-      "http://localhost:8080/finding/320", "url_api": "http://localhost:8080/api/v2/findings/320/"},
-      {"id": 321, "title": "2222Regular Expression Denial of Service - (Negotiator,
-      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/321",
-      "url_api": "http://localhost:8080/api/v2/findings/321/"}, {"id": 322, "title":
-      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/322", "url_api": "http://localhost:8080/api/v2/findings/322/"},
-      {"id": 323, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
-      "severity": "High", "url_ui": "http://localhost:8080/finding/323", "url_api":
-      "http://localhost:8080/api/v2/findings/323/"}, {"id": 324, "title": "2222Remote
-      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
-      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
-      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
-      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
-      "High", "url_ui": "http://localhost:8080/finding/324", "url_api": "http://localhost:8080/api/v2/findings/324/"}],
-      "reactivated": [], "mitigated": [], "untouched": []}}'
+      Denial of Service - (Negotiator, <= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/320",
+      "url_api": "http://localhost:8080/api/v2/findings/320/"}, {"id": 321, "title":
+      "2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/321", "url_api": "http://localhost:8080/api/v2/findings/321/"},
+      {"id": 322, "title": "Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4
+      ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6
+      || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+      || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/322",
+      "url_api": "http://localhost:8080/api/v2/findings/322/"}, {"id": 323, "title":
+      "Regular Expression Denial of Service - (Fresh, < 0.5.2)", "severity": "High",
+      "url_ui": "http://localhost:8080/finding/323", "url_api": "http://localhost:8080/api/v2/findings/323/"},
+      {"id": 324, "title": "2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+      < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0
+      < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0
+      < 7.0.2 || >= 7.1.0 < 7.1.2)", "severity": "High", "url_ui": "http://localhost:8080/finding/324",
+      "url_api": "http://localhost:8080/api/v2/findings/324/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
     headers:
       Accept:
       - application/json
@@ -1565,11 +1677,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '2507'
+      - '2372'
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - scan_added
       X-DefectDojo-Instance:
@@ -1581,11 +1693,11 @@ interactions:
       string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
         \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
-        \   ],\n    \"Content-Length\": [\n      \"2507\"\n    ],\n    \"Content-Type\":
+        \   ],\n    \"Content-Length\": [\n      \"2372\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33660\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:38546\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
         5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
@@ -1600,63 +1712,61 @@ interactions:
         \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 117, \\\"url_ui\\\": \\\"http://localhost:8080/test/117\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/117/\\\"}, \\\"finding_count\\\":
         5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 320, \\\"title\\\": \\\"Regular
-        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        Expression Denial of Service - (Negotiator, <= 0.6.0)\\\", \\\"severity\\\":
         \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/320\\\", \\\"url_api\\\":
         \\\"http://localhost:8080/api/v2/findings/320/\\\"}, {\\\"id\\\": 321, \\\"title\\\":
-        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"2222Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\\\",
         \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/321\\\",
         \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/321/\\\"}, {\\\"id\\\":
-        322, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/322\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/322/\\\"}, {\\\"id\\\":
-        323, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
-        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/323\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/323/\\\"}, {\\\"id\\\":
-        324, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
-        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
-        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
-        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
-        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/324\\\",
-        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/324/\\\"}], \\\"reactivated\\\":
-        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
-        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
-        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
-        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        322, \\\"title\\\": \\\"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\",
+        \\\"url_ui\\\": \\\"http://localhost:8080/finding/322\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/322/\\\"}, {\\\"id\\\": 323, \\\"title\\\":
+        \\\"Regular Expression Denial of Service - (Fresh, < 0.5.2)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/323\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/323/\\\"}, {\\\"id\\\": 324, \\\"title\\\":
+        \\\"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0
+        < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >=
+        6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2
+        || >= 7.1.0 < 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/324\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/324/\\\"}],
+        \\\"reactivated\\\": [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n
+        \ \"files\": {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event
+        scan_added has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
         \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
         5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
         \         \"id\": 320,\n          \"severity\": \"High\",\n          \"title\":
-        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"Regular Expression Denial of Service - (Negotiator, <= 0.6.0)\",\n          \"url_api\":
         \"http://localhost:8080/api/v2/findings/320/\",\n          \"url_ui\": \"http://localhost:8080/finding/320\"\n
         \       },\n        {\n          \"id\": 321,\n          \"severity\": \"High\",\n
         \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
-        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/321/\",\n
+        <= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/321/\",\n
         \         \"url_ui\": \"http://localhost:8080/finding/321\"\n        },\n
         \       {\n          \"id\": 322,\n          \"severity\": \"High\",\n          \"title\":
-        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
-        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
-        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
-        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/322/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/322\"\n        },\n        {\n          \"id\":
-        323,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
-        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/323/\",\n
-        \         \"url_ui\": \"http://localhost:8080/finding/323\"\n        },\n
-        \       {\n          \"id\": 324,\n          \"severity\": \"High\",\n          \"title\":
-        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
-        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
-        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
-        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
-        \         \"url_api\": \"http://localhost:8080/api/v2/findings/324/\",\n          \"url_ui\":
-        \"http://localhost:8080/finding/324\"\n        }\n      ],\n      \"reactivated\":
-        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
-        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
-        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
-        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
-        {\n      \"id\": 117,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/117/\",\n
+        \"Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0 < 3.6.4 ||  >= 4.0.0 <
+        4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >= 6.1.0 < 6.1.6 || >= 6.2.0
+        < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2 || >= 7.0.0 < 7.0.2 || >=
+        7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/322/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/322\"\n        },\n
+        \       {\n          \"id\": 323,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Fresh, < 0.5.2)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/323/\",\n          \"url_ui\": \"http://localhost:8080/finding/323\"\n
+        \       },\n        {\n          \"id\": 324,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Remote Code Execution - (Pg, < 2.11.2 || >= 3.0.0
+        < 3.6.4 ||  >= 4.0.0 < 4.5.7 || >= 5.0.0 < 5.2.1 || >= 6.0.0 < 6.0.5 || >=
+        6.1.0 < 6.1.6 || >= 6.2.0 < 6.2.5 || >= 6.3.0 < 6.3.3 || >= 6.4.0 < 6.4.2
+        || >= 7.0.0 < 7.0.2 || >= 7.1.0 < 7.1.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/324/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/324\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        117,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/117/\",\n
         \     \"url_ui\": \"http://localhost:8080/test/117\"\n    },\n    \"title\":
         \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
         NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/117/\",\n
@@ -1670,7 +1780,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:40 GMT
+      - Wed, 30 Apr 2025 16:28:06 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1nVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLD5/NS8EiGBDNhsDHQMy4oxnk95HsUAFxDhmPfxD9hXuj1nKVQMOF0klhbsm5Xt
-        jVUugjktFlIAzlBJOp2jyJXKFUjFltPZolZFjqxQwM4EwSTDre5FeiEqMZhw56RI7QMxp4qgfd2W
-        5Hh+2JOzaXJ9X5HjJwAAAP//AwDDZr+SIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:06.433+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 8c11d8d1-da84-4e2a-a7cb-63cbef69e887
+      - 8fcad182-3c98-4e96-af5b-a1160a3b1824
       Atl-Traceid:
-      - 8c11d8d1da844e2aa7cb63cbef69e887
+      - 8fcad1823c984e96af5ba1160a3b1824
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:41 GMT
+      - Wed, 30 Apr 2025 16:28:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=164,atl-edge-internal;dur=16,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=185,atl-edge;dur=153,atl-edge-internal;dur=15,atl-edge-upstream;dur=138,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="y6wfF715yosHyXx5_X8ShGAIZPY1L0HPpLRlnpaSp60cYt4ZQoT-WA==",cdn-downstream-fbl;dur=188
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5538280951642fc71308aa997730220e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - y6wfF715yosHyXx5_X8ShGAIZPY1L0HPpLRlnpaSp60cYt4ZQoT-WA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 239b70996fcc3458f437a05130d2670b
+      - 1d32e42f916907465fdc04628db8b13e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 74905df6-6ef4-4674-88bb-d74b0d749ada
+      - 3232475e-e4b1-4f8a-bc39-b04de968ea5b
       Atl-Traceid:
-      - 74905df66ef4467488bbd74b0d749ada
+      - 3232475ee4b14f8abc39b04de968ea5b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:41 GMT
+      - Wed, 30 Apr 2025 16:28:06 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=310,atl-edge-internal;dur=16,atl-edge-upstream;dur=295,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="MwHPffzY7HFb3Z2gnD6O_QYywmyxNfU_VhDJFGZhF_k41_8AgQuP5g==",cdn-downstream-fbl;dur=378,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=375,atl-edge;dur=301,atl-edge-internal;dur=21,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 3cab2977109e9e185607e6a3005951e0.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MwHPffzY7HFb3Z2gnD6O_QYywmyxNfU_VhDJFGZhF_k41_8AgQuP5g==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 5a2c6d93fe1aa907c7f60b3800ac8b63
+      - ebe9ad0e148759b380adecef5152478a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/325]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/325 (325)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/118]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16130","key":"NTEST-1646","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16130"}'
+      string: '{"id":"18267","key":"NTEST-1886","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18267"}'
     headers:
       Atl-Request-Id:
-      - 42960148-7b09-4478-8263-4d5f6000f176
+      - 8a147f21-0a8e-45c4-ba1b-9cc5241d34b2
       Atl-Traceid:
-      - 429601487b09447882634d5f6000f176
+      - 8a147f210a8e45c4ba1b9cc5241d34b2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:42 GMT
+      - Wed, 30 Apr 2025 16:28:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=756,atl-edge-internal;dur=12,atl-edge-upstream;dur=744,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="EA-cM8dhjPMJAZyO16sdn3oUkqet06bzMuEXR_o4ht4HIdHumtx95A==",cdn-downstream-fbl;dur=866,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=862,atl-edge;dur=773,atl-edge-internal;dur=15,atl-edge-upstream;dur=759,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 475bc4efb9c2dcfa6769dde201c9bbbc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - EA-cM8dhjPMJAZyO16sdn3oUkqet06bzMuEXR_o4ht4HIdHumtx95A==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - d7eb075b0d24e5c5ea50e52bbc5180a9
+      - 48eb5067a25b4ec156cbf429d9aab9f6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1646
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1886
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltibLjugKGoYvdLV2WZYnTAs2KgJHOMmuK1Egqttfmv++o
-        N7dO1CIZVhRILR7v/bmH98GDTc5k4kWeBpmAhuQlB5GYnmQZmJ6Jl5CxnspBM8uVND1IuM3Asl68
-        ZDIFodLeLWiDMkjOIddgQNr6blwYq7KFM3hNg4AGAw1/F2DsfJvDmWax5TF4PY87/3RMhwF+GBAL
-        /Fxam5vI9xNYQGwT9V4NmBXMGM7kQIL10ZP1Wc790OfGFOA3BlawRf3T+exi3qfj0RiPyhCMF33w
-        DMZWmJhZSJXeVjkk+IUaYRAe9gPap8E8DCI6iUbhYDga/4BxO7OlE4uBl2aeGKTT99FeELZp1x8J
-        mFjz3BUOT18QkzEheiThxnIZW5JziIGoBVkrvRo47VjJSy0eGUUhuWsXE9fsllmm/VsOa78Maxdg
-        LaLBkE5+Mvwf+DHDthcZenWwQJdzZlauV8WNdb+iBRMGel6leIx5lbo9b8kRODpebk/gFjDW4K7n
-        WY7IyhElXiQLzNHbgwk2sRbkWr3HjJ5Y8Fq7LHfZwKbceyDZZXUpubVowHitb4fU38q7Ri3smmmH
-        V8OzXHAMONnLHPtRomw02Ywmjwz3C51pMmn7MgqeYRjhaBOO/l8vVfdLLKJDOt7Q8bdwuGk8DsPN
-        MPwWHmuA393dhyPtwmnYJRg2ggXfvK7IEWFx9Q5hkqYaUuSbrw7BYSPAzJQoKl54+Oq4S/CsQxB2
-        CiZdguf3w6loszp1pFS+EF7Up/jJLD4cFeE+fnArOt8RuF+Z024sy59HqnCFo46U37gDLlMvsrqA
-        u5qnnTXN46pqH+6ducjwqlmqQiRTbnLBtvUo4zGGZV8jZtx419XQgMk6/njokQjCUfNI7JetpbJ9
-        QReowhZUueZKc7t9YhEbdX/0uLeCZywF4zsN0xjheCDUemBu0x1Znqh1Q6oj7/7YhO0QCHYDjhYd
-        /vc3gi7o0i6E0omrx5KZWc7jEy5XL51kCrnbXmTcdLHs7bqUtSdSyRkuL+xGwDkwUyFD17+8s5PL
-        X45Pr0+Oj2anF7Pr2fn5H+eYH06pwYLghfkSyBnyv7TE+SXcECXFliCXcOGMEqvIK64ZOdOQIZmQ
-        wiBmBw9xCsVx8oKPPAjy7SLyqjcRe4fF383UZ1yBbUi5ZGL/Ur171eUtcS4wuoZusK+phPZ2kbuh
-        7cTx83bZqdakJ0KvUm7f3c83m8ehcQe3n1m8wmWzgVxjvPJ1VO9z/yngZin0m90sbNYECQ7qsRJK
-        n1bR3IgC+qlG1titRIpMVdVsleW4Dkv7MOgPu0jhsCWFL3X883L+JXf/DubcCjiIyNVbltOIHCm1
-        4kDecIs8Z8kFxIUG8lKw9KOrDhZHqJiJpTI2mgSTwF9wmSCV+sPw8F1pcFoWD/N6r4iDVXRAvqpJ
-        vsM/35fqF7j0OQ5CNWSLOshpAWSK+eDh72xLaNAjDoxtEkdvZii6wv/6YzoqI3V9jNcwyLjVMFA6
-        9RHGzLWW48bm4O/j1cHSZqKMu7Lz2tm5lCup1p8W6UyrpMAdYCZTHOwM2+TPscbOZ1khjJf8qtZ9
-        qzqqlNcGwnfEJ1fUWPJnwbQFTXYmO1Rh55OW2m9fnJGLmMmO+24Z9SmdtFl9ksfF1ljIDOaR5Ioj
-        2A6i8rzskKtYxrg03MIA8YgFM8sbxXTSdeOe/ekOZwfRvwAAAP//7Flta9swEP4rolBooXadxFmS
-        QelC2WAfykYLK5RCkGW5MYtl45e6pet/73OSoqVe3I0ySj8U8sGJpLvT+e655y5Xas6ECSdgL4uk
-        VKySNWttbNUAx8rEV4L4OmDtMhVLlkmuKixys8NKwH2vVCQZFwLoKmN2k3LWIGFEeVcAnrBPKWkK
-        tb9h0Sne9bVuLcmgi6VUFF+MO7k5Ok/cCJbQtcACWaqSvMz0GZaXhNkcqxVBJuD6p1QHZBiEpzUz
-        bIDxVcvv6Iqs4Nq6pkJkM67YhoHoG5Vc+XjjFd3Z3dD44EqRE0gb+QgWWAurtYkksGrgoK2Wbtx5
-        4/ZnyEVUH7iMbm/jpW1bP295VeisQBLKW79YFjqioWQBmQure8Fr0J+oQUwt9r5dzM+/e+enHgq1
-        zlWnpMgplCkb9nicpWqf7e3/QqCs6vwjwvBPjjN2hb5b5PpwbhD2LTjSSwBYl4B8zeyIq3W2ho6Q
-        dhYCJ6O70Mc1Asc19NvTlGv7xj52HDhjntTsLnLjBXCxpOw3daFqsoxT0dr5G16T14mC5uULKxxR
-        kWPkGxHnr/HROB5NJ9NoMAnkSMwCMRsPk9kgoVGJ2wQNz2yTFBLzOIYOVDmUvPju04YhABSS9WxT
-        bHLFRxXV2zRM2cYslCB6PB6E4YeJmE7Go1kkokkA9QmXyVQcx0dayu5ovjv8go8552VcWXz1PPNT
-        5TeV18IR3tAn4PaLJlqlgjzlFZxX5Cic13UENBGPJ0gKv1Dk826D/fYt7nbob9/ibof/1i0GFMWm
-        YbRU8AShDyaTJI0QqU4gwnPTjhoguwQZxMbPTZkX8vASECOWvzONJkxYdalLGuxcbTt/DPtwNexr
-        KsO+SUXosLu0wP+OL68WSe/48hoWv+PLFnzpwoAjZI6/wOprk3v3NAq3zwEU5jW3g/yulF7m1YtL
-        vZRsuB35+qZCQR8HJUDYuhD0cdBR34mRI3lS3aRlrgyRMz/Fjf0XyXz9J+/lmZFwv360cP8C+N34
-        A+xwLfdgJ+O3Z7JqViR4Q7cempT1vDZ23OT1/5vUGmFOKHShXfyR65nTerxKs2Ka5JBKZ8hTa4dP
-        zLUHtHseHh4eAQAA//8DANkuFhi0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18267","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18267","key":"NTEST-1886","fields":{"statuscategorychangedate":"2025-04-30T18:28:07.923+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1886/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:07.550+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:07.680+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/325]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/325 (325)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/118]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1886/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18267/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - c0dfda27-991b-492c-a167-f257abaf384e
+      - 5485c21f-1394-482a-b04b-b143c4c398f0
       Atl-Traceid:
-      - c0dfda27991b492ca167f257abaf384e
+      - 5485c21f1394482ab04bb143c4c398f0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:42 GMT
+      - Wed, 30 Apr 2025 16:28:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=300,atl-edge-internal;dur=13,atl-edge-upstream;dur=287,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=314,atl-edge;dur=280,atl-edge-internal;dur=21,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="s2v48iNFZAUnGJ3-ZJpoRIz6YZtoypmGbP7RIo3PszN5CktGwxkJCQ==",cdn-downstream-fbl;dur=317
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9dbecd95f02024b36225d6b521598db6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - s2v48iNFZAUnGJ3-ZJpoRIz6YZtoypmGbP7RIo3PszN5CktGwxkJCQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d15a06cd5e8968483e021d576b228add
+      - 39f20f23616f04c1e01f54838d6a6282
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16130
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18267
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvdhxXQHD0MXuli3LssRpgWZFwEhnmTVFaiQV22v733ek
-        XtzaUYdkWFEgtXi8t+eeO957DzYFFakXewpECgrSlwx4qnuC5qB7OllCTnuyAEUNk0L3IGUmB0N7
-        yZKKDLjMevegNMogvYRCgQZh6rtJqY3MF9bgbRgEYTBQ8FcJ2sy3BVwomhiWgNfzmPUfjsNhgB8a
-        +AI/l8YUOvb9FBaQmFS+kwNqONWaUTEQYHz0ZHxaMD/ymdYl+I2BFWxR/3w+u5r3w/FojEcuBO3F
-        7z2NsZU6oQYyqbZVDil+oUYURMf9IOyHwTwK4nASj6LBcDT+DuO2Zp0Tg4E7M08M0ur7aC+I2rTr
-        jxR0olhhgcPTF0TnlPMeSZk2TCSGFAwSIHJB1lKtBlY7keJa8UdGUQpmy0X5Lb2nhir/nsHad2Ht
-        AqxFYTAMJz9o9jd8n2PZyxy9WlqgyznVK1ur8s7YX/GCcg09r1I8xbycbs9bMiSOSpbbM7gHjDX4
-        2PMMQ2YVyBIvFiXm6O3RBItYCwol32FGTwS81nZwuwI2cO+RZJfVtWDGoAHttb4tU391d7VcmDVV
-        lq+a5QVnGHC6lznWw7FsNNmMJo8M9wuVaTJp6zIKnmEY0WgTjf5fL1X1HRfRYTjehOOv4XDTeBxG
-        m2H0NTzWBP/48ZCOYRdPo0awYJtX1QzE6t+8Pbw5bG7SLFOQ4bw5aAJMQPKyav+H3R13CcZdgmcd
-        gqhTMOkSPD+Msxqb1akdSu6F8OJ+WM9KWxLFkiql9wdntlEQbb2UJU+nTBecbut2wuM1Nfj0VCP7
-        8a1fPQi7J8CvzCnb2O7niSwt9C7U1/aAicyLjSqtbzRqXiFnbHvXaCjAZO38eOiRCKJR80jsw9aO
-        sn1BF6millSFYlIxs30iBI26P3rcW8FymoH2rYZujDA84HI90PfZblieyXUzVEfeYdtELec5vQM7
-        Fh9oDDtNHoQh7GJoOLF4LKmeFSw5Y2L10kqmUNjtRSQNgxyv1k7WnggpZri80DsOl0B1xUpV//Iu
-        zq5/Oj2/PTs9mZ1fzW5nl5e/X2J+2KUaAcEL8yWQC5z/whDrlzBNpOBbgrOEcWuUGEl+YYqSCwU5
-        DhNSamTc4KGZEmI7ecEHFgTFdhF71ZuItUPwdz312azAMmRMUL5/qd69angd7zlGV3/bumYC2ttl
-        YZu2k8fP22WnWpOeSL1KuX13P99sHsfGHd1+pMkKl82Gco3xytdJvc/9p4CbpdBvdrOoWRMEWKon
-        kkt1XkVzx0voZwon1m4lkmQqq2LLvMB1WJiHSX/cDoUvFXZfqR0Yn8P5p9j9O5ozw+EoJjdvaBHG
-        5ETKFQPymhmcsYZcQVIqIC85zT5YdBAcLhPKl1KbeBJMAn/BRIqD0B9Gx2+dwakDD/N6J4mlVXxE
-        /lWTfIN/vnXqV7j02RmEajgt6iCnJZApJoqHv9EtCYMesWRskzh5PUPRDf7XH4cjF6mtY7KGQc6M
-        goFUmY80pra0DDc2S38frw6WJucu7srOK2vnWqyEXH8K0oWSaYk7wExk2Ng5lsmfI/jWp0MI4yU/
-        y3XfyA6UitpA9Jb45CbUhvxRUmVAkZ3JDlXY+Qyd9psXF+QqoaLjvl1G/TCctFl9ksfVVhvINeaR
-        FpIh2Y5id+4qZBHLKROaGRggHxEwvbyTVKVdNw7sT3c8O4r/AQAA///sWW1LG0EQ/iuLICh45yW5
-        NElBbJAW+kFaFCqIEDZ7e+Zosnfci6dY/7vP7G628Zq1RYr4QfDDebs7OzM388wzkys1ZcKEE7CX
-        zaVUrJI1a21s1QDHysRXivg6YO0iEwu2klxVWORmh5UAe6/UXDIuBNBVJuwm46xBwojyrgA8YZ9S
-        0pCEcEOjU3zra91akkIXC6kovhh3cnN0nrAImpBZYIEsU2lervQZlpeE2RyrFUEm4PqnVAekGIRn
-        NTNMhPFly+/IRFZwrV1TIbIZV2xDQfSNSi5DfPGKbHYWGh9cKXIC3UY+ggZWw2qtIgmsGjhoq6Yb
-        Nm9Yf4ZcRPWBy8h6Gy9t24Z5y6tCZwWSUN6GxaLQEY1LZpA5s3fPeA3qNW8QU7O9bxfT8+/B+WmA
-        Qq1z1V1S5BTKlA17PFllap/t7f9CoCzr/CPC8E+OM3SFvlvkfOSnF/sWHMUlZKxLQL7mZcQTO1sj
-        HxuOHVPtnnBcQ38kzay2b/Rxj8jHjiN3J3zMxYIS3BbgzRrehfiqWa04Fa2dv+E1eZ0oaF6+sMIR
-        FTlGvhHt/ZocDZPBeDSe90aRHIhJJCbDfjrppTQqcZtwwzPbJIXENElwB6ocSl5y92lDEQAKyXq2
-        KTa5EqKK6m0apmxjFksQPZ704vjDSIxHw8FkLuajCNenXKZjcZwcaSm7g+lu/wv+zLlgxZXF1yAw
-        r6qwqYIWjgj6IQF3WDTzZSbIU0HBeUWOwnldR0AT8XiCpAgLRT7vNthvX+Nuh/72Ne52+G9dY0BR
-        YppVSwVPEPpgMmnaCJHpBCI8N82kAbJLkEFs/NyUeSEPL4E9YvE702jChFWXunSDnatt54+xD1dj
-        X1MZu6aytPj+DiOvFjDvMPIaGr/DyBYY6cKAj6nFjpA5vgJzrk1S3tMo3D5H0CSvuR3kd6X4KFnk
-        w6Wovx3gfFOhyGuAl7L5qCZByNaFgXfBkTypbrIyV4blmVdJY39FMv/+i/du8vr/zTeNMCcUN6FN
-        +5HrWc96pIoUMCrfrx9tfXmxAvoXt8O13IOdFb89k1WzJMEbxuopTVlPa2M4zYppkkOmu/dPD/ef
-        nLYHtLYPDw+PAAAA//8DANBAAfi0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18267","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18267","key":"NTEST-1886","fields":{"statuscategorychangedate":"2025-04-30T18:28:07.923+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1886/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:07.550+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9j:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:07.680+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/325]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/325 (325)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/118]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1886/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18267/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 2cf982e8-e7b1-4bf3-a545-9be7c5ccfa75
+      - 325fe0cd-6a03-47f2-a174-ea73e0c4f87b
       Atl-Traceid:
-      - 2cf982e8e7b14bf3a5459be7c5ccfa75
+      - 325fe0cd6a0347f2a174ea73e0c4f87b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:43 GMT
+      - Wed, 30 Apr 2025 16:28:08 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=264,atl-edge-internal;dur=11,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=303,atl-edge;dur=270,atl-edge-internal;dur=14,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="FS3azC_dgbybZHCOhBp4-SOfWp-z8Dyh9DY-9ktx7_hA2hMzk3QoNw==",cdn-downstream-fbl;dur=307
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a183b6545fea485604515ba7931cb9b8.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - FS3azC_dgbybZHCOhBp4-SOfWp-z8Dyh9DY-9ktx7_hA2hMzk3QoNw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 3941cceb1a76f3921e57cf6e40b32ddc
+      - 2b2a5d68010c2d97dff280eeddd67890
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TtfvIDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC18LjtDeHkLYTO88mkQYUyNO7dZSIY4b0WNrMYyIg02ndG7P/Bl9jvtMQG/ccaTbdCG7D/
-        65KVs8oMaCX+LrnD3mtnI0wBaAYZjMvN5WO5fqh+ppuhrWNF+HOCRjCCl+jEzrh9G6+s9l2yrYwb
-        mhiqB22arwjhMcDm81PzSoQEMmDFGOgYlhVjPJ/yPIoBLiDCMe/jH7CvdHvOUqgYcLqIeJaz4puV
-        7Y1VLoI5nS2kACxQSTqdo8iVyhVIxZbTYlGrWY5spoCdCYJJhlvdi/RCVGIw4c5JkdoHYk4VQfu6
-        Lcnx/LAnZ9Pk+r4ix08AAAD//wMALyx5nCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:09.201+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 32512088-70a5-4e7a-b30c-a31756b72f7f
+      - 4b4e9c01-7ca1-40fd-8302-09df31b71b54
       Atl-Traceid:
-      - 3251208870a54e7ab30ca31756b72f7f
+      - 4b4e9c017ca140fd830209df31b71b54
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:43 GMT
+      - Wed, 30 Apr 2025 16:28:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=146,atl-edge-internal;dur=16,atl-edge-upstream;dur=131,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=196,atl-edge;dur=163,atl-edge-internal;dur=17,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="1OWqprnBD_3STlf26XEUPcIFNwKGVRTgOYb-2qFrMxxJEGs1TPCGgg==",cdn-downstream-fbl;dur=200
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 1OWqprnBD_3STlf26XEUPcIFNwKGVRTgOYb-2qFrMxxJEGs1TPCGgg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - d4bd649f87cdea63692be9515129eda7
+      - 69ba7dabb321374274d3ef8e707d5892
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - c1a5d541-f159-41e7-ae8a-c8e221c26208
+      - 5ffbcad0-7663-4faf-951f-802f4c862f91
       Atl-Traceid:
-      - c1a5d541f15941e7ae8ac8e221c26208
+      - 5ffbcad076634faf951f802f4c862f91
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:43 GMT
+      - Wed, 30 Apr 2025 16:28:09 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=316,atl-edge-internal;dur=14,atl-edge-upstream;dur=302,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=292,atl-edge;dur=258,atl-edge-internal;dur=14,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="frxVE3k7HicKqrGQuchqAdENz94JQgyHwNNZHlsoocfSoWWyG9vtxg==",cdn-downstream-fbl;dur=296
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 771067dca4682f83a6c9963c412d66cc.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - frxVE3k7HicKqrGQuchqAdENz94JQgyHwNNZHlsoocfSoWWyG9vtxg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7a500fe2f8a298f683e285168938bfda
+      - 4db5db55143d58877d741872662ba89e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/326]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/326 (326)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/118]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16131","key":"NTEST-1647","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16131"}'
+      string: '{"id":"18269","key":"NTEST-1887","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18269"}'
     headers:
       Atl-Request-Id:
-      - 30478a7d-492b-4a52-bf4f-aeff0e9b5e78
+      - 8f968c05-e98d-4f0a-aa66-57bf8d16e3c1
       Atl-Traceid:
-      - 30478a7d492b4a52bf4faeff0e9b5e78
+      - 8f968c05e98d4f0aaa6657bf8d16e3c1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:44 GMT
+      - Wed, 30 Apr 2025 16:28:10 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=767,atl-edge-internal;dur=11,atl-edge-upstream;dur=756,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="253vvapwogZcdhC9n7t1UzjJ_NPbt2CpW1PKSFpyv9mmKG7yEdJ49Q==",cdn-downstream-fbl;dur=722,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=719,atl-edge;dur=642,atl-edge-internal;dur=17,atl-edge-upstream;dur=625,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 2bdfafaaaec33c116889588ecd9de280.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 253vvapwogZcdhC9n7t1UzjJ_NPbt2CpW1PKSFpyv9mmKG7yEdJ49Q==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 1acbb3c061fa9a4cca98447cf9acb1d7
+      - f8511d8ec5e20bc45500757a0308de16
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1647
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1887
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfUkI6UpVdSWhpaWUkgDSUYTM7mRj4rW3tpck5fjvHe9L
-        AiR7J6h6OonLejzvzzyeRweWGRWxEzoKRAwK4iMGPNYtQVPQLR3NIKUtmYGihkmhWxAzk4KhrWhG
-        RQJcJq0HUBplEJ9DpkCDMNXdKNdGplNr8Nb3PN/rKPg7B20mqwzOFI0Mi8BpOcz69/t+18cPDXyK
-        nzNjMh26bgxTiEws72WHGk61ZlR0BBgXPRmXZswNXKZ1Dm5tYA4r1D+djMaTtt/vHeBREYJ2wkdH
-        Y2y5jqiBRKpVmUOMX6gReMF+2/PbvjcJvNAfhL1ep98NvsO4PRukdWIw8MLMO4O0+i7a84J12tVH
-        DDpSLLOFw9MPRKeU8xaJmTZMRIZkDCIgckoWUs07VjuS4kLxN0aRC2bbRfktfaCGKveBwcItwtoE
-        WIl8r+sPftTsH/ghxbbnKXq1sECXE6rntlf5nbG/winlGlpOqXiMeRW6LWfGEDgqmq1O4AEwVu+p
-        5RiGyMoQJU4ocszReQWTrlcLMiXvMaN3FrzSLspdNLAut/14BpJNVheCGYMGtLP2bZH6W3FXy6lZ
-        UGXxqlmacYYBx68yx34UKOsNlr3BG8P9TGfqTNZ96XkW1UFvGfT+Xy9l9wssokO/v/T7X8PhsvbY
-        DZbd4Gt4rAD+9LQNR78Jp0EtmLLlZcmB2P3rm+2b3fomTRIFCfLNF4dgvxZgZpLnJS/svtpvEhw0
-        CIJGwaBJ8P12OCVtlqeWlIoXwgnbfsWVtiWKRWXkj1tndlCw2nomcx4Pmc44XVXjhMcLavDpKSn7
-        7aNfPgibJ8AtzSk72MXPQ5nb0hehXtkDJhInNCq3vtGouUTM2PGuqqEAk7X8seuRCHoH9SPxumxr
-        KnstaAJVsAZVpphUzKzeWYJa3e297a1gKU1Au1ZD10YYHnC56OiHZEOWJ3JRk2rP2R6bYI15Tu/A
-        0uKOwbBssrMMfhNC/YGtx4zqUcaiEybmR1YyhMxuLyKqEVTgalHI1idCihEuL/SOwzlQXaJSVb+c
-        s5OLn49Pb0+OD0en49Ht6Pz8j3PMD6dUY0HwwmQG5Az5Xxhi/RKmiRR8RZBLGLdGiZHkV6YoOVOQ
-        IpmQXCPiOrs4xcdxcrxPzPOylQid8k3E3mHxNzP1giuwDQkTlL++VO1eVXkL3HOMrvq2fU0ErG/n
-        mR3aJhx3D7wax+Wa9E7olcrrd/flZvM2NG7g9hON5rhs1pCrjZe+Dqt97j8FXC+Fbr2bBfWaIMBC
-        PZJcqtMymjueQztRyFiblUiSoSybLdMM12FhdoN+v4kU9tek8LmOvyznX2Lzb2/CDIe9kFx/pFkQ
-        kkMp5wzIFTPIsYaMIcoVkCNOk0+2OlgcLiPKZ1KbcOANPHfKRIxE6HaD/k1hcFgUD/O6l8TCKtwj
-        X9Qk3+Cfbwv1MS59loNQDdmiCnKYAxliPnj4O10R32sRC8Z1EodXIxRd43/tvt8rIrV9jBbQSZlR
-        0JEqcRHG1LaW4cZm4e/i1c7MpLyIu7Rzae1ciLmQi+dFOlMyznEHGIkEBzvFNrkTrLH1WVQI4yW/
-        yEXbyIYqZZWB4Ia45NrXhvyZU2VAkY3JBlXY+PQL7Y8fzsg4oqLhvl1GXd8frLN6lsd4pQ2kGvOI
-        M8kQbHthcV50yFYspUxoZqCDeMSC6dmdpCpuurFlf7jB2V74LwAAAP//7FltS9xAEP4riyAomJi7
-        y3l3BbGHtNAP0qJQQYRjs9l4oXebkBejWP97n9nd28b0YosU8YPgh5jdnZ2ZzDzzzNy1mjNhwgnY
-        yyIpFStlxRobWxXAsTTxlSC+DlizTMWSrSVXJRa52WElwN5rFUnGhQC6ypjdppzVSBhR3OeAJ+xT
-        ShqS4Lc0OsO3vtGtJSl0uZSK4otxJzdD5wmLoAmZBRbIUpVkxVqfYVlBmM2xWhJkAq5/SHVAikF4
-        WjHDRBhfNfyeTGQ519rVJSKbccVaCqJvVHLl44uXZLOz0PjgWpET6DbyETSwGpYbFUlgWcNBWzVt
-        2dyy/hy5iOoDl5H1Nl6apvGzhpe5zgokobzz82WuIxqXLCBzYe9e8ArUK6oRU4u9r5fzi2/exZmH
-        Qq1z1V2SZxTKlA17PF6nap/t7f9EoKyq7APC8E+OM3aFvlvk+nBuELZxriqA7Jp+ER3sbnU0uLMQ
-        OkLaWQj6TgSOa+iPpJnV9o193CPoY8eBUwY+5mJJCW4LcLuGd5G8rNdrTkVr5294TV4nCpoVL6xw
-        REVOkG9Ee7/Ex+N4NJ1Mo8EkkCMxC8RsPExmg+QI97hNuOGZbZJCYh7HuANVDiUvvv/YUgSAQrKe
-        bYpNrvioonqbhinbmIUSRI/HgzA8mojpZDyaRSKaBLg+4TKZipP4WEvZHc13h5/xZ855a64svnqe
-        eVX6dek1cIQ39Am4/byOVqkgT3k55yU5Cud1HQFNxOMpksLPFfm822C/fY27Hfrb17jb4b91jYFR
-        sWlWLRU8ReiDySRJLUSqE4jw3DSTBuGuQAax8VNdZLk8vAL2iOXvTKMJE1Zd6tINdq62nT+Gfbga
-        9jWVoWsqC4vv7zDyagHzDiOvofE7jGyBkS4M9DG10BEyx1dgzo1JygcahdvnAJpkFbeD/K6UXubV
-        i0t9459guB35eplZr2W9lM2Z3FkY9Z0YOZIn1W1aZMqwPPMqru2vSObff/HebVb9v/mmEeaE4ia0
-        ad8zPevZjFSRAkblh82jrS8vVkD/4na4kXuws+Z357KsVyS4Zaye0hTVvDKG06yYJjlkunv/9PDw
-        yWl7QGv7+Pj4CwAA//8DAMYkz2G0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18269","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18269","key":"NTEST-1887","fields":{"statuscategorychangedate":"2025-04-30T18:28:10.386+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1887/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:10.077+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:10.201+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/326]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/326 (326)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/118]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1887/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18269/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d1e0ba12-6897-4feb-9fb2-1789ae61198a
+      - 86ca19bd-ded8-45b7-9cfe-d8cbc42d0387
       Atl-Traceid:
-      - d1e0ba1268974feb9fb21789ae61198a
+      - 86ca19bdded845b79cfed8cbc42d0387
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:45 GMT
+      - Wed, 30 Apr 2025 16:28:10 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=287,atl-edge-internal;dur=15,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=298,atl-edge;dur=265,atl-edge-internal;dur=14,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="QfDA7P2CRZlmJgHFypt3suMoFryvpz5CBFQPqHzgTrxXI8-3vDpoYg==",cdn-downstream-fbl;dur=302
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 848ee9f48eafd6caa6bf5371a2f79f28.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - QfDA7P2CRZlmJgHFypt3suMoFryvpz5CBFQPqHzgTrxXI8-3vDpoYg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4d769f494faf109ad178aa56a538e08c
+      - 7666ef0ee9699e068e6e3c421f0b558b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16131
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18269
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfUkI6UpVdSWh5UophQDSUYTM7mRj4rW3tpck5fjvHe9b
-        gLBXQdXTSVzW43l75pnxPDiwyqiIndBRIGJQEB8w4LHuCJqC7uhoDintyAwUNUwK3YGYmRQM7URz
-        KhLgMuncg9Iog/gUMgUahKnuRrk2Mp1Zgze+5/leT8FfOWgzXWdwomhkWAROx2HWvz/0+z5+aOAz
-        /Jwbk+nQdWOYQWRieSd71HCqNaOiJ8C46Mm4NGNu4DKtc3BrAwtYo/7xdHI27frDwR4eFSFoJ3xw
-        NMaW64gaSKRalznE+IUagRfsdj2/63vTwAv9UTgY9Ib94DuM27NBWicGAy/MvDNIq++iPS9o0q4+
-        YtCRYpkFDk8/EJ1SzjskZtowERmSMYiAyBlZSrXoWe1IinPF3xhFLpgtF+U39J4aqtx7Bku3CGsT
-        YCXyvb4/+lGzv+GHFMuep+jV0gJdTqle2Frlt8b+CmeUa+g4peIh5lXodpw5Q+KoaL4+gnvAWL3H
-        jmMYMitDljihyDFH5wVN+l4tyJS8w4zeCXilXcBdFLCG2348Ickmq3PBjEED2ml8W6b+WtzVcmaW
-        VFm+apZmnGHA8YvMsR4Fywaj1WD0xnC/UJk6k6YuA8+yOhisgsH/66WsfsFFdOgPV/7wazhc1R77
-        waoffA2PFcEfH7fp6LfxNKgFM7a6KGcgVv/qevtmv75Jk0RBgvNmqwkwAcnzsv1fd7fbJhi2CfZa
-        BEGrYNQm+H47znJslqd2KBUvhBN2/WpW2pIoFpUpPWyd2UZBtPVc5jweM51xuq7aCY+X1ODTU47s
-        t7d++SBsngC3NKdsYxc/92VuoS9CvbQHTCROaFRufaNRc4Gcse1doaEAk7Xz47VHIhjs1Y/ES9ia
-        UfZS0EaqoCFVpphUzKzfCUGt7g7e9lawlCagXauhayMMD7hc9vR9shmWR3JZD9WBs902QcN5Tm/B
-        jsVXGsNOk1dh8NsY6o8sHnOqJxmLjphYHFjJGDK7vYioZlDBq2Uha06EFBNcXugth1OgumSlqn45
-        J0fnPx8e3xwd7k+OzyY3k9PT308xP+xSjYDghekcyAnOf2GI9UuYJlLwNcFZwrg1SowkH5mi5ERB
-        isOE5BoZ13ttpvjYTo73mXlethahU76JWDsEf9NTz2YFliFhgvKXl6rdq4K34D3H6KpvW9dEQHM7
-        z2zTtvG4v+fVPC7XpHdSr1Ru3t3nm83b2Lih2080WuCyWVOuNl762q/2uf8UcL0UuvVuFtRrggBL
-        9UhyqY7LaG55Dt1E4cTarESSjGVZbJlmuA4L8zrpd5uh8KXCvlRqBsZzOP8Um387U2Y47ITk6hPN
-        gpDsS7lgQC6ZwRlryBlEuQJywGny2aKD4HAZUT6X2oQjb+S5MyZiHIRuPxheFwbHBXiY150kllbh
-        DvlXTfIN/vm2UD/Dpc/OIFTDaVEFOc6BjDFRPPyNronvdYglY5PE/uUERVf4X3foD4pIbR2jJfRS
-        ZhT0pEpcpDG1pWW4sVn6u3i1NzcpL+Iu7VxYO+diIeTyKUgnSsY57gATkWBjp1gmd4rgW58FQhgv
-        +UUuu0a2oJRVBoJr4pIrXxvyR06VAUU2JltUYePTL7Q/fTghZxEVLfftMur6/qjJ6kkeZ2ttINWY
-        R5xJhmTbCYvzokIWsZQyoZmBHvIRAdPzW0lV3HZjy/54w7Od8B8AAAD//+xZXUsbQRT9K4MgKLjr
-        JtmYpCA2SAt9kBaFCiKEyeysWZrMLvvhKtb/3nNnJtO4zdgiRXwQfFh3Zu7X3nvuuZNrNWXCpBOw
-        l82lVKySNWttbtUAx8rkV4r8OmDtIhMLtpJcVVjkZoeVAH+v1VwyLgTQVSbsNuOsQcGI8r4APGGf
-        UtKQhHDDojN86xs9WpJBlwupKL8Yd3JzTJ7wCJaQW2CBLFNpXq70GZaXhNkcqxVBJuD6h1QHZBiE
-        ZzUzTITxZcvvyUVWcG1dUyGzGVdsw0DMjUouQ3zxinx2HpoYXCsKAmmjGMECa2G1NpEEVg0CtNXS
-        DZ83vD9HLaL7IGTkvc2Xtm3DvOVVoasCRSjvwmJR6IyGkhlkzqzuGa9BveYNcmq29/VyevEtuDgL
-        0Kh1rTolRU6pTNWwx5NVpvbZ3v5PJMqyzj8gDf/kOEPX6LtNzkd+erFvwVFcQsa6BORrXkY8sbM1
-        8rHh2DHV7gnHNfRH0sxq+0Yf94h87DhyOhFjLhZU4LYBb/bwLsRXzWrFqWnt/A2vKepEQfPyhR2O
-        qMgJ6o1o75fkeJgMxqPxvDeK5EBMIjEZ9tNJLz2CHrcJGp7ZJiklpkkCHehyaHnJ/ccNQwAoJOvZ
-        odjUSoguqrdpmLKDWSxB9HjSi+OjkRiPhoPJXMxHEdSnXKZjcZIcaym7g+lu/zP+zLlgxZXF1yAw
-        r6qwqYIWgQj6IQF3WDTzZSYoUkHBeUWBwnndR0AT8XiKoggLRTHvDthv3+LuhP72Le5O+G/dYkBR
-        YoZVSwVPkfpgMmnaCJHpAiI8N8OkAbIrkEFs/NSUeSEPr4A9YvG70uiGCauudEmDvVfbzh9jH67G
-        vqEydkNlafH9HUZeLWHeYeQ1LH6HkS0w0oUBH1OLHSFzfAXu3JiifKCrcPscwZK85vYivyvFR8ki
-        Hy5F/e0A57sVirwOeCmbj2oShGxdGHgXHMmT6jYrc2VYnnmVNPZXJPPvv0TvNq//3/2mEeaEQhPG
-        tO+5vutZX6miBIzJD+tH219ebID+xe1wLfdgZ8XvzmXVLEnwhrP6lqasp7VxnO6K6SaHXHfvnx7u
-        PzltD2hrHx8ffwEAAP//AwBrS1fBtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18269","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18269","key":"NTEST-1887","fields":{"statuscategorychangedate":"2025-04-30T18:28:10.386+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1887/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:10.077+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9r:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:10.201+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/326]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/326 (326)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/118]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1887/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18269/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d5aefd15-a126-43d5-b637-242448d28334
+      - 0ac24f51-ace0-4151-81e0-9e8daf672af2
       Atl-Traceid:
-      - d5aefd15a12643d5b637242448d28334
+      - 0ac24f51ace0415181e09e8daf672af2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:45 GMT
+      - Wed, 30 Apr 2025 16:28:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=252,atl-edge-internal;dur=16,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=32,cdn-upstream-fbl;dur=380,atl-edge;dur=251,atl-edge-internal;dur=16,atl-edge-upstream;dur=235,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="WAv4Yf2i4HWzx_RO_picuA6rN-RcN0Custe4NvwoW8os_obv7lKgZw==",cdn-downstream-fbl;dur=384
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a65725dd05dc27eea7ae75a2e122228e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - WAv4Yf2i4HWzx_RO_picuA6rN-RcN0Custe4NvwoW8os_obv7lKgZw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 17abaf5ad62df4c999a2598305831c33
+      - c7daf17bf1e3a63d4ce6daf7ed722798
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33668\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:56102\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:45 GMT
+      - Wed, 30 Apr 2025 16:28:11 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/118", "url_api": "http://localhost:8080/api/v2/tests/118/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      118, "url_ui": "http://localhost:8080/test/118", "url_api": "http://localhost:8080/api/v2/tests/118/"},
+      "finding_count": 2, "findings": {"new": [{"id": 325, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/325",
+      "url_api": "http://localhost:8080/api/v2/findings/325/"}, {"id": 326, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/326",
+      "url_api": "http://localhost:8080/api/v2/findings/326/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:56108\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/118\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/118/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 118, \\\"url_ui\\\": \\\"http://localhost:8080/test/118\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/118/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 325, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/325\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/325/\\\"},
+        {\\\"id\\\": 326, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/326\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/326/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 325,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/325/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/325\"\n        },\n
+        \       {\n          \"id\": 326,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/326/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/326\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        118,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/118/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/118\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/118/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/118\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:11 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_add_comment.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_add_comment.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpr2m5d3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUjDHW4HTRh58753bDZrUaLwrX23CfeaO6e4SQx6MiGtcr3m+3/wFQ47JbBF97FG3a/QeBz+
-        umRljdQjGoG/S+5wcMqaAKcAaQIJTKvN5WO1fqh/ppuxa0JF2HOEJjCBl+DEXtt9F66s9320rbQd
-        2xBqRqXbrwhhIUAXi1PzivsIUqDFFNIpLGtKWZ6xPIgBLiDAIe/CH3CoVXfOplBTYGnJ8iIpM/rN
-        iu7GSBvAPJ2XggMWKEWaLZDnUuYShKTLrCgbOc+RziXQM4HX0XCrBh5fiJKP2t9ZwWP7QPSpImhe
-        txU5nh/2ZE2cXN/X5PgJAAD//wMA/UDTOiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:11.939+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 141cd399-1ca3-474a-bbde-948d2dcd8ea9
+      - fd74a4ec-3c95-46b9-a67d-bf0192b3de47
       Atl-Traceid:
-      - 141cd3991ca3474abbde948d2dcd8ea9
+      - fd74a4ec3c9546b9a67dbf0192b3de47
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:45 GMT
+      - Wed, 30 Apr 2025 16:28:11 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=184,atl-edge-internal;dur=17,atl-edge-upstream;dur=169,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="m-1XkFaxiSPtRM1xt_kIQlz-8QaiHdnjNTkieU68Pdl6qAxHKh6dQQ==",cdn-downstream-fbl;dur=273,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=271,atl-edge;dur=182,atl-edge-internal;dur=14,atl-edge-upstream;dur=168,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c1388c9ad241eb02cd4ddbe69b1a2d34.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - m-1XkFaxiSPtRM1xt_kIQlz-8QaiHdnjNTkieU68Pdl6qAxHKh6dQQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - a17c1d45e722f23130468dc912f234bd
+      - 47eecad61b482709952dd4dbefb2a359
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 420942ae-6234-4b29-a0b7-7132734362d0
+      - 3b963d9c-d561-4fd1-8d06-102238bcd833
       Atl-Traceid:
-      - 420942ae62344b29a0b77132734362d0
+      - 3b963d9cd5614fd18d06102238bcd833
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:46 GMT
+      - Wed, 30 Apr 2025 16:28:12 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=17,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=302,atl-edge;dur=270,atl-edge-internal;dur=15,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="VYiVm_DjdvkHPUexysv2oIy_9_BRsKcwv37x6BvUfxVxXW-3zsyxaA==",cdn-downstream-fbl;dur=306
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5538280951642fc71308aa997730220e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - VYiVm_DjdvkHPUexysv2oIy_9_BRsKcwv37x6BvUfxVxXW-3zsyxaA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7d8e69475b59d1b3ee648f9093066378
+      - 08e496dd3cef9c9e2eab1a78349c6693
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/327]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/327 (327)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16132","key":"NTEST-1648","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16132"}'
+      string: '{"id":"18271","key":"NTEST-1888","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271"}'
     headers:
       Atl-Request-Id:
-      - 4bb08b7b-87ea-4f42-a77a-304c27839213
+      - c1230d2c-4eaf-4c3b-ad27-b4e3d1657b2f
       Atl-Traceid:
-      - 4bb08b7b87ea4f42a77a304c27839213
+      - c1230d2c4eaf4c3bad27b4e3d1657b2f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:46 GMT
+      - Wed, 30 Apr 2025 16:28:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=710,atl-edge-internal;dur=15,atl-edge-upstream;dur=696,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=718,atl-edge;dur=686,atl-edge-internal;dur=15,atl-edge-upstream;dur=672,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="TW8p0zQDvXn8NvaQioENpm53_lg6mo2VSukoQ3TrxNhWtcfns_yspQ==",cdn-downstream-fbl;dur=722
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 e665d09233240df4d3172e59222e0ba2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - TW8p0zQDvXn8NvaQioENpm53_lg6mo2VSukoQ3TrxNhWtcfns_yspQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 34788c530742e775dffb712c2f6fec5d
+      - 305cc9b7fa8cf60de46acea6fa290200
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1648
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltibLjOAKGoYvdLVuWZYnTAs2KgJHOMmuK1Egqtpfmv++o
-        FzuJow7JsKJAavF4b889d7w7D1Y5k4kXeRpkAhqStxxEYjqSZWA6Jp5DxjoqB80sV9J0IOE2A8s6
-        8ZzJFIRKO7egDcogOYdcgwFp67txYazKZs7gNQ0CGvQ0/FWAsdN1DmeaxZbH4HU87vzTIe2H+GFA
-        zPBzbm1uIt9PYAaxTdQn1WNWMGM4kz0J1kdP1mc590OfG1OA3xhYwBr1T6eTi2mXDgcjPCpDMF50
-        5xmMrTAxs5Aqva5ySPALNcIg3O8GtEuDaRhEdBQNhr3R4f53GHfggnROLAZemnllkE7fR3uBC7RK
-        u/5IwMSa5w44PH1DTMaE6JCEG8tlbEnOIQaiZmSp9KLntGMlL7V4YRSF5K5cTFyzW2aZ9m85LP0y
-        rG2AtYgGfTr6wfC/4fsMy15k6NXRAl1OmVm4WhU31v2KZkwY6HiV4jHmVep2vDlH4uh4vj6BW8BY
-        g/uOZzkyK0eWeJEsMEfvCU36QSPItfqEGb0S8Fq7hLssYAO3+3hAkm1Wl5JbiwaMt/HtmPpredeo
-        mV0y7fhqeJYLjgEnTzLHepQsG4xWyLuXhfuFyjSZbOoyCA4wjHCwCgf/r5eq+iUX0SEdrujwazhc
-        NR774Qp7+it4rAl+f79LR9rG07ARzPjqXTUDsfpXH3dv9pubLE01pDhvdpoAE1CiqNr/eXf7bYJh
-        m+CgRRC2CkZtgsPdOKuxWZ26oVS+EF7UpfWsdCXRPK5Suts5c42CaJu5KkQy5iYXbF23Ex4vmcWn
-        pxrZL2/96kHYPgF+ZU67xi5/HqnCQV+G+t4dcJl6kdWF841G7TvkjGvvGg0NmKybH889Evv7/eaR
-        eArbZpQ9FbSRKtyQKtdcaW7Xr4SgUfcHL3sreMZSML7TMI0RjgdCLXvmNt0OyxO1bIbqwNttm3DD
-        ecFuwI3FZxrDTZNnYaBtDKUjh8ecmUnO4xMuF2+dZAy5215k3DCo5NWylG1OpJITXF7YjYBzYKZi
-        pa5/eWcnlz8dn16fHB9NTi8m15Pz89/PMT/sUoOA4IXpHMgZzn9pifNLuCFKijXBWcKFM0qsIr9w
-        zciZhgyHCSkMMq733Eyh2E5e8JkHQb6+jbzqTcTaIfjbnno0K7AMKZdMPL1U7141vCXvBUZXf7u6
-        phI2t4vcNW0bj4f0oOFxtSa9knqV8ubdfbzZvIyNW7r9yOIFLpsN5Rrjla+jep/7TwE3S6Hf7GZh
-        syZIcFSPlVD6tIrmRhTQTTVOrO1KpMhYVcVWWY7rsLTPk35/MxS+VNinSpuB8RjOP+X2396UWwF7
-        Ebn6wHIakSOlFhzIe25xxlpyAXGhgbwVLP3s0EFwhIqZmCtjo1EwCvwZlwkOQr8fHnwsDY5L8DCv
-        T4o4WkV75F81yTf459tS/QKXPjeDUA2nRR3kuAAyxkTx8De2JjToEEfGTRJH7ycousL/ukM6KCN1
-        dYyX0Mu41dBTOvWRxsyVluPG5ujv49Xe3GaijLuy887ZuZQLqZYPQTrTKilwB5jIFBs7wzL5UwTf
-        +SwRwnjJz2rZtaoFpbw2EH4kPrmixpI/CqYtaLI12aIKW5+01P7w5oxcxEy23HfLqE/p4SarB3lc
-        rI2FzGAeSa44km0vKs/LCjnEMsal4RZ6yEcEzMxvFNNJ240d++Mtz/aifwAAAP//7FldS9xAFP0r
-        gyAomJjdzbq7BbGLtNAHaVGoIMIymUzc0N1JyIdRrP+9587MTmO6sUWK+CD4EDMz9yv3nnvu7LWa
-        M2HSCdjLIikVK2XFGptbFcCxNPmVIL8OWLNMxZKtJVclFrnZYSXA32sVScaFALrKmN2mnNUoGFHc
-        54An7FNKGpLgtyw6w7e+0aMlGXS5lIryi3EnN8PkCY9gCbkFFshSlWTFWp9hWUGYzbFaEmQCrn9I
-        dUCGQXhaMcNEGF81/J5cZDnX1tUlMptxxVoGYm5UcuXji5fks/PQxOBaURBIG8UIFlgLy42JJLCs
-        EaCtlrZ8bnl/jlpE90HIyHubL03T+FnDy1xXBYpQ3vn5MtcZDSULyFxY3QtegXpFNXJqsff1cn7x
-        zbs489Coda06JXlGqUzVsMfjdar22d7+TyTKqso+IA3/5Dhj1+i7Ta6P/AzCNgBWBZBd0y+ig92t
-        faQ36FsIHVPtnnBcQ38kzay2b+zjHkEfOw6cTsSYiyUVuG3A7R7ehfiyXq85Na2dv+E1RZ0oaFa8
-        sMMRFTlBvRHt/RIfj+PRdDKNBpNAjsQsELPxMJkNkiPocZug4ZltklJiHsfQgS6Hlhfff2wZAkAh
-        Wc8OxaZWfHRRvU3DlB3MQgmix+NBGB5NxHQyHs0iEU0CqE+4TKbiJD7WUnZH893hZ/yZc96aK4uv
-        nmdelX5deg0C4Q19Am4/r6NVKihSXs55SYHCed1HQBPxeIqi8HNFMe8O2G/f4u6E/vYt7k74b91i
-        YFRshlVLBU+R+mAySVILkeoCIjw3w6RBuCuQQWz8VBdZLg+vgD1i+bvS6IYJq650SYO9V9vOH8M+
-        XA37hsrQDZWFxfd3GHm1hHmHkdew+B1GtsBIFwb6mFroCJnjK3DnxhTlA12F2+cAlmQVtxf5XSl9
-        lCzow6VguB3g+m6Fgl4Heimb86x7oo/LjXoXHMmT6jYtMmVYnnkV1/ZXJPPvv0TvNqv+3/2mEeaE
-        QhPGtO+ZvuvZXKmiBIzJD5tH219ebID+xe1wI/dgZ83vzmVZr0hwy1l9S1NU88o4TnfFdJNDrrv3
-        Tw8Pn5y2B7S1j4+PvwAAAP//AwDv/l6YtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18271","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271","key":"NTEST-1888","fields":{"statuscategorychangedate":"2025-04-30T18:28:13.122+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:12.837+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:12.921+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/327]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/327 (327)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 845e99ce-b1d6-4b29-a039-d3358a1e6526
+      - ef125604-641d-43ba-879d-0f04dfdad1a2
       Atl-Traceid:
-      - 845e99ceb1d64b29a039d3358a1e6526
+      - ef125604641d43ba879d0f04dfdad1a2
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:47 GMT
+      - Wed, 30 Apr 2025 16:28:13 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=256,atl-edge-internal;dur=16,atl-edge-upstream;dur=241,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=365,atl-edge;dur=332,atl-edge-internal;dur=17,atl-edge-upstream;dur=315,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="oUGrPrRLXnc0JqURLE65wVrpHHkT54ygyArbGWpqINVqnk_difFzcg==",cdn-downstream-fbl;dur=368
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - oUGrPrRLXnc0JqURLE65wVrpHHkT54ygyArbGWpqINVqnk_difFzcg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 2492740ea634cadcbf6775ab6f2a1661
+      - e8201df14f904c57dff2a7b22040de38
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16132
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18271
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltifJLHAHD0MXO1i3LssRJgGZBwEhnmTVFaiQV22vz33fU
-        i90mUYdkWFEgtXi89+ce3gcP1jmTiRd5GmQCGpIjDiIxHckyMB0TLyBjHZWDZpYraTqQcJuBZZ14
-        wWQKQqWde9AGZZCcQa7BgLT13bgwVmVzZ/CWBgENehr+KsDY2SaHU81iy2PwOh53/umI9kP8MCDm
-        +LmwNjeR7ycwh9gm6r3qMSuYMZzJngTroyfrs5z7oc+NKcBvDCxhg/ons+n5rEtHgzEelSEYL/rg
-        GYytMDGzkCq9qXJI8As1wiAcdgPapcEsDCI6jgaj3vhg+B3GHbggnROLgZdmXhmk0/fRXuACrdKu
-        PxIwsea5KxyeviEmY0J0SMKN5TK2JOcQA1FzslJ62XPasZIXWrwwikJy1y4mbtk9s0z79xxWfhnW
-        LsBaRIM+Hf9g+N/wfYZtLzL06mCBLmfMLF2vijvrfkVzJgx0vErxLeZV6na8BUfg6HixOYZ7wFiD
-        h45nOSIrR5R4kSwwR+8RTPpBI8i1eo8ZvbLgtXZZ7rKBTbndxycg2WV1Ibm1aMB4W98Oqb+Wd42a
-        2xXTDq+GZ7ngGHDyKHPsR4mywXiNuHtZuF/oTJPJti+DYB/DCAfrcPD/eqm6X2IRHdLRmo6+hsN1
-        47EfrnGmv4LHGuAPD0/hSNtwGrYJ+o1gzteXFTkiLK5vECZpqiFFvnkyBJiAEkU1/s9bHbYJRm2C
-        /RZB2CoYtwkOnsZZ0WZ16kipfCG8qEtrrnQt0TyuUvrw5MwNClbbLFQhkgk3uWCbepzweMUsPj0V
-        Zb989KsHYfcE+JU57Qa7/HmoClf6MtQrd8Bl6kVWF843GrWXiBk33nU1NGCyjj+eeySGw37zSDwu
-        25bKHgvaQBVuQZVrrjS3m1eWoFH3By97K3jGUjC+0zCNEY4HQq165j7dkeWxWjWkOvCejk24HQLB
-        7sDRosP/442gDbq0DaF07OqxYGaa8/iYy+WRk0wgd9uLjBsElbhalbLtiVRyissLuxNwBsxUqNT1
-        L+/0+OKntye3x28Ppyfn09vp2dnvZ5gfTqnBguCF2QLIKfK/tMT5JdwQJcWGIJdw4YwSq8gvXDNy
-        qiFDMiGFQcT1nuMUiuPkBR95EOSb+8ir3kTsHRZ/N1OfcQW2IeWSiceX6t2rLm+Je4HRNXSDfU0l
-        bG8XuRvaNhyP6H6D42pNeiX0KuXtu/v5ZvMyNO7g9iOLl7hsNpBrjFe+Dut97j8F3CyFfrObhc2a
-        IMFBPVZC6ZMqmjtRQDfVyFi7lUiRiaqarbIc12Fpnwf9sI0UhltS+FLHPy/nn3L3b2/GrYC9iFy/
-        YzmNyKFSSw7kilvkWEvOIS40kCPB0o+uOlgcoWImFsrYaByMA3/OZYJE6PfD/ZvS4KQsHub1XhEH
-        q2iP/Ksm+Qb/fFuqn+PS5zgI1ZAt6iAnBZAJ5oOHv7ENoUGHODBukzi8mqLoGv/rjuigjNT1MV5B
-        L+NWQ0/p1EcYM9dajhubg7+PV3sLm4ky7srOpbNzIZdSrT4t0qlWSYE7wFSmONgZtsmfYY2dz7JC
-        GC/5Wa26VrVUKa8NhDfEJ9fUWPJHwbQFTXYmW1Rh55OW2u/enJLzmMmW+24Z9Sk92Gb1SR7nG2Mh
-        M5hHkiuOYNuLyvOyQ65iGePScAs9xCMWzCzuFNNJ240n9ic7nO1F/wAAAP//7FnvSxtBEP1XFkFQ
-        8M5LcpqkIDZIC/0gLQoVRAibvT1zNLd33A9Psf7vfbO7buM1a4sU8YPghzO7N/N2MvP2zeRKzZgw
-        6QTuZQspFatlwzqbWw3IsTb5lSK/9li3zMSS5ZKrGovc7LAWcN4rtZCMCwF2lQm7yThrUTCiuitB
-        T9inlDQiIVxDdIrv+lq3lgToYikV5Rfjzm6BzhMnAhI6FlQgy1RaVLl+hxUVcTbHak2UCbr+IdUe
-        AYPxrGFGiTC+6vgdHZGVXKNra2Q244qtAUTfqOQqxDde05ndCU0MrhQFgbxRjIDAIqwfIZLBukWA
-        NiJdO/Pa6c9Qi7h9EDI6vc2XruvCouN1qasCRShvw3JZ6oyGkzlszq3vOW8gvRYtcmq+8/Vidv4t
-        OD8NcFHrWnVOyoJSmaphhyd5pnbZzu5PJMqqKT4gDf/UOAfuou9fcj6eG8S+BSdxiQCbCpSvdRnp
-        xN7W2AnS3kLkk8mRT2tETmvob09Lrs0bfeo4cmAQYy6WVOAb9H6fyes2zzldWlt/42uKOknQonrh
-        DUdS5Bj1RrL3S3J0kIwm48liMI7kSEwjMT0YptNBegg/bhM8PLNNUkrMkgQ+cMvhykvuPq4BAaGQ
-        rWebYlMrIW5RvU3TlG3MYgmhx5NBHB+OxWR8MJouxGIcwX3KZToRx8mRtrI9mm0PP+PPvBfkXFl+
-        DQLzUR22ddAhEMEwJOIOy3axygRFKig5rylQeF/fI5CJeDxBUYSlopj3G+y3j7jfob99xP0O/60j
-        BhUlplm1UvAEqQ8lk6atEJkuIOJz00waIruEGMTGT21VlHL/EhQjlr8rjSZMWHWlSx7sXG2zfox9
-        vBr7msrYN6mIHXdXlvjf+eXVMumdX14D8Tu/bOCXPg04Qeb0ClBfm9q7p1G4fY7gsGi4HeT3rXiV
-        l5eXvJJsuJn5fFOhyKdBiRA2LkQ+DTryvTFyIk+qm6wqlFF55qOktb8imX//KXpFbizcPz5aun8B
-        /a79ALb/aHdvK+e3Z7JuV2R4zbcemlTNrDE4borm/81ZjTFnFL7QLn4v9MzJjXaLSk9yyKUD8hTt
-        8Alc+4IOz8PDwy8AAAD//wMADaBAa7QcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18271","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271","key":"NTEST-1888","fields":{"statuscategorychangedate":"2025-04-30T18:28:13.122+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:12.837+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:12.921+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/327]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/327 (327)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - fa4aa312-dc62-4f92-bdc0-1adbe9d27304
+      - ccebc96e-1cd3-4a80-ad49-9c0d7d230e07
       Atl-Traceid:
-      - fa4aa312dc624f92bdc01adbe9d27304
+      - ccebc96e1cd34a80ad499c0d7d230e07
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:47 GMT
+      - Wed, 30 Apr 2025 16:28:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=290,atl-edge-internal;dur=14,atl-edge-upstream;dur=276,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="JUuwqQxsNRGp0c-JBO5PsbiLWbSIA-JjIZY60TkObcmDBg3JU_8IyA==",cdn-downstream-fbl;dur=351,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=348,atl-edge;dur=271,atl-edge-internal;dur=17,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c973663b623c0e82cd366d5ae7837bf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JUuwqQxsNRGp0c-JBO5PsbiLWbSIA-JjIZY60TkObcmDBg3JU_8IyA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 029ffec620bfe73ac2fdd86cb438a1a5
+      - 78f4865122a43a76b3a5c98132a9cb8e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bprlq5d3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Whe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDZrUKEMjXt3iQhGeK+FTSwGMiGN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCKcAaQIJTMvN5WO5fqh+ppuhrWNF+PMITWACL9GJnXH7Nl5Z7bvRtjJu
-        aGKoHrRpviKExwDN81PzSoQRpECzKaRTWFaUcjbnLIoBLiDCMe/jH7CvdHvOplBR4GnBWZ4si+yb
-        le2NVS6CLF0UUgBmqGQ6z1EwpZgCqehynhW1WjCkCwX0TBDMaLjVvRhfiEoMJtw5Kcb2gZhTRdC+
-        bktyPD/sydlxcn1fkeMnAAAA//8DACfNVLYgAgAA
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:14.698+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - abbc2abb-9d07-4ec6-8a84-86c5af5fadf0
+      - 63736a29-95ef-40aa-9499-2e9acf8ceb13
       Atl-Traceid:
-      - abbc2abb9d074ec68a8486c5af5fadf0
+      - 63736a2995ef40aa94992e9acf8ceb13
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:48 GMT
+      - Wed, 30 Apr 2025 16:28:14 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=155,atl-edge-internal;dur=13,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="JBr-3WR2VdgmibHyrnWkbN4Axx9xxnk3uSU6SpfmB44jenDMitdVhg==",cdn-downstream-fbl;dur=235,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=53,cdn-upstream-fbl;dur=233,atl-edge;dur=160,atl-edge-internal;dur=17,atl-edge-upstream;dur=142,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 087e16218fcf1ccb7472a2c9f6a4cbe2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - JBr-3WR2VdgmibHyrnWkbN4Axx9xxnk3uSU6SpfmB44jenDMitdVhg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 5581f52965cae6d4f9041ac9aef95fb5
+      - 63334d691c8d732dbda3cb8560c8ffaa
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - d6b25930-bf29-4bea-8cab-8ae1f6659b19
+      - 69ff9857-62e6-4d44-a76f-7d66c82b0209
       Atl-Traceid:
-      - d6b25930bf294bea8cab8ae1f6659b19
+      - 69ff985762e64d44a76f7d66c82b0209
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:48 GMT
+      - Wed, 30 Apr 2025 16:28:15 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=259,atl-edge-internal;dur=14,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=289,atl-edge;dur=257,atl-edge-internal;dur=17,atl-edge-upstream;dur=239,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="n-73BtUbmcnyqSx5lRFDy_KMZiKhPHnjt8rkmJ9tK3uNr4dymRTaXA==",cdn-downstream-fbl;dur=293
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1b7fa09f50c08a88d619f90eef5ee94a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - n-73BtUbmcnyqSx5lRFDy_KMZiKhPHnjt8rkmJ9tK3uNr4dymRTaXA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - a74a7dbdac6ab1dacbd7ac125d85e1e6
+      - c7b0866efd0d9936f6c50f3d8dcf8d31
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/328]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/328 (328)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16133","key":"NTEST-1649","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16133"}'
+      string: '{"id":"18273","key":"NTEST-1889","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18273"}'
     headers:
       Atl-Request-Id:
-      - a8b99b4a-d90e-4c77-98d3-309610ca1d7e
+      - 6d62c262-e983-48cb-8229-c7be9ddc611e
       Atl-Traceid:
-      - a8b99b4ad90e4c7798d3309610ca1d7e
+      - 6d62c262e98348cb8229c7be9ddc611e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:49 GMT
+      - Wed, 30 Apr 2025 16:28:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=643,atl-edge-internal;dur=15,atl-edge-upstream;dur=627,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=874,atl-edge;dur=842,atl-edge-internal;dur=13,atl-edge-upstream;dur=829,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ajZw4t65f-Ab7741VeYZn4wLIZtgjbqA8oGl0vmfa17PrXlod1tvHg==",cdn-downstream-fbl;dur=879
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b5141080f2dac9506b5156fa7721b41c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ajZw4t65f-Ab7741VeYZn4wLIZtgjbqA8oGl0vmfa17PrXlod1tvHg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 7c4520533933cc50cf261e5467132522
+      - 431d29e6c5d437e48d06241bb76fcfea
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1649
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1889
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxtXlqgRJqmO1o2NsYYLSBdhpBJTlNTx85sh7aXy3/fcdKk
-        0JJ7BdOukErs4/P++PF5dGCRURE7oaNAxKAgPmLAY90SNAXd0tEUUtqSGShqmBS6BTEzKRjaiqZU
-        JMBl0noApVEG8TlkCjQIszob5drIdGIN3vqe53sdBf/koM14mcGZopFhETgth1n//p7f7eJCA5/g
-        cmpMpkPXjWECkYnlvexQw6nWjIqOAOOiJ+PSjLmBy7TOwa0MzGCJ+qfj4Wjc9vd6B7hVhKCd8NHR
-        GFuuI2ogkWpZ5hDjCjUCL9hte37b98aBF/r9sHfQwaB/wLg9G6R1YjDwwsw7g7T6Ltrzgjrt1SIG
-        HSmW2cLh7geiU8p5i8RMGyYiQzIGERA5IXOpZh2rHUlxofgbo8gFs+2i/JY+UEOV+8Bg7hZhrQNc
-        iXyv6/d/0uwT/Jhi2/MUvVpYoMsx1TPbq/zO2K9wQrmGllMqHmNehW7LmTIEjoqmyxN4AIzVe2o5
-        hiGyMkSJE4occ3Q2YNL1KkGm5D1m9M6Cr7SLchcNrMptF89Ass7qQjBj0IB2at8Wqb8XZ7WcmDlV
-        Fq+apRlnGHC8kTn2o0BZr7/o9d8Y7hc6U2VS96Xn7WMYQW8R9P5fL2X3CyyiQ39v4e99C4eLymM3
-        WHSDb+FxBfCnp204+k04DZoE3UowYYvLkhwRFtc3CJMkUZAg33z1EuxWAsxM8rzkhdeP7jUJ9hsE
-        QaOg3yQ42A6npM1y15JS8UI4YdvHJTX4cJSE+/aLW9L5msDd0pyy17L4PJS5LZxvSfnKbjCROKFR
-        OWD70Ki5xI7by1kGV9iz9hWLyjo+bu3ZWFFZT2XO4wHTGafL1eW2kFCAyVr+2H4k+p19r189Eptl
-        q6lsU9AEqqAGVaaYVMws31nESt3tve2tYClNQLtWQ1dGGG5wOe/oh2RNlidyXpFqz9m+NkF9CTi9
-        A0uLFv+bE0ETdP0mhPp9W48p1cOMRSdMzI6sZACZnV5EVPWs6OS8kNU7QoohDi/0jsM5UF3iQK2+
-        nLOTi1+OT29Pjg+Hp6Ph7fD8/M9zzA9vqcaC4IHxFMgZ8r8wxPolTBMp+JIglzBujRIjyW9MUXKm
-        IEUyIblGzHZe4xQfr5PjfWael33qhk75JmLvsPjrO/WCK7ANCROUbx5azV6r8hao5hhdRTfY10RA
-        fTrP7KVtxPF+r8JxOSa9E3qlcv3uvpxs3obGNdx+ptEMh80KcpXx0tfhap77TwFXQ6FbzWZBNSYI
-        sFCPJJfqtIzmjufQThRyxHokkmQgy2bLNMNxWJjXQb9bk8KXGrupVBPGy3L+LdZ/O2NmOOyE5Poj
-        zYKQHEo5Y0CumEFWM2QEUa6AHHGafLbVweJwGVE+ldqEfa/vuRMmYqRStxv0bwqDg6J4mNe9JBZW
-        4Q75qib5Dn++L9RHOPRZDkI1ZItVkIMcyAATxc0/6JL4XotYMNZJHF4NUXSN/9p7fq+I1PYxmkMn
-        ZUZBR6rERRhT21qGE5uFv4tHO1OT8iLu0s6ltXMhZkLOnxfpTMk4xxlgKBK82Cm2yR1j8a3PokIY
-        L/lVzttGNlQpWxkIbohLrn1tyF85VQYUWZtsUIW1T7/Q/vjhjIwiKhrO22HU9f2DOqtneYyW2kCq
-        MY84kwzBthMW+0WHbMVSyoRmBjqIRyyYnt5JquKmE1v2B2uc7YT/AgAA///sWW1r2zAQ/iuiUGih
-        dp3EaZJB6ULZYB/KRgsrlEKQZbkxi2Xjl7ql63/fc5KipV7cjTJKPxTywYmku9P57rnnLtdqzoQJ
-        J2Avi6RUrJI1a21s1QDHysRXgvg6YO0yFUuWSa4qLHKzw0rAfa9VJBkXAugqY3abctYgYUR5XwCe
-        sE8pacqyv2HRGd71jW4tyaDLpVQUX4w7uTk6T9wIltC1wAJZqpK8zPQZlpeE2RyrFUEm4PqHVAdk
-        GISnNTO1n/FVy+/piqzg2rqmQmQzrtiGgegblVz5eOMV3dnd0PjgWpETSBv5CBZYC6u1iSSwauCg
-        rZZu3Hnj9ufIRVQfuIxub+OlbVs/b3lV6KxAEso7v1gWOqKhZAGZC6t7wWuQnahBTC32vl7OL755
-        F2ceCrXOVaekyCmUKRv2eJylap/t7f9EoKzq/APC8E+OM3aFvlvk+sjPIOxbcKSXkLEuAfma2REz
-        62wNHSHtLARORnehj2sEjmvot6cp1/aNfew4cMY8qdldSMcL4GJJ2W/qQtVkGaeitfM3vCavEwXN
-        yxdWOKIiJ8g3Is5f4uNxPJpOptFgEsiRmAViNh4ms0FyBD1uEzQ8s01SSMzjGDpQ5VDy4vuPG4YA
-        UEjWs02xyRUfVVRv0zBlG7NQgujxeBCGRxMxnYxHs0hEkwDqEy6TqTiJj7WU3dF8d/gZH3POy7iy
-        +Op55qfKbyqvhSO8oU/A7RdNtEoFecorOK/IUTiv6whoIh5PkRR+ocjn3Qb77Vvc7dDfvsXdDv+t
-        Wwwoik17aKngKUIfTCZJGiFSnUCE56YdNUB2BTKIjZ+aMi/k4RUgRix/ZxpNmLDqUpc02Lnadv4Y
-        9uFq2NdUhn2TitBhd2mB/x1fXi2S3vHlNSx+x5ct+NKFAUfIHH+B1Tcm9x5oFG6fAyjMa24H+V0p
-        vcyrF5d6KdlwO/L1TYWCPg5KgLB1IejjoKO+EyNH8qS6TctcGSJnfoob+y+S+fpP3sszI+Fh/Wjh
-        /gXwu/EH2OFa7sFOxu/OZdWsSPCGbj00Ket5bey4zev/N6k1wpxQ6EK7+D3XM6f1MJVmxTTJIZXO
-        kKfWDp+Yaw9o9zw+Pv4CAAD//wMAtv2BKbQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18273","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18273","key":"NTEST-1889","fields":{"statuscategorychangedate":"2025-04-30T18:28:16.013+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1889/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:15.724+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00ta7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:15.803+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/328]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/328 (328)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1889/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18273/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 580ea336-f85d-4deb-ac11-94e7220c4bfd
+      - b912e4ac-2346-4b49-b7e1-a05dc515a268
       Atl-Traceid:
-      - 580ea336f85d4debac1194e7220c4bfd
+      - b912e4ac23464b49b7e1a05dc515a268
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:49 GMT
+      - Wed, 30 Apr 2025 16:28:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=14,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=298,atl-edge;dur=265,atl-edge-internal;dur=15,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="3GJv6Of7KPtL-6GHL0G-zGbp4HvQDMLbcGJWnIpaYy2zhD57CbHvJw==",cdn-downstream-fbl;dur=303
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 995d6494814d695ff2add6899f970080.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 3GJv6Of7KPtL-6GHL0G-zGbp4HvQDMLbcGJWnIpaYy2zhD57CbHvJw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - da2d3a808ac1cd34559bca6c9cc837ca
+      - 197f51a22daf07ebfc9d0bb052c9e58c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16133
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18273
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeSSEMFJVbUloaSmlEEBaipCZuZmYeOyp7SHJsvz3Xs8j
-        gYTZFVRdIYWxr+/7+Pg+OrDIqIid0FEgYlAQHzLgsW4JmoJu6WgKKW3JDBQ1TArdgpiZFAxtRVMq
-        EuAyaT2A0iiD+AwyBRqEqc5GuTYynViDt77n+V5HwT85aDNeZnCqaGRYBE7LYda/3/e7XVxo4BNc
-        To3JdOi6MUwgMrG8lx1qONWaUdERYFz0ZFyaMTdwmdY5uLWBGSxR/2Q8Oh+3/X5vH7eKELQTPjoa
-        Y8t1RA0kUi3LHGJcoUbgBbttz2/73jjwQn8Q9vY7GPQPGLdng7RODAZemHlnkFbfRXtesEq7WsSg
-        I8UyWzjc/UB0SjlvkZhpw0RkSMYgAiInZC7VrGO1IykuFH9jFLlgtl2U39IHaqhyHxjM3SKsdYCV
-        yPe6/uAnzT7Bjym2PU/Rq4UFuhxTPbO9yu+M/QonlGtoOaXiEeZV6LacKUPgqGi6PIYHwFi9p5Zj
-        GCIrQ5Q4ocgxR2cDJl2vFmRK3mNG7yx4pV2Uu2hgXW67eAaSdVYXghmDBrSz8m2R+ntxVsuJmVNl
-        8apZmnGGAccbmWM/CpT1Bove4I3hfqEzdSarvvS8PQwj6C2C3v/rpex+gUV06PcXfv9bOFzUHrvB
-        oht8C48VwJ+etuHoN+E0aBJ0a8GELS5LckRYXN8gTJJEQYJ889VLsFsLMDPJ85IXXj/abxLsNQiC
-        RsGgSbC/HU5Jm+WuJaXihXDCto9LavDhKAn37Re3pPM1gbulOWWvZfF5IHNbON+S8pXdYCJxQqNy
-        eKp42lpTLCqr9ri1ZyPDo3oqcx4Pmc44XVZXGbcxLHOJmLHXu6qGAkzW8sf2IzHo7HmD+pHYLNuK
-        yjYFTaAKVqDKFJOKmeU7i1iru723vRUspQlo12ro2gjDDS7nHf2QrMnyWM5rUu0529cmWF0CTu/A
-        0qLF/+ZE0ARdvwmh/sDWY0r1KGPRMROzQysZQmanFxHVXSx6Oy9kqx0hxQiHF3rH4QyoLpGhqi/n
-        9Pjil6OT2+Ojg9HJ+eh2dHb25xnmh7dUY0HwwHgK5BT5Xxhi/RKmiRR8SZBLGLdGiZHkN6YoOVWQ
-        IpmQXCNmO69xio/XyfE+M8/LPnVDp3wTsXdY/PWdesEV2IaECco3D1WzV1XeAucco6vpBvuaCFid
-        zjN7aRtxvNercVyOSe+EXqm8endfTjZvQ+Mabj/TaIbDZg252njp66Ca5/5TwPVQ6NazWVCPCQIs
-        1CPJpTopo7njObQThayxHokkGcqy2TLNcBwW5nXQ7zaRwu6KFL7U8Zfl/Fus/3bGzHDYCcn1R5oF
-        ITmQcsaAXDGDPGfIOUS5AnLIafLZVgeLw2VE+VRqEw68gedOmIiRSt1uMLgpDA6L4mFe95JYWIU7
-        5Kua5Dv8+b5QP8ehz3IQqiFbVEEOcyBDzAc3/6BL4nstYsG4SuLgaoSia/zX7vu9IlLbx2gOnZQZ
-        BR2pEhdhTG1rGU5sFv4uHu1MTcqLuEs7l9bOhZgJOX9epFMl4xxngJFI8GKn2CZ3jDW2PosKYbzk
-        VzlvG9lQpawyENwQl1z72pC/cqoMKLI22aAKa59+of3xwyk5j6hoOG+HUdf391dZPcvjfKkNpBrz
-        iDPJEGw7YbFfdMhWLKVMaGagg3jEgunpnaQqbjqxZX+4xtlO+C8AAAD//+xZbWvbMBD+K6JQaKF2
-        ncRpkkHpQtlgH8pGCyuUQpBluTGLZeOXuqXrf99zkqKlXtyNMko/FPLBiaS70/nuuecu12rOhAkn
-        YC+LpFSskjVrbWzVAMfKxFeC+Dpg7TIVS5ZJrioscrPDSsB9r1UkGRcC6Cpjdpty1iBhRHlfAJ6w
-        TylpCrW/YdEZ3vWNbi3JoMulVBRfjDu5OTpP3AiW0LXAAlmqkrzM9BmWl4TZHKsVQSbg+odUB2QY
-        hKc1M2yA8VXL7+mKrODauqZCZDOu2IaB6BuVXPl44xXd2d3Q+OBakRNIG/kIFlgLq7WJJLBq4KCt
-        lm7ceeP258hFVB+4jG5v46VtWz9veVXorEASyju/WBY6oqFkAZkLq3vBa9CfqEFMLfa+Xs4vvnkX
-        Zx4Ktc5Vp6TIKZQpG/Z4nKVqn+3t/0SgrOr8A8LwT44zdoW+W+T6cG4Q9i040ksAWJeAfM3siKt1
-        toaOkHYWAieju9DHNQLHNfTb05Rr+8Y+dhw4Y57U7C5y4wVwsaTsN3WharKMU9Ha+Rtek9eJgubl
-        CyscUZET5BsR5y/x8TgeTSfTaDAJ5EjMAjEbD5PZIDmCHrcJGp7ZJikk5nEMHahyKHnx/ccNQwAo
-        JOvZptjkio8qqrdpmLKNWShB9Hg8CMOjiZhOxqNZJKJJAPUJl8lUnMTHWsruaL47/IyPOedlXFl8
-        9TzzU+U3ldfCEd7QJ+D2iyZapYI85RWcV+QonNd1BDQRj6dICr9Q5PNug/32Le526G/f4m6H/9Yt
-        BhTFpmG0VPAUoQ8mkySNEKlOIMJz044aILsCGcTGT02ZF/LwChAjlr8zjSZMWHWpSxrsXG07fwz7
-        cDXsayrDvklF6LC7tMD/ji+vFknv+PIaFr/jyxZ86cKAI2SOv8DqG5N7DzQKt88BFOY1t4P8rpRe
-        5tWLS72UbLgd+fqmQkEfByVA2LoQ9HHQUd+JkSN5Ut2mZa4MkTM/xY39F8l8/Sfv5ZmR8LB+tHD/
-        Avjd+APscC33YCfjd+eyalYkeEO3HpqU9bw2dtzm9f+b1BphTih0oV38nuuZ03q8SrNimuSQSmfI
-        U2uHT8y1B7R7Hh8ffwEAAP//AwCaHY/ytBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18273","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18273","key":"NTEST-1889","fields":{"statuscategorychangedate":"2025-04-30T18:28:16.013+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1889/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:15.724+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00ta7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:15.803+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/328]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/328 (328)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1889/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18273/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 5606bc42-50c0-4cc8-81fb-db3fe26eb5e0
+      - a53f8b61-d565-493f-8f99-b9b729500bab
       Atl-Traceid:
-      - 5606bc4250c04cc881fbdb3fe26eb5e0
+      - a53f8b61d565493f8f99b9b729500bab
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:49 GMT
+      - Wed, 30 Apr 2025 16:28:16 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=312,atl-edge-internal;dur=33,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=317,atl-edge;dur=284,atl-edge-internal;dur=17,atl-edge-upstream;dur=267,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="9eZ3zGYgzWL-Tj-HcBJXSkzquJI1W59aW4IkoG4Hdiz01QRybOngEA==",cdn-downstream-fbl;dur=321
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9fe7d47ea2a815113a41181f1d63f69e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 9eZ3zGYgzWL-Tj-HcBJXSkzquJI1W59aW4IkoG4Hdiz01QRybOngEA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - cf645db45e121a7fe2948671e3fcf189
+      - e19500e95868138db747a765d4faca6e
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:37134\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:56120\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:49 GMT
+      - Wed, 30 Apr 2025 16:28:16 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/119", "url_api": "http://localhost:8080/api/v2/tests/119/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      119, "url_ui": "http://localhost:8080/test/119", "url_api": "http://localhost:8080/api/v2/tests/119/"},
+      "finding_count": 2, "findings": {"new": [{"id": 327, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/327",
+      "url_api": "http://localhost:8080/api/v2/findings/327/"}, {"id": 328, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/328",
+      "url_api": "http://localhost:8080/api/v2/findings/328/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:56132\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/119\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/119/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 119, \\\"url_ui\\\": \\\"http://localhost:8080/test/119\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/119/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 327, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/327\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/327/\\\"},
+        {\\\"id\\\": 328, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/328\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/328/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 327,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/327/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/327\"\n        },\n
+        \       {\n          \"id\": 328,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/328/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/328\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        119,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/119/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/119\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/119/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/119\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:16 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -959,26 +1046,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTUsDMRCG/0uutttJutuP3KSCVbQKu70oItnsBKPZZNlkC6X0v5tgoT2qt2Hm
-        eecZ5kBq4XHbG8LJRwid55NJgwplaNyny0QwwnstbGYxkBFptO+M2P+DL7HfaYkN+q81mm6FNmD/
-        1yUrZ5UZ0Er8XXKHvdfORpgC0AwyGJeb6+dy/VSdp5uhrWNF+GuCRjCCt+jEzrh9G6+s9l2yrYwb
-        mhiqB22anwjhMcDm81PzRoQEMmDFGOgYlhVjPJ/yPIoBriDCMe/jH7CvdHvJUqgYcLrgBWSMnlnZ
-        3lnlIpjT2UIKwAKVpNM5ilypXIFUbDktFrWa5chmCtiFIJhkuNe9SC9EJQYTHpwUqX0g5lQRtO/b
-        khwvD3txNk1uHyty/AYAAP//AwBn9fBeIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:17.354+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - c68c92e0-cb43-4986-99f0-983a8d3aaf41
+      - 84dd02cc-8ea0-49ce-b29c-8652ee0d46ab
       Atl-Traceid:
-      - c68c92e0cb43498699f0983a8d3aaf41
+      - 84dd02cc8ea049ceb29c8652ee0d46ab
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:50 GMT
+      - Wed, 30 Apr 2025 16:28:17 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -988,7 +1071,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=167,atl-edge-internal;dur=17,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="2nH7hc1e5iS5KmTRC_5H332575_lK_bzU0BoR0ezC2pE8i73kWPE-w==",cdn-downstream-fbl;dur=239,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=236,atl-edge;dur=162,atl-edge-internal;dur=16,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -997,10 +1080,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 d4aa84013921cdd269ab20fbd29fbe1e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 2nH7hc1e5iS5KmTRC_5H332575_lK_bzU0BoR0ezC2pE8i73kWPE-w==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - e779cb4cbae6961d91cd7005f800dc4b
+      - 8c3625fdb1fc9082e3d8a0e32681c77d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1026,26 +1117,28 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: POST
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16132/comment
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment
   response:
     body:
-      string: '{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/16132/comment/10705","id":"10705","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+      string: '{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment/11332","id":"11332","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
         Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"body":"(admin):
         testing note. creating it and pushing it to JIRA","updateAuthor":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
-        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-01-10T20:18:50.443+0100","updated":"2025-01-10T20:18:50.443+0100","jsdPublic":true}'
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-04-30T18:28:17.767+0200","updated":"2025-04-30T18:28:17.767+0200","jsdPublic":true}'
     headers:
       Atl-Request-Id:
-      - 70a3b3c2-28c5-4a81-a033-3b7e353fe204
+      - 12d2eea2-2c46-42b0-91dc-381170400384
       Atl-Traceid:
-      - 70a3b3c228c54a81a0333b7e353fe204
+      - 12d2eea22c4642b091dc381170400384
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:50 GMT
+      - Wed, 30 Apr 2025 16:28:17 GMT
       Location:
-      - https://defectdojo.atlassian.net/rest/api/2/issue/16132/comment/10705
+      - https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment/11332
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1055,7 +1148,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=325,atl-edge-internal;dur=15,atl-edge-upstream;dur=310,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="2-SmMujzUojrIWxlGFJThgXuylflmkPZbWNn5E_u6qTVifhLFptxnA==",cdn-downstream-fbl;dur=481,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=67,cdn-upstream-fbl;dur=479,atl-edge;dur=389,atl-edge-internal;dur=16,atl-edge-upstream;dur=372,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1064,10 +1157,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 bbfdc39b99d2b072cca90c3f38450aea.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 2-SmMujzUojrIWxlGFJThgXuylflmkPZbWNn5E_u6qTVifhLFptxnA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 66126eecb00e08621ee2498368564c8a
+      - eeb5bcde73e09d94b8bfbb82d4647d76
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1094,26 +1195,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1nZb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwCbz0/NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4HTB88gW36zs
-        boyyAcxosZACMEcl6WyOIlMqUyAVW87yRa2KDFmhgJ0JvI6G23YQ8YWoxKj9nZUitg9EnyqC5nVb
-        kuP5YU/WxMn1fUWOnwAAAP//AwCX+KufIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:18.345+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 616ce86e-f20a-45a0-8775-7cefb26b0d46
+      - 4c914492-86d8-4139-b73b-7293b9a89c19
       Atl-Traceid:
-      - 616ce86ef20a45a087757cefb26b0d46
+      - 4c91449286d84139b73b7293b9a89c19
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:51 GMT
+      - Wed, 30 Apr 2025 16:28:18 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1123,7 +1220,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=171,atl-edge-internal;dur=14,atl-edge-upstream;dur=158,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="MiXDTJBXMIbIQD7sfyyYq_zcxu7zxFVbVIjbdNTMmaw-TaD2INv1pw==",cdn-downstream-fbl;dur=238,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=236,atl-edge;dur=157,atl-edge-internal;dur=14,atl-edge-upstream;dur=144,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1132,10 +1229,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 13926aef629bc9518d9ad769185e8c4e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MiXDTJBXMIbIQD7sfyyYq_zcxu7zxFVbVIjbdNTMmaw-TaD2INv1pw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 166603dec14de9dc51c40f488fa8617a
+      - d19636909f237357da0e902d77c879c1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1159,64 +1264,47 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16132
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18271
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9pEHYaWqupLQ0lJKIYB0FCGzO9n44rW3tpck5fjfO95X
-        gCRXQdXTSVzW43l98814Hh1YZlTETugoEDEoiI8Y8Fi3BE1Bt3Q0g5S2ZAaKGiaFbkHMTAqGtqIZ
-        FQlwmbQeQGmUQXwOmQINwlR3o1wbmU6twTvf83yvo+CvHLSZrDI4UzQyLAKn5TDr3x/43QA/NPAp
-        fs6MyXToujFMITKx/CQ71HCqNaOiI8C46Mm4NGNu4DKtc3BrA3NYof7pZHwxafuD3hCPihC0Ez46
-        GmPLdUQNJFKtyhxi/EKNwAv6bc9v+94k8EJ/GPYGneFB/zuM27NBWicGAy/MvDNIq++iPc8GWqZd
-        fcSgI8UyCxyefiA6pZy3SMy0YSIyJGMQAZFTspBq3rHakRSXir8xilwwWy7K7+gDNVS5DwwWbhHW
-        OsBK5Htdf/iDZn/D9ymWPU/Rq6UFupxQPbe1yu+N/RVOKdfQckrFY8yr0G05M4bEUdFsdQIPgLF6
-        Ty3HMGRWhixxQpFjjs4rmnS9WpAp+QkzeifglXYBd1HAGm778Ywk66wuBTMGDWin8W2Z+mtxV8up
-        WVBl+apZmnGGAcevMsd6FCzrDZfIu7eF+4XK1Jk0del5+xhG0FsGvf/XS1n9govo0B8s/cHXcLis
-        PXaDJfb0V/BYEfzpaZOO/i6eBrVgypZX5QzE6t/cbt7s1jdpkihIcN5sNAEmIHletv92d/1dgsEu
-        wf4OQbBTMNwlONiMsxyb5akdSsUL4YRtv5qVtiSKRWVKjxtntlEQbT2TOY9HTGecrqp2wuMFNfj0
-        lCP77a1fPgjrJ8AtzSnb2MXPQ5lb6ItQr+0BE4kTGpVb32jUXCFnbHtXaCjAZO382PZI9Pvd+pF4
-        DVszyl4LdpEqaEiVKSYVM6t3QlCru723vRUspQlo12ro2gjDAy4XHf2QrIfliVzUQ7XnbLZN0HCe
-        03uwY3FLY9hpshUGfxdD/aHFY0b1OGPRCRPzIysZQWa3FxHVDCp4tShkzYmQYozLC73ncA5Ul6xU
-        1S/n7OTyp+PTu5Pjw/HpxfhufH7++znmh12qERC8MJkBOcP5LwyxfgnTRAq+IjhLGLdGiZHkF6Yo
-        OVOQ4jAhuUbGdbbNFB/byfE+M8/LVg+hU76JWDsEf91TL2YFliFhgvLXl6rdq4K34D3H6KpvW9dE
-        QHM7z2zTbuVx3+v0eg2PyzXpndQrlZt39+Vm8zY2run2I43muGzWlKuNl74Oq33uPwVcL4VuvZsF
-        9ZogwFI9klyq0zKae55DO1E4sdYrkSQjWRZbphmuw8JsJ32/GQpfKuxrpWZgvITzT7H+tzdhhsNe
-        SG4+0swPyaGUcwbkmhmcsYZcQJQrIEecJp8tOggOlxHlM6lNOPSGnjtlIsZB6HaD/dvC4KgAD/P6
-        JImlVbhH/lWTfIN/vi3UL3DpszMI1XBaVEGOciAjTBQPf6Mr4nstYsnYJHF4PUbRDf7XHvi9IlJb
-        x2gBnZQZBR2pEhdpTG1pGW5slv4uXu3MTMqLuEs7V9bOpZgLuXgO0pmScY47wFgk2NgplsmdIPjW
-        Z4EQxkt+lou2kTtQyioDwS1xyY2vDfkjp8qAImuTO1Rh7dMvtD9+OCMXERU77ttl1PX9gyarZ3lc
-        rLSBVGMecSYZkm0vLM6LClnEUsqEZgY6yEcETM/uJVXxrhsb9kdrnu2F/wAAAP//7Flba9swFP4r
-        olBooXadxGmSQelC2WAPZWOFFUohyLLcmCWy8aVe6X58vyOpWvCibuxS+hDIg2PJ5+ZzvvMd+UbN
-        mTDpBOxliZSK1bJhnc2tBuBYm/zKkF9HrFvmYsnWkqsai9zssBLg741KJONCAF1lyu5yzloUjKju
-        S8AT9iklDUkINyy6wLu+1aMlGXS1lIryi3Ent8DkCY9gCbkFFshylRXVWj/Dioowm2O1JsgEXH+V
-        6ogMg/C8YYaJML7q+D25yEqurWtrZDbjim0YiLlRyVWIN16Tz85DE4MbRUEgbRQjWGAtrJ9MJIF1
-        iwBttXTD5w3vP6MW0X0QMvLe5kvXdWHR8brUVYEilN/CclnqjIaSBWQurO4Fb0C9khY5tTj4eDW/
-        /BRcXgRo1LpWnZKyoFSmajjg6TpXh+zg8DsSZdUUb5CGP3OcsWv0/SbnIz+D2LfgKC4hY1MB8jUv
-        I57Y2xr52HDsmGr/Ccc19EvSzGr7Rh/3iHzsOHI6EWMullTgtgFv9vA+xNftes2pae39Cq8p6kRB
-        i+oPOxxRkTPUG9HeD+npOB1NJ9NkMInkSMwiMRsPs9kgO4EetwkantkmKSXmaQod6HJoeen92w1D
-        ACgk69mh2NRKiC6qt2mYsoNZLEH0eDqI45OJmE7Go1kikkkE9RmX2VScpadayv5ovj98j595Llhz
-        ZfE1CMytOmzroEMggmFIwB2WbbLKBUUqKDmvKVB4XvcR0ERcnqMowlJRzPsD9uu3uD+hv36L+xP+
-        a7cYUJSaYdVSwXOkPphMlrVC5LqACM/NMGmA7BpkEBvftVVRyuNrYI9Y/qg0OmHCqitd0mDP1bbz
-        x9iHq7FvqIzdUFlZfN/ByIslzA5GXsLiHYxsgZE+DPiYWuwImeMrcOfWFOUDHYXb6wiWFA23B/l9
-        KT5KFvlwKRpuBzjfqVDkdcBL2XxUkyBk68LIu+BInlR3eVUow/LMrbS1X5HM39+J3l3R/LvzTSPM
-        CYUmjGlfCn3W83SkihIwJj88XVJ/+Qv9+oPbsZV1PIhQQ3vueMb84S247K7bvByu/Kdu8wgAAP//
-        oqmLR2sbWrsYZ20DAAAA//+iZm2TBDQTKAYdNrBSAA1egQY68oDFkJ4CuP8K4maWKCTmpSgUlBaD
-        Jl1AXNC4uWeQoxJsfNpxtNCgb/IYLTTo4eLRQgNLoYFnZhV1Roroqaus4pQAsB+h87kAAAAA//+K
-        pXRJEayFAzQ7N7EiKLW4NAfUcjKEt+YMwdNQRSWOJZCWHWgyHDRVBSrA4OKomo2Q2oJwDaDmWGxt
-        bS0AAAD//wMAJ+t/MZUlAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18271","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271","key":"NTEST-1888","fields":{"statuscategorychangedate":"2025-04-30T18:28:13.122+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:12.837+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:17.767+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/327]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/327 (327)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/votes","votes":0,"hasVoted":false},"comment":{"comments":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment/11332","id":"11332","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"body":"(admin):
+        testing note. creating it and pushing it to JIRA","updateAuthor":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-04-30T18:28:17.767+0200","updated":"2025-04-30T18:28:17.767+0200","jsdPublic":true}],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment","maxResults":1,"total":1,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 560bc4e5-4f74-4cda-a64a-6dabc082a63e
+      - e37e1e26-5a7b-4706-abbf-fac501500d1f
       Atl-Traceid:
-      - 560bc4e54f744cdaa64a6dabc082a63e
+      - e37e1e265a7b4706abbffac501500d1f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:51 GMT
+      - Wed, 30 Apr 2025 16:28:18 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1226,7 +1314,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=283,atl-edge-internal;dur=16,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="qBmbvmcohlndl_7oHgl7Cs0Y23nK8-WEW-YrWkxXLFEmgY_iggjLaQ==",cdn-downstream-fbl;dur=363,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=54,cdn-upstream-fbl;dur=360,atl-edge;dur=286,atl-edge-internal;dur=20,atl-edge-upstream;dur=266,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1235,10 +1323,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8dac9acbf37a4821f35529f7cc336eba.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qBmbvmcohlndl_7oHgl7Cs0Y23nK8-WEW-YrWkxXLFEmgY_iggjLaQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 095c1cabc69155e06e3c1d355b7cd356
+      - 2c5b88767a8afa27fee1f0afeb59570c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1265,41 +1361,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - b99c8e8b-1f88-430c-92fd-a16cc03c38c2
+      - 4214c38f-46c8-407c-a5f3-38eeb9b47f6c
       Atl-Traceid:
-      - b99c8e8b1f88430c92fda16cc03c38c2
+      - 4214c38f46c8407ca5f338eeb9b47f6c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:51 GMT
+      - Wed, 30 Apr 2025 16:28:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1309,7 +1392,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=329,atl-edge-internal;dur=13,atl-edge-upstream;dur=315,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=20,cdn-upstream-fbl;dur=403,atl-edge;dur=319,atl-edge-internal;dur=17,atl-edge-upstream;dur=303,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="-Vv80AHh5t5OPe1RLi1QpUIp1tQ9CpzLTXtOHiBMdcXFS2-K1L_C7A==",cdn-downstream-fbl;dur=406
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1318,13 +1401,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 596b1ac54ac9ee415236dc72536ba33a.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -Vv80AHh5t5OPe1RLi1QpUIp1tQ9CpzLTXtOHiBMdcXFS2-K1L_C7A==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - c4e3e3e2091819f7f338844c9b35deab
+      - 8f1260f955957bb05158d4b2f90720f2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1337,7 +1428,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/327]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/327 (327)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1345,7 +1436,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n"}, "update": {}}'
     headers:
       Accept:
@@ -1357,27 +1448,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1288'
+      - '1308'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16132
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18271
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - eebc857d-f6fc-4bd7-9141-b2a4ad0a80e9
+      - 825a3de4-71eb-493d-a4fd-697244c9a247
       Atl-Traceid:
-      - eebc857df6fc4bd79141b2a4ad0a80e9
+      - 825a3de471eb493da4fd697244c9a247
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:52 GMT
+      - Wed, 30 Apr 2025 16:28:19 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1387,17 +1480,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=265,atl-edge-internal;dur=16,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=298,atl-edge;dur=265,atl-edge-internal;dur=18,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="lL1sKZZl3HztoQMkUhjlZGf4fqcovSPHi7rIEjxCA1lPqQo5vbgEPA==",cdn-downstream-fbl;dur=302
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - lL1sKZZl3HztoQMkUhjlZGf4fqcovSPHi7rIEjxCA1lPqQo5vbgEPA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 57217d95edf1239103747efbde7b0db0
+      - 5cd559f7cd6b9cef133f412a7f084f9a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1421,64 +1522,47 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16132
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18271
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltifJLXQHD0MXuli7LssRJgGZBwEhnmTVFaiQV22vz33fU
-        i50mUYtkWFEgtXi89+ce3kcP1jmTiRd5GmQCGpK3HERiOpJlYDomXkDGOioHzSxX0nQg4TYDyzrx
-        gskUhEo7t6ANyiA5gVyDAWnru3FhrMrmzuA1DQIa9DT8XYCxs00Ox5rFlsfgdTzu/NMR7Yf4YUDM
-        8XNhbW4i309gDrFN1AfVY1YwYziTPQnWR0/WZzn3Q58bU4DfGFjCBvWPZtPTWZeOBmM8KkMwXvTR
-        MxhbYWJmIVV6U+WQ4BdqhEE47Aa0S4NZGER0HA1GvfHr4Q8Yd+CCdE4sBl6aeWGQTt9He4ELtEq7
-        /kjAxJrnrnB4+oaYjAnRIQk3lsvYkpxDDETNyUrpZc9px0qeafHMKArJXbuYuGa3zDLt33JY+WVY
-        uwBrEQ36dPyT4f/Ajxm2vcjQq4MFupwxs3S9Km6s+xXNmTDQ8SrFA8yr1O14C47A0fFicwi3gLEG
-        dx3PckRWjijxIllgjt4DmPSDRpBr9QEzemHBa+2y3GUDm3K7j3sg2WV1Jrm1aMB4W98Oqb+Vd42a
-        2xXTDq+GZ7ngGHDyIHPsR4mywXiNuHteuF/oTJPJti+D4BWGEQ7W4eD/9VJ1v8QiOqSjNR19C4fr
-        xmM/XONMfwOPNcDv7h7DkbbhNGwT9BvBnK/PK3JEWFxeIUzSVEOKfPPVIRg2AsxMiaLihaevjtoE
-        r1oEYatg3CZ4/TicijarU0dK5QvhRV2Kn8ziw1ER7vMHt6LzHYH7lTntxrL8ua8KVzjqSPnCHXCZ
-        epHVBdzVPO2saR5XVfv46MxFhlfNQhUimXCTC7apRxmPMSx7jphx411XQwMm6/jjqUdiOOw3j8TD
-        sm2p7KGgDVThFlS55kpzu3lhERt1f/C8t4JnLAXjOw3TGOF4INSqZ27THVkeqlVDqgPv8diE2yEQ
-        7AYcLTr8P9wI2qBL2xBKx64eC2amOY8PuVy+dZIJ5G57kXHTxbK3q1K2PZFKTnF5YTcCToCZChm6
-        /uUdH579cnB0fXiwPz06nV5PT07+OMH8cEoNFgQvzBZAjpH/pSXOL+GGKCk2BLmEC2eUWEXecc3I
-        sYYMyYQUBjHbe4pTKI6TF3ziQZBvbiOvehOxd1j83Ux9xhXYhpRLJh5eqnevurwlzgVG19AN9jWV
-        sL1d5G5on8TxMOgNBlscV2vSC6FXKW/f3c83m+ehcQe3n1m8xGWzgVxjvPK1X+9z/yngZin0m90s
-        bNYECQ7qsRJKH1XR3IgCuqlG1titRIpMVNVsleW4Dkv7NOiHbaQw3JLClzr+eTn/krt/ezNuBexF
-        5PI9y2lE9pVaciAX3CLPWXIKcaGBvBUs/eSqg8URKmZioYyNxsE48OdcJkilfj98dVUanJTFw7w+
-        KOJgFe2Rr2qS7/DP96X6KS59joNQDdmiDnJSAJlgPnj4O9sQGnSIA+M2if2LKYou8b/uiA7KSF0f
-        4xX0Mm419JROfYQxc63luLE5+Pt4tbewmSjjruycOztncinV6n6RjrVKCtwBpjLFwc6wTf4Ma+x8
-        lhXCeMmvatW1qqVKeW0gvCI+uaTGkj8Lpi1osjPZogo7n7TUfv/mmJzGTLbcd8uoT+nrbVb38jjd
-        GAuZwTySXHEE215UnpcdchXLGJeGW+ghHrFgZnGjmE7abjyyP9nhbC/6FwAA///sWV1r2zAU/Sui
-        UEihdp3EaZJB6ULZYA9lY30olEKQZbkxi2Vjx/VK9+N3rqRqmRd1ow+ljEAeHEu+X7733HPlW7Vg
-        wqQTsJclUirWyA3rbG5tAI6Nya8M+XXMulUuVqyQXDVY5GaHlQB/b1UiGRcC6CpTdp9z1qJgRP1Q
-        AZ6wTylpGnW4ZdEl3vWdHi3JoOuVVJRfjDu5JSZPeARLyC2wQJarrKwL/Qwra8JsjtWGIBNw/U2q
-        YzIMwvMNM2yA8XXHH8hFVnFtXdsgsxlXbMtAzI1KrkO88YZ8dh6aGNwqCgJpoxjBAmth82QiCWxa
-        BGinpVs+b3n/FbWI7oOQkfc2X7quC8uON5WuChSh/B5Wq0pnNJQsIXNpdS/5BvQnaZFTy8Hn68XV
-        l+DqMkCj1rXqlFQlpTJVw4CnRa6O2ODoBxJlvSnfIQ3/5DgT1+j7Tc6Hc8PYt+BILwHgpgbka2ZH
-        XK23NXaEtLcQORn9BR/XiBzX0G9PU67dG33sOHLG/Naz+8iNF8DFiqrf9IWmLQpOTevgb3hNUScK
-        WtYv7HBERc5Rb0ScP6Vnk3Q8m86S4TSSYzGPxHwyyubD7BR63CZoeGabpJRYpCl0oMuh5aUP77cM
-        AaCQrGeHYlMrIbqo3qZhyg5msQTR4+kwjk+nYjadjOeJSKYR1GdcZjNxnp5pKYfjxeHoI37muaDg
-        yuJrEJhbTdg2QYdABKOQgDus2mSdC4pUUHHeUKDwvO4joIm4vEBRhJWimPcH7LdvcX9Cf/sW9yf8
-        t24xoCg1A6OlghdIfTCZLGuFyHUBEZ6bcdQA2Q3IIDZ+aOuykic3gBix+lVpdMKEVVe6pMGeq+3m
-        j7EPV2PfUBn7Tipih921Bf49vrxaJu3x5TUs3uPLDnzpw4AjZI6/wOo7U3uPdBRuryMoLDfcHuT3
-        pXiZlxeXvJRstBv5fKdCkY+DEiDsXIh8HHTse2LsSJ5U93ldKkPkzK20tV+RzN9/il5ZGAmPT5cE
-        9y9C363vXydW1skwQuYeuNMS84e3oJZ7jH+9av5fMP4nAAAA//8a3C4eLeOxlPFJQDOBYtBevJUC
-        aCwJNO6Ql1+SqqcA7k5m5gEAAAD//0pXyCxRSMxLUSgoLQbNooC4oGFszyBHJdhwseNooUHf5DFa
-        aNDDxaOFBpZCA89EJ+oEEdEzSVnFKQFgP0InaAEAAAD//wKNe5FejGBp4QDNzk2sCEotLs0BtZwM
-        4Y0rQ/CsUFGJYwmkoVUGLPDA5QDZ9iJNRUMMgxsKbNJlJBaH5YODAjZ/DJoMB01VgayEOwTVtUZI
-        bUG4BlD7L7a2thYAAAD//wMAp5FykJUlAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18271","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271","key":"NTEST-1888","fields":{"statuscategorychangedate":"2025-04-30T18:28:13.122+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:12.837+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:17.767+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/327]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/327 (327)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/votes","votes":0,"hasVoted":false},"comment":{"comments":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment/11332","id":"11332","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"body":"(admin):
+        testing note. creating it and pushing it to JIRA","updateAuthor":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-04-30T18:28:17.767+0200","updated":"2025-04-30T18:28:17.767+0200","jsdPublic":true}],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment","maxResults":1,"total":1,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - fb8fb78f-73f2-4844-a264-f3b1c03aa551
+      - 5b324e2e-16cd-42b6-9f22-a4126d554dc8
       Atl-Traceid:
-      - fb8fb78f73f24844a264f3b1c03aa551
+      - 5b324e2e16cd42b69f22a4126d554dc8
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:52 GMT
+      - Wed, 30 Apr 2025 16:28:20 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1488,7 +1572,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=307,atl-edge-internal;dur=14,atl-edge-upstream;dur=294,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="0Zw1o94rQjU_R2qbIwwwFQsG3kf5J3YXu6KuJMaTgJtpluc61aE5hQ==",cdn-downstream-fbl;dur=304,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=302,atl-edge;dur=279,atl-edge-internal;dur=21,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1497,10 +1581,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 35f3ad5aa26e63a13ffedf420998e698.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0Zw1o94rQjU_R2qbIwwwFQsG3kf5J3YXu6KuJMaTgJtpluc61aE5hQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - c35b3e9e6ed539a08f8093e58ef9d92b
+      - f6789fb927178d71ac708f4ec2ea3d42
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1527,26 +1619,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1m5d3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwBbLE7NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4LTgOUsLmn+z
-        srsxygYwo/NCCsAclaSzBYpMqUyBVGw5y4tazTNkcwXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAtOVVbCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:20.845+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 7dbe8ef7-501a-4819-ac58-7dce901797c5
+      - 18289c02-25b1-4078-b7dc-d096e2e1bd06
       Atl-Traceid:
-      - 7dbe8ef7501a4819ac587dce901797c5
+      - 18289c0225b14078b7dcd096e2e1bd06
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:52 GMT
+      - Wed, 30 Apr 2025 16:28:20 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1556,7 +1644,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=171,atl-edge-internal;dur=50,atl-edge-upstream;dur=156,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="-eNAPDb-INRZFAZZKTkWwvI62PLhQRddUj-PagBa3NQxis0-MNP--Q==",cdn-downstream-fbl;dur=248,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=68,cdn-upstream-fbl;dur=246,atl-edge;dur=156,atl-edge-internal;dur=14,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1565,10 +1653,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 475bc4efb9c2dcfa6769dde201c9bbbc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -eNAPDb-INRZFAZZKTkWwvI62PLhQRddUj-PagBa3NQxis0-MNP--Q==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - b69dc9119c454470b8c36b183a08dda2
+      - 09f79fc8b6b7de723e06499e254a5288
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1592,64 +1688,47 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16132
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18271
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+2/bNhD+Vwj9tGW2JcqPOAKGoYvdLV2WebHTAs2KgJHOMmuK1EjKj7X933eU
-        LLt5qEUyrCiQWjze+7uP98GDTc5k4kWeBpmAhuQlB5GYlmQZmJaJF5CxlspBM8uVNC1IuM3Asla8
-        YDIFodLWCrRBGSSXkGswIO3ublwYq7K5M3hDg4AGHQ1/F2DsbJvDRLPY8hi8lsedfzqg3RA/DIg5
-        fi6szU3k+wnMIbaJeq86zApmDGeyI8H66Mn6LOd+6HNjCvBrA0vYov7FbDydtemgN8SjMgTjRR88
-        g7EVJmYWUqW3VQ4JfqFGGIT9dkDbNJiFQUSHUW/QGZ70f8C4Axekc2Ix8NLMM4N0+j7aC1ygVdq7
-        jwRMrHnuCoenL4jJmBAtknBjuYwtyTnEQNScrJVedpx2rOSVFk+MopDctYuJG7Zilml/xWHtl2Ed
-        AtyJaNClw58M/wd+zLDtRYZeHSzQ5YyZpetVcWvdr2jOhIGWVymeYV6lbstbcASOjhfbc1gBxhp8
-        anmWI7JyRIkXyQJz9O7BpBvUglyr95jRMwu+0y7LXTawLrf7+Awkh6yuJLcWDRhv79sh9bfyrlFz
-        u2ba4dXwLBccA07uZY79KFHWG24Qd08L9wudqTPZ96UXHGMYYW8T9v5fL1X3SyyiQzrY0MG3cLip
-        PXbDDc70N/C4A/inTw/hSJtwGjYJurVgzjevK3JEWFy/Q5ikqYYU+earQ9CvBZiZEkXFC49fHTQJ
-        jhsEYaNg2CQ4eRhORZvVqSOl8oXwojbFT2bx4agI9+mDW9H5gcD9ypx2Y1n+PFWFKxx1pPzGHXCZ
-        epHVBWD70Kh9jR13w1kFV9pz9jWPqzp+eHDmYkVls1CFSEbc5IJtd8PtIKEBk3X88dgj0e9360fi
-        ftn2VHZf0ASqcA+qXHOlud0+s4i1ut972lvBM5aC8Z2GqY1wPBBq3TGr9ECW52pdk2rPezg24X4I
-        BLsFR4sO//c3gibo0iaE0qGrx4KZcc7jcy6XL51kBLnbXmRc96zs5LqU7U+kkmNcXtitgEtgpsKB
-        3v3yJudXv5xd3JyfnY4vpuOb8eXlH5eYH06pwYLghdkCyAT5X1ri/BJuiJJiS5BLuHBGiVXkFdeM
-        TDRkSCakMIjZzmOcQnGcvOAjD4J8u4q86k3E3mHxDzN1hyuwDSmXTNy/tNu9duUtUS0wuppusK+p
-        hP3tIndD+yiO+0Gn19vjuFqTngm9Snn/7t7dbJ6GxgPcfmbxEpfNGnK18crX6W6f+08B10uhX+9m
-        Yb0mSHBQj5VQ+qKK5lYU0E41csRhJVJkpKpmqyzHdVjax0HfbyKF/p4UvtTxu+X8Sx7+Hc24FXAU
-        keu3LKcROVVqyYG84RZZzZIpxIUG8lKw9KOrDhZHqJiJhTI2GgbDwJ9zmSCV+t3w+F1pcFQWD/N6
-        r4iDVXREvqpJvsM/35fqU1z6HAehGrLFLshRAWSE+eDh72xLaNAiDoz7JE7fjFF0jf+1B7RXRur6
-        GK+hk3GroaN06iOMmWstx43Nwd/Hq52FzUQZd2XntbNzJZdSrT8v0kSrpMAdYCxTHOwM2+TPsMbO
-        Z1khjJf8qtZtqxqqlO8MhO+IT66pseTPgmkLmhxMNqjCwScttd++mJBpzGTDfbeM+pSe7LP6LI/p
-        1ljIDOaR5Ioj2I6i8rzskKtYxrg03EIH8YgFM4tbxXTSdOOB/dEBZ0fRvwAAAP//7Flda9swFP0r
-        olBIoXadxGmSQelC2WAPZWN9KJRCkGW5MYtlY8f1Svfjd66kapkXdaMPpYxAHhxLvl++99xz5Vu1
-        YMKkE7CXJVIq1sgN62xubQCOjcmvDPl1zLpVLlaskFw1WORmh5UAf29VIhkXAugqU3afc9aiYET9
-        UAGesE8padpyuGXRJd71nR4tyaDrlVSUX4w7uSUmT3gES8gtsECWq6ysC/0MK2vCbI7VhiATcP1N
-        qmMyDMLzDTO9n/F1xx/IRVZxbV3bILMZV2zLQMyNSq5DvPGGfHYemhjcKgoCaaMYwQJrYfNkIgls
-        WgRop6VbPm95/xW1iO6DkJH3Nl+6rgvLjjeVrgoUofweVqtKZzSULCFzaXUv+QZkJ2mRU8vB5+vF
-        1Zfg6jJAo9a16pRUJaUyVcOAp0Wujtjg6AcSZb0p3yEN/+Q4E9fo+03Oh3PD2LfgSC8B4KYG5Gtm
-        R8ystzV2hLS3EDkZ/QUf14gc19BvT1Ou3Rt97DhyxvzWs/vIjRfAxYqq3/SFpi0KTk3r4G94TVEn
-        ClrWL+xwREXOUW9EnD+lZ5N0PJvOkuE0kmMxj8R8Msrmw+wUetwmaHhmm6SUWKQpdKDLoeWlD++3
-        DAGgkKxnh2JTKyG6qN6mYcoOZrEE0ePpMI5Pp2I2nYzniUimEdRnXGYzcZ6eaSmH48Xh6CN+5rmg
-        4MriaxCYW03YNkGHQASjkIA7rNpknQuKVFBx3lCg8LzuI6CJuLxAUYSVopj3B+y3b3F/Qn/7Fvcn
-        /LduMaAoNeOhpYIXSH0wmSxrhch1ARGem3HUANkNyCA2fmjrspInN4AYsfpVaXTChFVXuqTBnqvt
-        5o+xD1dj31AZ+04qYofdtQX+Pb68Wibt8eU1LN7jyw586cOAI2SOv8DqO1N7j3QUbq8jKCw33B7k
-        96V4mZcXl7yUbLQb+XynQpGPgxIg7FyIfBx07Hti7EieVPd5XSpD5MyttLVfkczff4peWRgJj0+X
-        BPcvQt+t718nVtbJMELmHrjTEvOHt6CWe4x/vWr+XzD+JwAAAP//GtwuHi3jsZTxSUAzgWLQXryV
-        AmgsCTTukJdfkqqnAO5OZuYBAAAA//9KV8gsUUjMS1EoKC0GzaKAuKBhbM8gRyXYcLHjaKFB3+Qx
-        WmjQw8WjhQaWQgPPRCfqBBHRM0lZxSkBYD9CJ2gBAAAA//8CjXuRXoxgaeEAzc5NrAhKLS7NAbWc
-        DOGNK0PwrFBRiWMJpKFVBizwwOUA2fYiTUVDDIMbCmzSZSQWh+WDgwI2WwyaDAdNVYGshDsE1bVG
-        SG1BuAZQ+y+2trYWAAAA//8DAHp7bTiVJQAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18271","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271","key":"NTEST-1888","fields":{"statuscategorychangedate":"2025-04-30T18:28:13.122+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:12.837+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00t9z:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:17.767+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/327]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/327 (327)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/119]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1888/votes","votes":0,"hasVoted":false},"comment":{"comments":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment/11332","id":"11332","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"body":"(admin):
+        testing note. creating it and pushing it to JIRA","updateAuthor":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2025-04-30T18:28:17.767+0200","updated":"2025-04-30T18:28:17.767+0200","jsdPublic":true}],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18271/comment","maxResults":1,"total":1,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a5e5f86a-3fc8-4522-84ef-5de035e0a961
+      - b1c228f9-c321-4c54-baa8-6b8651cf5438
       Atl-Traceid:
-      - a5e5f86a3fc8452284ef5de035e0a961
+      - b1c228f9c3214c54baa86b8651cf5438
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:53 GMT
+      - Wed, 30 Apr 2025 16:28:21 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1659,7 +1738,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=248,atl-edge-internal;dur=16,atl-edge-upstream;dur=232,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=284,atl-edge;dur=250,atl-edge-internal;dur=17,atl-edge-upstream;dur=233,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="3rPWbsdlHJHEylpNgLODAnS2e7sAKl9gZzT5zi8SLCP_ewp6E1vP9Q==",cdn-downstream-fbl;dur=288
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1668,10 +1747,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 d45e064f8c3e1035d136019303749e0e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 3rPWbsdlHJHEylpNgLODAnS2e7sAKl9gZzT5zi8SLCP_ewp6E1vP9Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c99a8c09609906e86454fb93d97f5104
+      - a9ba9c515c5a7d685c6830d00cdbff65
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_add_tags.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_add_tags.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL2m5d3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDZrUKH0jX23ifBaONcKkxj0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoAkkMC03l4/l+qH6mW7Grg4V4c8RmsAEXoITe233Xbiy2vfRttJ2
-        bEKoHlvdfEUIDwG2WJyaV8JHkAHLp0CnsKwY41nKsyAGuIAAh7wLf8ChartzlkLFgNOC52mSF/k3
-        K7sbo2wAMzovpADMUUmaLlBkSmUKpGLLNC9qNc+QzRWwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAqOjFICACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:21.601+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - ffb5ec64-bb88-4661-a078-591622be1649
+      - b7faa5e4-3f8b-421c-bda2-8de4fdae08a5
       Atl-Traceid:
-      - ffb5ec64bb884661a078591622be1649
+      - b7faa5e43f8b421cbda28de4fdae08a5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:53 GMT
+      - Wed, 30 Apr 2025 16:28:21 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=166,atl-edge-internal;dur=14,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=194,atl-edge;dur=162,atl-edge-internal;dur=16,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="F9R5yqpasEaRAR5Hsq0DYARNkA4JgX4L8AsKUZQ3l-WNJLN3rIu0ug==",cdn-downstream-fbl;dur=198
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 73e04d645babcbb9ee8f20cc865b009c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - F9R5yqpasEaRAR5Hsq0DYARNkA4JgX4L8AsKUZQ3l-WNJLN3rIu0ug==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c9cbf4c0f892ff068e10ed9c9874db7a
+      - aa6d88d49bc4e960ada6718fd7833e9c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 067ffb3c-6254-4c7a-8d0b-31b59bb3a46f
+      - 77dee06d-1b39-4b29-8830-44bda05b064b
       Atl-Traceid:
-      - 067ffb3c62544c7a8d0b31b59bb3a46f
+      - 77dee06d1b394b29883044bda05b064b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:54 GMT
+      - Wed, 30 Apr 2025 16:28:22 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=340,atl-edge-internal;dur=17,atl-edge-upstream;dur=324,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="vMEXRsN1oAPaa7_TQX8V8tHkF3iwyYHUGFEq-J5SLQlbiNv42HNeAQ==",cdn-downstream-fbl;dur=441,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=438,atl-edge;dur=354,atl-edge-internal;dur=15,atl-edge-upstream;dur=339,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9832e15ad117dafc81b031983cbde91e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - vMEXRsN1oAPaa7_TQX8V8tHkF3iwyYHUGFEq-J5SLQlbiNv42HNeAQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 094079357e2d54e5055f9144f7d97d41
+      - 6c924acb51dc0eb610368f01920c0b9d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/329]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/329 (329)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16134","key":"NTEST-1650","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16134"}'
+      string: '{"id":"18275","key":"NTEST-1890","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275"}'
     headers:
       Atl-Request-Id:
-      - 79113a87-c883-420a-ab7c-8568c681c709
+      - dd322e09-8003-4012-a167-c2565ca8dead
       Atl-Traceid:
-      - 79113a87c883420aab7c8568c681c709
+      - dd322e0980034012a167c2565ca8dead
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:54 GMT
+      - Wed, 30 Apr 2025 16:28:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=725,atl-edge-internal;dur=17,atl-edge-upstream;dur=712,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=744,atl-edge;dur=711,atl-edge-internal;dur=25,atl-edge-upstream;dur=685,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="g7jUPHDhjPuC9519uetYxngAF0HSYwC3dK-uxyXeGh4dr_goI2sTZw==",cdn-downstream-fbl;dur=748
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a78d8f4a6ccd81221651cd6112d5330a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - g7jUPHDhjPuC9519uetYxngAF0HSYwC3dK-uxyXeGh4dr_goI2sTZw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 03a78f53fee7346e5b588e90e817cae1
+      - d228a55816c4a15526805e8484406264
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1650
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+2/bNhD+Vwj9tGW29fAjroBh6GJ3y5ZlWeK0QLMiYKSzzJoiNZKK7T7+9x2p
-        h9skapEMKwqkFo/3/u7jvfdgW1CRerGnQKSgIH3BgKe6J2gOuqeTFeS0JwtQ1DApdA9SZnIwtJes
-        qMiAy6x3C0qjDNJzKBRoEKa+m5TayHxpDV6HQRAGAwX/lKDNYlfAmaKJYQl4PY9Z/+EkHI7wQwNf
-        4ufKmELHvp/CEhKTyrdyQA2nWjMqBgKMj56MTwvmRz7TugS/MbCGHeqfLuYXi344GQd45ELQXvze
-        0xhbqRNqIJNqV+WQ4hdqREE07gdhPwwWURCH03g8GhweTn7AuK0N58Rg4M7ME4O0+j7aC6I27foj
-        BZ0oVtjC4elzonPKeY+kTBsmEkMKBgkQuSQbqdYDq51Ican4I6MoBbPtovya3lJDlX/LYOO7sPYB
-        1qIwGIbTnzR7Bz/m2PYyR68WFuhyQfXa9qq8MfZXvKRcQ8+rFI8xL6fb81YMgaOS1e4EbgFjDT72
-        PMMQWQWixItFiTl6d2AyDLoEYSMolHyLqT6xE7W264PrbNMH+/EJevbpXgpmDBrQXuvbQvh3d1fL
-        pdlQZYGsWV5whgGnd0qCjXLwG023o+kjw/1Cy5pM2oaNgkMMIxpto9H/66WChQMpOgwn23DyLRxu
-        G4/DaDuMvoXHGvkfP96HY9TAccm2LysOxCZfvbl/c9jcpFmmIEO++eoQjBsBJiB5WfHCw1cnXYLD
-        DkHUKZh2CZ7dD6eizerUkpJ7Iby4H9ZcaSuvWFJF/v7emZ0HLKpeyZKnM6YLTnf11OAxttC8xPbY
-        SapdUIOPUUXij5/56onYPwp+ZU7ZiXY/j2Rpm+GCf2UPmMi82KjSRpMowGQtTTz0SAyn4+aRuFu2
-        LiqLWiq7K2hBVSgmFTO7JybcqPv2SXzEW8FymoH2rYZujDA84HIz0LfZnhNP5KbhzpF3fzqiFvOc
-        3oBlvwcGw5LGg2UIuxAaTm09VlTPC5acMLF+YSUzKOz2IpIGQQ5XGydrT4QUc1xe6A2Hc6C6QqWq
-        f3lnJ5e/HJ9enxwfzU8v5tfz8/M/zzE/nFKNBcELixWQM6R5YYj1S5gmUvAdQcpg3BolRpLfmKLk
-        TEGOnEFKjfgaPEQdIY6TF3xgQVC8u4m96k3E3mHx9zP1GVdgGzImKL97qd696vI6lHOMrv62fc0E
-        tLfLwg5tF45Hk3bZqdakJ0KvUm6f1883m8ehcQ+3n2myxmWzgVxjvPJ1VO9z/yngZin0m90sarYB
-        ARbqieRSnVbR3PAS+plCxtqvRJLMZNVsmRe4DgvzMOjHXaQwbknhSx3/vJx/i/2/gwUzHA5icvWa
-        FmFMjqRcMyCvmEGONeQCklIBecFp9sFWB4vDZUL5SmoTT4Np4C+ZSJH2/GH07I0zOHPFw7zeSmJh
-        FR+Qr2qS7/DP9079Apc+y0GohmxRBzkrgcwwHzz8g+5IGPSIBWObxNGrOYqu8L/+JBy5SG0fkw0M
-        cmYUDKTKfIQxta1luJhZ+Pt4dbAyOXdxV3ZeWjuXYi3k5tMinSmZlvjUz0WGg51jm/wF1tj6dBXC
-        eMmvctM3sqNKRW0gekN8chVqQ/4qqTKgyN5khyrsfYZO+/XzM3KRUNFx3+6cfhgFbVaf5HGx0wZy
-        jXmkhWQItoPYnbsO2YrllAnNDAwQj1gwvbqRVKVdN+7Zn+1xdhD/CwAA///sWW1L3EAQ/iuLICiY
-        mLvLeXcFsYe00A/SolBBhGOz2Xihd5uQF6NY/3uf2d3bxvRiixTxg+CHmN2dnZnMPPPM3LWaM2HC
-        CdjLIikVK2XFGhtbFcCxNPGVIL4OWLNMxZKtJVclFrnZYSXA3msVScaFALrKmN2mnNVIGFHc54An
-        7FNKGpLgtzQ6w7e+0a0lKXS5lIrii3EnN0PnCYugCZkFssdSlWTFWp9hWUGYzbFaEmQCrn9IdUCK
-        QXhaMcNEGF81/J5MZDnX2tUlIptxxVoKom9UcuXji5dks7PQ+OBakRPoNvIRNLAalhsVSWBZw0Fb
-        NW3Z3LL+HLmI6gOXkfU2Xpqm8bOGl7nOCiShvPPzZa4jGpcsIHNh717wCtQrqhFTi72vl/OLb97F
-        mYdCrXPVXZJnFMqUDXs8Xqdqn+3t/0SgrKrsA8LwT44zdoW+W+T6cG4QtnGuKoDsmmwRHexudTS4
-        sxA6QtpZCPpOBI5r6I+kmdX2jX3cI+hjx4FTBj7mYkkJbgtwu4Z3kbys12tORWvnb3hNXicKmhUv
-        rHBERU6Qb0Ryv8TH43g0nUyjwSSQIzELxGw8TGaD5Aj3uE244ZltkkJiHse4A1UOJS++/9hSBIBC
-        sp7tfU2u+KiiepuGKdt/hRJEj8eDMDyaiOlkPJpFIpoEuD7hMpmKk/hYS9kdzXeHn/Fnznlrriy+
-        ep55Vfp16TVwhDf0Cbj9vI5WqSBPeTnnJTkK53UdAU3E4ymSws8V+bzbR799jbuN+NvXuNvIv3WN
-        gVGxaVYtFTxF6IPJJEktRKoTiPDctI4G4a5ABrHxU11kuTy8AvaI5e9Mo0ESVl3q0g12rradP4Z9
-        uBr2NZWhayoLi+/vMPJqAfMOI6+h8TuMbIGRLgz0MbXQETLHV2DOjUnKB5p42+cAmmQVt4P8rpRe
-        5tWLS33jn2C4Hfl6mVmvZb2UzZncWRj1nRg5kifVbVpkyrA88yqu7a9I5t9/8d5tVv2/aaYR5oTi
-        JrRp3zM969mMVJECRuWHzaOtLy9WQP/idriRe7Cz5nfnsqxXJLhlrJ7SFNW8MobTrJgmOWS6e//0
-        8PDJaXtAa/v4+PgLAAD//wMAoRm1FLQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18275","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275","key":"NTEST-1890","fields":{"statuscategorychangedate":"2025-04-30T18:28:22.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:22.649+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00taf:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:22.733+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/329]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/329 (329)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 16c8d398-ee1e-4717-9e1a-00d2af89c822
+      - f1fffdfb-aff1-4fdd-9d66-09ca9c2a75f1
       Atl-Traceid:
-      - 16c8d398ee1e47179e1a00d2af89c822
+      - f1fffdfbaff14fdd9d6609ca9c2a75f1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:55 GMT
+      - Wed, 30 Apr 2025 16:28:23 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=290,atl-edge-internal;dur=13,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=312,atl-edge;dur=278,atl-edge-internal;dur=17,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="sJCo7AU4vOA1xILctjwKkackmD5v8cbgY9Orz30PoApv4K-vfadqYw==",cdn-downstream-fbl;dur=316
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 cbe94ab27088fc4bb73abf8e3179b3d2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - sJCo7AU4vOA1xILctjwKkackmD5v8cbgY9Orz30PoApv4K-vfadqYw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 6a18c9ee4c0fcdb570198ef97bcf0cbc
+      - b9f13aabd44fdc5881b8e2c6db10e7fb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16134
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18275
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+2/bNhD+Vwj9tGW29fAjroBh6GJ3y5ZlWeK0QLMiYKSzzJoiNZKK7T7+9x2p
-        h9skapEMKwqkFo/3/u7jvfdgW1CRerGnQKSgIH3BgKe6J2gOuqeTFeS0JwtQ1DApdA9SZnIwtJes
-        qMiAy6x3C0qjDNJzKBRoEKa+m5TayHxpDV6HQRAGAwX/lKDNYlfAmaKJYQl4PY9Z/+EkHI7wQwNf
-        4ufKmELHvp/CEhKTyrdyQA2nWjMqBgKMj56MTwvmRz7TugS/MbCGHeqfLuYXi344GQd45ELQXvze
-        0xhbqRNqIJNqV+WQ4hdqREE07gdhPwwWURCH03g8GhweTn7AuK0N58Rg4M7ME4O0+j7aC6I27foj
-        BZ0oVtjC4elzonPKeY+kTBsmEkMKBgkQuSQbqdYDq51Ican4I6MoBbPtovya3lJDlX/LYOO7sPYB
-        1qIwGIbTnzR7Bz/m2PYyR68WFuhyQfXa9qq8MfZXvKRcQ8+rFI8xL6fb81YMgaOS1e4EbgFjDT72
-        PMMQWQWixItFiTl6d2AyDLoEYSMolHyLqT6xE7W264PrbNMH+/EJevbpXgpmDBrQXuvbQvh3d1fL
-        pdlQZYGsWV5whgGnd0qCjXLwG023o+kjw/1Cy5pM2oaNgkMMIxpto9H/66WChQMpOgwn23DyLRxu
-        G4/DaDuMvoXHGvkfP96HY9TAccm2LysOxCZfvbl/c9jcpFmmIEO++eoQjBsBJiB5WfHCw1cnXYLD
-        DkHUKZh2CZ7dD6eizerUkpJ7Iby4H9ZcaSuvWFJF/v7emZ0HLKpeyZKnM6YLTnf11OAxttC8xPbY
-        SapdUIOPUUXij5/56onYPwp+ZU7ZiXY/j2Rpm+GCf2UPmMi82KjSRpMowGQtTTz0SAyn4+aRuFu2
-        LiqLWiq7K2hBVSgmFTO7JybcqPv2SXzEW8FymoH2rYZujDA84HIz0LfZnhNP5KbhzpF3fzqiFvOc
-        3oBlvwcGw5LGg2UIuxAaTm09VlTPC5acMLF+YSUzKOz2IpIGQQ5XGydrT4QUc1xe6A2Hc6C6QqWq
-        f3lnJ5e/HJ9enxwfzU8v5tfz8/M/zzE/nFKNBcELixWQM6R5YYj1S5gmUvAdQcpg3BolRpLfmKLk
-        TEGOnEFKjfgaPEQdIY6TF3xgQVC8u4m96k3E3mHx9zP1GVdgGzImKL97qd696vI6lHOMrv62fc0E
-        tLfLwg5tF45Hk3bZqdakJ0KvUm6f1883m8ehcQ+3n2myxmWzgVxjvPJ1VO9z/yngZin0m90sarYB
-        ARbqieRSnVbR3PAS+plCxtqvRJLMZNVsmRe4DgvzMOjHXaQwbknhSx3/vJx/i/2/gwUzHA5icvWa
-        FmFMjqRcMyCvmEGONeQCklIBecFp9sFWB4vDZUL5SmoTT4Np4C+ZSJH2/GH07I0zOHPFw7zeSmJh
-        FR+Qr2qS7/DP9079Apc+y0GohmxRBzkrgcwwHzz8g+5IGPSIBWObxNGrOYqu8L/+JBy5SG0fkw0M
-        cmYUDKTKfIQxta1luJhZ+Pt4dbAyOXdxV3ZeWjuXYi3k5tMinSmZlvjUz0WGg51jm/wF1tj6dBXC
-        eMmvctM3sqNKRW0gekN8chVqQ/4qqTKgyN5khyrsfYZO+/XzM3KRUNFx3+6cfhgFbVaf5HGx0wZy
-        jXmkhWQItoPYnbsO2YrllAnNDAwQj1gwvbqRVKVdN+7Zn+1xdhD/CwAA///sWW1L3EAQ/iuLICiY
-        mLvLeXcFsYe00A/SolBBhGOz2Xihd5uQF6NY/3uf2d3bxvRiixTxg+CHmN2dnZnMPPPM3LWaM2HC
-        CdjLIikVK2XFGhtbFcCxNPGVIL4OWLNMxZKtJVclFrnZYSXA3msVScaFALrKmN2mnNVIGFHc54An
-        7FNKGpLgtzQ6w7e+0a0lKXS5lIrii3EnN0PnCYugCZkFssdSlWTFWp9hWUGYzbFaEmQCrn9IdUCK
-        QXhaMcNEGF81/J5MZDnX2tUlIptxxVoKom9UcuXji5dks7PQ+OBakRPoNvIRNLAalhsVSWBZw0Fb
-        NW3Z3LL+HLmI6gOXkfU2Xpqm8bOGl7nOCiShvPPzZa4jGpcsIHNh717wCtQrqhFTi72vl/OLb97F
-        mYdCrXPVXZJnFMqUDXs8Xqdqn+3t/0SgrKrsA8LwT44zdoW+W+T6cG4QtnGuKoDsmmwRHexudTS4
-        sxA6QtpZCPpOBI5r6I+kmdX2jX3cI+hjx4FTBj7mYkkJbgtwu4Z3kbys12tORWvnb3hNXicKmhUv
-        rHBERU6Qb0Ryv8TH43g0nUyjwSSQIzELxGw8TGaD5Aj3uE244ZltkkJiHse4A1UOJS++/9hSBIBC
-        sp7tfU2u+KiiepuGKdt/hRJEj8eDMDyaiOlkPJpFIpoEuD7hMpmKk/hYS9kdzXeHn/Fnznlrriy+
-        ep55Vfp16TVwhDf0Cbj9vI5WqSBPeTnnJTkK53UdAU3E4ymSws8V+bzbR799jbuN+NvXuNvIv3WN
-        gVGxaVYtFTxF6IPJJEktRKoTiPDctI4G4a5ABrHxU11kuTy8AvaI5e9Mo0ESVl3q0g12rradP4Z9
-        uBr2NZWhayoLi+/vMPJqAfMOI6+h8TuMbIGRLgz0MbXQETLHV2DOjUnKB5p42+cAmmQVt4P8rpRe
-        5tWLS33jn2C4Hfl6mVmvZb2UzZncWRj1nRg5kifVbVpkyrA88yqu7a9I5t9/8d5tVv2/aaYR5oTi
-        JrRp3zM969mMVJECRuWHzaOtLy9WQP/idriRe7Cz5nfnsqxXJLhlrJ7SFNW8MobTrJgmOWS6e//0
-        8PDJaXtAa/v4+PgLAAD//wMAoRm1FLQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18275","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275","key":"NTEST-1890","fields":{"statuscategorychangedate":"2025-04-30T18:28:22.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:22.649+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00taf:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:22.733+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/329]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/329 (329)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - d6c4a7f3-a39e-4da2-bb7a-7c5ccf6192a1
+      - 1adb4d87-e4c6-4227-9986-eb4c75fa1c75
       Atl-Traceid:
-      - d6c4a7f3a39e4da2bb7a7c5ccf6192a1
+      - 1adb4d87e4c642279986eb4c75fa1c75
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:55 GMT
+      - Wed, 30 Apr 2025 16:28:24 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=247,atl-edge-internal;dur=16,atl-edge-upstream;dur=232,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="2le6dblhRGl6KP1VbBWsrNaCUXUFjjjM0WMyjWL4X7S-gepO7RNUJw==",cdn-downstream-fbl;dur=373,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=370,atl-edge;dur=283,atl-edge-internal;dur=22,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ed78483d37e5338746e5a4b545e5818e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 2le6dblhRGl6KP1VbBWsrNaCUXUFjjjM0WMyjWL4X7S-gepO7RNUJw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 8ae9419d8839c7f3e02a4bee71a738f3
+      - 47d4cd637b08146785c7b44d7ee17398
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1m5d3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwBbLE7NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4LTgeZ4WjH6z
-        srsxygYwo/NCCsAclaSzBYpMqUyBVGw5y4tazTNkcwXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMA/wSXKyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:24.413+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - cd0ceedb-16ec-4780-ae41-0fd55745fa57
+      - 21048798-b5dc-4ecb-8852-00d99005d262
       Atl-Traceid:
-      - cd0ceedb16ec4780ae410fd55745fa57
+      - 21048798b5dc4ecb885200d99005d262
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:55 GMT
+      - Wed, 30 Apr 2025 16:28:24 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=166,atl-edge-internal;dur=12,atl-edge-upstream;dur=154,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="alU2jqQsUXY1d6Eg4Q8T6zWZFgKeYYWUGD7Oohf_g8orVYCDcGsgrw==",cdn-downstream-fbl;dur=245,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=67,cdn-upstream-fbl;dur=243,atl-edge;dur=153,atl-edge-internal;dur=14,atl-edge-upstream;dur=139,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9041bc1ab42f996e0fd971e734eff2e2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - alU2jqQsUXY1d6Eg4Q8T6zWZFgKeYYWUGD7Oohf_g8orVYCDcGsgrw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - c399fe059c31173a4af16c75834fa575
+      - 6230498c69e14b5258ccaaa958e01e7f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 16ebc4cf-05c3-4e9c-8542-737aab555462
+      - 660e2fc6-e283-4312-91f5-31d3f7e9ab4b
       Atl-Traceid:
-      - 16ebc4cf05c34e9c8542737aab555462
+      - 660e2fc6e283431291f531d3f7e9ab4b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:56 GMT
+      - Wed, 30 Apr 2025 16:28:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=321,atl-edge-internal;dur=20,atl-edge-upstream;dur=301,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="MYAzU6tXpHz-7QbeCg4p-15xk6uoMkATmbQ9iZoCv4Cs2av9ryZjrg==",cdn-downstream-fbl;dur=464,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=461,atl-edge;dur=373,atl-edge-internal;dur=21,atl-edge-upstream;dur=353,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 475bc4efb9c2dcfa6769dde201c9bbbc.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MYAzU6tXpHz-7QbeCg4p-15xk6uoMkATmbQ9iZoCv4Cs2av9ryZjrg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 87d7e231636f0781b7d3a9010cb3ed68
+      - 4cbc31861e55ac525e750e5d7a02543a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/330]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/330 (330)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16135","key":"NTEST-1651","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16135"}'
+      string: '{"id":"18277","key":"NTEST-1891","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18277"}'
     headers:
       Atl-Request-Id:
-      - 30bd1393-26eb-4c3c-b071-22e254058550
+      - 904bb497-06ac-4ce3-9967-6c10c56730be
       Atl-Traceid:
-      - 30bd139326eb4c3cb07122e254058550
+      - 904bb49706ac4ce399676c10c56730be
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:57 GMT
+      - Wed, 30 Apr 2025 16:28:25 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=682,atl-edge-internal;dur=13,atl-edge-upstream;dur=669,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="qOyEilMZbERomrQ_JaUFogalwbdtrkrMF90rSvMHaD5yEY4TNngLqQ==",cdn-downstream-fbl;dur=774,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=67,cdn-upstream-fbl;dur=772,atl-edge;dur=683,atl-edge-internal;dur=15,atl-edge-upstream;dur=668,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 57f0537bdb26692a5be92bbbe93e4ea2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - qOyEilMZbERomrQ_JaUFogalwbdtrkrMF90rSvMHaD5yEY4TNngLqQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 7e0a04ba87ab1426692f080844063c91
+      - 423b807ae163ee2429c682dbe566dc3a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1651
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1891
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeeRBGKmqtiTb0lJKSQBpKUJm5mZi4rGntocky/Lfez2P
-        ZIHMrqDqKhKMH/d97vF9cGCVURE7oaNAxKAgfs+Ax7olaAq6paM5pLQlM1DUMCl0C2JmUjC0Fc2p
-        SIDLpHUPSuMZxGeQKdAgTHU3yrWR6cwqvPE9z/c6Cv7JQZvpOoNTRSPDInBaDrP2/YHf7eNCA5/h
-        cm5MpkPXjWEGkYnlnexQw6nWjIqOAOOiJePSjLmBy7TOwa0VLGCN8ifT8WTa9gd9H7cKF7QTPjga
-        fct1RA0kUq3LGGJcoUTgBf2257d9bxp4oT8M+4POQW//B/Tbs05aIwYdL9S80Ukr76I+L9iEXS1i
-        0JFimU0c7r4jOqWct0jMtGEiMiRjEAGRM7KUatGx0pEU54q/0otcMFsuym/oPTVUufcMlm7h1tbB
-        6sj3uv7wJ80+wo8plj1P0aqFBZqcUr2wtcpvjf0KZ5RraDml4BHGVci2nDlD4Khovj6Ge0BfvceW
-        YxgiK0OUOKHIMUbnGUy6XtOBXx9kSt5hqG+sRCVd1KGobF0Hu/gMPdtwzwUzBhVoZ2PbQvj34q6W
-        M7OkygJZszTjDB2On6UEC1XArzdc9YavdPcLJasj2RSs5+2jG0FvFfT+XyslLAqQokF/sPIH38Lg
-        qrbYDVbd4FtYrJD/+PgSjkENxxlbXZQciEW+un55s1vfpEmiIEG++WoT9OsDDEDyvOSF3VcHTQf7
-        DQdB48Gw6eDgpTslbZa7lpSKF8IJ237FlTbzikWl5w8v9mw/YFL1XOY8HjGdcbquuga3sYTmAstj
-        O6kyQQ0+RiWJv77nyydi+yi4pTplO7r4PJS5LUbh/KXdYCJxQqNy602kAIO1NLHrkRj0DupH4nna
-        mqgs2FDZ84MNqDLFpGJm/caAa3G397q3gqU0Ae1aCV0rYbjB5bKj75MtJx7LZc2dPedldwQbzHN6
-        C5b9djSGJY2dafCbEOoPbT7mVI8zFh0zsXhvT0aQ2elFRDWCClwti7PNjpBijMMLveVwBlSXqFTV
-        l3N6fP7L0cnN8dHh+GQyvhmfnf15hvFhl2pMCF6YzoGcIs0LQ6xdwjSRgq8JUgbjVikxkvzGFCWn
-        ClLkDJJrxFdnF3X42E6O94l5XvbxLnTKNxFrh8nf9tQTrsAyJExQ/vxSNXtV6S1QztG7am3rmgjY
-        3M4z27RNON73Nzgux6Q3Qq8U3jyvTyeb16FxC7efabTAYbOGXK28tHVYzXP/yeF6KHTr2SyopwEB
-        FuqR5FKdlN7c8hzaiULG2o5EkoxkWWyZZjgOC7Mb9P0mUuhvSOFLFX+azr/F9rc3ZYbDXkiuPtAs
-        CMmhlAsG5JIZ5FhDJhDlCsh7TpNPNjuYHC4jyudSm3DoDT13xkSMtOd2u951oXBUJA/jupPEwirc
-        I1+VJN/hn+8L8QkOfZaDUAzZonJylAMZYTy4+QddE99rEQvGTRCHl2M8usJ/7YHfKzy1dYyW0EmZ
-        UdCRKnERxtSWluFgZuHv4tXO3KS88LvUc2H1nIuFkMvPk3SqZJzjUz8WCTZ2imVyp5hja7PIEPpL
-        fpXLtpENWcoqBcE1ccmVrw35K6fKgCJblQ2isLXpF9If3p2SSURFw307c7p+UFbj6W9vstYGUo1x
-        xJlkCLa9sNgvKmQzllImNDPQQTxiwvT8VlIVN914oX+0xdle+C8AAAD//+xZbUvcQBD+K4sgKJiY
-        u8t5dwWxh7TQD9KiUEGEY7PZeKF3m5AXo1j/e5/Z3dvG9GKLFPGD4IeY3Z2dmcw888zctZozYcIJ
-        2MsiKRUrZcUaG1sVwLE08ZUgvg5Ys0zFkq0lVyUWudlhJcDeaxVJxoUAusqY3aac1UgYUdzngCfs
-        U0oakuC3NDrDt77RrSUpdLmUiuKLcSc3Q+cJi6AJmQWyx1KVZMVan2FZQZjNsVoSZAKuf0h1QIpB
-        eFoxw0QYXzX8nkxkOdfa1SUim3HFWgqib1Ry5eOLl2Szs9D44FqRE+g28hE0sBqWGxVJYFnDQVs1
-        bdncsv4cuYjqA5eR9TZemqbxs4aXuc4KJKG88/NlriMalywgc2HvXvAK1CuqEVOLva+X84tv3sWZ
-        h0Ktc9VdkmcUypQNezxep2qf7e3/RKCsquwDwvBPjjN2hb5b5PpwbhC2ca4qgOyabBEd7G51NLiz
-        EDpC2lkI+k4Ejmvoj6SZ1faNfdwj6GPHgVMGPuZiSQluC3C7hneRvKzXa05Fa+dveE1eJwqaFS+s
-        cERFTpBvRHK/xMfjeDSdTKPBJJAjMQvEbDxMZoPkCPe4TbjhmW2SQmIex7gDVQ4lL77/2FIEgEKy
-        nu19Ta74qKJ6m4Yp23+FEkSPx4MwPJqI6WQ8mkUimgS4PuEymYqT+FhL2R3Nd4ef8WfOeWuuLL56
-        nnlV+nXpNXCEN/QJuP28jlapIE95OeclOQrndR0BTcTjKZLCzxX5vNtHv32Nu43429e428i/dY2B
-        UbFpVi0VPEXog8kkSS1EqhOI8Ny0jgbhrkAGsfFTXWS5PLwC9ojl70yjQRJWXerSDXautp0/hn24
-        GvY1laFrKguL7+8w8moB8w4jr6HxO4xsgZEuDPQxtdARMsdXYM6NScoHmnjb5wCaZBW3g/yulF7m
-        1YtLfeOfYLgd+XqZWa9lvZTNmdxZGPWdGDmSJ9VtWmTKsDzzKq7tr0jm33/x3m1W/b9pphHmhOIm
-        tGnfMz3r2YxUkQJG5YfNo60vL1ZA/+J2uJF7sLPmd+eyrFckuGWsntIU1bwyhtOsmCY5ZLp7//Tw
-        8Mlpe0Br+/j4+AsAAP//AwBjbAEstBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18277","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18277","key":"NTEST-1891","fields":{"statuscategorychangedate":"2025-04-30T18:28:25.833+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1891/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:25.539+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tan:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:25.628+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/330]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/330 (330)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1891/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18277/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 5e7ea71a-efd4-4a7a-a557-8cc1eacc2069
+      - 04a5cd0b-e591-455b-ad68-e54c99933555
       Atl-Traceid:
-      - 5e7ea71aefd44a7aa5578cc1eacc2069
+      - 04a5cd0be591455bad68e54c99933555
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:57 GMT
+      - Wed, 30 Apr 2025 16:28:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=240,atl-edge-internal;dur=13,atl-edge-upstream;dur=227,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="FDEcAndy7ZxqAxq4mg4np_oXyvf7HVKNPoIZ-ZxVJ7BvttLXopZ2cQ==",cdn-downstream-fbl;dur=313,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=311,atl-edge;dur=236,atl-edge-internal;dur=16,atl-edge-upstream;dur=220,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 13926aef629bc9518d9ad769185e8c4e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - FDEcAndy7ZxqAxq4mg4np_oXyvf7HVKNPoIZ-ZxVJ7BvttLXopZ2cQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 098eeb4d4391bc88cd99e222189e189f
+      - 563d4ff635a67b346440df5c8ba8b8e1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16135
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18277
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeeRBGKmqtiTb0lJKSQBpKUJm5mZi4rGntocky/Lfez2P
-        ZIHMrqDqKhKMH/d97vF9cGCVURE7oaNAxKAgfs+Ax7olaAq6paM5pLQlM1DUMCl0C2JmUjC0Fc2p
-        SIDLpHUPSuMZxGeQKdAgTHU3yrWR6cwqvPE9z/c6Cv7JQZvpOoNTRSPDInBaDrP2/YHf7eNCA5/h
-        cm5MpkPXjWEGkYnlnexQw6nWjIqOAOOiJePSjLmBy7TOwa0VLGCN8ifT8WTa9gd9H7cKF7QTPjga
-        fct1RA0kUq3LGGJcoUTgBf2257d9bxp4oT8M+4POQW//B/Tbs05aIwYdL9S80Ukr76I+L9iEXS1i
-        0JFimU0c7r4jOqWct0jMtGEiMiRjEAGRM7KUatGx0pEU54q/0otcMFsuym/oPTVUufcMlm7h1tbB
-        6sj3uv7wJ80+wo8plj1P0aqFBZqcUr2wtcpvjf0KZ5RraDml4BHGVci2nDlD4Khovj6Ge0BfvceW
-        YxgiK0OUOKHIMUbnGUy6Xn2QKXmHEb0x4ZV0ke6igHW67eIzkGyjOhfMGFSgnY1ti9Tfi7tazsyS
-        KotXzdKMM3Q4fhY51qNAWW+46g1f6e4XKlNHsqlLz9tHN4LeKuj9v1bK6hdYRIP+YOUPvoXBVW2x
-        G6y6wbewWAH88fElHP0mnAb1wYytLkoOxOpfXb+82a1v0iRRkCDffLUJ+vUBRiZ5XvLC7quDpoP9
-        hoOg8WDYdHDw0p2SNstdS0rFC+GEbb/iSlsSxaLS84cXe7ZRMNt6LnMej5jOOF1X7YTbS2rw6Skp
-        +/WtXz4I2yfALdUp29jF56HMbeoLVy/tBhOJExqVW9uo1FwgZmx7V9lQgMFa/tj1SAx6B/Uj8Txt
-        Gyp7ftAEqmADqkwxqZhZvzEFtbjbe91bwVKagHathK6VMNzgctnR98mWLI/lsibVnvOybYIN5jm9
-        BUuLOxrDssnONPhNCPWHNh9zqscZi46ZWLy3JyPI7PQiohpBBa6WxdlmR0gxxuGF3nI4A6pLVKrq
-        yzk9Pv/l6OTm+OhwfDIZ34zPzv48w/iwSzUmBC9M50BOkf+FIdYuYZpIwdcEuYRxq5QYSX5jipJT
-        BSmSCck1Iq6zi1N8bCfH+8Q8L/t4Fzrlm4i1w+Rve+oJV2AZEiYof36pmr2q9Ba45+hdtbZ1TQRs
-        bueZbdomHO/7GxyXY9IboVcKb97dp5PN69C4hdvPNFrgsFlDrlZe2jqs5rn/5HA9FLr1bBbUY4IA
-        C/VIcqlOSm9ueQ7tRCFjbUciSUayLLZMMxyHhdkN+n4TKfQ3pPClij9N599i+9ubMsNhLyRXH2gW
-        hORQygUDcskMcqwhE4hyBeQ9p8knmx1MDpcR5XOpTTj0hp47YyJGInS7Xe+6UDgqkodx3UliYRXu
-        ka9Kku/wz/eF+ASHPstBKIZsUTk5yoGMMB7c/IOuie+1iAXjJojDyzEeXeG/9sDvFZ7aOkZL6KTM
-        KOhIlbgIY2pLy3Bis/B38WpnblJe+F3qubB6zsVCyOXnSTpVMs5xBhiLBBs7xTK5U8yxtVlkCP0l
-        v8pl28iGLGWVguCauOTK14b8lVNlQJGtygZR2Nr0C+kP707JJKKi4b4dRl0/KKvx9Lc3WWsDqcY4
-        4kwyBNteWOwXFbIZSykTmhnoIB4xYXp+K6mKm2680D/a4mwv/BcAAP//7FltS9xAEP4riyAomJi7
-        y3l3BbGHtNAP0qJQQYRjs9l4oXebkBejWP97n9nd28b0YosU8YPgh5jdnZ2ZzDzzzNy1mjNhwgnY
-        yyIpFStlxRobWxXAsTTxlSC+DlizTMWSrSVXJRa52WElwN5rFUnGhQC6ypjdppzVSBhR3OeAJ+xT
-        ShqS4Lc0OsO3vtGtJSl0uZSK4otxJzdD5wmLoAmZBRbIUpVkxVqfYVlBmM2xWhJkAq5/SHVAikF4
-        WjHDRBhfNfyeTGQ519rVJSKbccVaCqJvVHLl44uXZLOz0PjgWpET6DbyETSwGpYbFUlgWcNBWzVt
-        2dyy/hy5iOoDl5H1Nl6apvGzhpe5zgokobzz82WuIxqXLCBzYe9e8ArUK6oRU4u9r5fzi2/exZmH
-        Qq1z1V2SZxTKlA17PF6nap/t7f9EoKyq7APC8E+OM3aFvlvk+nBuELZxriqA7Jp+ER3sbnU0uLMQ
-        OkLaWQj6TgSOa+iPpJnV9o193CPoY8eBUwY+5mJJCW4LcLuGd5G8rNdrTkVr5294TV4nCpoVL6xw
-        REVOkG9Ee7/Ex+N4NJ1Mo8EkkCMxC8RsPExmg+QI97hNuOGZbZJCYh7HuANVDiUvvv/YUgSAQrKe
-        bYpNrvioonqbhinbmIUSRI/HgzA8mojpZDyaRSKaBLg+4TKZipP4WEvZHc13h5/xZ855a64svnqe
-        eVX6dek1cIQ39Am4/byOVqkgT3k55yU5Cud1HQFNxOMpksLPFfm822C/fY27Hfrb17jb4b91jYFR
-        sWlWLRU8ReiDySRJLUSqE4jw3DSTBuGuQAax8VNdZLk8vAL2iOXvTKMJE1Zd6tINdq62nT+Gfbga
-        9jWVoWsqC4vv7zDyagHzDiOvofE7jGyBkS4M9DG10BEyx1dgzo1JygcahdvnAJpkFbeD/K6UXubV
-        i0t9459guB35eplZr2W9lM2Z3FkY9Z0YOZIn1W1aZMqwPPMqru2vSObff/HebVb9v/mmEeaE4ia0
-        ad8zPevZjFSRAkblh82jrS8vVkD/4na4kXuws+Z357KsVyS4Zaye0hTVvDKG06yYJjlkunv/9PDw
-        yWl7QGv7+Pj4CwAA//8DAMlcdua0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18277","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18277","key":"NTEST-1891","fields":{"statuscategorychangedate":"2025-04-30T18:28:25.833+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1891/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:25.539+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tan:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:25.628+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/330]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/330 (330)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1891/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18277/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f0286119-3a85-41a3-96d4-3c78c642eb3d
+      - e8b37f22-d981-46cf-b1ef-852bad232c91
       Atl-Traceid:
-      - f02861193a8541a396d43c78c642eb3d
+      - e8b37f22d98146cfb1ef852bad232c91
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:57 GMT
+      - Wed, 30 Apr 2025 16:28:26 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=243,atl-edge-internal;dur=15,atl-edge-upstream;dur=228,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=308,atl-edge;dur=276,atl-edge-internal;dur=16,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="nnEBBgRC3dSmq-Q84c5esvIjZKuMzgvBfkCAYzez_s1YAwMgUog61Q==",cdn-downstream-fbl;dur=312
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9c93b7820e04954dd3278b106daa8da.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - nnEBBgRC3dSmq-Q84c5esvIjZKuMzgvBfkCAYzez_s1YAwMgUog61Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 92c01d0dabb318d074be4a9b82907454
+      - 2ef5244cb10c7f810f2ebdfa98cad686
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:37136\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:45916\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:18:57 GMT
+      - Wed, 30 Apr 2025 16:28:26 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/120", "url_api": "http://localhost:8080/api/v2/tests/120/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      120, "url_ui": "http://localhost:8080/test/120", "url_api": "http://localhost:8080/api/v2/tests/120/"},
+      "finding_count": 2, "findings": {"new": [{"id": 329, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/329",
+      "url_api": "http://localhost:8080/api/v2/findings/329/"}, {"id": 330, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/330",
+      "url_api": "http://localhost:8080/api/v2/findings/330/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:45920\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/120\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/120/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 120, \\\"url_ui\\\": \\\"http://localhost:8080/test/120\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/120/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 329, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/329\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/329/\\\"},
+        {\\\"id\\\": 330, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/330\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/330/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 329,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/329/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/329\"\n        },\n
+        \       {\n          \"id\": 330,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/330/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/330\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        120,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/120/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/120\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/120/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/120\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:26 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -959,26 +1046,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1m5d3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwBbLE7NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4LTgeZFSln+z
-        srsxygYwo/NCCsAclaSzBYpMqUyBVGw5y4tazTNkcwXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAViuekyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:27.355+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 2266d567-0550-4cee-b74a-a659de3382be
+      - 21086398-ec1c-4c52-b133-424227019d46
       Atl-Traceid:
-      - 2266d56705504ceeb74aa659de3382be
+      - 21086398ec1c4c52b133424227019d46
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:58 GMT
+      - Wed, 30 Apr 2025 16:28:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -988,7 +1071,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=174,atl-edge-internal;dur=14,atl-edge-upstream;dur=161,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=203,atl-edge;dur=170,atl-edge-internal;dur=18,atl-edge-upstream;dur=153,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="wjN549vzxqFiTaCbJDR5arrqmGlV5yeUX6zIQs22vJMaEIJtEkhAIw==",cdn-downstream-fbl;dur=207
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -997,10 +1080,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 aa3674a12327640af71c59263be8ffc6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - wjN549vzxqFiTaCbJDR5arrqmGlV5yeUX6zIQs22vJMaEIJtEkhAIw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 63d1524def43c68846df80a9e692ed43
+      - 37a4eb5cae6828df939fb23d15689fe1
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1024,61 +1115,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16134
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18275
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeeRBdqSq2pLQ0lJKIYC0FCEzczPxxmNPbQ9JluW/93pe
-        AZLsCqqukMLY1/d9fHwfHFhmVMRO6CgQMSiIDxnwWLcETUG3dDSDlLZkBooaJoVuQcxMCoa2ohkV
-        CXCZtO5BaZRBfAaZAg3CVGejXBuZTq3BW9/zfK+j4J8ctJmsMjhVNDIsAqflMOvfH/jdHi408Cku
-        Z8ZkOnTdGKYQmVh+lB1qONWaUdERYFz0ZFyaMTdwmdY5uLWBOaxQ/2QyPp+0/UHfw60iBO2ED47G
-        2HIdUQOJVKsyhxhXqBF4Qb/t+W3fmwRe6A/Dfq+zvz/4AeO2NgonBgMvzLwxSKvvoj0vaNKuFjHo
-        SLHMFg533xOdUs5bJGbaMBEZkjGIgMgpWUg171jtSIoLxV8ZRS6YbRflt/SeGqrcewYLtwhrHWAl
-        8r2uP/xJs0/wY4ptz1P0amGBLidUz22v8jtjv8Ip5RpaTql4hHkVui1nxhA4KpqtjuEeMFbvseUY
-        hsjKECVOKHLM0XkBk65XCzIlP2JGbyx4pV2Uu2hgXW67eAKSdVYXghmDBrTT+LZI/b04q+XULKiy
-        eNUszTjDgOMXmWM/CpT1hsve8JXhfqEzdSZNX3rePoYR9JZB7//1Una/wCI69AdLf/AtHC5rj91g
-        2Q2+hccK4I+Pm3D0d+E0qAVTtrwsORC7f32zebJbn6RJoiBBvvnqJejXAsxM8rzkhe1HB7sE+zsE
-        wU7BcJfg3WY4JW2Wu5aUihfCCds+LqnBh6Mk3Ndf3JLO1wTuluaUvZbF54HMbeF8S8pXdoOJxAmN
-        yuGx4mlrTbGorNrDxp6NDI/qmcx5PGI643RVXWXcxrDMJWLGXu+qGgowWcsf2x6J7rBfPxIvy9ZQ
-        2UvBLlAFDagyxaRiZvXGItbqrn0SX/FWsJQmoF2roWsjDDe4XHT0fbImy2O5qEm152xem6DBPKd3
-        YGlxy8WwbLK1DP4uhPpDW48Z1eOMRcdMzA+tZASZnV5EVHex6O2ikDU7QooxDi/0jsMZUF0iQ1Vf
-        zunxxS9HJ7fHRwfjk/Px7fjs7M8zzA9vqcaC4IHJDMgp8r8wxPolTBMp+IoglzBujRIjyW9MUXKq
-        IEUyIblGzHa2cYqP18nxPjPPyz7dhU75JmLvsPjrO/WMK7ANCROUvzxUzV5VeQucc4yuWtu+JgKa
-        03lmL+0uHPcGzbBTjklvhF6p3Ly7zyeb16FxDbefaTTHYbOGXG289HVQzXP/KeB6KHTr2SyoxwQB
-        FuqR5FKdlNHc8RzaiULWWI9Ekoxk2WyZZjgOC7Md9P2GFL7U2JdKDWE8L+ffYv23N2GGw15Irj/Q
-        zA/JgZRzBuSKGeQ5Q84hyhWQQ06Tz7Y6WBwuI8pnUptw6A09d8pEjFTqdoN3N4XBUVE8zOujJBZW
-        4R75qib5Dn++L9TPceizHIRqyBZVkKMcyAgTxc0/6Ir4XotYMDZJHFyNUXSN/9oDv1dEavsYLaCT
-        MqOgI1XiIoypbS3Dic3C38WjnZlJeRF3aefS2rkQcyEXT4t0qmSc4wwwFgle7BTb5E6w+NZnUSGM
-        l/wqF20jd1QpqwwEN8Ql17425K+cKgOKrE3uUIW1T7/Q/vD+lJxHVOw4b4dR1w+8JqsneZyvtIFU
-        Yx5xJhmCbS8s9osO2YqllAnNDHQQj1gwPbuTVMW7TmzYH61xthf+CwAA///sWW1L3EAQ/iuLICiY
-        mLvLeXcFsYe00A/SolBBhGOz2Xihd5uQF6NY/3uf2d3bxvRiixTxg+CHmN2dl83MM8/MXas5Eyac
-        gL0sklKxUlassbFVARxLE18J4uuANctULNlaclVikZsdVgL8vVaRZFwIoKuM2W3KWY2EEcV9DnjC
-        PqWkKdR+y6IzfOsb3VqSQZdLqSi+GHdyM3Se8AiWkFtggSxVSVas9RmWFYTZHKslQSbg+odUB2QY
-        hKcVM2yA8VXD78lFlnNtXV0ishlXrGUg+kYlVz6+eEk+Ow/NHVwrugTSRncEC6yF5cZEEljWuKCt
-        lrZ8bnl/jlxE9cGVkfc2Xpqm8bOGl7nOCiShvPPzZa4jGkoWkLmwuhe8Av2JasTUYu/r5fzim3dx
-        5qFQ61x1SvKMQpmyYY/H61Tts739nwiUVZV9QBj+yXHGrtB3i1wf+RmEbQCsCiC7JnBEybpbHQ3u
-        LAR9C6Fjqt0Tjmvoj6SZ1faNfdwj6GPHgdP5pGZ3IR0fgIslZb+pC2W9XnMqWjt/w2u6daKgWfHC
-        CkdU5AT5RsT5S3w8jkfTyTQaTAI5ErNAzMbDZDZIjqDHbYKGZ7ZJCol5HEMHqhxKXnz/sWUIAIVk
-        PdsUm1zxUUX1Ng1TtjELJYgejwdheDQR08l4NItENAmgPuEymYqT+FhL2R3Nd4ef8WfOeWuuLL56
-        nnlV+nXpNbgIb+gTcPt5Ha1SQTfl5ZyXdFE4r+sIaCIeT5EUfq7ozrsN9tu3uNuhv32Lux3+W7cY
-        GBWbhtFSwVOEPphMktRCpDqBCM9NO2oQ7gpkEBs/1UWWy8MrYI9Y/s40mjBh1aUuabBzte38MezD
-        1bCvqQxdU1lYfH+HkVcLmHcYeQ2L32FkC4x0YaCPqYWOkDn+AnduTFI+0CjcPgewJKu4HeR3pfRR
-        sqAPl4LhdoDrmwoFvQ70UjbnWfdEH5cb9S44kifVbVpkyhA58yqu7a9I5t9/ub3brPp/E1IjzAmF
-        JrRp3zM969mMNZECxuSHzaOtLy82QP/idriRe7Cz5nfnsqxXJLjlrJ7SFNW8Mo7TrJgmOeS6e//0
-        8PDJaXtAW/v4+PgLAAD//wMAS4F2lbQcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18275","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275","key":"NTEST-1890","fields":{"statuscategorychangedate":"2025-04-30T18:28:22.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:22.649+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00taf:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:22.733+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/329]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/329 (329)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f0582b41-e433-4b83-b9b6-cc822e932a77
+      - 0b863474-e1a6-4198-bcfa-241eed94b80c
       Atl-Traceid:
-      - f0582b41e4334b83b9b6cc822e932a77
+      - 0b863474e1a64198bcfa241eed94b80c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:58 GMT
+      - Wed, 30 Apr 2025 16:28:27 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1088,7 +1162,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=257,atl-edge-internal;dur=12,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=31,cdn-upstream-fbl;dur=391,atl-edge;dur=262,atl-edge-internal;dur=18,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="rY8o1-pAxwhqxprY0SM1UvgEprF8NbdJ5Qzx5gugmUoFm5LhHGDQ2Q==",cdn-downstream-fbl;dur=396
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1097,10 +1171,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1b7fa09f50c08a88d619f90eef5ee94a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - rY8o1-pAxwhqxprY0SM1UvgEprF8NbdJ5Qzx5gugmUoFm5LhHGDQ2Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 46fbfd40e124d07f7553ea0ed39ead5f
+      - 19586b30b0821206328d65110c91578b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1127,41 +1209,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - c21860f6-00bf-440c-aa36-6e5e3387e558
+      - 26fe5216-e8c4-446d-ba3b-c930858fe497
       Atl-Traceid:
-      - c21860f600bf440caa366e5e3387e558
+      - 26fe5216e8c4446dba3bc930858fe497
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:58 GMT
+      - Wed, 30 Apr 2025 16:28:28 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1171,7 +1240,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=334,atl-edge-internal;dur=14,atl-edge-upstream;dur=321,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="IULU9fj4K9iTe6JXQiUWN_xMsLuT_RUyiIl3uZv_MUhwttJKFGkNzA==",cdn-downstream-fbl;dur=395,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=71,cdn-upstream-fbl;dur=392,atl-edge;dur=298,atl-edge-internal;dur=17,atl-edge-upstream;dur=281,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1180,13 +1249,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9832e15ad117dafc81b031983cbde91e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - IULU9fj4K9iTe6JXQiUWN_xMsLuT_RUyiIl3uZv_MUhwttJKFGkNzA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - d21b76b17572ef8f6b9806aeb7ef8a03
+      - c821340f856466b17869156f3747f939
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1199,7 +1276,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/329]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/329 (329)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1207,7 +1284,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "labels": ["tag1", "tag2"]}, "update": {}}'
     headers:
       Accept:
@@ -1219,27 +1296,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1316'
+      - '1336'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16134
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18275
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - ef0f1ca0-0d93-48b1-b6e2-b54300e7ec61
+      - ec3addd0-06fa-4125-a7aa-4b81cc5ebb5d
       Atl-Traceid:
-      - ef0f1ca00d9348b1b6e2b54300e7ec61
+      - ec3addd006fa4125a7aa4b81cc5ebb5d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:59 GMT
+      - Wed, 30 Apr 2025 16:28:29 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1249,17 +1328,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=570,atl-edge-internal;dur=12,atl-edge-upstream;dur=558,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="m11sQlF8-TKnHTMHTnCzeMwpAgRREYF82sPnBvtUxkxgLzu7ln7O8Q==",cdn-downstream-fbl;dur=651,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=648,atl-edge;dur=570,atl-edge-internal;dur=18,atl-edge-upstream;dur=552,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 087e16218fcf1ccb7472a2c9f6a4cbe2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - m11sQlF8-TKnHTMHTnCzeMwpAgRREYF82sPnBvtUxkxgLzu7ln7O8Q==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 339fe460215138ac97329ca1dde9eea5
+      - 6b8acb7c3796072de6343f3b2d14f862
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1283,61 +1370,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16134
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18275
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSeSSEMFJVbSHbsqWUQgBp6QqZmZuJNx57antIsiz/vdee
-        RxZCtoKqKyQyftz3ucf33oNlQUXqxZ4CkYKC9C0DnuqOoDnojk5mkNOOLEBRw6TQHUiZycHQTjKj
-        IgMus84dKI1nkJ5BoUCDMPXdpNRG5lOr8CYMgjDoKfi7BG0mqwJOFU0MS8DreMzaD4dhf4ALDXyK
-        y5kxhY59P4UpJCaVH2WPGk61ZlT0BBgfLRmfFsyPfKZ1CX6jYA4rlD+ZjM8n3XC4G+CWc0F78b2n
-        0bdSJ9RAJtWqiiHFFUpEQbTbDcJuGEyiIA5H8e6gt7c3/AH9tjqcEYOOOzWvdNLK+6gviNqw60UK
-        OlGssInD3TdE55TzDkmZNkwkhhQMEiByShZSzXtWOpHiQvEXelEKZstF+Q29o4Yq/47BwndurR2s
-        j8KgH45+0uwT/Jhj2cscrVpYoMkJ1XNbq/LW2K94SrmGjlcJHmFcTrbjzRgCRyWz1THcAfoaPHQ8
-        wxBZBaLEi0WJMXpPYNIPmoNCyY8Y0SsTXku7dLsCNum2iy9Aso7qQjBjUIH2WtsWqb+5u1pOzYIq
-        i1fN8oIzdDh9EjnWw6FsMFoORi909yuVaSJp6zII9tCNaLCMBv+vlar6DotoMBwuw+G3MLhsLPaj
-        ZT/6FhZrgD88bMIx3IbTqDmYsuVlxYFY/esPmzf7zU2aZQoy5JuNJsAAJC+r9n/e3O62g+G2g70t
-        B9HWg9G2g/1NPyvarHYtKbkXwou7Yc2VtiSKJVVI9xt7tlEw23omS54eMl1wuqrbCbcX1ODTU1H2
-        y1u/ehDWT4BfqVO2sd3ngSxt6p2rV3aDicyLjSqtbVRqLhEztr3rbCjAYC1/PPdI9Ee7zSPxNG0t
-        lT092AaqqAVVoZhUzKxemYJG3LdP4gveCpbTDLRvJXSjhOEGl4uevsvWZHksFw2pDrzNtolazHN6
-        C5YWrz1DsxBl8CfyNrvEUsuzOQm3wTUc2eTMqB4XLDlmYv7WnhxCYUcZkTRwciBbuLN2R0gxxkmG
-        3nI4A6oriKr6yzs9vvjl6OTm+OhgfHI+vhmfnf1xho5jy2rMDl6YzICc4mMgDLF2CdNECr4iSCyM
-        W6XESPKOKUpOFeTILKTUCL/ecwQTYm95wWcWBMWn29jmB7kBC4mVWDfYI+LAmmRMUP70Uj2I1STk
-        moCjd/XaFjkT0N4uC9vBz4N6vxcNWlBXM9MrcVgJt4/w4zHnZdBcY+9nmsxx8mzw1yivbB3Uw91/
-        criZEP1mUIuamUGAxX0iuVQnlTe3vIRuppC+1vORJIeyKrbMC5yNhXn+adhtGeJrhX0q1LLH43T+
-        JdZ/OxNmOOzE5Po9LcKYHEg5Z0CumEHCNeQcklIBectp9tlmB5PDZUL5TGoTj4JR4E+ZSJEV/X60
-        /8EpPHTJw7g+SmJhFe+Qf5Uk3+G/7534OU6AlpBQDKmjdvKwBHKIgeLm73RFwqBDLBjbIA6uxnh0
-        jT/dYThwnto6Jgvo5cwo6EmV+QhjakvLcHyz8Pfxam9mcu78rvRcWj0XYi7k4ssknSqZljgQjEWG
-        jZ1jmfwJJt/adBlCf8mvctE1ckuWilpB9IH45DrUhvxZUmVAkbXKLaKwthk66fdvTsl5QsWW+3Yy
-        9cMoaKP6Io7zlTaQa4wjLSRDsO3Ebt9VyGYsp0xoZqCHeMSE6dmtpCrddmND/z8AAAD//+xZXUvj
-        QBT9K4MgKJiYtqltF8Qt7i7sg+yisIIIZTqZ2LDtJOTDKG7/+547Mx1jtnEXWcQHwYeYmblfuffc
-        c6efHvOMJE+ZMOkE7GVzKRUrZMlqm1slwLEw+RUjvw5YvUjEgq0kVwUWudlhJcDfazWXjAsBdJUR
-        u004q1AwIr/PAE/Yp5Q0jMFvWHSGb32j50wy6HIhFeUX405uijEUHsEScguUkCUqTvOVPsPSnDCb
-        Y7UgyARc/5TqgAyD8KRkhpYwvqz5PbnIMq6tqwpkNuOKNQzEEKnk0scXL8hn56GJwbWiIJA2ihEs
-        sBYWGxNJYFEhQFstbfjc8P4ctYjug5CR9zZf6rr205oXma4KFKG887NFpjMaSmaQObO6Z7wED5tX
-        yKnZ3rfL6cV37+LMQ9fWteqUZCmlMlXDHo9Widpne/u/kCjLMv2ANPyT8Axd1283uS4m1AubAFjm
-        QHbNxYgbtrd2MeCgayF0tLV9wnEN/ZE0zdq+sYt7BF1UOXA6EWMuFlTgtgE3e3gb4otqteLUtHb+
-        htcUdeKjaf7CDkdU5AT1Rhz4a3Q8jAbj0XjeGwVyICaBmAz78aQXH0GP2wQNz2yTlBLTKIIOdDm0
-        vOj+Y8MQAArJenZCNrXio4vqbRqm7JQWShA9HvXC8GgkxqPhYDIX81EA9TGX8VicRMdayu5gutv/
-        gj9zzltxZfHV88yrwq8Kr0YgvL5PwO1n1XyZCIqUl3FeUKBwXvcR0EQ8nqIo/ExRzNvT9tu3uD2u
-        v32L2+P+W7cYGBWZydVSwVOkPphMHFdCJLqACM/NZGkQ7gpkEBs/V3maycMrYI9YPFYaXTdh1ZUu
-        abCXbNv5Y9iFq2HXhBm6CTO3+P4OI6+WMO8w8hoWv8PIFhhpw0AXUwsdIXN8Be7cmKJ8oHtx+xzA
-        krTk9la/LaWLkgVduBT0twNc161Q0OlAJ2VznrVPdHG5QeeCI3lS3SZ5qgzLM6+iyv6kZP79l+jd
-        puX/u+w0wpxQaMKY9iPVdz2b+1WUgDH5YfNo+8uLDdA/vx1u5B7srPjduSyqJQluOKtvafJyWhrH
-        6eKYbnLIdff+6eH+k9P2gLZ2vV7/BgAA//8DABae4A3BHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18275","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275","key":"NTEST-1890","fields":{"statuscategorychangedate":"2025-04-30T18:28:22.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:22.649+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":["tag1","tag2"],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00taf:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:29.077+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/329]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/329 (329)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 4cad61dd-410b-483e-988e-f13814f6965d
+      - 2be7658a-04dd-430c-b374-3e0fbb000a00
       Atl-Traceid:
-      - 4cad61dd410b483e988ef13814f6965d
+      - 2be7658a04dd430cb3743e0fbb000a00
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:18:59 GMT
+      - Wed, 30 Apr 2025 16:28:29 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1347,7 +1417,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=271,atl-edge-internal;dur=14,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=298,atl-edge;dur=264,atl-edge-internal;dur=14,atl-edge-upstream;dur=250,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="IpD9uY7inREVRqFNCApIr7QY8Yk1eaVpmNoSP7fqtAZCQZypTUqKSA==",cdn-downstream-fbl;dur=302
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1356,10 +1426,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 4bbf91f2f9edc22eb68408b6405ae452.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - IpD9uY7inREVRqFNCApIr7QY8Yk1eaVpmNoSP7fqtAZCQZypTUqKSA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - fa94ea48a660eb55f5d68a2c7532e3ef
+      - dca7a325f174db191d24a88c0cc5ff32
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1386,26 +1464,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TtfvIDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC18LjtDeHkLYTO88mkQYUyNO7dZSIY4b0WNrMYyIg02ndG7P/Bl9jvtMQG/ccaTbdCG7D/
-        65KVs8oMaCX+LrnD3mtnI0wBaAYZjMvN5WO5fqh+ppuhrWNF+HOCRjCCl+jEzrh9G6+s9l2yrYwb
-        mhiqB22arwjhMcDm81PzSoQEMmDFGOgYlhVjPJ/yPIoBLiDCMe/jH7CvdHvOUqgYcLrkABktFt+s
-        bG+schHM6WwhBWCBStLpHEWuVK5AKracFotazXJkMwXsTBBMMtzqXqQXohKDCXdOitQ+EHOqCNrX
-        bUmO54c9OZsm1/cVOX4CAAD//wMAKGwFAiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:30.284+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 9cce1f59-885c-4ac6-99fe-d37aec462b6d
+      - 34b8ac81-d8d8-424a-ba9d-19bbd99cc641
       Atl-Traceid:
-      - 9cce1f59885c4ac699fed37aec462b6d
+      - 34b8ac81d8d8424aba9d19bbd99cc641
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:00 GMT
+      - Wed, 30 Apr 2025 16:28:30 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1415,7 +1489,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=159,atl-edge-internal;dur=15,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=188,atl-edge;dur=155,atl-edge-internal;dur=12,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="aOMw6uAg1e1x3s2PI9qRQq-ea7itMltiunrrOxDbxQXDNsjORMko5w==",cdn-downstream-fbl;dur=191
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1424,10 +1498,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 7d27498ef63e76e5a81975299a76fae4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - aOMw6uAg1e1x3s2PI9qRQq-ea7itMltiunrrOxDbxQXDNsjORMko5w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 238c280271f585a45cac48c2fd2acebe
+      - ab4858e772d3785728dd8fff823cbca8
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1451,61 +1533,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16134
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18275
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+U8jNxT+V6z5qaVJ5shBdqSq2kK2paWUQgBpKUJm5mXijcee2h6S7PG/99lz
-        hCVkV1B1hUTGx7u/9/l98GBVUJF6sadApKAgfcOAp7ojaA66o5M55LQjC1DUMCl0B1JmcjC0k8yp
-        yIDLrHMPSuMZpGdQKNAgTH03KbWR+cwqvA2DIAx6Cv4pQZvpuoBTRRPDEvA6HrP2w1HYH+BCA5/h
-        cm5MoWPfT2EGiUnlO9mjhlOtGRU9AcZHS8anBfMjn2ldgt8oWMAa5U+mk/NpNxwNA9xyLmgv/uBp
-        9K3UCTWQSbWuYkhxhRJREA27QdgNg2kUxOE4Hg56+/ujH9Bvq8MZMei4U/NCJ628j/qCqA27XqSg
-        E8UKmzjcfU10TjnvkJRpw0RiSMEgASJnZCnVomelEykuFH+mF6VgtlyU39J7aqjy7xksfefWxsH6
-        KAz64fgnzd7DjzmWvczRqoUFmpxSvbC1Ku+M/YpnlGvoeJXgEcblZDvenCFwVDJfH8M9oK/Bp45n
-        GCKrQJR4sSgxRu8RTPpBc1Ao+Q4jemHCa2mXblfAJt128QAkm6guBDMGFWivtW2R+ru7q+XMLKmy
-        eNUsLzhDh9NHkWM9HMoG49Vg/Ex3v1CZJpK2LoNgH92IBqto8P9aqarvsIgGw9EqHH0Lg6vGYj9a
-        9aNvYbEG+KdP23AMd+E0ag5mbHVZcSBW//pm+2a/uUmzTEGGfPPVJhg2BxiZ5GXFC09fHe062N9x
-        EO08GO86eLXtTkWb1a4lJfdCeHE3rLnSlkSxpPL8w9aebRTMtp7LkqeHTBecrut2wu0lNfj0VJT9
-        /NavHoTNE+BX6pRtbPd5IEubeufqld1gIvNio0prG5WaS8SMbe86GwowWMsfTz0S/fGweSQep62l
-        sscHu0AVtaAqFJOKmfULU9CI+/ZJfMZbwXKagfathG6UMNzgctnT99mGLI/lsiHVgbfdNlGLeU7v
-        wNLitWdoFqIM/kTedpdYankyJ+EuuIZjm5w51ZOCJcdMLN7Yk0Mo7CgjkgZODmRLd9buCCkmOMnQ
-        Ow5nQHUFUVV/eafHF78cndweHx1MTs4nt5Ozsz/P0HFsWY3ZwQvTOZBTfAyEIdYuYZpIwdcEiYVx
-        q5QYSX5jipJTBTkyCyk1wq/3FMGE2Fte8JEFQfH+Lrb5QW7AQmIlNg32GXFgTTImKH98qR7EahJy
-        TcDRu3pti5wJaG+Xhe3gp0H9qhcNWlBXM9MLcVgJt4/w52PO86C5wd7PNFng5Nngr1Fe2Tqoh7v/
-        5HAzIfrNoBY1M4MAi/tEcqlOKm/ueAndTCF9beYjSQ5lVWyZFzgbC/P00zDcxRDDliG+VPHP0/m3
-        2PztTZnhsBeT67e0CGNyIOWCAbliBgnXkHNISgXkDafZR5sdTA6XCeVzqU08DsaBP2MiRVb0+9Gr
-        G6fw0CUP43oniYVVvEe+Kkm+w3/fO/FznAAtIaEYUkft5GEJ5BDjwc0/6JqEQYdYMLZBHFxN8Oga
-        f7qjcOA8tXVMltDLmVHQkyrzEcbUlpbh+Gbh7+PV3tzk3Pld6bm0ei7EQsjlwySdKpmWOBBMRIaN
-        nWOZ/Cnm2Np0GUJ/ya9y2TVyR5aKWkF0Q3xyHWpD/iqpMqDIRuUOUdjYDJ3029en5DyhYsd9O5n6
-        YRS0UT2I43ytDeQa40gLyRBse7HbdxWyGcspE5oZ6CEeMWF6fiepSnfd2NL/LwAAAP//7FltS+NA
-        EP4riyAomJi2qW0PxCveHdwHuUPhBBHKdrOx4dpNyItRvP73e2Z3u8Zc4x1yiB8EP8Ts7uzMZOaZ
-        Z6afHuOMJE+ZMOEE7GVzKRUrZMlqG1slwLEw8RUjvg5YvUjEgq0kVwUWudlhJcDeazWXjAsBdJUR
-        u004q5AwIr/PAE/Yp5Q0jMFvaHSGb32j+0xS6HIhFcUX405uijYUFkETMguUkCUqTvOVPsPSnDCb
-        Y7UgyARc/5TqgBSD8KRkhpYwvqz5PZnIMq61qwpENuOKNRREE6nk0scXL8hmZ6HxwbUiJ9Bt5CNo
-        YDUsNiqSwKKCg7Zq2rC5Yf05chHVBy4j62281HXtpzUvMp0VSEJ552eLTEc0LplB5szePeMleNi8
-        QkzN9r5dTi++exdnHqq2zlV3SZZSKFM27PFolah9trf/C4GyLNMPCMM/Cc/QVf12kevCuV7YxLky
-        B7JrLkbcsL3VceLWQujYaWsh6DoROK6hP5KmWds3dnGPoIsqB04Z+JiLBSW4LcDNGt5G8qJarTgV
-        rZ2/4TV5nfhomr+wwhEVOUG+EQf+Gh0Po8F4NJ73RoEciEkgJsN+POnFR7jHbcINz2yTFBLTKMId
-        qHIoedH9x4YiABSS9WyHbHLFRxXV2zRM2S4tlCB6POqF4dFIjEfDwWQu5qMA18dcxmNxEh1rKbuD
-        6W7/C/7MOW/FlcVXzzOvCr8qvBqO8Po+AbefVfNlIshTXsZ5QY7CeV1HQBPxeIqk8DNFPm93229f
-        43a7/vY1brf7b11jYFRkOldLBU8R+mAycVwJkegEIjw3naVBuCuQQWz8XOVpJg+vgD1i8ZhpNG7C
-        qktdusEO2bbzx7ALV8OuDjN0HWZu8f0dRl4tYN5h5DU0foeRLTDShoEuphY6Qub4Csy5MUn5QHNx
-        +xxAk7TkdqrfltLJvDpxqWv8E/S3I18nM+u0rJOyOZNbC4OuEwNH8qS6TfJUGZZnXkWV/UnJ/Psv
-        3rtNy/837DTCnFDchDbtR6pnPZv5KlLAqPywebT15cUK6J/fDjdyD3ZW/O5cFtWSBDeM1VOavJyW
-        xnAaHNMkh0x3758e7j85bQ9obdfr9W8AAAD//wMAP8WBRMEcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18275","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275","key":"NTEST-1890","fields":{"statuscategorychangedate":"2025-04-30T18:28:22.952+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:22.649+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":["tag1","tag2"],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00taf:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:29.077+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/329]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/329 (329)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/120]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1890/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18275/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 5373e7f0-14a1-43e9-9f73-1e5e36893e52
+      - af6c7c84-5f1b-436d-ba85-d181c11de76b
       Atl-Traceid:
-      - 5373e7f014a143e99f731e5e36893e52
+      - af6c7c845f1b436dba85d181c11de76b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:00 GMT
+      - Wed, 30 Apr 2025 16:28:30 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1515,7 +1580,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=253,atl-edge-internal;dur=13,atl-edge-upstream;dur=241,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=276,atl-edge;dur=243,atl-edge-internal;dur=15,atl-edge-upstream;dur=228,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="CGNj1198u-zpZDz6Zgy2TuPjO6PQyCmSci3g9oUvG0w0N9sPWpxBJQ==",cdn-downstream-fbl;dur=280
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1524,10 +1589,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - CGNj1198u-zpZDz6Zgy2TuPjO6PQyCmSci3g9oUvG0w0N9sPWpxBJQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 67dbf6adb79d930c7e3b77af9eee1e8b
+      - 27fec07f0ed6664df3fc2fa24940a2ad
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_epic_as_issue_type.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_epic_as_issue_type.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2TdR/NDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCC18LjtDeHkLYTO88mkQYUyNO7dZSIY4b0WNrMYyIg02ndG7P/Bl9jvtMQG/ccaTbdCG7D/
-        65KVs8oMaCX+LrnD3mtnI0wBaAYZjMvN5WO5fqh+ppuhrWNF+HOCRjCCl+jEzrh9G6+s9l2yrYwb
-        mhiqB22arwjhMcAWi1PzSoQEMmCzMdAxFBVjPJ/yPIoBLiDCMe/jH7CvdHvOUqgYcFpwgGxZ0G9W
-        tjdWuQjmdL6UAnCGStLpAkWuVK5AKlZMZ8tazXNkcwXsTBBMMtzqXqQXohKDCXdOitQ+EHOqCNrX
-        bUmO54c9OZsm1/cVOX4CAAD//wMAoWz87CACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:31.070+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - a69606a6-5992-4854-960a-8c476d88dfbd
+      - aafe79da-5460-457e-9564-df053c6db2f0
       Atl-Traceid:
-      - a69606a659924854960a8c476d88dfbd
+      - aafe79da5460457e9564df053c6db2f0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:00 GMT
+      - Wed, 30 Apr 2025 16:28:31 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=164,atl-edge-internal;dur=14,atl-edge-upstream;dur=151,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="6yGqPQuaqG0DZ2wRPZXxgAQc6XH08Abdp-w1pW0x2mN0sZNCy_SvHw==",cdn-downstream-fbl;dur=231,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=229,atl-edge;dur=155,atl-edge-internal;dur=13,atl-edge-upstream;dur=142,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 9d71affbaf22baf23eab459f3d2ee77a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 6yGqPQuaqG0DZ2wRPZXxgAQc6XH08Abdp-w1pW0x2mN0sZNCy_SvHw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 9d427364e9f6bf20eaff643793604e36
+      - 6cee77a965f6194d67d47d7a9d40374a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,42 +90,31 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Epic&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xWW0/bMBT+K1aeS0JLxVClaZqASWwTmsTlZULIbU5bg2NnttMmQ/3vO6e5OKVs
-        S9nGXshTfHIu37G/88UPAeQpV3EwClKj72DibNDzr6OvD95BWJuBK1IgFwtyira5c6kdRVEMUwyI
-        9Z0OuZPcWsFVqMBFBqyLeCqiQVRljfr7+GAKQUnrxT0UuDq/PL24xJXiCeDySgnnMAEV5AvuuLky
-        ElE9BMOjfHi0Y/1MiQUYy+VtmStaCFhG1FADrfrQ3x/uv8Gag2E+GP7bKu+s+A5vbcKlxIL9w7x/
-        +BIF87riwSA/GLxExQRikSXBqtfmEfHrGUxqMjzNpRjsxIjUCa3Q+p6NxYxlFgyzTpuCuTl3TAHE
-        ljnNxsDGRt+DYrFeqpAdG+AOYjYu2EdhOLvQU7fkBtgeOjClHcNGHNOGxSDBQUjVJ1ohM7t0IRI+
-        AxtRhPV92AhSMQntYubJf4oWXGXKGa6sJFDnG19sNnbc3gejKZcWesFcgOFmMi8+wwIQTL/nZ3cq
-        QMY0RtULjpDNkoSbgl4NfMuEAXR0JsNMdjKHhNMXAofh1hmhCJstrIOELFX0qsF7UVnqWa49EBi3
-        JzDlmXTXXGbQANYpAqZTIiIgD1xw06ZHJ2TeuwXOGz28M7Kxy9KzRNiO7YTxBmVISr2EeO30yt8O
-        /P0tS1d06BOdpFqBon9O+9SroK1j58ZwopbAA8cQH9+mQSup58GxN9Y8aPl1JELA45gqAdUzkOgF
-        BE+QgzrbOMwurW3PWjuFb+SkZa07aXt2baWeu0q6O01d7dsCWZs8wC+NUwnOB+0AbHtTnzVxf3b3
-        qKJJPD6V2lYNFW2ASFIpUFb9kb5eVf5mwf93VSmVKUPVTda/zVskTL+/4xSX8cFaZcK0yIUNZwZA
-        zXWKbA/vUKNHs/ke6eee5GOgTsuYM0y/ruhHijSVrW8BjXZtwdtpvFZ0I8ivcYtKc5fWHmsvbXAp
-        OI0YtHN69B9EzipnL75t112g9yoN/rX6pkZoI9yjW87POmu8N3StsrWFrXGrla0xbDVQKug2/icA
-        P1PZhP4BAAD//7xYwW6DMAz9lx16XLaWHhHabZOYVKm79kAZAlQGGxBVPfTfZ8cJOINJlKAea7Dz
-        Yr/afuDZAis/d5DrIDkYsjzNILo9y1/JiCeoxgnJcAO7Xg7sEKmBuXaGuVkGJjUUG+g7NRkNdeMM
-        1VsGKjDSxhlWZwPScwa5XQzkgKKhshmo24frAXcv/k90g35PKoyMHW9aB4tKbEI3zZy8PHUuZuR4
-        f0ZOSC+Njxxk3qDt/du3sSurOTdz2gzXYx2thxySweDVz6HfyrbC9R9lz8Qydkx4fnwSFEg0MoXS
-        tsGPTOqLP/nyY5IBMEdtG8XZF0qXWflg/iwnzNrn5YW/SrmxvKfdg24QV9+XXq4jiWbWk/kz/MzK
-        6gq/QdkqJd+X1wrgUmKtywUQ/pTUQSzrGvKiVczbp79qsuq8l8cPkLO7CJ/5ONy5uSGLdlVAQTD4
-        pSyK1Sy6dGlGwCmI/mlJxq8FFh2MNyODMXVU6A1uWcTDBUWLjkUimgT1fqD3bV/prFuzQZ0DN/LD
-        9RcAAP//AwBwEqjntBYAAA==
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","untranslatedName":"Epic","subtask":false,"hierarchyLevel":1,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1}]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"customfield_10011":{"required":false,"schema":{"type":"string","custom":"com.pyxis.greenhopper.jira:gh-epic-label","customId":10011},"name":"Epic
+        Name","key":"customfield_10011","hasDefaultValue":false,"operations":["set"]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 9eb5ac84-1189-4e85-9c0a-5a464f57eb36
+      - 42e29019-7b0a-45e4-afd8-b9308cb1928f
       Atl-Traceid:
-      - 9eb5ac8411894e859c0a5a464f57eb36
+      - 42e290197b0a45e4afd8b9308cb1928f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:01 GMT
+      - Wed, 30 Apr 2025 16:28:31 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -131,7 +124,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=312,atl-edge-internal;dur=21,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=287,atl-edge;dur=254,atl-edge-internal;dur=16,atl-edge-upstream;dur=238,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="-jlvkV05zqBE_tJb-54L1YwfA364URn9QDrT8DTxU-yby9cBArxW4Q==",cdn-downstream-fbl;dur=292
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -140,13 +133,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b5141080f2dac9506b5156fa7721b41c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -jlvkV05zqBE_tJb-54L1YwfA364URn9QDrT8DTxU-yby9cBArxW4Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - eff8b9d23d05cbc94fa015c42520fb13
+      - 6413aa331c9f0d26937b569280e4a9de
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -159,7 +160,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/331]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/331 (331)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/121]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -167,7 +168,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}, "customfield_10011": "Zap1:
       Cookie Without Secure Flag"}}'
     headers:
@@ -180,7 +181,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1360'
+      - '1380'
       Content-Type:
       - application/json
       User-Agent:
@@ -189,18 +190,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16136","key":"NTEST-1652","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16136"}'
+      string: '{"id":"18279","key":"NTEST-1892","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18279"}'
     headers:
       Atl-Request-Id:
-      - 821f4ea6-2610-450c-858a-38b31705d942
+      - 3c4f315d-0a57-46b6-894c-2f2b8b17cd21
       Atl-Traceid:
-      - 821f4ea62610450c858a38b31705d942
+      - 3c4f315d0a5746b6894c2f2b8b17cd21
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:02 GMT
+      - Wed, 30 Apr 2025 16:28:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -210,7 +213,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=748,atl-edge-internal;dur=13,atl-edge-upstream;dur=735,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="1-RU1G7fA8P5mImwxFOx5U_rwHHmEuSkP03Ru4SKlAPmzLKajB-0bg==",cdn-downstream-fbl;dur=835,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=831,atl-edge;dur=745,atl-edge-internal;dur=16,atl-edge-upstream;dur=730,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -219,10 +222,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 452324c4cfd54555e3a2d8c074edaf78.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 1-RU1G7fA8P5mImwxFOx5U_rwHHmEuSkP03Ru4SKlAPmzLKajB-0bg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 7639062dd332599e888a72975d52020b
+      - f3ecfc4815afa3dbb4361711bfce3c89
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -246,62 +257,47 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1652
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1892
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX+2/bNhD+Vwj9tGW2JcqO4woYhi5xtm5ZlsVOCzQLAlo6y6wpUiOp2O7jf99R
-        D7vxY1tSrDCQmDzeg3fffTx/8GCZM5l4kadBJqAhOecgEtOSLAPTMvEMMtZSOWhmuZKmBQm3GVjW
-        imdMpiBU2noAbVAGyTXkGgxIW5+NC2NVNnUG72kQ0KCj4a8CjB2vcrjSLLY8Bq/lceef9mm3jwsD
-        YorLmbW5iXw/gSnENlHvVIdZwYzhTHYkWB89WZ/l3A99bkwBfmNgDivUvxwPR+M27R+HuFWGYLzo
-        g2cwtsLEzEKq9Kq6Q4Ir1AiD8Lgd0DYNxmEQ0RdREHaC4+PvMO7ABemcWAy8NPPMIJ2+j/Yqi+W1
-        60UCJtY8d4nD3ZdkwlNSGNAEU6hXxM6YJRIgMcQqMgEy0WoOkiRqITvkVAPeISGTFfmFa0ZGamoX
-        TANp4wEilSWubERpkoAACx3nPVbyRov/cguesRSM7zTM5h7Gh5zHHfOQojUHFzQ1xB1Xw2JimZl7
-        0ZQJAy1vxhE/Op6tLuAB0CX91PIsR4DlCBYvkoUQLW8LLd3gkIA2glyrdxjxMwtSa+8vx2cg2tzu
-        RnJr0YDx1r4dkn8tz5o65+76PMsFx4CTdQbYA7NMY75LFPYGy97gieEWkrtGY+K+suU/cFj4JaCa
-        m9QCGvSCEwwj7C3D3v/r5QfD38P3JmNCoEPaX9L+13C4bDx2w2U3/BoeM2ygIvM+fdqFY9jAccqX
-        rysqxCLf3u2e7DYnWZpqSLFld5oA41SiqFhgP/qPDwn6hwQnBwThQcHgkODFbpwVe1a7C6Xn5UPh
-        RW2KS2bx/ah49+n9WbH6hsf9ypx23Vd+PVWFSxx13PzGbXCZepHVBWCV0Kh9jYV1PVgFV9pz9jWP
-        qwR/2NlzsaKymalCJGfc5IKt6h52la9odu9bQTsnAW3eiu20HaKycE1l24I1qHLNleZ29cwkNup+
-        7wsovzbCcUOoxWPGv1CLhjt73m53hGvMbwvWcBVsAo4W93SMY5O92hSh661AiNL7tnDgkjVjxr1G
-        F1zOz53kDHI34ci4KWhZ5kUpW+9IJYf4UrKJgGtgpgKJrr95Vxc3P726vL94dTq8HA3vh9fXv1+j
-        e2xhg9nCA+MZkCt8A6Qlzi/hhigpVgT5hAtn1D3e5Qt9pSFDQimfeNPZxysUe80LPvIgyN/ryKse
-        TCwsVmbTcI+IBGuUcsnE9qF6PqtTXEJeYHT12hU9xcmiOV3krqMPgXwQhg3Iq1HqmbislNdv7+Pp
-        52lQ3WDxRxbPcSBt8NgYr3yd1jPfFwXcDI6+myqdk7AZFSSUSFRC6csqmokooJ1qJJB1gGNFzlRV
-        bJXlODJLux/4x2vG+KfCbiut2eRxOv+Um8/RmFsBRxG5fctyGpFTpeYcyBtukfIsGUFc4Nh4Llj6
-        0WUHkyNUzMRMGRsNgkHgT7lMkGf9bpfelQbPyuThvd4p4mAVHZF/1STf4J9vS/URToSOoFANqaQO
-        8qwAcoYXxc3f2IrQoEUcGNeXOH0zRNEt/mv3aa+M1NUxXkAn41ZDR+nURxgzV1qOU5uDv49HOzOb
-        iTLuys5rZ+dGziWO0Z8l6UqrpMA5YChTbOwMy+SPMfnOZ5khjJf8rBZtqw5kKa8NhHfEJ7fUWPJH
-        wbTFcX5j8oAqbHzSUvvtyysyipk8cN4NpD4Nq2o8/hyNVsZCZvAeSa44gu0oKvfLCrmMZYxLw/EH
-        AeIRE2ZmE8V0snvibwAAAP//7FldS+QwFP0rRRAUbG1nOjszC+IO7i7sg7gorCDCkElbW5h+0I+p
-        4vrfPTeJsdbGFVnEB8GH2iQ396Y3555zR854Zv/7Y56R5YXFZToBe6FRIE+qsLZalVs1wLGS+RUh
-        v/asNk54bKUhyyqpb2iGsoB4LzPIHMY50BXSZpMwq8GF4eVNQVIH+JCFsmY7HY+O8a2vhPwkh87j
-        MKP8spi2m0OdIiJ4QmGBCVpJFuVlKtaQQgJmM4xWBJmAa4isPXIMxqGgJDGw2LplNxSiVTDhXVMh
-        sy2WWR0HoS2zcO3gi1cUs45QnsFlRodAu9EZwQPlYfXgIhmsGhzQoKedmDvRn+IuovrgyCh6lS9t
-        2zp5y6pC3ApcwvDaKeJCZDQ2WcLmUu29ZDWY0KpBTi13Ts4XZ7/ts2MbxVrcVb1JkVMq023YYUGa
-        ZLvWzu5fJMq6zr8iDZ9X5ImJBXgmZuQBy7b+BVHPN/JGb4R3aUeQgRORz1SaPGonbBhwXGP3Y2nB
-        4EDRRqBbV/G1LUiNPR7w0DdFrIk9QX5dopYJPkt8tDfV1zS8N+CaxIGriZTIPsEnhyeaNIFr0gSu
-        dgbJw3hMyKWYRZec9GtX1aQpo2r8qq9MxDsv3/htiWMdAkhILvwKDibBeDadrbypG4753OXzySia
-        exF9az0JO7wwLaRcXwQB9kD5Ri0Pbr51HAFSkq0XFb8EAQf0QEwT+KtUpx+CwbLA8/0vUz6bTsbz
-        FV9NXWwfsTCa8cPgQFjZHi+2Rz/xJ9fZKctU4bBt+apymspucRD2yKGK5BTNap1wOim7YKyig8J6
-        USDBf/F4hNvuFBmdeb978PE97rcfPr7H/fbFR/cYUBRIUaw47hFSHxQtihrOE3GBqFBJES6B7AIs
-        FxN/NGVehPsXwB4eP940ap9hVF9d2kE1D4eJsW8qGL5JSvtaSvcHdFEqVUX7xJd3y6RPfHkPjz/x
-        ZQBf+jCgCZnmK/D6St69W+rzq2cXG+Y1W+NpwIqReRlxydTbckfDyGdkZiZyTYAwOOCaOOjYtGKs
-        SV6YbZIyzyTLk6+CRv2EJv99zelt8vr/9YWlMW0UO0F//slFE0u3bvNUunz78Kjqy5sdED837j/Y
-        3dtK2fVpWDVrMtwJVrSfynpRy8CpQ04tKgpdv3+6ePRktVogvL27u7sHAAD//wMAG5CBHLEdAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18279","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18279","key":"NTEST-1892","fields":{"statuscategorychangedate":"2025-04-30T18:28:32.412+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1},"timespent":null,"customfield_10030":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10031":null,"customfield_10032":null,"fixVersions":[],"customfield_10033":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"aggregatetimespent":null,"resolution":null,"customfield_10035":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"lastViewed":null,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1892/watchers","watchCount":1,"isWatching":true},"created":"2025-04-30T18:28:32.085+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"customfield_10023":null,"labels":[],"customfield_10026":null,"customfield_10016":null,"customfield_10017":"purple","customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tav:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:32.216+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/331]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/331 (331)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/121]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10011":"Zap1:
+        Cookie Without Secure Flag","customfield_10056":null,"customfield_10012":{"self":"https://defectdojo.atlassian.net/rest/api/2/customFieldOption/10016","value":"To
+        Do","id":"10016"},"customfield_10013":"ghx-label-7","customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10049":null,"customfield_10005":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"aggregatetimeestimate":null,"attachment":[],"customfield_10009":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10047":null,"customfield_10003":null,"customfield_10048":null,"customfield_10004":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1892/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18279/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 19390716-7bff-4950-989f-67ce219ff949
+      - bfde8bce-3c4f-4f93-8fcc-fe12f253d6b1
       Atl-Traceid:
-      - 193907167bff4950989f67ce219ff949
+      - bfde8bce3c4f4f938fccfe12f253d6b1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:02 GMT
+      - Wed, 30 Apr 2025 16:28:32 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -311,7 +307,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=253,atl-edge-internal;dur=14,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=303,atl-edge;dur=270,atl-edge-internal;dur=17,atl-edge-upstream;dur=253,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0y7YuHB4F-9wWQPqRy4taUkOy0TV4bMqHOC9LV68sYanPY5usIWo1w==",cdn-downstream-fbl;dur=306
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -320,10 +316,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5ea7f8bcbac3004590a821cdd0466e1c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0y7YuHB4F-9wWQPqRy4taUkOy0TV4bMqHOC9LV68sYanPY5usIWo1w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 03323cfcde2b58cbdd2e2fe88fd6aec5
+      - a81fead0ece54db477daa9ab42d0b08c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -347,62 +351,47 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16136
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18279
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX+2/bNhD+Vwj9tGW29fAjroBh6BJ3a5dlWeykQLMioKWzzJoiNZKK7T7+9x0p
-        yW4eWpcUKwIkNo+853ffXT54sCmoSL3YUyBSUJC+YMBT3RE0B93RyRJy2pEFKGqYFLoDKTM5GNpJ
-        llRkwGXWuQGlUQbpORQKNAhT301KbWS+sAqvwyAIg56Cv0vQZrYt4EzRxLAEvI7HrP1wFPZH+EUD
-        X+DXpTGFjn0/hQUkJpXvZI8aTrVmVPQEGB8tGZ8WzI98pnUJfqNgBVt8fzqbTGfdcDSM8Mi5oL34
-        g6fRt1In1EAm1baKIcVv+CIKomE3CLthMIuCOHwWB1EvGA5/QL8D66Q1YtBxp+aJTtr3PuqrNLqw
-        6y8p6ESxwiYOT5+TOctIqUERTKHaErOkhgiAVBMjyRzIXMkVCJLKteiRIwUYQ0rmW/KKKUqmcmHW
-        VAHp4gUipCG2bEQqkgIHAz1rPZHiQvH/EgXLaQbaty/0Pg7tQ8GSnr7JUJuFC6qa4ImtYTk3VK+8
-        eEG5ho63ZIgflSy3J3ADaDL81PEMQ4AVCBYvFiXnHe8OWvpBIyiUfIeOPTHv9euHs/4ZVvZBXAhm
-        DCrQ3s62Bexv7q6uU2ujZHnBGTqc7gKlN9RQhWl1YBuMN4PxI90tBbP9RPl1pcu/YbD2HW6aSGpB
-        GAyCQ3QjGmyiwf9r5SfN3sOPOqeco8FwtAlH38LgprHYjzb96FtYzLFPytz79Ok+HMM2nEZtgn4j
-        WLDNZcWRCIurtwiTLFOQYct+sQmGjQAjk7ys6OHhq6M2wWGLIGoVjNsEz+67U7FndbqWauUGhRd3
-        w5oybUkUSyrPP9w7s42C2dZLWfL0mOmC023dTni8pgYnUMXcj2/9ai7sJ4FfqVO2sd3HI1na1DtX
-        X9sDJjIvNqq0tlGpuUTM2Paus1HR7IOzIuwdBmEzK+6mbUdldwVtoIp2oCoUk4qZ7RNT0Dz3B19B
-        +bUShgdcrm8z/olcN6Q68O63TbRrAk7nYGnR4v/upTboWpp5WIDQ9bbAubN+Vzi2yVpSbafRCROr
-        F1ZyDIXdcETSwMuBbu1kuxMhxQQnJZ1zOAeqK8iq+pN3dnLxy8vT65OXR5PT6eR6cn7+xzmaxxbW
-        mC28MFsCOcPhIAyxdgnTRAq+JUg0jFuldni7CX2mIEemcSNe9x4inBB7zQs+siAo3qvYqwYmFhYr
-        s2+4W0SCNcqYoPzupXo/q3PvmoKjdw0XYdEz3Cya22VhO7oN5OMoakBerVJPxGX1eDeUb28/j4Pq
-        Hos/02SFC2mDx0Z5Zeuo3vm+yuFmcfTtVmmNRM0OIcAhUXKpTitv5ryEbqaQznYOziQ5llWxZV7g
-        yizMwx0xbGOM4Y4x/q3it9P5l9j/HMyY4XAQk6s3tAhjciTligF5zQwSsCFTSEpcG19wmn202cHk
-        cJlQvpTaxONgHPgLJlJkSb/fD986hccueRjXO0ksrOID8sWX5Dv89b17PsWN0BIUPkMqqZ08LoEc
-        Yzx4+DvdkjDoEAvGXRBHrycousI/3VE4cJ7aOiZr6OXMKOhJlfkIY2pLy3Cds/D38WpvaXLu/K70
-        XFo9F2IlcI3+LElnSqYlLggTkWFj51gmf4Y5tjZdhtBf8qtcd41syVJRK4jeEp9chdqQP0uqDK7z
-        e5UtT2FvM3Sv3zw/I9OEipb7dlP1w6iqxu2fg+lWG8g1xpEWkiHYDmJ37ipkM5ZTJjTDfwgQj5gw
-        vZxLqtL7N/4BAAD//+xZbUvcQBD+K0EQFEzMXXK9u4LYw7bQD9KiUEGEY2+TmMDlhbxcFOt/7zO7
-        e2uMWStSxA/Cfchld2dndmeeeWYiZzyR//XBz0jywuLSnYC9qFFQnlRhbbXKt2qAYyX9K4J/HVht
-        nPDYSkOWVbK+oRlKAuy9ylDmMM6BrihtNgmzGgQML28LKnWAD1koGYTT0egUd30tyk9S6CIOM/Iv
-        i2m5OapTWARNyCxQRCvJorxMxRqqkIDZDKMVQSbgGkXWASkG4aigJE2x2Lplt2SiVTChXVPBsy2W
-        WR0FUVtm4drBjVdks7ZQnsFVRodAu9EZQQOlYbVVkQRWDQ5oUNOOzR3rzxCLyD44MrJe+Uvbtk7e
-        sqoQUYEgDG+cIi6ER2OTJWQu1d5LVoOXrRr41HLv58Xi/Jd9fmojQYtY1ZsUObkyRcMeC9Ik27f2
-        9v/AUdZ1/hlu+DQjTzQL6Cc5E86NgHM7/4KopxuNxq+EdylHkIGfwp8pNY2onbBhwHGN3Q+pBYMD
-        SRuG7lzHN7ZgO7Y3oKHfBfC6RMoSpJNIcH+qJv+9AV/T8N6Aa1rhaiIlvE/wyeGJpprANdUErlbm
-        ERnppyR4FuMxwZpMeFWTpoyy8YtumYh3Xr7yboljHQNIiOz/CI4mgTebzlajqRt6fO7y+WQczUcR
-        3bWehB2emRaSry+CAHsgfSOXB7dfOooAKUnWs60ACQIO6IGYJvBXlaN+CAbLgpHvf5ry2XTizVd8
-        NXWxfcTCaMaPgyMhZddb7I6/4yfX2SnLVOKwbfmqcprKbnEQ9tihjOQUzWqdcDopu2CsooPCepEg
-        wX/xeIJod4qMzrzfVnj/Gvf7Eu9f435f471rDIwKZImuOO4JXB8ULYoazhMRQJSoZAktEe4SLBcT
-        vzVlXoSHl8AeHj9EGvXVMKpDl3ZQzcNhYuybEoZvKqV9XUqXKnF9wMibOcwHjLyFxh8wMgAjfRgw
-        UVBfEzLNX2DOtQzKO/oAoJ5daJLXbI2nAfFG5mXEJVNvyx0PI5+RmRktM1I2bXJvwDOt8DTJC7NN
-        UuaZJHLyVdCoT2jy70tOb5PX/6+rK4VpodgJ9efvXDSxto1khIBU+W77qPLLqxUQnxsPt3IPdlJ2
-        cxZWzZoEd4wV7aeyXtTScOqQU4uKTNfvHy8eP1qtFght7+/v/wIAAP//AwA2GDZWsR0AAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18279","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18279","key":"NTEST-1892","fields":{"statuscategorychangedate":"2025-04-30T18:28:32.412+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1},"timespent":null,"customfield_10030":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10031":null,"customfield_10032":null,"fixVersions":[],"customfield_10033":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"aggregatetimespent":null,"resolution":null,"customfield_10035":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"lastViewed":null,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1892/watchers","watchCount":1,"isWatching":true},"created":"2025-04-30T18:28:32.085+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"customfield_10023":null,"labels":[],"customfield_10026":null,"customfield_10016":null,"customfield_10017":"purple","customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tav:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:32.216+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/331]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/331 (331)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/121]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10011":"Zap1:
+        Cookie Without Secure Flag","customfield_10056":null,"customfield_10012":{"self":"https://defectdojo.atlassian.net/rest/api/2/customFieldOption/10016","value":"To
+        Do","id":"10016"},"customfield_10013":"ghx-label-7","customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10049":null,"customfield_10005":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"aggregatetimeestimate":null,"attachment":[],"customfield_10009":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10047":null,"customfield_10003":null,"customfield_10048":null,"customfield_10004":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1892/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18279/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a0015bd6-7031-4f2c-8ea5-988511b0b928
+      - aec2a5b0-e095-465b-8128-fb5f239bb31d
       Atl-Traceid:
-      - a0015bd670314f2c8ea5988511b0b928
+      - aec2a5b0e095465b8128fb5f239bb31d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:02 GMT
+      - Wed, 30 Apr 2025 16:28:33 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -412,7 +401,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=289,atl-edge-internal;dur=14,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="Lf-RyF7zhgdPjdToRxXaXlR3Pa_HwG8DaZwJSidUS1bQ-oIvY5OWKw==",cdn-downstream-fbl;dur=359,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=357,atl-edge;dur=268,atl-edge-internal;dur=19,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -421,10 +410,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Lf-RyF7zhgdPjdToRxXaXlR3Pa_HwG8DaZwJSidUS1bQ-oIvY5OWKw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - dddc3f48d00a511964f9aa1bcb33fac0
+      - 6e727b6ba762432b4aac7f068fa6b697
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -451,26 +448,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL2q1b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmCzBGgCy4oxnmc8D2KACwhwyLvwBxyqtjtnKVQMOF1yyFLKim9W
-        djdG2QDmdL6QAnCGStKsQJErlSuQii2z2aJW8xzZXAE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMA5F85+iACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:33.829+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 6eb55f97-e259-4485-8110-c83c62b8f504
+      - 9fdd9ea2-17c9-44e8-8a65-7484c13f6b2d
       Atl-Traceid:
-      - 6eb55f97e25944858110c83c62b8f504
+      - 9fdd9ea217c944e88a657484c13f6b2d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:03 GMT
+      - Wed, 30 Apr 2025 16:28:33 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -480,7 +473,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=180,atl-edge-internal;dur=15,atl-edge-upstream;dur=166,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="5BugPBxoS4frxVs7iUNxvFYHw2Le41ltk0TPHbPY7svzw9b0JW5BMg==",cdn-downstream-fbl;dur=246,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=244,atl-edge;dur=159,atl-edge-internal;dur=14,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -489,10 +482,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 48f2e5da4dd7651bfa3bfd0054610cf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 5BugPBxoS4frxVs7iUNxvFYHw2Le41ltk0TPHbPY7svzw9b0JW5BMg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 8f0d9b813d155fa8df4e25cdc4cc50aa
+      - c1a9d0dff5cb3e278a1c4e91357b3e79
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -519,42 +520,31 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Epic&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xWW0/bMBT+K1aeS0JLxVClaZqASWwTmsTlZULIbU5bg2NnttMmQ/3vO6e5OKVs
-        S9nGXshTfHIu37G/88UPAeQpV3EwClKj72DibNDzr6OvD95BWJuBK1IgFwtyira5c6kdRVEMUwyI
-        9Z0OuZPcWsFVqMBFBqyLeCqiQVRljfr7+GAKQUnrxT0UuDq/PL24xJXiCeDySgnnMAEV5AvuuLky
-        ElE9BMOjfHi0Y/1MiQUYy+VtmStaCFhG1FADrfrQ3x/uv8Gag2E+GP7bKu+s+A5vbcKlxIL9w7x/
-        +BIF87riwSA/GLxExQRikSXBqtfmEfHrGUxqMjzNpRjsxIjUCa3Q+p6NxYxlFgyzTpuCuTl3TAHE
-        ljnNxsDGRt+DYrFeqpAdG+AOYjYu2EdhOLvQU7fkBtgeOjClHcNGHNOGxSDBQUjVJ1ohM7t0IRI+
-        AxtRhPV92AhSMQntYubJf4oWXGXKGa6sJFDnG19sNnbc3gejKZcWesFcgOFmMi8+wwIQTL/nZ3cq
-        QMY0RtULjpDNkoSbgl4NfMuEAXR0JsNMdjKHhNMXAofh1hmhCJstrIOELFX0qsF7UVnqWa49EBi3
-        JzDlmXTXXGbQANYpAqZTIiIgD1xw06ZHJ2TeuwXOGz28M7Kxy9KzRNiO7YTxBmVISr2EeO30yt8O
-        /P0tS1d06BOdpFqBon9O+9SroK1j58ZwopbAA8cQH9+mQSup58GxN9Y8aPl1JELA45gqAdUzkOgF
-        BE+QgzrbOMwurW3PWjuFb+SkZa07aXt2baWeu0q6O01d7dsCWZs8wC+NUwnOB+0AbHtTnzVxf3b3
-        qKJJPD6V2lYNFW2ASFIpUFb9kb5eVf5mwf93VSmVKUPVTda/zVskTL+/4xSX8cFaZcK0yIUNZwZA
-        zXWKbA/vUKNHs/ke6eee5GOgTsuYM0y/ruhHijSVrW8BjXZtwdtpvFZ0I8ivcYtKc5fWHmsvbXAp
-        OI0YtHN69B9EzipnL75t112g9yoN/rX6pkZoI9yjW87POmu8N3StsrWFrXGrla0xbDVQKug2/icA
-        P1PZhP4BAAD//7xYwW6DMAz9lx16XLaWHhHabZOYVKm79kAZAlQGGxBVPfTfZ8cJOINJlKAea7Dz
-        Yr/afuDZAis/d5DrIDkYsjzNILo9y1/JiCeoxgnJcAO7Xg7sEKmBuXaGuVkGJjUUG+g7NRkNdeMM
-        1VsGKjDSxhlWZwPScwa5XQzkgKKhshmo24frAXcv/k90g35PKoyMHW9aB4tKbEI3zZy8PHUuZuR4
-        f0ZOSC+Njxxk3qDt/du3sSurOTdz2gzXYx2thxySweDVz6HfyrbC9R9lz8Qydkx4fnwSFEg0MoXS
-        tsGPTOqLP/nyY5IBMEdtG8XZF0qXWflg/iwnzNrn5YW/SrmxvKfdg24QV9+XXq4jiWbWk/kz/MzK
-        6gq/QdkqJd+X1wrgUmKtywUQ/pTUQSzrGvKiVczbp79qsuq8l8cPkLO7CJ/5ONy5uSGLdlVAQTD4
-        pSyK1Sy6dGlGwCmI/mlJxq8FFh2MNyODMXVU6A1uWcTDBUWLjkUimgT1fqD3bV/prFuzQZ0DN/LD
-        9RcAAP//AwBwEqjntBYAAA==
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","untranslatedName":"Epic","subtask":false,"hierarchyLevel":1,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1}]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"customfield_10011":{"required":false,"schema":{"type":"string","custom":"com.pyxis.greenhopper.jira:gh-epic-label","customId":10011},"name":"Epic
+        Name","key":"customfield_10011","hasDefaultValue":false,"operations":["set"]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - b4c451ce-34e8-4960-affa-7c166472f625
+      - 9ff3fabe-0008-410b-82dc-2834ebbde811
       Atl-Traceid:
-      - b4c451ce34e84960affa7c166472f625
+      - 9ff3fabe0008410b82dc2834ebbde811
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:03 GMT
+      - Wed, 30 Apr 2025 16:28:34 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -564,7 +554,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=278,atl-edge-internal;dur=24,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="jJFPpr10iA9f1L69XebJMfmlYolNKmH0d_Uq1kSg_WLk1oGpBNYn_A==",cdn-downstream-fbl;dur=397,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=101,cdn-upstream-fbl;dur=394,atl-edge;dur=257,atl-edge-internal;dur=18,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -573,13 +563,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a65725dd05dc27eea7ae75a2e122228e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - jJFPpr10iA9f1L69XebJMfmlYolNKmH0d_Uq1kSg_WLk1oGpBNYn_A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - f772f21f4765eb558c177cc5de3582c9
+      - 0513450174a52dcde1221024c2cafefe
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -592,7 +590,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/332]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/332 (332)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/121]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -600,7 +598,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}, "customfield_10011": "Zap2:
       Cookie Without Secure Flag"}}'
     headers:
@@ -613,7 +611,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1360'
+      - '1380'
       Content-Type:
       - application/json
       User-Agent:
@@ -622,18 +620,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16137","key":"NTEST-1653","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16137"}'
+      string: '{"id":"18281","key":"NTEST-1893","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18281"}'
     headers:
       Atl-Request-Id:
-      - 22e67920-6a90-42a5-8339-b52afd8a02f4
+      - 1788d899-7cb6-4a29-82a8-4963ac0a932a
       Atl-Traceid:
-      - 22e679206a9042a58339b52afd8a02f4
+      - 1788d8997cb64a2982a84963ac0a932a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:04 GMT
+      - Wed, 30 Apr 2025 16:28:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -643,7 +643,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=725,atl-edge-internal;dur=26,atl-edge-upstream;dur=695,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=750,atl-edge;dur=717,atl-edge-internal;dur=14,atl-edge-upstream;dur=703,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="aNEpnh-QrzCxPryEvy2_l_x-zHqSSgQ_jj9Xv8pFtu1xMOZ99cKUUg==",cdn-downstream-fbl;dur=755
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -652,10 +652,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 de5b26aba33b480d2b740b96a34fe916.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - aNEpnh-QrzCxPryEvy2_l_x-zHqSSgQ_jj9Xv8pFtu1xMOZ99cKUUg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 75798405e039fc60984d52739c368345
+      - b2231863ec4c01795c45ba0f6b614127
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -679,62 +687,47 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1653
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1893
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX+08jNxD+V6z9qaXJvpJwuZWq6gqhvZZSSgJIRxFydicbE6+9tb0kgeN/73gf
-        CZCkLZx6QjpYjz2Pb7553IMDi5yKxIkcBSIBBckRA57olqAZ6JaOp5DRlsxBUcOk0C1ImMnA0FY8
-        pSIFLtPWHSiNMkjOIFegQZj6blxoI7OJVXgT+H7guwr+KkCb0TKHU0Vjw2JwWg6z9oP9oPMOPzTw
-        CX5Ojcl15HkJTCA2ibyVLjWcas2ocAUYDy0Zj+bMCz2mdQFeo2AGS3x/MhoMR+1gv9fBo9IF7UQP
-        jkbfCh1TA6lUyyqGBL/wReiHvbYftAN/FPpR8D7yu27Y879Dv33rpDVi0PFSzRudtO891FdpLMOu
-        PxLQsWK5BQ5PP5AxS0mhQRGEUC2JmVJDBECiiZFkDGSs5AwESeRcuORAAcaQkPGS/MIUJUM5MXOq
-        gLTxAhHSEJs2IhVJgIMB11qPpThX/L9EwTKagvbsC72OQ3uQs9jVdylqs3RBVQM8sTksxobqmRNN
-        KNfQcqYM+aPi6fIY7gBNBo8txzAkWI5kcSJRcN5yXrCl4zeCXMlbdOyNuNevt6P+hCvrIM4FMwYV
-        aGdl2xL21/KurqG1UbIs5wwdTlaB0jtqqEJYS7J1+4tu/5XuFoLZeqL8ptLl3TGYeyVvmkhqQeB3
-        fcv3sLsIu/+vlR80u4fvdUY5R4PB/iLY/xoGF43FTrjohF/DYoZ1UmTO4+MmHYNdPA0bwYQtLqpW
-        iNm/ut682Wlu0jRVkGLJbhQBBiB5UXWB7eZ6uwT7uwTvdgjCnYL+LsH7TT+r7lmdzqWalYPCidpB
-        3TJtShSLq5AeNs5soSDaeioLnhwynXO6rMsJj+fU4ASqOvfrS7+aC+tJ4FXqlC3s8s8DWVjoS1cv
-        7QETqRMZVVjbqNRcIGdseddoVG1266zouP1+v5kVL2FbtbKXgl2kClekyhWTipnlGyFonnvdL2j5
-        tRKGB1zOn3f8YzlvmmrX2SybcMV5Tsdg2+KWwgh3Ude2me0CpK6DNbTcBDvoW6imVNtZdMzE7MhK
-        DiG3+42IG3KVlJuXstWJkGKAc5KOOZwB1RVhVf2Xc3p8/tPHk5vjjweDk+HgZnB29vsZmscC1ogV
-        XhhNgZziaBCGWLuEaSIFXxJsM4xbpXZ0l/P5VEGGfaYc8Nrd1m4CrDTH/8x8P7+/j5xqXGJaMS/r
-        cnvWRjBDKROUv7xUb2c18mVJcPSu/rYpT3GvaG4Xua3n7RTvun4QNhSvFqk3srJ6vBrJz3ef1xF1
-        zcQfaTzDdbRhY6O8snVQb3xf5HCzNnphbSRsNggBtgpiyaU6qbwZ8wLaqaKWobWDI0kOZZVsmeW4
-        MAuzvR56u/pFb9Uv/injz+H8U6x/9kbMcNiLyNUnmocROZByxoBcMoPt15AhxAUujUecpp8tOggO
-        lzHlU6lN1Pf7vjdhIsEe6XU64XWp8LAED+O6lcTSKtoj//qSfIP/fFs+H+I+aNsTPsNGUjt5WAA5
-        xHjw8De6JIHfIpaMqyAOLgcousJf7f2gW3pq8xjPwc2YUeBKlXpIY2pTy3CZs/T38Ko7NRkv/a70
-        XFg952ImcIl+AtKpkkmB68FApFjYGabJGyHG1maJEPpLfpbztpE7UMprBeE18chVoA35o6DK4DK/
-        VrnjKaxtBuXrTx9OyTCmYsd9u6d6QRisonoSx3CpDWQa40hyyZBse1F5XmbIIpZRJjTD/w4gHxEw
-        PR1LqpJtN/4GAAD//+xZbUvjQBD+K0EQFExM2/TaHohXvDu4D3KHwgkilO0mMYHmhWxiFM//fs/s
-        rmuMWU/kED8I/ZA2m3nLzDPPTOnEE/lfH/KMJC8drtIJ2IsJBcOJiGqn1blVAxyFyq8Y+bXntEnK
-        EyeLWC7UdEMntAT4e5FjyGGcA10x2FylzGlQMLy6KWnQAT7kkeIPXseiY7zrSzl8kkFnSZRTfjnM
-        yC0wm8IjWEJugSA6aR4XVSafofkImM1wVxBkAq4xYu2RYRCO+UmRFIdtWnZDLjolk9Y1ApntsNzp
-        GIjJMo82Ht64IJ+NhyoGFzkFgbRRjGCBtlDcm0gCRYMADVra8bnj/QlqEd0HISPvdb60besVLROl
-        rAoUYXTtlUkpMxpKVpC50rpXrAYrWzfIqdXOz7Pl6S/39NhFe5a1apSUBaUyVcMOC7M033V2dv8g
-        UTZ18Rlp+LQjTw0H6Dc5G86NgHNb/4Kop4pG41fCu5IjycBPmc/UmkA+0D0ZcNxg90Nrwc2Bpg1H
-        ty6Ta1dyHXdEbaJ/JLC5bHg9QXtdoZlJMkrkuHfUt40AgaHn/SdsPMo3I4DMS8kzhw/aRgLf6HzE
-        Rvo9CanFeEK4pjqeaLKMUTt+0Wsm3l1Ur3y5RLIOgSTE9X+EB9NwMp/N16OZH034wueL6ThejGJ6
-        2eYQNDxzLKJkX4YhdKB/o5mHN186hgAqSdazmwCFAh74gTwmAVhPo0EECsvCURB8mvH5bDpZrPl6
-        5kN9zKJ4zg/DAylle7LcHn/HRz3nZizXncN11U/Ca4TbIhDu2KOW5JXNepNyipRbMiYoUHhedkgQ
-        YFweody9MqeY97cK79/i/lri/VvcX2u8d4sBRaGa0DXJPULqg6PFccN5KguIOpWaoBWQnYPm4uC3
-        pirKaP8cEMOTh0qjtRrumtIlDXp3OMyMA1vHCGyTdGAm6Up3rg8YebOE+YCRt7D4A0YGYKQPAzYO
-        GhhCZvgL3LlURXlL+3997cOSomYbXA2It1Ey34ZL/ngY4KxMzeqAbYvr26gmQcjgjYn1hiF5UX6V
-        VkWuiJz6KWz0P2jq64uiV2RKwu39pYb7V+By58+//Xu5e1sZuz6JRLMhwR3dch1U1cta2XFV1P9v
-        uayEGaHQhUH4dyG3aWafXVRyR0UqjSGPrR0/Mlc/IMNzd3f3FwAA//8DAGqOB6iwHQAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18281","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18281","key":"NTEST-1893","fields":{"statuscategorychangedate":"2025-04-30T18:28:35.157+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1},"timespent":null,"customfield_10030":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10031":null,"customfield_10032":null,"fixVersions":[],"customfield_10033":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"aggregatetimespent":null,"resolution":null,"customfield_10035":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"lastViewed":null,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1893/watchers","watchCount":1,"isWatching":true},"created":"2025-04-30T18:28:34.855+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"customfield_10023":null,"labels":[],"customfield_10026":null,"customfield_10016":null,"customfield_10017":"grey","customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tb3:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:34.964+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/332]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/332 (332)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/121]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10011":"Zap2:
+        Cookie Without Secure Flag","customfield_10056":null,"customfield_10012":{"self":"https://defectdojo.atlassian.net/rest/api/2/customFieldOption/10016","value":"To
+        Do","id":"10016"},"customfield_10013":"ghx-label-12","customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10049":null,"customfield_10005":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"aggregatetimeestimate":null,"attachment":[],"customfield_10009":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10047":null,"customfield_10003":null,"customfield_10048":null,"customfield_10004":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1893/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18281/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - a077d7ce-313e-4993-aa76-487753766ec8
+      - 1e082183-d900-44ff-b4e7-6a99a351f543
       Atl-Traceid:
-      - a077d7ce313e4993aa76487753766ec8
+      - 1e082183d90044ffb4e76a99a351f543
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:04 GMT
+      - Wed, 30 Apr 2025 16:28:35 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -744,7 +737,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=279,atl-edge-internal;dur=41,atl-edge-upstream;dur=237,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="KikHThxoPO-1VMkYMXLxkF5UjQjFVOt8vsHj1hmYmysU3SrtLOkOvg==",cdn-downstream-fbl;dur=357,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=354,atl-edge;dur=267,atl-edge-internal;dur=15,atl-edge-upstream;dur=252,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -753,10 +746,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9a3eef6ee6df44793fb3d5e366a7238.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - KikHThxoPO-1VMkYMXLxkF5UjQjFVOt8vsHj1hmYmysU3SrtLOkOvg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 22b59026a4b77ee1020bb3cf9055b403
+      - 364bb5bb767d761153775d5d99a91369
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -780,62 +781,47 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16137
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18281
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xX+08jNxD+V6z9qaXJvhK43EpVdQ2hvSulKQkgHUXI2Z1sfPHaW9tLEjj+9473
-        kfBIeoVTT0iQeOx5fvPNcOfAMqcicSJHgUhAQXLEgCe6JWgGuqXjGWS0JXNQ1DApdAsSZjIwtBXP
-        qEiBy7R1A0qjDJJTyBVoEKa+GxfayGxqFV4Hvh/4roK/C9BmvMphqGhsWAxOy2HWfnAQdN7gFw18
-        il9nxuQ68rwEphCbRH6SLjWcas2ocAUYDy0Zj+bMCz2mdQFeo2AOK3x/Mh6Mxu3gYL+DR6UL2onu
-        HI2+FTqmBlKpVlUMCX7DF6Ef7rf9oB3449CPgreR33XDff8H9Nu3TlojBh0v1bzSSfveQ32VxjLs
-        +ksCOlYst4nD03dkwlJSaFAEU6hWxMyoIQIg0cRIMgEyUXIOgiRyIVzSV4AxJGSyIh+YomQkp2ZB
-        FZA2XiBCGmLLRqQiCXAw4FrrsRRniv+XKFhGU9CefaE3cWgPcha7+iZFbRYuqGqAJ7aGxcRQPXei
-        KeUaWs6MIX5UPFsdww2gyeC+5RiGAMsRLE4kCs5bzhO0dPxGkCv5CR17Zd7r19uz/gArmyDOBDMG
-        FWhnbdsC9rfyrq5Ta6NkWc4ZOpysA6U31FCFaS3B1u0tu70XulsIZvuJ8utKl3fDYOGVuGkiqQWB
-        3/Ut3sPuMuz+v1Z+0uwWftQZ5RwNBgfL4OBbGFw2FjvhshN+C4sZ9kmROff3z+EY7MJpuEvQaQRT
-        tjyvOBJhcXmFMElTBSm27BebYL8RYGSSFxU9bL96sEvwZocg3Cno7RK8fe5OxZ7V6UKqeTkonKgd
-        1JRpS6JYXHl+9+zMNgpmW89kwZNDpnNOV3U74THW1pxj3WyL1SaowZlUcfnLyaCaFJvZ4FXqlG31
-        8mNfFrYYpfMX9oCJ1ImMKqw3cUWzW2dFx+31es2seJq2NZU9FewCVbgGVa6YVMysXhlw89zrfgXl
-        10oYHnC5eMz4x3LRkGrXed424boJOJ2ApUWL/6eXdkHX0sx2AULXwR5aPU920LOpmlFtZ9ExE/Mj
-        KzmE3O43Im7AVUJuUcrWJ0KKAc5JOuFwClRXgFX1J2d4fPbL+5Pr4/f9wclocD04Pf3jFM1jA2vM
-        FV4Yz4AMcTQIQ6xdwjSRgq8I0gzjVqkd3eV8HirIkGfKAa/dbXQTYKc5/mfm+/ntbeRU4xLLinXZ
-        tNsjGsEKpUxQ/vRSvZ3VmS8bgKN3DRNhyVPcK5rbRW77eTvEu64fhA3Eq0XqlaisHq9H8uPd52VA
-        3SDxZxrPcR1t0Ngor2z1643vqxxu1kYvrI2EzQYhwHZBLLlUJ5U3E15AO1XUIrR2cCzJoayKLbMc
-        F2ZhtvfD/i6+2F/zxb9V/HE6/xKbn70xMxz2InL5keZhRPpSzhmQC2aQfg0ZQVzg0njEafrZZgeT
-        w2VM+UxqE/X8nu9NmUiQEb1OJ7wqFR6WycO4PkliYRXtkS++JN/hr+/L5yPcBy094TMkktrJwwLI
-        IcaDh7/TFQn8FrFgXAfRvxig6BL/tA+CbumprWO8ADdjRoErVeohjKktLcNlzsLfw6vuzGS89LvS
-        c271nIm5wCX6QZKGSiYFrgcDkWJjZ1gmb4w5tjbLDKG/5Fe5aBu5I0t5rSC8Ih65DLQhfxZUGVzm
-        Nyp3PIWNzaB8/fHdkIxiKnbct3uqF4TBOqoHcYxW2kCmMY4klwzBtheV52WFbMYyyoRm+O8A4hET
-        pmcTSVWy7cY/AAAA///sWV1L40AU/StBEBRMTNt02y6IW9xd2AdxUVhBhDKdJKbQfJBJjOL63z13
-        ZjrGmHFFFvFB6EPamblfuXPuube045n87495RpLnDlfpBOxFh4LmRESV0+jcqgCOQuVXjPzac5pk
-        xRMnjVgmVHdDO7QE+HuZoclhnANd0dhcr5hT48Lw8ragRgf4kEWKP3gti47xrq9k80kGnSdRRvnl
-        MCM3R28Kj2AJuQWC6KyyOC9TeYb6I2A2w6ogyARco8XaI8MgHP2TIikOWzfsllx0CiatqwUy22GZ
-        0zIQnWUWrT28cUE+Gw9VDC4zCgJpoxjBAm2h2JhIAkWNAPVa2vK55f0p7iKqD0JG3ut8aZrGyxsm
-        CnkrcAmjG69ICpnRULKAzIXWvWAVWNmyRk4tdk7O52e/3bNjF+VZ3lWjpMgplek27LAwXWW7zs7u
-        XyTKusq/Ig2fV+Sx4QDdImfDuQFwbutfEPVc0WD4RnhXciQZOJH5TKUJ5APVkwHHDXY/lhYs9hRt
-        OLp1ldy4kuu4AyoT3S1BG8GrEjVLMkziwN2thvt3FnzbQmDoefeEjUf5pgWQeSl5Zv9GW0vgG51P
-        2Ei3JiG1GE8I11TFE3WaMirHr3rNxLvz8o0vl0jWIZCEmP2v8GAcjqaT6XIw8aMRn/l8Nh7Gs0FM
-        L9tsgoYXtkWU7PMwhA7UbxTz8PZbyxBAJcl6cRKgUMADP5DbJADrbjSIQGFZOAiCLxM+nYxHsyVf
-        Tnyoj1kUT/lheCClbI/m28Of+KhzbsoyXTlcV/0kvFq4DQLhDj0qSV5RL9crTpFyC8YEBQrnZYUE
-        AcbjEa67V2QU8+5U4eNb3B1LfHyLu2ONj24xMCpUHbomuUdIfXC0OK45X8kLRJVK9csK4S5Ac7Hx
-        R13mRbR/AYjhyeNNo7EaVs3VJQ16dtjPjANbxQhsnXRgOulSV65PGHm3hPmEkfew+BNGemCkCwM2
-        DhoYQmb4C9y5Upfyjub/+tmHJXnF1njqEW+jZL4Nl/xhP8BZmZrVAdsU1zeedU/YuNzIumBIXpRd
-        r8o8U0RO/RTW+h809fVV0ctTJeFu86jh/g243Przb38jd28rZTenkajXJLilW46DympeKTuu8+r/
-        jZKVMCMUutAI/8nlNG0zz6YBOc2oSKUx5Km1wyfm6gMyPPf39w8AAAD//wMAgrOUmLAdAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18281","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18281","key":"NTEST-1893","fields":{"statuscategorychangedate":"2025-04-30T18:28:35.157+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10000","id":"10000","description":"A
+        big user story that needs to be broken down. Created by Jira Software - do
+        not edit or delete.","iconUrl":"https://defectdojo.atlassian.net/images/icons/issuetypes/epic.svg","name":"Epic","subtask":false,"hierarchyLevel":1},"timespent":null,"customfield_10030":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10031":null,"customfield_10032":null,"fixVersions":[],"customfield_10033":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"aggregatetimespent":null,"resolution":null,"customfield_10035":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"lastViewed":null,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1893/watchers","watchCount":1,"isWatching":true},"created":"2025-04-30T18:28:34.855+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"customfield_10023":null,"labels":[],"customfield_10026":null,"customfield_10016":null,"customfield_10017":"grey","customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tb3:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:34.964+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/332]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/332 (332)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/121]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10011":"Zap2:
+        Cookie Without Secure Flag","customfield_10056":null,"customfield_10012":{"self":"https://defectdojo.atlassian.net/rest/api/2/customFieldOption/10016","value":"To
+        Do","id":"10016"},"customfield_10013":"ghx-label-12","customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10049":null,"customfield_10005":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"aggregatetimeestimate":null,"attachment":[],"customfield_10009":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10047":null,"customfield_10003":null,"customfield_10048":null,"customfield_10004":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1893/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18281/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f849b431-d964-4c1c-adb4-c929c10da50f
+      - 62bc0e50-2109-441f-9272-18f311c3b564
       Atl-Traceid:
-      - f849b431d9644c1cadb4c929c10da50f
+      - 62bc0e502109441f927218f311c3b564
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:04 GMT
+      - Wed, 30 Apr 2025 16:28:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -845,7 +831,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=270,atl-edge-internal;dur=15,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=273,atl-edge;dur=240,atl-edge-internal;dur=15,atl-edge-upstream;dur=225,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="WjR853BifEHGZ_WoZ2yUHUynZtxjPM4xLY7XQj-c2WwVM4WJ140euA==",cdn-downstream-fbl;dur=278
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -854,10 +840,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - WjR853BifEHGZ_WoZ2yUHUynZtxjPM4xLY7XQj-c2WwVM4WJ140euA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 146dbddc7a91034aec41131e557b6d8f
+      - 43719126ec8130ab1de6c1b2f01672fa
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -890,7 +884,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -904,9 +898,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:34794\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:51418\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -942,7 +936,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:19:04 GMT
+      - Wed, 30 Apr 2025 16:28:36 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/121", "url_api": "http://localhost:8080/api/v2/tests/121/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      121, "url_ui": "http://localhost:8080/test/121", "url_api": "http://localhost:8080/api/v2/tests/121/"},
+      "finding_count": 2, "findings": {"new": [{"id": 331, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/331",
+      "url_api": "http://localhost:8080/api/v2/findings/331/"}, {"id": 332, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/332",
+      "url_api": "http://localhost:8080/api/v2/findings/332/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:51426\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/121\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/121/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 121, \\\"url_ui\\\": \\\"http://localhost:8080/test/121\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/121/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 331, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/331\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/331/\\\"},
+        {\\\"id\\\": 332, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/332\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/332/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 331,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/331/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/331\"\n        },\n
+        \       {\n          \"id\": 332,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/332/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/332\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        121,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/121/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/121\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/121/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/121\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:36 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_is_false.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_is_false.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:34800\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:51440\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:19:05 GMT
+      - Wed, 30 Apr 2025 16:28:36 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/122", "url_api": "http://localhost:8080/api/v2/tests/122/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      122, "url_ui": "http://localhost:8080/test/122", "url_api": "http://localhost:8080/api/v2/tests/122/"},
+      "finding_count": 2, "findings": {"new": [{"id": 333, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/333",
+      "url_api": "http://localhost:8080/api/v2/findings/333/"}, {"id": 334, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/334",
+      "url_api": "http://localhost:8080/api/v2/findings/334/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:51456\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/122\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/122/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 122, \\\"url_ui\\\": \\\"http://localhost:8080/test/122\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/122/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 333, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/333\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/333/\\\"},
+        {\\\"id\\\": 334, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/334\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/334/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 333,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/333/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/333\"\n        },\n
+        \       {\n          \"id\": 334,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/334/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/334\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        122,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/122/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/122\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/122/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/122\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:36 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_is_false_but_push_all.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_is_false_but_push_all.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1nZb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwCbz0/NK+EjyIDlCdAElhVjPJvxLIgBLiDAIe/CH3Co2u6cpVAx4HTJIU8Lmn+z
-        srsxygYwo8VCCsAclaSzOYpMqUyBVGw5yxe1KjJkhQJ2JvA6Gm7bQcQXohKj9ndWitg+EH2qCJrX
-        bUmO54c9WRMn1/cVOX4CAAD//wMAoY57USACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:36.874+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 0ac789af-2fb0-4d64-8c7f-761c76cbfd0e
+      - d992a220-1d86-4935-9a52-6e1cc51414ae
       Atl-Traceid:
-      - 0ac789af2fb04d648c7f761c76cbfd0e
+      - d992a2201d8649359a526e1cc51414ae
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:05 GMT
+      - Wed, 30 Apr 2025 16:28:36 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=156,atl-edge-internal;dur=12,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="Blr8fZuM5AxqAJFa_9DTseCKHJrqoZrJmGl5FU9G3oD9Q0K3cduvEg==",cdn-downstream-fbl;dur=250,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=68,cdn-upstream-fbl;dur=247,atl-edge;dur=155,atl-edge-internal;dur=15,atl-edge-upstream;dur=140,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 57f0537bdb26692a5be92bbbe93e4ea2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Blr8fZuM5AxqAJFa_9DTseCKHJrqoZrJmGl5FU9G3oD9Q0K3cduvEg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - c07e995096843691552c16905943405d
+      - 742652b39844b9bf07cae1d0dcc7d80c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 62437afc-9c45-46b2-af27-11f1280f0469
+      - 56dc45d7-38bd-46cf-be95-c8ff565958a9
       Atl-Traceid:
-      - 62437afc9c4546b2af2711f1280f0469
+      - 56dc45d738bd46cfbe95c8ff565958a9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:05 GMT
+      - Wed, 30 Apr 2025 16:28:37 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=223,atl-edge-internal;dur=14,atl-edge-upstream;dur=210,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="TgSjaDfdyf_V9ikthbUt0yx1jEsUBmKvAJ0Ssh-rlQk2De-Yu50VzQ==",cdn-downstream-fbl;dur=359,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=56,cdn-upstream-fbl;dur=356,atl-edge;dur=281,atl-edge-internal;dur=16,atl-edge-upstream;dur=265,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 05df0d22c8cc3d4b946b6f2dc43d6b9c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - TgSjaDfdyf_V9ikthbUt0yx1jEsUBmKvAJ0Ssh-rlQk2De-Yu50VzQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 6310e8b8a070c03e694cf07d858709fa
+      - 5923138c9dfb6d110617d38a9deabbeb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/335]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/335 (335)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/123]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16138","key":"NTEST-1654","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16138"}'
+      string: '{"id":"18283","key":"NTEST-1894","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18283"}'
     headers:
       Atl-Request-Id:
-      - fdaf88fb-3679-4d87-93c9-efdb913590ed
+      - 39473f85-6652-4295-ad5e-c5bcde5623b1
       Atl-Traceid:
-      - fdaf88fb36794d8793c9efdb913590ed
+      - 39473f8566524295ad5ec5bcde5623b1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:06 GMT
+      - Wed, 30 Apr 2025 16:28:38 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=709,atl-edge-internal;dur=15,atl-edge-upstream;dur=694,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="OJ9r04HzXpDS6yUyAtNqkYqcSizAdsrHQHxlbLg4kkK5oNgYzPZUOg==",cdn-downstream-fbl;dur=807,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=77,cdn-upstream-fbl;dur=804,atl-edge;dur=704,atl-edge-internal;dur=17,atl-edge-upstream;dur=687,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 16bedbdd3b6cf84254f58a51bce00b14.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - OJ9r04HzXpDS6yUyAtNqkYqcSizAdsrHQHxlbLg4kkK5oNgYzPZUOg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 58fb5af9020ab4113e8d4d6b88338f0b
+      - 6d6fcf7a7fe3ea26b6c137469eaccdad
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1654
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1894
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvdhxHAHD0MXuli7LvNhpgWZFwEhnmTVFqiQV22v733fU
-        mxs76pAMKwqkFo/39txzx/vowCajInZCR4GIQUH8kgGPdUfQFHRHR0tIaUdmoKhhUugOxMykYGgn
-        WlKRAJdJ5x6URhnEV5Ap0CBMdTfKtZHpwhq89T3P93oKPuSgzXybwVTRyLAInI7DrH9/6PdH+KGB
-        L/BzaUymQ9eNYQGRieV72aOGU60ZFT0BxkVPxqUZcwOXaZ2DWxtYwRb1L+eT2bzrD48HeFSEoJ3w
-        o6MxtlxH1EAi1bbMIcYv1Ai84Ljr+V3fmwde6J+G3rA3HJz+gHF7NkjrxGDghZlnBmn1XbTnBU3a
-        1UcMOlIss8Dh6QuiU8p5h8RMGyYiQzIGERC5IGupVj2rHUlxrfgTo8gFs+Wi/JbeU0OVe89g7RZh
-        7QKsRL7X90c/afY3/Jhi2fMUvVpaoMs51Stbq/zO2F/hgnINHadUPMe8Ct2Os2RIHBUttxdwDxir
-        97njGIbMypAlTihyzNHZo0nfqwWZku8xo2cCXmkXcBcFrOG2H1+QZJfVtWDGoAHtNL4tU38r7mq5
-        MGuqLF81SzPOMOB4L3OsR8GywWgzGD0x3K9Ups6kqcvAO8EwgsEmGPy/XsrqF1xEh/5w4w+/hcNN
-        7bEfbPrBt/BYEfzz50M6+m08DWrBgm1elzMQq3/z7vBmv75Jk0RBgvPmoAkwAcnzsv0fd3fcJhi2
-        CU5aBEGrYNQmOD2Msxyb5akdSsUL4YRdv5qVtiSKRWVKHw/ObKMg2nopcx6Pmc443VbthMdravDp
-        KUf201u/fBB2T4BbmlO2sYufZzK30BehvrEHTCROaFRufaNR8xo5Y9u7QkMBJmvnx2OPRH/k14/E
-        PmzNKNsXtJEqaEiVKSYVM9tnQlCru/b9e8JbwVKagHathq6NMDzgct3T98luWF7IdT1UB85h2wQN
-        5zm9AzsWH2kMO00ehcFvY6g/sngsqZ5kLLpgYvXSSsaQ2e1FRDWDCl6tC1lzIqSY4PJC7zhcAdUl
-        K1X1y5leXP9yfnl7cX42uZxNbidXV39cYX7YpRoBwQvzJZApzn9hiPVLmCZS8C3BWcK4NUqMJK+Y
-        omSqIMVhQnKNjOs9NlN8bCfH+8Q874N3Ejrlm4i1Q/B3PfVgVmAZEiYo379U7V4VvAXvOUZXfdu6
-        JgKa23lmm7aNx4NBUPO4XJOeSb1SuXl3H242T2Pjjm4/02iFy2ZNudp46eus2uf+U8D1UujWu1lQ
-        rwkCLNUjyaW6LKO54zl0E4UTa7cSSTKWZbFlmuE6LMzjpD9uhsLXCruv1AyMh3D+JXb/jubMcDgK
-        yc1bmvkhOZNyxYC8YQZnrCEziHIF5CWnySeLDoLDZUT5UmoTjryR5y6YiHEQuv3+8bvC4LgAD/N6
-        L4mlVXhE/lWTfId/vi/UZ7j02RmEajgtqiDHOZAxJoqHv9Mt8b0OsWRskjh7M0HRDf7XHfqDIlJb
-        x2gNvZQZBT2pEhdpTG1pGW5slv4uXu0tTcqLuEs7r62da7EScv0lSFMl4xx3gIlIsLFTLJM7R/Ct
-        zwIhjJf8KtddI1tQyioDwTvikhtfG/JnTpUBRXYmW1Rh59MvtN++mJJZREXLfbuMun7Qb7L6Io/Z
-        VhtINeYRZ5Ih2Y7C4ryokEUspUxoZqCHfETA9PJOUhW33TiwP97x7Cj8BwAA///sWV1L3EAU/SuD
-        ICiYmN3NursFsYu00AdpUaggwjKZTNzQ3UnIh1Gs/73nzsxOY7qxRYr4IPgQMzP3K/eee+7stZoz
-        YdIJ2MsiKRUrZcUam1sVwLE0+ZUgvw5Ys0zFkq0lVyUWudlhJcDfaxVJxoUAusqY3aac1SgYUdzn
-        gCfsU0oakuC3LDrDt77RoyUZdLmUivKLcSc3w+QJj2AJuQUWyFKVZMVan2FZQZjNsVoSZAKuf0h1
-        QIZBeFoxw0QYXzX8nlxkOdfW1SUym3HFWgZiblRy5eOLl+Sz89DE4FpREEgbxQgWWAvLjYkksKwR
-        oK2WtnxueX+OWkT3QcjIe5svTdP4WcPLXFcFilDe+fky1xkNJQvIXFjdC16BekU1cmqx9/VyfvHN
-        uzjz0Kh1rToleUapTNWwx+N1qvbZ3v5PJMqqyj4gDf/kOGPX6LtNro/8DMI2AFYFkF3TL6KD3a19
-        pDfoWwgdU+2ecFxDfyTNrLZv7OMeQR87DpxOxJiLJRW4bcDtHt6F+LJerzk1rZ2/4TVFnShoVryw
-        wxEVOUG9Ee39Eh+P49F0Mo0Gk0COxCwQs/EwmQ2SI+hxm6DhmW2SUmIex9CBLoeWF99/bBkCQCFZ
-        zw7FplZ8dFG9TcOUHcxCCaLH40EYHk3EdDIezSIRTQKoT7hMpuIkPtZSdkfz3eFn/Jlz3pori6+e
-        Z16Vfl16DQLhDX0Cbj+vo1UqKFJeznlJgcJ53UdAE/F4iqLwc0Ux7w7Yb9/i7oT+9i3uTvhv3WJg
-        VGyGVUsFT5H6YDJJUguR6gIiPDfDpEG4K5BBbPxUF1kuD6+APWL5u9LohgmrrnRJg71X284fwz5c
-        DfuGytANlYXF93cYebWEeYeR17D4HUa2wEgXBvqYWugImeMrcOfGFOUDXYXb5wCWZBW3F/ldKX2U
-        LOjDpWC4HeD6boWCXgd6KZvzrHuij8uNehccyZPqNi0yZVieeRXX9lck8++/RO82q/7f/aYR5oRC
-        E8a075m+69lcqaIEjMkPm0fbX15sgP7F7XAj92Bnze/OZVmvSHDLWX1LU1TzyjhOd8V0k0Ouu/dP
-        Dw+fnLYHtLWPj4+/AAAA//8DAETBSnS0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18283","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18283","key":"NTEST-1894","fields":{"statuscategorychangedate":"2025-04-30T18:28:38.430+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1894/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:38.144+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tbb:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:38.224+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/335]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/335 (335)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/123]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1894/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18283/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 9926da3a-237c-4d75-a6c7-f109e5eddd03
+      - 8673ee58-1a10-4ebf-8685-db93b5a13df1
       Atl-Traceid:
-      - 9926da3a237c4d75a6c7f109e5eddd03
+      - 8673ee581a104ebf8685db93b5a13df1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:07 GMT
+      - Wed, 30 Apr 2025 16:28:39 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=256,atl-edge-internal;dur=12,atl-edge-upstream;dur=244,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=18,cdn-upstream-fbl;dur=345,atl-edge;dur=270,atl-edge-internal;dur=14,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="jBRO6liul-rb8RD30xxVb9kG45B9x_--IB-bbAjzi5ZTDeIVAPJWeQ==",cdn-downstream-fbl;dur=349
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 13926aef629bc9518d9ad769185e8c4e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - jBRO6liul-rb8RD30xxVb9kG45B9x_--IB-bbAjzi5ZTDeIVAPJWeQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 6bcfa6c56f56ddb13b14bf01b8aa65d2
+      - 57c5bf75de905b5700ddd72b82f5a8fe
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16138
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18283
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxt4rSUEmma7mjZ2BhjUEC6DCGTnKamjp1rO7Qdl/++46Rp
-        ecu9gmlXSCX28Xl//Pjce7DImUy8yNMgE9CQ7HMQiWlJloFpmXgKGWupHDSzXEnTgoTbDCxrxVMm
-        UxAqbd2BNiiD5ARyDQakXZ2NC2NVNnEGr2kQ0KCj4VMBxo6XORxrFlseg9fyuPNP+7Q7wIUBMcHl
-        1NrcRL6fwARim6hb1WFWMGM4kx0J1kdP1mc590OfG1OAXxuYwRL1j8aj03Gb9rd7uFWGYLzo3jMY
-        W2FiZiFVelnlkOAKNcIg3G4HtE2DcRhEdDcK+p1+b/cHjDtwQTonFgMvzbwzSKfvo70gXKe9WiRg
-        Ys1zVzjc/UBMxoRokYQby2VsSc4hBqImZK70rOO0YyXPtHhjFIXkrl1MXLM7Zpn27zjM/TKsTYAr
-        EQ26dPCT4f/Ajxm2vcjQq4MFuhwzM3O9Km6s+4omTBhoeZXiAeZV6ra8KUfg6Hi6PIQ7wFiDh5Zn
-        OSIrR5R4kSwwR+8ZTLpBLci1usWM3lnwlXZZ7rKBdbnd4hFINlmdSW4tGjDe2rdD6u/lWaMmds60
-        w6vhWS44Bpw8yxz7UaKsN1j0Bm8M9wudqTNZ96UX7GAYYW8R9v5fL1X3SyyiQ9pf0P63cLioPXbD
-        RTf8Fh5XAH94eAlH2oTTsEnQrQUTvjivyBFhcXmFMElTDSnyzVcvwXYtwMyUKCpeeP1ov0mw0yAI
-        GwWDJsHuy3Aq2qx2HSmVL4QXtSkumcWHoyLct1/cis43BO5X5rS7luXnnipc4agj5Qu3wWXqRVYX
-        gO1Do/YcO+4uZxVcac/Z1zyu6nj/Ys/FispmqgqRDLnJBVuuLreDhAZM1vHHa49Ed0DrR+J52dZU
-        9lzQBKpwDapcc6W5Xb6ziLW6796/N7wVPGMpGN9pmNoIxw2h5h1zl27I8lDNa1LteS+vTbi+BILd
-        gKNFh//nE0ETdGkTQunA1WPKzCjn8SGXs30nGULuphcZ1z0rOzkvZesdqeQIhxd2I+AEmKlwoFdf
-        3vHh2S8HR9eHB3ujo9PR9ejk5M8TzA9vqcGC4IHxFMgx8r+0xPkl3BAlxZIgl3DhjBKryG9cM3Ks
-        IUMyIYVBzHZe4xSK18kLPvMg+BTsRF71JmLvsPibO/WEK7ANKZdMPD+0mr1W5S1RLTC6mm6wr6mE
-        9ekid5e2Cce9XljjuBqT3gm9Snn97j6dbN6Gxg3cfmbxDIfNGnK18crX3mqe+08B10OhX89mYT0m
-        SHBQj5VQ+qiK5kYU0E41csRmJFJkqKpmqyzHcVja10G/3UQK22tS+FLHn5bzb7n52xpzK2ArIpcf
-        WU4jsqfUjAO54BZZzZJTiAsNZF+w9LOrDhZHqJiJqTI2GgSDwJ9wmSCV+t3u9lVpcFgWD/O6VcTB
-        KtoiX9Uk3+HP96X6KQ59joNQDdliFeSwADLEfHDzD7YkNGgRB8Z1EnsXIxRd4r92n/bKSF0f4zl0
-        Mm41dJROfYQxc63lOLE5+Pt4tDO1mSjjruycOztncibV/HGRjrVKCpwBRjLFi51hm/wx1tj5LCuE
-        8ZJf1bxtVUOV8pWB8Ir45JIaS/4qmLagycZkgypsfNJS++OHY3IaM9lw3g2jPg2766we5XG6NBYy
-        g3kkueIItq2o3C875CqWMS4Nt9BBPGLBzPRGMZ00nXhhf7jB2Vb0LwAAAP//7Flta9swEP4rolBo
-        oXadxGmSQelC2WAfykYLK5RCkGW5MYtl45e6pet/33OSoqVe3I0ySj8U8sGJpLvT+e655y7Xas6E
-        CSdgL4ukVKySNWttbNUAx8rEV4L4OmDtMhVLlkmuKixys8NKwH2vVSQZFwLoKmN2m3LWIGFEeV8A
-        nrBPKWnKsr9h0Rne9Y1uLcmgy6VUFF+MO7k5Ok/cCJbQtcACWaqSvMz0GZaXhNkcqxVBJuD6h1QH
-        ZBiEpzUztZ/xVcvv6Yqs4Nq6pkJkM67YhoHoG5Vc+XjjFd3Z3dD44FqRE0gb+QgWWAurtYkksGrg
-        oK2Wbtx54/bnyEVUH7iMbm/jpW1bP295VeisQBLKO79YFjqioWQBmQure8FrkJ2oQUwt9r5ezi++
-        eRdnHgq1zlWnpMgplCkb9nicpWqf7e3/RKCs6vwDwvBPjjN2hb5b5PpwbhD2LTjSSwBYl4B8zeyI
-        mXW2ho6QdhYCJ6O70Mc1Asc19NvTlGv7xj52HDhjntTsLnLjBXCxpOw3daFqsoxT0dr5G16T14mC
-        5uULKxxRkRPkGxHnL/HxOB5NJ9NoMAnkSMwCMRsPk9kgOYIetwkantkmKSTmcQwdqHIoefH9xw1D
-        ACgk69mm2OSKjyqqt2mYso1ZKEH0eDwIw6OJmE7Go1kkokkA9QmXyVScxMdayu5ovjv8jI8552Vc
-        WXz1PPNT5TeV18IR3tAn4PaLJlqlgjzlFZxX5Cic13UENBGPp0gKv1Dk826D/fYt7nbob9/ibof/
-        1i0GFMWmPbRU8BShDyaTJI0QqU4gwnPTjhoguwIZxMZPTZkX8vAKECOWvzONJkxYdalLGuxcbTt/
-        DPtwNexrKsO+SUXosLu0wP+OL68WSe/48hoWv+PLFnzpwoAjZI6/wOobk3sPNAq3zwEU5jW3g/yu
-        lF7m1YtLvZRsuB35+qZCQR8HJUDYuhD0cdBR34mRI3lS3aZlrgyRMz/Fjf0XyXz9J+/lmZHwsH60
-        cP8C+N34A+xwLfdgJ+N357JqViR4Q7cempT1vDZ23Ob1/5vUGmFOKHShXfye65nTephKs2Ka5JBK
-        Z8hTa4dPzLUHtHseHx9/AQAA//8DAHOJcEC0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18283","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18283","key":"NTEST-1894","fields":{"statuscategorychangedate":"2025-04-30T18:28:38.430+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1894/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:38.144+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tbb:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:38.224+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/335]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/335 (335)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/123]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1894/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18283/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - ef4029e0-4b46-4906-a7ec-1cfe30bf68fb
+      - e9351a19-da5b-459b-8f98-77dc10cd58d1
       Atl-Traceid:
-      - ef4029e04b464906a7ec1cfe30bf68fb
+      - e9351a19da5b459b8f9877dc10cd58d1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:07 GMT
+      - Wed, 30 Apr 2025 16:28:39 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=279,atl-edge-internal;dur=11,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="gnm5_WqNM3e6PY_Pd7AiBVE8Fj6uNk_Afkbd6QRMr1swDHmSn_5IFg==",cdn-downstream-fbl;dur=327,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=325,atl-edge;dur=250,atl-edge-internal;dur=14,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 471c951325b4c2c11c6c583a1d28e92a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - gnm5_WqNM3e6PY_Pd7AiBVE8Fj6uNk_Afkbd6QRMr1swDHmSn_5IFg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 662d4f1942bf79536e8b94bf6bd98735
+      - c851f3ae4bf1cbff97296bea7267ef8b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0te3bpL1q1b3mSCU3QK7V4UkTS9YDRNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtPG57Qzh5C6HzfDJpUKEMjXt3mQhGeK+FzSwGMiKN9p0R+3/wJfY7LbFB/7FG063QBuz/
-        umTlrDIDWom/S+6w99rZCFMAmkEG43Jz+ViuH6qf6WZo61gR/pygEYzgJTqxM27fxiurfZdsK+OG
-        JobqQZvmK0J4DLCiODWvREggAzYbAx3DsmKM51OeRzHABUQ45n38A/aVbs9ZChUDTpcciqwA+s3K
-        9sYqF8GczhdSAM5QSTotUORK5QqkYsvpbFGreY5sroCdCYJJhlvdi/RCVGIw4c5JkdoHYk4VQfu6
-        Lcnx/LAnZ9Pk+r4ix08AAAD//wMAHebx2CACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:40.076+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 475e0123-fb52-4e98-bc4c-369bb3029d21
+      - d149a81a-2fb9-4c51-8429-d77302726453
       Atl-Traceid:
-      - 475e0123fb524e98bc4c369bb3029d21
+      - d149a81a2fb94c518429d77302726453
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:07 GMT
+      - Wed, 30 Apr 2025 16:28:40 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=169,atl-edge-internal;dur=13,atl-edge-upstream;dur=157,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="KCINUVBon2DWsRLRsom_3zMXj61eCXc0mjN4SmODWvG8sm_OMGhlKg==",cdn-downstream-fbl;dur=229,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=67,cdn-upstream-fbl;dur=226,atl-edge;dur=136,atl-edge-internal;dur=14,atl-edge-upstream;dur=123,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 595c26368a4c8eede29e4b5da7206efc.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - KCINUVBon2DWsRLRsom_3zMXj61eCXc0mjN4SmODWvG8sm_OMGhlKg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - fba220f32634c84e9f3fda4a27eaca94
+      - b2bb2b87ce4d0bb1c9d72b02aafd49b6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - d9113cd1-b403-47c4-b85d-4dc35f9ad216
+      - 6e23cefd-e95d-4a4c-9bfc-da53ab898516
       Atl-Traceid:
-      - d9113cd1b40347c4b85d4dc35f9ad216
+      - 6e23cefde95d4a4c9bfcda53ab898516
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:08 GMT
+      - Wed, 30 Apr 2025 16:28:40 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=338,atl-edge-internal;dur=24,atl-edge-upstream;dur=311,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=282,atl-edge;dur=250,atl-edge-internal;dur=13,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="_SHDrCclqBvkOyw79vj44_K6F5mQqHR3OzClEFuTfVo0xvtKkMlWyA==",cdn-downstream-fbl;dur=286
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 800cba2437ee092ab9e4755c65d34a72.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - _SHDrCclqBvkOyw79vj44_K6F5mQqHR3OzClEFuTfVo0xvtKkMlWyA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - faddcd5323f926501964dd455b9aa5f5
+      - c72451ff81e673606d1b8e0815da1c90
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/336]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/336 (336)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/123]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16139","key":"NTEST-1655","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16139"}'
+      string: '{"id":"18285","key":"NTEST-1895","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18285"}'
     headers:
       Atl-Request-Id:
-      - dd338f01-52a6-4748-bb3b-6b58f3175afb
+      - 7cb5bcd1-e1ed-423c-b241-bac57e955ab7
       Atl-Traceid:
-      - dd338f0152a64748bb3b6b58f3175afb
+      - 7cb5bcd1e1ed423cb241bac57e955ab7
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:08 GMT
+      - Wed, 30 Apr 2025 16:28:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=680,atl-edge-internal;dur=14,atl-edge-upstream;dur=668,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=741,atl-edge;dur=719,atl-edge-internal;dur=20,atl-edge-upstream;dur=700,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="dsFh0fZFXvmQMpg0NloJ9ViNKCPpDL5QUdqFPQQvOeLdel3erFjhqQ==",cdn-downstream-fbl;dur=746
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 7b64a70fe0edcfd6cd8e281be975ea8a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - dsFh0fZFXvmQMpg0NloJ9ViNKCPpDL5QUdqFPQQvOeLdel3erFjhqQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - af46015a516a41538431f5a38dd91361
+      - 0895250a73dc7fc49fc2436f896b98b7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1655
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1895
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9pEHYaWqupLQ0lKaQgDpKEJmd7Ix8dp7tpck5fjfO95H
-        wmvvBFVPJ3FZj+f9zee5d2CVURE7oaNAxKAgPmDAY90SNAXd0tEcUtqSGShqmBS6BTEzKRjaiuZU
-        JMBl0roDpVEG8QlkCjQIU92Ncm1kOrMGr33P872Ogk85aDNdZzBRNDIsAqflMOvfH/jdPfzQwGf4
-        OTcm06HrxjCDyMTyVnao4VRrRkVHgHHRk3FpxtzAZVrn4NYGFrBG/ePp+HTa9gf9Ph4VIWgnvHc0
-        xpbriBpIpFqXOcT4hRqBF/Tbnt/2vWnghf5e6A07w6D7A8bt2SCtE4OBF2beGaTVd9GeF2zSrj5i
-        0JFimS0cnn4gOqWct0jMtGEiMiRjEAGRM7KUatGx2pEUZ4q/MYpcMNsuyq/pHTVUuXcMlm4R1jbA
-        SuR7XX/4k2b/wI8ptj1P0auFBbqcUr2wvcpvjP0VzijX0HJKxUPMq9BtOXOGwFHRfH0Ed4Cxeg8t
-        xzBEVoYocUKRY47OM5h0vVqQKXmLGb2z4JV2Ue6igXW57ccjkGyzOhPMGDSgnY1vi9Tfi7tazsyS
-        KotXzdKMMww4fpY59qNAWW+46g3fGO4XOlNnsulLz9vFMILeKuj9v17K7hdYRIf+YOUPvoXDVe2x
-        G6y6wbfwWAH84eElHP0mnAa1YMZW5yUHYvcvr17e7NY3aZIoSJBvvjoE/VqAmUmel7zw+tVBk2C3
-        QRA0CoZNgr2X4ZS0WZ5aUipeCCds+xVX2pYoFpWR3784s4OC1dZzmfN4xHTG6boaJzxeUoNPT0nZ
-        bx/98kHYPgFuaU7ZwS5+7svclr4I9cIeMJE4oVG59Y1GzTlixo53VQ0FmKzlj9ceib7n14/E87Jt
-        qOy5oAlUwQZUmWJSMbN+Zwlqdbf3treCpTQB7VoNXRtheMDlsqPvki1ZHsllTao95+XYBBvMc3oD
-        lhZfGQzLJq+WwW9CqD+09ZhTPc5YdMTE4sBKRpDZ7UVENYIKXC0L2eZESDHG5YXecDgBqktUquqX
-        Mzk6++Xw+ProcH98fDq+Hp+c/HmC+eGUaiwIXpjOgUyQ/4Uh1i9hmkjB1wS5hHFrlBhJfmOKkomC
-        FMmE5BoR13mNU3wcJ8f7zDzvkzcLnfJNxN5h8bcz9YQrsA0JE5Q/v1TtXlV5C9xzjK76tn1NBGxu
-        55kd2kYc7w5qHJdr0juhVypv3t2nm83b0LiF2880WuCyWUOuNl762q/2uf8UcL0UuvVuFtRrggAL
-        9UhyqY7LaG54Du1EIWNtVyJJRrJstkwzXIeFeR30/SZS6G9I4Usdf1rOv8X2386UGQ47Ibn8SLMg
-        JPtSLhiQC2aQYw05hShXQA44TT7b6mBxuIwon0ttwqE39NwZEzESodvtDq4Kg6OieJjXrSQWVuEO
-        +aom+Q7/fF+on+LSZzkI1ZAtqiBHOZAR5oOHf9A18b0WsWDcJLF/MUbRJf7XHvi9IlLbx2gJnZQZ
-        BR2pEhdhTG1rGW5sFv4uXu3MTcqLuEs759bOmVgIuXxcpImScY47wFgkONgptsmdYo2tz6JCGC/5
-        VS7bRjZUKasMBFfEJZe+NuSvnCoDimxNNqjC1qdfaH/8MCGnERUN9+0y6vpBd5PVozxO19pAqjGP
-        OJMMwbYTFudFh2zFUsqEZgY6iEcsmJ7fSKriphsv7I+2ONsJ/wUAAP//7FltS9xAEP4riyAomJi7
-        y3l3BbGHtNAP0qJQQYRjs9l4oXebkBejWP97n9nd28b0YosU8YPgh5jdnZ2ZzDzzzNy1mjNhwgnY
-        yyIpFStlxRobWxXAsTTxlSC+DlizTMWSrSVXJRa52WElwN5rFUnGhQC6ypjdppzVSBhR3OeAJ+xT
-        ShqS4Lc0OsO3vtGtJSl0uZSK4otxJzdD5wmLoAmZBRbIUpVkxVqfYVlBmM2xWhJkAq5/SHVAikF4
-        WjHDRBhfNfyeTGQ519rVJSKbccVaCqJvVHLl44uXZLOz0PjgWpET6DbyETSwGpYbFUlgWcNBWzVt
-        2dyy/hy5iOoDl5H1Nl6apvGzhpe5zgokobzz82WuIxqXLCBzYe9e8ArUK6oRU4u9r5fzi2/exZmH
-        Qq1z1V2SZxTKlA17PF6nap/t7f9EoKyq7APC8E+OM3aFvlvk+nBuELZxriqA7Jp+ER3sbnU0uLMQ
-        OkLaWQj6TgSOa+iPpJnV9o193CPoY8eBUwY+5mJJCW4LcLuGd5G8rNdrTkVr5294TV4nCpoVL6xw
-        REVOkG9Ee7/Ex+N4NJ1Mo8EkkCMxC8RsPExmg+QI97hNuOGZbZJCYh7HuANVDiUvvv/YUgSAQrKe
-        bYpNrvioonqbhinbmIUSRI/HgzA8mojpZDyaRSKaBLg+4TKZipP4WEvZHc13h5/xZ855a64svnqe
-        eVX6dek1cIQ39Am4/byOVqkgT3k55yU5Cud1HQFNxOMpksLPFfm822C/fY27Hfrb17jb4b91jYFR
-        sWlWLRU8ReiDySRJLUSqE4jw3DSTBuGuQAax8VNdZLk8vAL2iOXvTKMJE1Zd6tINdq62nT+Gfbga
-        9jWVoWsqC4vv7zDyagHzDiOvofE7jGyBkS4M9DG10BEyx1dgzo1JygcahdvnAJpkFbeD/K6UXubV
-        i0t9459guB35eplZr2W9lM2Z3FkY9Z0YOZIn1W1aZMqwPPMqru2vSObff/HebVb9v/mmEeaE4ia0
-        ad8zPevZjFSRAkblh82jrS8vVkD/4na4kXuws+Z357KsVyS4Zaye0hTVvDKG06yYJjlkunv/9PDw
-        yWl7QGv7+Pj4CwAA//8DABu+t3G0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18285","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18285","key":"NTEST-1895","fields":{"statuscategorychangedate":"2025-04-30T18:28:41.315+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1895/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:41.014+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tbj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:41.090+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/336]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/336 (336)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/123]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1895/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18285/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 7a016a42-5710-4981-b3d6-96458e4b75fe
+      - da0ee09c-64c3-47d3-9583-66d1d7c3047f
       Atl-Traceid:
-      - 7a016a4257104981b3d696458e4b75fe
+      - da0ee09c64c347d3958366d1d7c3047f
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:09 GMT
+      - Wed, 30 Apr 2025 16:28:41 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=290,atl-edge-internal;dur=18,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="-vKQRO6KQa3-hrfea6RauNsKvIy_pr0OKJidrQEqa3DGGjkROPUp8Q==",cdn-downstream-fbl;dur=398,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=53,cdn-upstream-fbl;dur=395,atl-edge;dur=323,atl-edge-internal;dur=16,atl-edge-upstream;dur=307,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f6567fa2210130239a3a2c737c9517ac.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - -vKQRO6KQa3-hrfea6RauNsKvIy_pr0OKJidrQEqa3DGGjkROPUp8Q==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 95580a1c1b4c3530387eaf09a317b03c
+      - 92d182c20fe22e49418d399f52e00c8b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16139
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18285
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaVJ9pEHYaWqupLQ0lKaQgDpKEJmd7Ix8dp7tpck5fjfO95H
-        wmvvBFVPJ3FZj+f9zee5d2CVURE7oaNAxKAgPmDAY90SNAXd0tEcUtqSGShqmBS6BTEzKRjaiuZU
-        JMBl0roDpVEG8QlkCjQIU92Ncm1kOrMGr33P872Ogk85aDNdZzBRNDIsAqflMOvfH/jdPfzQwGf4
-        OTcm06HrxjCDyMTyVnao4VRrRkVHgHHRk3FpxtzAZVrn4NYGFrBG/ePp+HTa9gf9Ph4VIWgnvHc0
-        xpbriBpIpFqXOcT4hRqBF/Tbnt/2vWnghf5e6A07w6D7A8bt2SCtE4OBF2beGaTVd9GeF2zSrj5i
-        0JFimS0cnn4gOqWct0jMtGEiMiRjEAGRM7KUatGx2pEUZ4q/MYpcMNsuyq/pHTVUuXcMlm4R1jbA
-        SuR7XX/4k2b/wI8ptj1P0auFBbqcUr2wvcpvjP0VzijX0HJKxUPMq9BtOXOGwFHRfH0Ed4Cxeg8t
-        xzBEVoYocUKRY47OM5h0vVqQKXmLGb2z4JV2Ue6igXW57ccjkGyzOhPMGDSgnY1vi9Tfi7tazsyS
-        KotXzdKMMww4fpY59qNAWW+46g3fGO4XOlNnsulLz9vFMILeKuj9v17K7hdYRIf+YOUPvoXDVe2x
-        G6y6wbfwWAH84eElHP0mnAa1YMZW5yUHYvcvr17e7NY3aZIoSJBvvjoE/VqAmUmel7zw+tVBk2C3
-        QRA0CoZNgr2X4ZS0WZ5aUipeCCds+xVX2pYoFpWR3784s4OC1dZzmfN4xHTG6boaJzxeUoNPT0nZ
-        bx/98kHYPgFuaU7ZwS5+7svclr4I9cIeMJE4oVG59Y1GzTlixo53VQ0FmKzlj9ceib7n14/E87Jt
-        qOy5oAlUwQZUmWJSMbN+Zwlqdbf3treCpTQB7VoNXRtheMDlsqPvki1ZHsllTao95+XYBBvMc3oD
-        lhZfGQzLJq+WwW9CqD+09ZhTPc5YdMTE4sBKRpDZ7UVENYIKXC0L2eZESDHG5YXecDgBqktUquqX
-        Mzk6++Xw+ProcH98fDq+Hp+c/HmC+eGUaiwIXpjOgUyQ/4Uh1i9hmkjB1wS5hHFrlBhJfmOKkomC
-        FMmE5BoR13mNU3wcJ8f7zDzvkzcLnfJNxN5h8bcz9YQrsA0JE5Q/v1TtXlV5C9xzjK76tn1NBGxu
-        55kd2kYc7w5qHJdr0juhVypv3t2nm83b0LiF2880WuCyWUOuNl762q/2uf8UcL0UuvVuFtRrggAL
-        9UhyqY7LaG54Du1EIWNtVyJJRrJstkwzXIeFeR30/SZS6G9I4Usdf1rOv8X2386UGQ47Ibn8SLMg
-        JPtSLhiQC2aQYw05hShXQA44TT7b6mBxuIwon0ttwqE39NwZEzESodvtDq4Kg6OieJjXrSQWVuEO
-        +aom+Q7/fF+on+LSZzkI1ZAtqiBHOZAR5oOHf9A18b0WsWDcJLF/MUbRJf7XHvi9IlLbx2gJnZQZ
-        BR2pEhdhTG1rGW5sFv4uXu3MTcqLuEs759bOmVgIuXxcpImScY47wFgkONgptsmdYo2tz6JCGC/5
-        VS7bRjZUKasMBFfEJZe+NuSvnCoDimxNNqjC1qdfaH/8MCGnERUN9+0y6vpBd5PVozxO19pAqjGP
-        OJMMwbYTFudFh2zFUsqEZgY6iEcsmJ7fSKriphsv7I+2ONsJ/wUAAP//7FltS9xAEP4riyAomJi7
-        y3l3BbGHtNAP0qJQQYRjs9l4oXebkBejWP97n9nd28b0YosU8YPgh5jdnZ2ZzDzzzNy1mjNhwgnY
-        yyIpFStlxRobWxXAsTTxlSC+DlizTMWSrSVXJRa52WElwN5rFUnGhQC6ypjdppzVSBhR3OeAJ+xT
-        ShqS4Lc0OsO3vtGtJSl0uZSK4otxJzdD5wmLoAmZBRbIUpVkxVqfYVlBmM2xWhJkAq5/SHVAikF4
-        WjHDRBhfNfyeTGQ519rVJSKbccVaCqJvVHLl44uXZLOz0PjgWpET6DbyETSwGpYbFUlgWcNBWzVt
-        2dyy/hy5iOoDl5H1Nl6apvGzhpe5zgokobzz82WuIxqXLCBzYe9e8ArUK6oRU4u9r5fzi2/exZmH
-        Qq1z1V2SZxTKlA17PF6nap/t7f9EoKyq7APC8E+OM3aFvlvk+nBuELZxriqA7Jp+ER3sbnU0uLMQ
-        OkLaWQj6TgSOa+iPpJnV9o193CPoY8eBUwY+5mJJCW4LcLuGd5G8rNdrTkVr5294TV4nCpoVL6xw
-        REVOkG9Ee7/Ex+N4NJ1Mo8EkkCMxC8RsPExmg+QI97hNuOGZbZJCYh7HuANVDiUvvv/YUgSAQrKe
-        bYpNrvioonqbhinbmIUSRI/HgzA8mojpZDyaRSKaBLg+4TKZipP4WEvZHc13h5/xZ855a64svnqe
-        eVX6dek1cIQ39Am4/byOVqkgT3k55yU5Cud1HQFNxOMpksLPFfm822C/fY27Hfrb17jb4b91jYFR
-        sWlWLRU8ReiDySRJLUSqE4jw3DSTBuGuQAax8VNdZLk8vAL2iOXvTKMJE1Zd6tINdq62nT+Gfbga
-        9jWVoWsqC4vv7zDyagHzDiOvofE7jGyBkS4M9DG10BEyx1dgzo1JygcahdvnAJpkFbeD/K6UXubV
-        i0t9459guB35eplZr2W9lM2Z3FkY9Z0YOZIn1W1aZMqwPPMqru2vSObff/HebVb9v/mmEeaE4ia0
-        ad8zPevZjFSRAkblh82jrS8vVkD/4na4kXuws+Z357KsVyS4Zaye0hTVvDKG06yYJjlkunv/9PDw
-        yWl7QGv7+Pj4CwAA//8DABu+t3G0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18285","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18285","key":"NTEST-1895","fields":{"statuscategorychangedate":"2025-04-30T18:28:41.315+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1895/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:41.014+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tbj:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:41.090+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/336]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/336 (336)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/123]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1895/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18285/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 02870268-66c7-44a2-b10f-9e92294274e5
+      - fb5865f3-35de-4a05-9b4e-88bcebe2ff34
       Atl-Traceid:
-      - 0287026866c744a2b10f9e92294274e5
+      - fb5865f335de4a059b4e88bcebe2ff34
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:09 GMT
+      - Wed, 30 Apr 2025 16:28:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=292,atl-edge-internal;dur=25,atl-edge-upstream;dur=261,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="7dcPdecRuWgX3MNiw_u4SIDRC8WN4r7FPvnE-CufCXVRwbbGMwyaww==",cdn-downstream-fbl;dur=300,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=298,atl-edge;dur=278,atl-edge-internal;dur=15,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c973663b623c0e82cd366d5ae7837bf4.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 7dcPdecRuWgX3MNiw_u4SIDRC8WN4r7FPvnE-CufCXVRwbbGMwyaww==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 04ef4c5f3fd7366421d98c758c0f14de
+      - f4a8654b5d30aeb0be30a04c8c0dd1a7
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33372\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:42266\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:19:09 GMT
+      - Wed, 30 Apr 2025 16:28:42 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/123", "url_api": "http://localhost:8080/api/v2/tests/123/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      123, "url_ui": "http://localhost:8080/test/123", "url_api": "http://localhost:8080/api/v2/tests/123/"},
+      "finding_count": 2, "findings": {"new": [{"id": 335, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/335",
+      "url_api": "http://localhost:8080/api/v2/findings/335/"}, {"id": 336, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/336",
+      "url_api": "http://localhost:8080/api/v2/findings/336/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:42272\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/123\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/123/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 123, \\\"url_ui\\\": \\\"http://localhost:8080/test/123\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/123/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 335, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/335\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/335/\\\"},
+        {\\\"id\\\": 336, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/336\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/336/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 335,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/335/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/335\"\n        },\n
+        \       {\n          \"id\": 336,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/336/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/336\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        123,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/123/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/123\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/123/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/123\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:42 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_not_verified_enforced_verified_globally_false_enforced_verified_jira_false.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_not_verified_enforced_verified_globally_false_enforced_verified_jira_false.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uurJ2TtvvoDQ2JgWAgtbuAEEpTRwTSpGrSSdO0/04iJtgRuFn2
-        8/qxfCANd7gdNCnJm/e9K6fTFiUK39p3m3KvuXOKm9SgJxPSKtdrvv8HX+GwUwJbdB9r1P0Kjcfh
-        r0tW1kg9ohH4u+QOB6esCTAFoCmkkFSby8dq/VD/TDdj14SKlM8RmsAEXoITe233Xbiy3vfRttJ2
-        bEOoGZVuvyKkDAE2n5+aV9xHkAErEqAJLGvGyjwr8yAGuIAAh7wLf8ChVt05S6FmUNJlWJhCkX2z
-        orsx0gYwp7OF4IAFSkGzOfJcylyCkGyZFYtGznJkMwnsTOB1NNyqgccXouSj9ndW8Ng+EH2qCJrX
-        bUWO54c9WRMn1/c1OX4CAAD//wMAg2eWYyACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:42.909+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 2e265822-0bf2-443d-9858-b9c94ea6bdb5
+      - 4267798e-17aa-4482-9750-d1a02157218d
       Atl-Traceid:
-      - 2e2658220bf2443d9858b9c94ea6bdb5
+      - 4267798e17aa44829750d1a02157218d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:10 GMT
+      - Wed, 30 Apr 2025 16:28:42 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=162,atl-edge-internal;dur=13,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=224,atl-edge;dur=191,atl-edge-internal;dur=14,atl-edge-upstream;dur=177,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="HBgdbXBBm631l1D8RKOeokADHOEoS60-042FJT5ncowoL5krupK_Hw==",cdn-downstream-fbl;dur=228
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a78d8f4a6ccd81221651cd6112d5330a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - HBgdbXBBm631l1D8RKOeokADHOEoS60-042FJT5ncowoL5krupK_Hw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 789c638d22aa24f9ba0ff5e81194cf5f
+      - 85fbc8cc369e67c60245560519a9c5b2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 4a2cda04-5da2-4e0d-9ce9-eeb4b410e3dc
+      - 0e67a6f3-3658-44fd-a5b2-0faa901ca98b
       Atl-Traceid:
-      - 4a2cda045da24e0d9ce9eeb4b410e3dc
+      - 0e67a6f3365844fda5b20faa901ca98b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:10 GMT
+      - Wed, 30 Apr 2025 16:28:43 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=324,atl-edge-internal;dur=14,atl-edge-upstream;dur=310,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=362,atl-edge;dur=330,atl-edge-internal;dur=15,atl-edge-upstream;dur=315,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ZOQbZlj0c0i0j-lpm5RVaRwm0LNPDC4ZTuxTLbqfanm2zBF8nYo43A==",cdn-downstream-fbl;dur=366
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ZOQbZlj0c0i0j-lpm5RVaRwm0LNPDC4ZTuxTLbqfanm2zBF8nYo43A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 576ac3c3be6db0f77643017a80ddb63c
+      - f96e3f486d7610d623b33d98d1149a8c
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/337]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/337 (337)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/124]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16140","key":"NTEST-1656","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16140"}'
+      string: '{"id":"18287","key":"NTEST-1896","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18287"}'
     headers:
       Atl-Request-Id:
-      - ad07001d-4a27-466f-89af-6a2326389aa4
+      - 834a9439-db65-4abd-9697-46c4ac33c820
       Atl-Traceid:
-      - ad07001d4a27466f89af6a2326389aa4
+      - 834a9439db654abd969746c4ac33c820
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:11 GMT
+      - Wed, 30 Apr 2025 16:28:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=665,atl-edge-internal;dur=13,atl-edge-upstream;dur=653,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="IBNvbcofP8rdRf7R7ULpnM9zOloEF9nVrmB5HJEexgjQswe_7d469w==",cdn-downstream-fbl;dur=755,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=752,atl-edge;dur=668,atl-edge-internal;dur=17,atl-edge-upstream;dur=651,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b376080c70ff0aef5ae83cd4d75e16d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - IBNvbcofP8rdRf7R7ULpnM9zOloEF9nVrmB5HJEexgjQswe_7d469w==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 65d2601c0575453c19292feed5839062
+      - 4e974f3cd6f892a5de87833ac4136255
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1656
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1896
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltvdhJHQHD0MXuli7LssRpgWZFwEhnmTVFqiQV22v733ek
-        XtzaUYdkWFEgtXi89+ce3gcP1gUVqRd7CkQKCtIXDHiqe4LmoHs6WUBOe7IARQ2TQvcgZSYHQ3vJ
-        gooMuMx696A0yiC9hEKBBmHqu0mpjczn1uBtGARhMFDwvgRtZpsCLhRNDEvA63nM+g+PwlGAHxr4
-        HD8XxhQ69v0U5pCYVL6TA2o41ZpRMRBgfPRkfFowP/KZ1iX4jYElbFD/fDa9mvXDo8MjPHIhaC/+
-        4GmMrdQJNZBJtalySPELNaIgOuwHYT8MZlEQh8dxGA7Cw+MfMG5r1jkxGLgz88Qgrb6P9oKoTbv+
-        SEEnihW2cHj6nOicct4jKdOGicSQgkECRM7JSqrlwGonUlwr/sgoSsFsuyi/pffUUOXfM1j5Lqxt
-        gLUoDIbh+CfN/oYfc2x7maNXCwt0OaN6aXtV3hn7K55TrqHnVYqnmJfT7XkLhsBRyWJzBveAsQaf
-        ep5hiKwCUeLFosQcvR2YDIMuQdgICiXfYapP7ESt7frgOtv0YQc923SvBTMGDWiv9W0h/Ju7q+Xc
-        rKiyQNYsLzjDgNOdkmCjHPxG4/Vo/Mhwv9KyJpO2YaPgGYYRjdbR6P/1UsHCgRQdhkfr8OhbOFw3
-        HofRehh9C4818j992odj1MBxztavKg7EJt+83b85bG7SLFOQId/sDQHGKXlZjf/D6D/sEhx1CZ51
-        CKJOwbhLcLwfZ0Wb1aklJfdCeHE/rLnSVl6xpErpw96ZnQcsql7IkqcTpgtON/XU4DG20LzC9thJ
-        ql1Qg49RReKPn/nqidg+Cn5lTtmJdj9PZGmb4YJ/bQ+YyLzYqNJGkyjAZC1N7D8SwWAcHTaPxG7Z
-        uqgsaqlsV9CCqlBMKmY2T0y4UfdHj3srWE4z0L7V0I0Rhgdcrgb6Ptty4plcNdw58vanI2oxz+kd
-        WPZ7YDAsaTxYhrALoeHY1mNB9bRgyRkTyxdWMoHCbi8iaRDkcLVysvZESDHF5YXecbgEqitUqvqX
-        d3F2/cvp+e3Z6cn0/Gp6O728/OMS88Mp1VgQvDBbALlAmheGWL+EaSIF3xCkDMatUWIkeckUJRcK
-        cuQMUmrE1+Ah6ghxnLzgIwuC94GIvepNxN5h8bcz9QVXYBsyJijfvVTvXnV5Hco5Rld/275mAtrb
-        ZWGHthPHx+MGx9Wa9EToVcrt8/rlZvM4NG7h9jNNlrhsNpBrjFe+Tup97j8F3CyFfrObRc02IMBC
-        PZFcqvMqmjteQj9TyFjblUiSiayaLfMC12FhHgb9YUsKX2vsrlJLGF+W8y+x/XcwY4bDQUxu3tAi
-        jMmJlEsG5DUzyLGGXEFSKiAvOM0+2upgcbhMKF9IbeJxMA78ORMp0p4/HD576wxOXPEwr3eSWFjF
-        B+RfNcl3+Od7p36FS5/lIFRDtqiDnJRAJpgoHv5ONyQMesSCsU3i5PUURTf4Xx8Xehep7WOygkHO
-        jIKBVJmPMKa2tQwXMwt/H68OFibnLu7Kzitr51oshVx9XqQLJdMSn/qpyHCwc2yTP8PiW5+uQhgv
-        +VWu+kZ2VKmoDURviU9uQm3InyVVBhTZmuxQha3P0Gm/eX5BrhIqOu7bndMPo1Gb1Wd5XG20gVxj
-        HmkhGYLtIHbnrkO2YjllQjMDA8QjFkwv7iRVadeNPfuTLc4O4n8AAAD//+xZbWvbMBD+K6JQaKF2
-        ncRdkkHpQtlgH8pGCyuUQlBkuTFLZOOXumXrf99zkqK5XtSNMko/FPrBtaTT3fnuuecu12rGhAkn
-        YC9bSKlYJWvW2tiqAY6Via8U8XXA2mUmlmwtuaqwyM0OKwH2XquFZFwIoKtM2G3GWYOEEeV9AXjC
-        PqWkIQlhR6MzfOsb3VqSQpdLqSi+GHdyc3SesAiakFkgeyxTaV6u9RmWl4TZHKsVQSbg+rtUB6QY
-        hGc1M0yE8VXL78lEVnCtXVMhshlXrKMg+kYlVyG+eEU2OwuND64VOYFuIx9BA6thtVGRBFYNHLRV
-        047NHevPkYuoPnAZWW/jpW3bMG95VeisQBLKu7BYFjqicckcMuf27jmvQb0WDWJqvvflcnbxNbg4
-        C1Coda66S4qcQpmyYY8n60zts739nwiUVZ2/Rxj+yXGOXKHvFzkf+RnEXQCsSyC7JltEB/tbfaQ3
-        8i3Ejqn2TziuoT+SZlbbN/q4R+Rjx5G7Ez7mYkkJbgtwt4b3Ib5q1mtORWvnb3hNXicKmpfPrHBE
-        RU6Qb0RyPyfHR8loMp4sBuNIjsQ0EtOjYTodpDQqcZtwwxPbJIXELElwB6ocSl5y/6GjCACFZD3Z
-        +5pcCVFF9TYNU7b/iiWIHk8GcfxuLCbjo9F0IRbjCNenXKYTcZIcaym7o9nu8BP+zLlgzZXF1yAw
-        r6qwqYIWjgiGIQF3WDSLVSbIU0HBeUWOwnldR0AT8XiKpAgLRT7v99GvX+N+I/76Ne438q9dY2BU
-        YppVSwVPEfpgMmnaCJHpBCI8N62jQbgrkEFs/NiUeSEPr4A9Yvk702iQhFWXunSDnatt54+xD1dj
-        X1MZu6aytPj+BiMvFjBvMPISGr/ByBYY6cOAj6nFjpA5vgJzbkxS/qCJt32OoEleczvI70vxUbLI
-        h0vRcDvA+aZCkdcAL2VzlvVP+LjcyLvgSJ5Ut1mZK8PyzKuksb8imX//xXu3ef3/pplGmBOKm9Cm
-        fcv1rGczUkUKGJV/bB5tfXm2AvoXt8ON3IOdNb87l1WzIsEdY/WUpqxntTGcZsU0ySHT3fvHh4eP
-        TtsDWtuHh4dfAAAA//8DADBsisi0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18287","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18287","key":"NTEST-1896","fields":{"statuscategorychangedate":"2025-04-30T18:28:44.206+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1896/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:43.910+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tbr:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:43.989+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/337]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/337 (337)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/124]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1896/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18287/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - e160ed48-9fe1-45f2-8e2c-79048443f7f9
+      - c1786e54-9c5a-4dd9-80ab-f6cb3829fb28
       Atl-Traceid:
-      - e160ed489fe145f28e2c79048443f7f9
+      - c1786e549c5a4dd980abf6cb3829fb28
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:11 GMT
+      - Wed, 30 Apr 2025 16:28:44 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=265,atl-edge-internal;dur=16,atl-edge-upstream;dur=249,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="MQyTCyn4P2LMgyVtXwgVBAPemY_7PS75P-54AJNn5pEbv5wrSRztkA==",cdn-downstream-fbl;dur=273,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=270,atl-edge;dur=245,atl-edge-internal;dur=15,atl-edge-upstream;dur=231,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 51e6f466f192ce588105b138cebcc0d0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - MQyTCyn4P2LMgyVtXwgVBAPemY_7PS75P-54AJNn5pEbv5wrSRztkA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 4d35e517ea9bf5d366992c8c52c8b717
+      - b2656e6c230d3427c0b233389d00b6eb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16140
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18287
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZlsifJLHAHD0MXuli7LssRpgWZFwEhnmTVFqiQV22v733eU
-        LLu1qw7JsKJAavF47889vPcerAomUy/2NMgUNKTPOYjU+JLlYHyTzCFnvipAM8uVND6k3OZgmZ/M
-        mcxAqMx/AG1QBukVFBoMSLu5m5TGqnzmDN7RMKRhV8O7Eoydrgu41CyxPAHP97jzT4e0H+KHATHD
-        z7m1hYmDIIUZJDZVb1WXWcGM4Ux2JdgAPdmAFTyIAm5MCUFjYAFr1L+YTq6nHTocDPGoCsF48XvP
-        YGylSZiFTOl1nUOKX6gRhdGgE9IODadRGNOTmNIuHZz8gHE7s5UTi4FXZp4YpNMP0F4YbdPefKRg
-        Es0LVzg8fUZMzoTwScqN5TKxpOCQAFEzslR60XXaiZI3WjwyilJy1y4m7tgDs0wHDxyWQRXWLsCN
-        iIY9OvrJ8L/hxxzbXubo1cECXU6ZWbhelffW/YpnTBjwvVrxDPOqdH1vzhE4Opmvz+EBMNbwo+9Z
-        jsgqECVeLEvM0duDSS9sBIVWbzGjJxZ8o12Vu2pgU+49kOyyupHcWjRgvK1vh9TfqrtGzeySaYdX
-        w/NCcAw43csc+1GhrD9a9UePDPcrnWky2falHx5jGFF/FfX/Xy919yssokM6XNHht3C4ajz2olUv
-        +hYeNwD/+PEQjrQNp1GboNcIZnz1siZHhMXtG4RJlmnIkG8OhgATUKKsx//LVgdtgmGb4LhFELUK
-        Rm2Ck8M4a9qsTx0pVS+EF3eo72Fn7EusuhuQ+kJFLq5Jmid1ku8PztzoYP3NXJUiHXNTCLbeDBge
-        L5nFx6gm8ceTQf1E7B6FoDan3ahXP09V6ZpBXaiv3AGXmRdbXTrfiQZM1vHH4SMRdkfRoHkk9su2
-        pbJ9QRuooi2oCs2V5nb9xIQb9aD/uLeC5ywDEzgN0xjheCDUsmsesh1ZnqtlQ6p973Bsou0QCHYP
-        jhYd/vc3gjbo0jaE0pGrx5yZScGTcy4Xz51kDIXbXmTS4KVC0bKSbU+kkhNcXti9gCtgpsag3vzy
-        Ls9vfjm7uDs/O51cXE/uJldXf1xhfjilBguCF6ZzIJfI/9IS55dwQ5QUa4JcwoUzSqwiL7hm5FJD
-        jmRCSoP46n6JUyiOkxd+4GH4LpSxV7+J2Dss/m6mPuMKbEPGJRP7lza716a8FcoFRtfQDfY1k7C9
-        XRZuaFtxfDJqcFyvSU+EXq28fXc/32weh8Yd3H5myQKXzQZyjfHa1+lmn/tPATdLYdDsZlGzJkhw
-        UE+UUPqijuZelNDJNPLTbiVSZKzqZqu8wHVY2i+DftBGCoMtKXyt45+X8y+5+3c05VbAUUxuX7OC
-        xuRUqQUH8opbZFRLriEpNZDngmUfXHWwOEIlTMyVsfEoHIXBjMsUaS/o9Y7fVAbHVfEwr7eKOFjF
-        R+RfNcl3+Of7Sv0alz7HQaiGbLEJclwCGWM+ePg7WxMa+sSBcZvE6asJim7xvw4u9FWkro/JEro5
-        txq6SmcBwpi51nLc2Bz8A7zandtcVHHXdl46OzdyIdXy0yJdapWWuANMZIaDnWObginW2PmsKoTx
-        kl/VsmNVS5WKjYHoDQnILTWW/FkybUGTnckWVdj5pJX262eX5DphsuW+W0YDGvW3WX2Sx/XaWMgN
-        5pEWiiPYjuLqvOqQq1jOuDTcQhfxiAUz83vFdNp248D+eIezo/gfAAAA///sWe9r2zAQ/VdEodBC
-        7TqJsySD0oWywT6UjRZWKIWgyHJjFsvGP+qWrf/73kmqlnpRN8oo/VDoBzeS754ud0/vLldqzoRJ
-        J3AvW0qpWC0b1tncakCOtcmvFPl1wLpVJlYsl1zVWORmh7WA816ppWRcCLCrTNhNxlmLghHVXQl6
-        wj6lpJEE4QaiU3zX17q1JEAXK6kovxh3dgt0njgRkNCxoAJZptKiyvU7rKiIszlWa6JM0PV3qQ4I
-        GIxnDTO6g/F1x+/oiKzkGl1bI7MZV2wDIPpGJdchvvGazuxOaGJwpSgI5I1iBAQWYf0AkQzWLQK0
-        FenGmTdOf4ZaxO2DkNHpbb50XRcWHa9LXRUoQnkblqtSZzScLGBzYX0veAOhtWyRU4u9Lxfz86/B
-        +WmAi1rXqnNSFpTKVA17PMkztc/29n8iUdZN8R5p+KfGGbuLvn/J+XhuEPsWnMQlAmwqUL5WYaQK
-        e1tjJ0h7C5FPJkc+rRE5raG/PS25tm/0qePIgUGMuVhRgW/R+30mr9s853Rp7fyNrynqJEGL6pk3
-        HEmRY9QbidzPydE4GU0n0+VgEsmRmEViNh6ms0FKoxK3CR6e2CYpJeZJAh+45XDlJXcfNoCAUMjW
-        k02xqZUQt6jepmnKNmaxhNDjySCO303EdDIezZZiOYngPuUynYrj5Ehb2R3Nd4ef8GfeC3KuLL8G
-        gfmoDts66BCIYBgScYdlu1xngiIVlJzXFCi8r+8RyEQ8nqAowlJRzPsN9utH3O/QXz/ifof/2hGD
-        ihLTmlopeILUh5JJ01aITBcQ8blpHQ2RXUIMYuPHtipKeXgJihGr35VGEyasutIlD3autl0/xj5e
-        jX1NZeybVMSOuytL/G/88mKZ9MYvL4H4jV+28EufBpwgc3oFqK9N7f2gUbh9juCwaLgd5PeteJWX
-        l5e8kmy4nfl8U6HIp0GJELYuRD4NOvK9MXIiT6qbrCqUUXnmo6S1vyKZf/8pekVuLPx4eLR0/wz6
-        3fgB7PDB7sFOzm/PZN2uyfCGbz00qZp5Y3DcFM3/m6oaY84ofKFd/FbomZMb5BaVnuSQSwfkMdrh
-        I7j2BR2e+/v7XwAAAP//AwC5Gom6tBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18287","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18287","key":"NTEST-1896","fields":{"statuscategorychangedate":"2025-04-30T18:28:44.206+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1896/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:43.910+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tbr:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:43.989+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/337]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/337 (337)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/124]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1896/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18287/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 9d4db87b-8afa-4ecd-b68a-eea9abf4f2aa
+      - d3b8aa48-5185-41ad-8d54-4135b6631b3a
       Atl-Traceid:
-      - 9d4db87b8afa4ecdb68aeea9abf4f2aa
+      - d3b8aa48518541ad8d544135b6631b3a
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:11 GMT
+      - Wed, 30 Apr 2025 16:28:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=258,atl-edge-internal;dur=13,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=279,atl-edge;dur=247,atl-edge-internal;dur=14,atl-edge-upstream;dur=232,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="HTBGZnCAlzTDLqAhCqy4jLOIv4snaPB9djMPOdX5WTfyGL_KCYSDTw==",cdn-downstream-fbl;dur=284
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 de5b26aba33b480d2b740b96a34fe916.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - HTBGZnCAlzTDLqAhCqy4jLOIv4snaPB9djMPOdX5WTfyGL_KCYSDTw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 011015109d4ac6a32b89595b570cff1a
+      - fcd57d24c5e8062644d9d80a2ba49d3b
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2Tdl+5oSExEAykdhcQQmnqiECaVE06aZr230nEBDsCN8t+
-        Xj+WD6QWHre9IZy8hdB5Ppk0qFCGxr27TAQjvNfCZhYDGZFG+86I/T/4Evudltig/1ij6VZoA/Z/
-        XbJyVpkBrcTfJXfYe+1shCkAzSCDcbm5fCzXD9XPdDO0dawIf07QCEbwEp3YGbdv45XVvku2lXFD
-        E0P1oE3zFSE8Bth8fmpeiZBABmw6BjqGZcUYL3JeRDHABUQ45n38A/aVbs9ZChUDTpecsozR/JuV
-        7Y1VLoIFnS2kAJyikjSfoyiUKhRIxZb5dFGrWYFspoCdCYJJhlvdi/RCVGIw4c5JkdoHYk4VQfu6
-        Lcnx/LAnZ9Pk+r4ix08AAAD//wMAhRW/yiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:45.731+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - fef29fdd-9fa5-4a68-a8ac-e043119757eb
+      - 2eaa84e8-b281-4aa9-ad87-ee113a55823d
       Atl-Traceid:
-      - fef29fdd9fa54a68a8ace043119757eb
+      - 2eaa84e8b2814aa9ad87ee113a55823d
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:12 GMT
+      - Wed, 30 Apr 2025 16:28:45 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=166,atl-edge-internal;dur=14,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=175,atl-edge;dur=141,atl-edge-internal;dur=13,atl-edge-upstream;dur=129,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="tiUkz6oB3f0g-p6w7Umb5fVvLZSwILLZ6mg0PdeeofR_4Q94GJ6OyA==",cdn-downstream-fbl;dur=180
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 ad310b4d7c581c35032fa3fce068e53c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - tiUkz6oB3f0g-p6w7Umb5fVvLZSwILLZ6mg0PdeeofR_4Q94GJ6OyA==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 5ab322fb295317138d01d98a9f5d4609
+      - 97ac3136734f74bdc4129e52ed274ee2
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 7ae2ffb3-e1f9-4df7-83dd-ac820a4bffdb
+      - 1cd59631-77a0-4583-b787-9ece098f4f39
       Atl-Traceid:
-      - 7ae2ffb3e1f94df783ddac820a4bffdb
+      - 1cd5963177a04583b7879ece098f4f39
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:12 GMT
+      - Wed, 30 Apr 2025 16:28:46 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=302,atl-edge-internal;dur=13,atl-edge-upstream;dur=289,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=22,cdn-upstream-fbl;dur=415,atl-edge;dur=324,atl-edge-internal;dur=15,atl-edge-upstream;dur=309,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="gYe-L7qXUUSt4puh5zSg8yzMHJ7ajUbtv7UfqRfGEcx7rknI9zE3mA==",cdn-downstream-fbl;dur=419
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 87d6d7b4889aec5ce2bf57d717a99d3c.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - gYe-L7qXUUSt4puh5zSg8yzMHJ7ajUbtv7UfqRfGEcx7rknI9zE3mA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - ad7d6cd7eefb2151084e8c07a697989a
+      - eedd0c726ffc0090b67f2dfa4e888b9d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/338]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/338 (338)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/124]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16141","key":"NTEST-1657","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16141"}'
+      string: '{"id":"18289","key":"NTEST-1897","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18289"}'
     headers:
       Atl-Request-Id:
-      - 9891d1c9-ad15-45e1-9543-9a8f5a891151
+      - 0280ef58-59aa-4aae-9c31-91f7bab4645e
       Atl-Traceid:
-      - 9891d1c9ad1545e195439a8f5a891151
+      - 0280ef5859aa4aae9c3191f7bab4645e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:13 GMT
+      - Wed, 30 Apr 2025 16:28:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=637,atl-edge-internal;dur=12,atl-edge-upstream;dur=625,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="LlDp-R97-8zUzf3TUHIkqT0IELDNx2DmtRHB2mgysI-R85wrS5ZqQQ==",cdn-downstream-fbl;dur=797,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=793,atl-edge;dur=706,atl-edge-internal;dur=15,atl-edge-upstream;dur=691,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 3699bc5ea5aacbe1d32ebe3e874f0c68.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - LlDp-R97-8zUzf3TUHIkqT0IELDNx2DmtRHB2mgysI-R85wrS5ZqQQ==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - cc320b7727c562435424a22808bf6f5e
+      - 0896a0ba1c9f6575fffad62a17a4f82d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1657
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1897
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW+08jNxD+V6z9qaXJvhK4sFJVXUlouVJKIYB0FCGzO9n44rX3bG8e5fjfO95X
-        gJCroOrpJC7r8by/+Tz3DixzKhInchSIBBQkhwx4ojuCZqA7Op5CRjsyB0UNk0J3IGEmA0M78ZSK
-        FLhMO3NQGmWQnEGuQIMw9d240EZmE2vwNvD9wHcVfC5Am/Eqh1NFY8NicDoOs/6DvaAf4IcGPsHP
-        qTG5jjwvgQnEJpGfpEsNp1ozKlwBxkNPxqM580KPaV2A1xiYwQr1T8aj83E32Nt9h0dlCNqJ7h2N
-        sRU6pgZSqVZVDgl+oUboh7tdP+gG/jj0o2A/CnpuuOv/gHH7NkjrxGDgpZk3Bmn1PbTnh23a9UcC
-        OlYst4XD0/dEZ5TzDkmYNkzEhuQMYiByQhZSzVyrHUtxofgroygEs+2i/JbOqaHKmzNYeGVY6wBr
-        UeD3gsFPmv0NP2bY9iJDrxYW6HJM9cz2qrgz9lc0oVxDx6kUjzCvUrfjTBkCR8XT1THMAWP1HzqO
-        YYisHFHiRKLAHJ1nMOn5jSBX8hNm9MaC19plucsGNuW2H49Ass7qQjBj0IB2Wt8Wqb+Vd7WcmAVV
-        Fq+aZTlnGHDyLHPsR4my/mDZH7wy3K90psmk7Uvft6gO+8uw//96qbpfYhEdBnvLYO9bOFw2Hnvh
-        shd+C481wB8eNuEYbMNp2AgmbHlZcSB2//pm82avuUnTVEGKfLMxBJiA5EU1/i+7290m2NsmeLdF
-        EG4VDLYJ9jfjrGizOrWkVL4QTtQNaq60LVEsrlK63zizg4LV1lNZ8GTIdM7pqh4nPF5Qg09PRdmv
-        H/3qQVg/AV5lTtnBLn8eyMKWvgz1yh4wkTqRUYX1jUbNJWLGjnddDQWYrOWPzUcidPf7YfNIPC9b
-        S2XPBdtAFbagyhWTipnVG0vQqHv9170VLKMpaM9q6MYIwwMuF66ep2uyPJaLhlT7zubYhC3mOb0D
-        S4svDIZlkxfLEGxDaDCw9ZhSPcpZfMzE7NBKhpDb7UXEDYJKXC1KWXsipBjh8kLvOJwB1RUqVf3L
-        OT2++OXo5Pb46GB0cj66HZ2d/XGG+eGUaiwIXhhPgZwi/wtDrF/CNJGCrwhyCePWKDGSfGCKklMF
-        GZIJKTQizn2JUwIcJ8f/wnz/sz+PnOpNxN5h8dcz9YQrsA0pE5Q/v1TvXnV5S9xzjK7+tn1NBbS3
-        i9wO7cs47rl+0G9wXK1Jb4Repdy+u083m9ehcQ23n2k8w2WzgVxjvPJ1UO9z/yngZin0mt0sbNYE
-        ARbqseRSnVTR3PECuqlCxlqvRJIMZdVsmeW4DgvzMuh3W1L4WmOfK7WE8bScf4n1v50xMxx2InL9
-        keZhRA6knDEgV8wgxxpyDnGhgBxymn6x1cHicBlTPpXaRAN/4HsTJhIkQq/XG9yUBodl8TCvT5JY
-        WEU75F81yXf45/tS/RyXPstBqIZsUQc5LIAMMVE8/J2uSOB3iAVjm8TB1QhF1/hfFxf6MlLbx3gB
-        bsaMAleq1EMYU9tahhubhb+HV92pyXgZd2Xn0tq5EDMhF4+LdKpkUuAOMBIpDnaGbfLGWHzrs6wQ
-        xkt+lYuukVuqlNcGwhviketAG/JnQZUBRdYmt6jC2mdQan98f0rOYyq23LfLqBeE/TarR3mcr7SB
-        TGMeSS4Zgm0nKs/LDtmKZZQJzQy4iEcsmJ7eSaqSbTc27A/XONuJ/gEAAP//7FldSxtBFP0rgyAo
-        uOsm2ZikIDZIC32QFoUKIoTJ7KxZmswu++Eq1v/ec2cm07jN2CJFfBB8WHdm7tfee+65k2s1ZcKk
-        E7CXzaVUrJI1a21u1QDHyuRXivw6YO0iEwu2klxVWORmh5UAf6/VXDIuBNBVJuw246xBwYjyvgA8
-        YZ9S0pCEcMOiM3zrGz1akkGXC6kovxh3cnNMnvAIlpBbYIEsU2lervQZlpeE2RyrFUEm4PqHVAdk
-        GIRnNTNMhPFly+/JRVZwbV1TIbMZV2zDQMyNSi5DfPGKfHYemhhcKwoCaaMYwQJrYbU2kQRWDQK0
-        1dINnze8P0ctovsgZOS9zZe2bcO85VWhqwJFKO/CYlHojIaSGWTOrO4Zr0G95g1yarb39XJ68S24
-        OAvQqHWtOiVFTqlM1bDHk1Wm9tne/k8kyrLOPyAN/+Q4Q9fou03OR356sW/BUVxCxroE5GteRjyx
-        szXyseHYMdXuCcc19EfSzGr7Rh/3iHzsOHI6EWMuFlTgtgFv9vAuxFfNasWpae38Da8p6kRB8/KF
-        HY6oyAnqjWjvl+R4mAzGo/G8N4rkQEwiMRn200kvPYIetwkantkmKSWmSQId6HJoecn9xw1DACgk
-        69mh2NRKiC6qt2mYsoNZLEH0eNKL46ORGI+Gg8lczEcR1KdcpmNxkhxrKbuD6W7/M/7MuWDFlcXX
-        IDCvqrCpghaBCPohAXdYNPNlJihSQcF5RYHCed1HQBPxeIqiCAtFMe8O2G/f4u6E/vYt7k74b91i
-        QFFihlVLBU+R+mAyadoIkekCIjw3w6QBsiuQQWz81JR5IQ+vgD1i8bvS6IYJq650SYO9V9vOH2Mf
-        rsa+oTJ2Q2Vp8f0dRl4tYd5h5DUsfoeRLTDShQEfU4sdIXN8Be7cmKJ8oKtw+xzBkrzm9iK/K8VH
-        ySIfLkX97QDnuxWKvA54KZuPahKEbF0YeBccyZPqNitzZVieeZU09lck8++/RO82r//f/aYR5oRC
-        E8a077m+61lfqaIEjMkP60fbX15sgP7F7XAt92Bnxe/OZdUsSfCGs/qWpqyntXGc7orpJodcd++f
-        Hu4/OW0PaGsfHx9/AQAA//8DAPuTSDm0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18289","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18289","key":"NTEST-1897","fields":{"statuscategorychangedate":"2025-04-30T18:28:47.191+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1897/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:46.897+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tbz:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:46.978+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/338]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/338 (338)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/124]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1897/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18289/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - dfec6e9d-83b2-4599-9ce6-851a9f7f75b7
+      - 1c3f3c1b-f021-4592-8a92-69542d4a0b06
       Atl-Traceid:
-      - dfec6e9d83b245999ce6851a9f7f75b7
+      - 1c3f3c1bf02145928a9269542d4a0b06
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:13 GMT
+      - Wed, 30 Apr 2025 16:28:47 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=272,atl-edge-internal;dur=15,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=313,atl-edge;dur=280,atl-edge-internal;dur=16,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="nh2-Ew46-ydcHRIMaSGdz6pOKxaPu8R55k1D-oWA944XJag_YwUYjg==",cdn-downstream-fbl;dur=318
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 d45e064f8c3e1035d136019303749e0e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - nh2-Ew46-ydcHRIMaSGdz6pOKxaPu8R55k1D-oWA944XJag_YwUYjg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - bf9971e6e62b9bcf3c92c7238048f857
+      - f6be88eb1026de5bb0823e9d01da3273
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16141
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18289
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW/0/jNhT/V6z8tLE2idPClUjTdKNlY2OMQbmTjiFkktfUV8fO2Q5tx/G/7zlf
-        2jsgd4JpJ6QS+/l9//jjd+fBqmAy9WJPg0xBQ3rIQaSmJ1kOpmeSOeSspwrQzHIlTQ9SbnOwrJfM
-        mcxAqKx3C9qgDNIzKDQYkLY5m5TGqnzmDF7TMKShr+FDCcZO1wWcapZYnoDX87jzT/fokOLCgJjh
-        cm5tYeIgSGEGiU3Ve+UzK5gxnElfgg3Qkw1YwYMo4MaUELQGFrBG/ZPp5Hzap3u7r3CrCsF48Z1n
-        MLbSJMxCpvS6ziHFFWpEYbTbD2mfhtMojOl+TAd+tBv+gHGHLkjnxGLglZkXBun0A7QXRpu0m0UK
-        JtG8cIXD3dfE5EyIHkm5sVwmlhQcEiBqRpZKL3ynnSh5ocUzoygld+1i4prdMst0cMthGVRhbQNs
-        RDQc0NFPhv8DP+bY9jJHrw4W6HLKzML1qryx7iueMWGg59WKR5hXpdvz5hyBo5P5+hhuAWMN73ue
-        5YisAlHixbLEHL0HMBmEraDQ6j1m9MKCN9pVuasGtuV2i09Ass3qQnJr0YDxNr4dUn+vzho1s0um
-        HV4NzwvBMeD0QebYjwplw9FqOHpmuF/oTJvJpi/D0KE6Gq6i4f/rpe5+hUV0SPdWdO9bOFy1HgfR
-        ahB9C48NwO/vH8ORduE06hIMWsGMr97U5IiwuLxCmGSZhgz55quXYLcVYGZKlDUvPH10r0vwqkMQ
-        dQpGXYL9x+HUtFnvOlKqXggv7lNcMosPR024z7+4NZ1vCTyozWl3LavPA1W6wlFHym/dBpeZF1td
-        wn3D086a5kldtbtHey4yPGrmqhTpmJtCsHVzlXEbw7JvEDPuejfV0IDJOv54/EhE/v4wah+Jh2Xb
-        UNlDQReoog2oCs2V5nb9wiK26sHweW8Fz1kGJnAapjXCcUOopW9usy1ZHqtlS6pD7/G1iTaXQLAb
-        cLTo8P9wIuiCLu1CKB25esyZmRQ8OeZycegkYyjc9CKTtotVb5eVbLMjlZzg8MJuBJwBMzUydPPl
-        nR5f/HJ0cn18dDA5OZ9cT87O/jzD/PCWGiwIHpjOgZwi/0tLnF/CDVFSrAlyCRfOKLGK/MY1I6ca
-        ciQTUhrErP8Up1C8Tl74kYfhh/A29uo3EXuHxd/eqc+4AtuQccnEw0PN7NWUt8K5wOhausG+ZhI2
-        p8vCXdqncTzwQzpscVyPSS+EXq28eXc/n2yeh8Yt3H5myQKHzRZyrfHa10Ezz/2ngNuhMGhns6gd
-        EyQ4qCdKKH1SR3MjSuhnGlljOxIpMlZ1s1Ve4Dgs7dOg3+0ihd0NKXyp45+X82+5/duZcitgJyaX
-        71gRxeRAqQUH8pZb5DlLziEpNZBDwbKPrjpYHKESJubK2HgUjsJgxmWKVBoMBqOryuC4Kh7m9V4R
-        B6t4h3xVk3yHP99X6uc49DkOQjVkiybIcQlkjPng5h9sTWjYIw6MmyQO3k5QdIn/+jjQV5G6PiZL
-        8HNuNfhKZwHCmLnWcpzYHPwDPOrPbS6quGs7b5ydC7mQavlpkU61SkucASYyw4udY5uCKdbY+awq
-        hPGSX9Wyb1VHlYrGQHRFAnJJjSV/lUxb0GRrskMVtj5ppf3u9Sk5T5jsOO+G0YBGw01Wn+RxvjYW
-        coN5pIXiCLaduNqvOuQqljMuDbfgIx6xYGZ+o5hOu048sj/e4mwn/hcAAP//7Flta9swEP4rolBo
-        oXadxGmSQelC2WAfykYLK5RCkGW5MYtl45e6pet/33OSoqVe3I0ySj8U8sGJpLvT+e655y7Xas6E
-        CSdgL4ukVKySNWttbNUAx8rEV4L4OmDtMhVLlkmuKixys8NKwH2vVSQZFwLoKmN2m3LWIGFEeV8A
-        nrBPKWkKtb9h0Rne9Y1uLcmgy6VUFF+MO7k5Ok/cCJbQtcACWaqSvMz0GZaXhNkcqxVBJuD6h1QH
-        ZBiEpzUzbIDxVcvv6Yqs4Nq6pkJkM67YhoHoG5Vc+XjjFd3Z3dD44FqRE0gb+QgWWAurtYkksGrg
-        oK2Wbtx54/bnyEVUH7iMbm/jpW1bP295VeisQBLKO79YFjqioWQBmQure8Fr0J+oQUwt9r5ezi++
-        eRdnHgq1zlWnpMgplCkb9nicpWqf7e3/RKCs6vwDwvBPjjN2hb5b5PpwbhD2LTjSSwBYl4B8zeyI
-        q3W2ho6QdhYCJ6O70Mc1Asc19NvTlGv7xj52HDhjntTsLnLjBXCxpOw3daFqsoxT0dr5G16T14mC
-        5uULKxxRkRPkGxHnL/HxOB5NJ9NoMAnkSMwCMRsPk9kgOYIetwkantkmKSTmcQwdqHIoefH9xw1D
-        ACgk69mm2OSKjyqqt2mYso1ZKEH0eDwIw6OJmE7Go1kkokkA9QmXyVScxMdayu5ovjv8jI8552Vc
-        WXz1PPNT5TeV18IR3tAn4PaLJlqlgjzlFZxX5Cic13UENBGPp0gKv1Dk826D/fYt7nbob9/ibof/
-        1i0GFMWmYbRU8BShDyaTJI0QqU4gwnPTjhoguwIZxMZPTZkX8vAKECOWvzONJkxYdalLGuxcbTt/
-        DPtwNexrKsO+SUXosLu0wP+OL68WSe/48hoWv+PLFnzpwoAjZI6/wOobk3sPNAq3zwEU5jW3g/yu
-        lF7m1YtLvZRsuB35+qZCQR8HJUDYuhD0cdBR34mRI3lS3aZlrgyRMz/Fjf0XyXz9J+/lmZHwsH60
-        cP8C+N34A+xwLfdgJ+N357JqViR4Q7cempT1vDZ23Ob1/5vUGmFOKHShXfye65nTerxKs2Ka5JBK
-        Z8hTa4dPzLUHtHseHx9/AQAA//8DAMzyTUS0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18289","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18289","key":"NTEST-1897","fields":{"statuscategorychangedate":"2025-04-30T18:28:47.191+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1897/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:46.897+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tbz:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:46.978+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/338]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/338 (338)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/124]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1897/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18289/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 6938fd75-4aa6-4971-b73b-31aaf5207696
+      - 950ef7dc-6c68-41a1-adb2-d25ac5a944e5
       Atl-Traceid:
-      - 6938fd754aa64971b73b31aaf5207696
+      - 950ef7dc6c6841a1adb2d25ac5a944e5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:14 GMT
+      - Wed, 30 Apr 2025 16:28:48 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=299,atl-edge-internal;dur=15,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="HphXcO0eaNxVmhT7GwZY6QJAm3jSEpK5Doo439Y1cIkJAUOADxI3Yg==",cdn-downstream-fbl;dur=423,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=95,cdn-upstream-fbl;dur=420,atl-edge;dur=293,atl-edge-internal;dur=16,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 22067fb5d7eb764108747a104222f50a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - HphXcO0eaNxVmhT7GwZY6QJAm3jSEpK5Doo439Y1cIkJAUOADxI3Yg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - ee24310cd1db9e57c3428d6882cc9a6c
+      - c7baf634693707122d1163973926b469
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33380\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57210\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:19:14 GMT
+      - Wed, 30 Apr 2025 16:28:48 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/124", "url_api": "http://localhost:8080/api/v2/tests/124/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      124, "url_ui": "http://localhost:8080/test/124", "url_api": "http://localhost:8080/api/v2/tests/124/"},
+      "finding_count": 2, "findings": {"new": [{"id": 337, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/337",
+      "url_api": "http://localhost:8080/api/v2/findings/337/"}, {"id": 338, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/338",
+      "url_api": "http://localhost:8080/api/v2/findings/338/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57218\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/124\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/124/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 124, \\\"url_ui\\\": \\\"http://localhost:8080/test/124\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/124/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 337, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/337\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/337/\\\"},
+        {\\\"id\\\": 338, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/338\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/338/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 337,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/337/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/337\"\n        },\n
+        \       {\n          \"id\": 338,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/338/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/338\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        124,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/124/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/124\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/124/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/124\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:48 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_not_verified_enforced_verified_globally_false_enforced_verified_jira_true.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_not_verified_enforced_verified_globally_false_enforced_verified_jira_true.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33390\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57226\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:19:14 GMT
+      - Wed, 30 Apr 2025 16:28:48 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/125", "url_api": "http://localhost:8080/api/v2/tests/125/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      125, "url_ui": "http://localhost:8080/test/125", "url_api": "http://localhost:8080/api/v2/tests/125/"},
+      "finding_count": 2, "findings": {"new": [{"id": 339, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/339",
+      "url_api": "http://localhost:8080/api/v2/findings/339/"}, {"id": 340, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/340",
+      "url_api": "http://localhost:8080/api/v2/findings/340/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57238\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/125\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/125/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 125, \\\"url_ui\\\": \\\"http://localhost:8080/test/125\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/125/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 339, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/339\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/339/\\\"},
+        {\\\"id\\\": 340, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/340\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/340/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 339,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/339/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/339\"\n        },\n
+        \       {\n          \"id\": 340,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/340/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/340\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        125,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/125/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/125\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/125/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/125\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:48 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_not_verified_enforced_verified_globally_true_enforced_verified_jira_false.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_not_verified_enforced_verified_globally_true_enforced_verified_jira_false.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33392\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57240\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:19:14 GMT
+      - Wed, 30 Apr 2025 16:28:48 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/126", "url_api": "http://localhost:8080/api/v2/tests/126/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      126, "url_ui": "http://localhost:8080/test/126", "url_api": "http://localhost:8080/api/v2/tests/126/"},
+      "finding_count": 2, "findings": {"new": [{"id": 341, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/341",
+      "url_api": "http://localhost:8080/api/v2/findings/341/"}, {"id": 342, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/342",
+      "url_api": "http://localhost:8080/api/v2/findings/342/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57250\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/126\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/126/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 126, \\\"url_ui\\\": \\\"http://localhost:8080/test/126\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/126/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 341, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/341\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/341/\\\"},
+        {\\\"id\\\": 342, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/342\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/342/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 341,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/341/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/341\"\n        },\n
+        \       {\n          \"id\": 342,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/342/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/342\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        126,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/126/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/126\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/126/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/126\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:48 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_not_verified_enforced_verified_globally_true_enforced_verified_jira_true.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_not_verified_enforced_verified_globally_true_enforced_verified_jira_true.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -38,9 +38,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:33404\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57252\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -76,7 +76,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:19:14 GMT
+      - Wed, 30 Apr 2025 16:28:48 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/127", "url_api": "http://localhost:8080/api/v2/tests/127/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      127, "url_ui": "http://localhost:8080/test/127", "url_api": "http://localhost:8080/api/v2/tests/127/"},
+      "finding_count": 2, "findings": {"new": [{"id": 343, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/343",
+      "url_api": "http://localhost:8080/api/v2/findings/343/"}, {"id": 344, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/344",
+      "url_api": "http://localhost:8080/api/v2/findings/344/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57260\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/127\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/127/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 127, \\\"url_ui\\\": \\\"http://localhost:8080/test/127\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/127/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 343, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/343\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/343/\\\"},
+        {\\\"id\\\": 344, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/344\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/344/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 343,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/343/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/343\"\n        },\n
+        \       {\n          \"id\": 344,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/344/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/344\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        127,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/127/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/127\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/127/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/127\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:48 GMT
       Transfer-Encoding:
       - chunked
     status:

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_update_tags.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_with_push_to_jira_update_tags.yaml
@@ -18,26 +18,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1m5r3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwBbLE7NK+EjyIDlCdAEiooxns14FsQAFxDgkHfhDzhUbXfOUqgYcFpwmqesKL5Z
-        2d0YZQOY0flSCsAclaSzBYpMqUyBVKyY5ctazTNkcwXsTOB1NNy2g4gvRCVG7e+sFLF9IPpUETSv
-        25Iczw97siZOru8rcvwEAAD//wMAapj5riACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:49.305+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - d5609974-58d0-473f-930d-e3344c891efb
+      - 6fbe944f-58e5-4b16-905b-c64606ae4a6c
       Atl-Traceid:
-      - d560997458d0473f930de3344c891efb
+      - 6fbe944f58e54b16905bc64606ae4a6c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:15 GMT
+      - Wed, 30 Apr 2025 16:28:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -47,7 +43,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=155,atl-edge-internal;dur=14,atl-edge-upstream;dur=142,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=184,atl-edge;dur=161,atl-edge-internal;dur=14,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="KhZMGBF8x9lR85aezLUkkV6garEfdPOSLpJ4W7_7L3s50R2KGzQHgg==",cdn-downstream-fbl;dur=188
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -56,10 +52,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 476cbc24d5f1a673aca06385c3863276.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - KhZMGBF8x9lR85aezLUkkV6garEfdPOSLpJ4W7_7L3s50R2KGzQHgg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - fb5476bc75f65ece123f7cc679ef4ef3
+      - 77282381a1b0a80cf5c9251789fc06ef
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -86,41 +90,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - b57869b8-5ea6-49df-81aa-e505e6b3022c
+      - fab690f2-1ebf-42cd-90a3-cfca05365ca5
       Atl-Traceid:
-      - b57869b85ea649df81aae505e6b3022c
+      - fab690f21ebf42cd90a3cfca05365ca5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:15 GMT
+      - Wed, 30 Apr 2025 16:28:49 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -130,7 +121,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=382,atl-edge-internal;dur=28,atl-edge-upstream;dur=353,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=333,atl-edge;dur=300,atl-edge-internal;dur=15,atl-edge-upstream;dur=285,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="zc3me9C-Fvrh-bChk3nIeYm6gsTZO3Ph6XHItoUvW2ILWK_D12lvDQ==",cdn-downstream-fbl;dur=338
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -139,13 +130,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 4bbf91f2f9edc22eb68408b6405ae452.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - zc3me9C-Fvrh-bChk3nIeYm6gsTZO3Ph6XHItoUvW2ILWK_D12lvDQ==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - e11b0bbbc0bdd402c2ff234f6756bbda
+      - 8dc257975d2d6cd970a95b78e4ca3c3a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -158,7 +157,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -166,7 +165,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -178,7 +177,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -187,18 +186,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16142","key":"NTEST-1658","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16142"}'
+      string: '{"id":"18291","key":"NTEST-1898","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291"}'
     headers:
       Atl-Request-Id:
-      - 2787fd82-b9be-453e-806f-da2b4c6b987d
+      - da6addcd-6650-4d43-9e6e-5980db18d488
       Atl-Traceid:
-      - 2787fd82b9be453e806fda2b4c6b987d
+      - da6addcd66504d439e6e5980db18d488
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:16 GMT
+      - Wed, 30 Apr 2025 16:28:50 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -208,7 +209,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=694,atl-edge-internal;dur=15,atl-edge-upstream;dur=681,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=647,atl-edge;dur=614,atl-edge-internal;dur=16,atl-edge-upstream;dur=599,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="wFbeSP-GCcNTQx2AYbv-9TmRCuHzbR1z7z7n3_r8uD0z2bUu1yl93Q==",cdn-downstream-fbl;dur=651
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -217,10 +218,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 535c2b5354e6ba6798fd64420ee97a2c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - wFbeSP-GCcNTQx2AYbv-9TmRCuHzbR1z7z7n3_r8uD0z2bUu1yl93Q==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - c8f57417444e95d38e2e525a79826ec4
+      - 941eeaae9a6d661d1232987a73cfc8e4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -244,61 +253,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1658
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW/0/jNhT/V6z8tLG2idMCvUjTdKNlY2OsowWkYwiZ5DX11bFztkPbcfzve06a
-        lm+5E0w7IZXYz+/7xx+/Ow+WOZOJF3kaZAIakkMOIjEtyTIwLRPPIGMtlYNmlitpWpBwm4FlrXjG
-        ZApCpa1b0AZlkJxCrsGAtOuzcWGsyqbO4DUNAhp0NHwqwNjJKoeRZrHlMXgtjzv/dI/2QlwYEFNc
-        zqzNTeT7CUwhton6qDrMCmYMZ7Ijwfroyfos537oc2MK8GsDc1ih/slkOJ606d5uH7fKEIwX3XkG
-        YytMzCykSq+qHBJcoUYYhLvtgLZpMAmDiL6L6F6nt9//AeMOXJDOicXASzNvDNLp+2gvcIFWaa8X
-        CZhY89wVDnffE5MxIVok4cZyGVuSc4iBqClZKD3vOO1YyTMtXhlFIblrFxPX7JZZpv1bDgu/DGsb
-        4FpEgy7t/2T4P/Bjhm0vMvTqYIEuJ8zMXa+KG+u+oikTBlpepXiEeZW6LW/GETg6nq2O4RYw1uC+
-        5VmOyMoRJV4kC8zRewKTblALcq0+YkZvLPhauyx32cC63G7xACTbrM4ktxYNGG/j2yH19/KsUVO7
-        YNrh1fAsFxwDTp5kjv0oUdbrL3v9V4b7hc7UmWz60gv2MYywtwx7/6+XqvslFtEh3VvSvW/hcFl7
-        7IbLbvgtPK4Bfn//HI60Cadhk6BbC6Z8eV6RI8Li8gphkqYaUuSbr16C3VqAmSlRVLzw8tG9JsF+
-        gyBsFPSbBO+eh1PRZrXrSKl8IbyoTXHJLD4cFeG+/uJWdL4lcL8yp921LD8PVOEKRx0pX7gNLlMv
-        sroAbB8atefYcXc5q+BKe86+5nFVx7tney5WVDYzVYhkwE0u2Gp9uR0kNGCyjj9eeiRouF8/Ek/L
-        tqGyp4ImUIUbUOWaK83t6o1FrNX93uveCp6xFIzvNExthOOGUIuOuU23ZHmsFjWp9rzn1ybcXALB
-        bsDRosP/04mgCbq0CaG07+oxY2aY8/iYy/mhkwwgd9OLjOuelZ1clLLNjlRyiMMLuxFwCsxUONDr
-        L290fPbL0cn18dHB8GQ8vB6env55ivnhLTVYEDwwmQEZIf9LS5xfwg1RUqwIcgkXziixivzGNSMj
-        DRmSCSkMYrbzEqdQvE5e8JkHwSfajbzqTcTeYfG3d+oRV2AbUi6ZeHpoPXuty1uiWmB0Nd1gX1MJ
-        m9NF7i5tE47DoFfjuBqT3gi9Snnz7j6ebF6Hxi3cfmbxHIfNGnK18crXwXqe+08B10OhX89mYT0m
-        SHBQj5VQ+qSK5kYU0E41csR2JFJkoKpmqyzHcVjal0G/20QKuxtS+FLHH5fzb7n925lwK2AnIpcf
-        WE4jcqDUnAO54BZZzZIxxIUGcihY+tlVB4sjVMzETBkb9YN+4E+5TJBK/W5v96o0OCiLh3l9VMTB
-        KtohX9Uk3+HP96X6GIc+x0GohmyxDnJQABlgPrj5B1sRGrSIA+MmiYOLIYou8V8bB/oyUtfHeAGd
-        jFsNHaVTH2HMXGs5TmwO/j4e7cxsJsq4Kzvnzs6ZnEu1eFikkVZJgTPAUKZ4sTNskz/BGjufZYUw
-        XvKrWrStaqhSvjYQXhGfXFJjyV8F0xY02ZpsUIWtT1pqf3g/IuOYyYbzbhj1adjfZPUgj/HKWMgM
-        5pHkiiPYdqJyv+yQq1jGuDTcQgfxiAUzsxvFdNJ04pn9wRZnO9G/AAAA///sWW1r2zAQ/iuiUGih
-        dp3EaZJB6ULZYB/KRgsrlEKQZbkxi2Xjl7ql63/fc5KipV7cjTJKPxTywYmku9P57rnnLtdqzoQJ
-        J2Avi6RUrJI1a21s1QDHysRXgvg6YO0yFUuWSa4qLHKzw0rAfa9VJBkXAugqY3abctYgYUR5XwCe
-        sE8pacqyv2HRGd71jW4tyaDLpVQUX4w7uTk6T9wIltC1wAJZqpK8zPQZlpeE2RyrFUEm4PqHVAdk
-        GISnNTO1n/FVy+/piqzg2rqmQmQzrtiGgegblVz5eOMV3dnd0PjgWpETSBv5CBZYC6u1iSSwauCg
-        rZZu3Hnj9ufIRVQfuIxub+OlbVs/b3lV6KxAEso7v1gWOqKhZAGZC6t7wWuQnahBTC32vl7OL755
-        F2ceCrXOVaekyCmUKRv2eJylap/t7f9EoKzq/APC8E+OM3aFvlvk+nBuEPYtONJLAFiXgHzN7IiZ
-        dbaGjpB2FgIno7vQxzUCxzX029OUa/vGPnYcOGOe1OwucuMFcLGk7Dd1oWqyjFPR2vkbXpPXiYLm
-        5QsrHFGRE+QbEecv8fE4Hk0n02gwCeRIzAIxGw+T2SA5gh63CRqe2SYpJOZxDB2ocih58f3HDUMA
-        KCTr2abY5IqPKqq3aZiyjVkoQfR4PAjDo4mYTsajWSSiSQD1CZfJVJzEx1rK7mi+O/yMjznnZVxZ
-        fPU881PlN5XXwhHe0Cfg9osmWqWCPOUVnFfkKJzXdQQ0EY+nSAq/UOTzboP99i3uduhv3+Juh//W
-        LQYUxaY9tFTwFKEPJpMkjRCpTiDCc9OOGiC7AhnExk9NmRfy8AoQI5a/M40mTFh1qUsa7FxtO38M
-        +3A17Gsqw75JReiwu7TA/44vrxZJ7/jyGha/48sWfOnCgCNkjr/A6huTew80CrfPARTmNbeD/K6U
-        XubVi0u9lGy4Hfn6pkJBHwclQNi6EPRx0FHfiZEjeVLdpmWuDJEzP8WN/RfJfP0n7+WZkfCwfrRw
-        /wL43fgD7HAt92An43fnsmpWJHhDtx6alPW8Nnbc5vX/m9QaYU4odKFd/J7rmdN6mEqzYprkkEpn
-        yFNrh0/MtQe0ex4fH38BAAD//wMAMb7Xl7QcAAA=
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18291","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291","key":"NTEST-1898","fields":{"statuscategorychangedate":"2025-04-30T18:28:50.547+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:50.307+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tc7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:50.383+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - f425dd4e-964e-445e-ae67-66ee147d135b
+      - c5fb2052-3381-4f03-b28d-f297a486ecbb
       Atl-Traceid:
-      - f425dd4e964e445eae6766ee147d135b
+      - c5fb205233814f03b28df297a486ecbb
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:16 GMT
+      - Wed, 30 Apr 2025 16:28:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -308,7 +300,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=14,atl-edge-upstream;dur=266,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="gQX0G6ly_df8SrH-JAnKqhFzB6sZmsq4r3h-Rd6MtjkYNdq5_2BI4g==",cdn-downstream-fbl;dur=367,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=68,cdn-upstream-fbl;dur=364,atl-edge;dur=274,atl-edge-internal;dur=17,atl-edge-upstream;dur=257,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -317,10 +309,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0d9c2d5ae2c28ab89ceaef885af258e6.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - gQX0G6ly_df8SrH-JAnKqhFzB6sZmsq4r3h-Rd6MtjkYNdq5_2BI4g==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - b49d468a687edac919d7435df7fad8b7
+      - d5278b0f9e78dd60d9493264c1d92c17
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -344,61 +344,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16142
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18291
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbW/bNhD+K4Q+bZltibKTuAKGoYvdLV2WZYmTAM2KgJHOMmuKVEkqtpfmv++o
-        FzuJow7JsKJAavF4d8/dPXe8Ow+WOZOJF3kaZAIaknccRGI6kmVgOiaeQcY6KgfNLFfSdCDhNgPL
-        OvGMyRSESju3oA3KIDmFXIMBaeu7cWGsyqbO4DUNAhr0NHwuwNjJKocTzWLLY/A6Hnf+6R4dhPhh
-        QEzxc2ZtbiLfT2AKsU3UJ9VjVjBjOJM9CdZHT9ZnOfdDnxtTgN8YmMMK9Y8n47NJl+7tDvGohGC8
-        6M4ziK0wMbOQKr2qYkjwCzXCINztBrRLg0kYRPRNRPd6g/3hD4g7cCCdE4vASzOvBOn0fbQXOKBV
-        2PVHAibWPHeJw9O3xGRMiA5JuLFcxpbkHGIgakoWSs97TjtW8lyLF6IoJHflYuKa3TLLtH/LYeGX
-        sDYAaxEN+nT4k+F/w48Zlr3I0KujBbqcMDN3tSpurPsVTZkw0PEqxUOMq9TteDOOxNHxbHUEt4BY
-        g/uOZzkyK0eWeJEsMEbvCU36QZuANoJcq08Y6isrUWuXdSgr29TBfTxgzybcc8mtRQPGW/t2FP6t
-        vGvU1C6YdkQ2PMsFR8DJk5RgoUr6DYbLwfCFcL9SsiaSdcEGwT7CCAfLcPD/eqloUZIUHdK9Jd37
-        Fg6Xjcd+uOyH38Jjzfz7+206hg0dp3x5Uc1ALPLVx+2b/eYmS1MNKc6brSZAnEoUVfs/z/7dNsFe
-        m2C/RRC2CoZtgjfbOKuxWZ26oVS+EF7UpfWsdJnXPK5Cuts6c/2ASTUzVYhkxE0u2KruGjzGEtoL
-        LI/rpNoFs/gYVUP85T1fPRGbR8GvzGnX0eXPA1W4YpTgL90Bl6kXWV04NLEGDNaNieceCRruN4/E
-        07S1jbJwPcqeCtakyjVXmtvVKwNu1P3By94KnrEUjO80TGOE44FQi565TTcz8Ugtmtk58La7I1xz
-        XrAbcNPvmcZwQ+PZNNA2htKhy8eMmXHO4yMu5++cZAS5215k3DCo5NWilK1PpJJjXF7YjYBTYKZi
-        pa5/eSdH578cHl8fHR6Mj8/G1+PT0z9OMT7sUoMJwQuTGZATHPPSEueXcEOUFCuCI4MLZ5RYRd5z
-        zciJhgxnBikM8qv33Oig2E5e8IUHwWfaj7zqTcTaYfI3PfVoVmAZUi6ZeHqp3r3q9JYsF4iu/nZ1
-        TSWsbxe5a9o2HofBoOFxtSa9knqV8vp5fbzZvIyNG7r9zOI5LpsN5Rrjla+Dep/7T4CbpdBvdrOw
-        2QYkOKrHSih9XKG5EQV0U40Ta7MSKTJSVbFVluM6LO3zpN9dD4WvFfap0npgPE7nX3Lzb2fCrYCd
-        iFx9YDmNyIFScw7kklucsZacQVxoIO8ES7+47GByhIqZmCljo2EwDPwplwmOPb8/2P1YGhyVycO4
-        PiniaBXtkH/VJN/hn+9L9TNc+twMQjWcFjXIUQFkhIHi4e9sRWjQIY6M6yAOLscousL/urjQl0hd
-        HeMF9DJuNfSUTn2kMXOl5biYOfr7eLU3s5kocVd2LpydczmXavEwSSdaJQU+9WOZYmNnWCZ/gsl3
-        PssMIV7yq1p0rWrJUl4bCD8Sn1xRY8mfBdMWNNmYbFGFjU9aan94e0LOYiZb7rud06fhcB3VgzjO
-        VsZCZjCOJFccybYTledlhVzGMsal4RZ6yEdMmJndKKaTthtb9kcbnu1E/wAAAP//7FldS9xAFP0r
-        gyAomJjdzbq7BbGLtNAHaVGoIMIymUzc0N1JyIdRrP+9587MTmO6sUWK+CD4EDMz9yv3nnvu7LWa
-        M2HSCdjLIikVK2XFGptbFcCxNPmVIL8OWLNMxZKtJVclFrnZYSXA32sVScaFALrKmN2mnNUoGFHc
-        54An7FNKGpLgtyw6w7e+0aMlGXS5lIryi3EnN8PkCY9gCbkFssdSlWTFWp9hWUGYzbFaEmQCrn9I
-        dUCGQXhaMcNEGF81/J5cZDnX1tUlMptxxVoGYm5UcuXji5fks/PQxOBaURBIG8UIFlgLy42JJLCs
-        EaCtlrZ8bnl/jlpE90HIyHubL03T+FnDy1xXBYpQ3vn5MtcZDSULyFxY3QtegXpFNXJqsff1cn7x
-        zbs489Coda06JXlGqUzVsMfjdar22d7+TyTKqso+IA3/5Dhj1+i7Ta6P/AzCNgBWBZBdky2ig92t
-        faQ36FsIHVPtnnBcQ38kzay2b+zjHkEfOw6cTsSYiyUVuG3A7R7ehfiyXq85Na2dv+E1RZ0oaFa8
-        sMMRFTlBvRHJ/RIfj+PRdDKNBpNAjsQsELPxMJkNkiPocZug4ZltklJiHsfQgS6Hlhfff2wZAkAh
-        Wc/OvqZWfHRRvU3DlJ2/Qgmix+NBGB5NxHQyHs0iEU0CqE+4TKbiJD7WUnZH893hZ/yZc96aK4uv
-        nmdelX5deg0C4Q19Am4/r6NVKihSXs55SYHCed1HQBPxeIqi8HNFMe/O0W/f4u4g/vYt7g7yb91i
-        YFRshlVLBU+R+mAySVILkeoCIjw3o6NBuCuQQWz8VBdZLg+vgD1i+bvS6CIJq650SYO9V9vOH8M+
-        XA37hsrQDZWFxfd3GHm1hHmHkdew+B1GtsBIFwb6mFroCJnjK3DnxhTlA9142+cAlmQVtxf5XSl9
-        lCzow6VguB3g+m6Fgl4Heimb86x7oo/LjXoXHMmT6jYtMmVYnnkV1/ZXJPPvv0TvNqv+322mEeaE
-        QhPGtO+ZvuvZXKmiBIzJD5tH219ebID+xe1wI/dgZ83vzmVZr0hwy1l9S1NU88o4TnfFdJNDrrv3
-        Tw8Pn5y2B7S1j4+PvwAAAP//AwDUXuIOtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18291","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291","key":"NTEST-1898","fields":{"statuscategorychangedate":"2025-04-30T18:28:50.547+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:50.307+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tc7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:50.383+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 3053b950-1591-4142-8cc6-08bdb1d7e2e0
+      - ef5c078c-cf13-4b26-8201-7593ddbccb77
       Atl-Traceid:
-      - 3053b950159141428cc608bdb1d7e2e0
+      - ef5c078ccf134b2682017593ddbccb77
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:17 GMT
+      - Wed, 30 Apr 2025 16:28:51 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -408,7 +391,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=319,atl-edge-internal;dur=13,atl-edge-upstream;dur=306,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=287,atl-edge;dur=255,atl-edge-internal;dur=15,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="Exe6rwETgCtikFB5Yqp4kauWBeJ9jMFvvtP-GASRUdpLHv9IVGjGZg==",cdn-downstream-fbl;dur=292
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -417,10 +400,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f9c7cdbfd821ee3522abb640c0e0a228.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Exe6rwETgCtikFB5Yqp4kauWBeJ9jMFvvtP-GASRUdpLHv9IVGjGZg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 1518ba8247d5bcf24cd70286d93f6f5d
+      - fdef4480d4f9e5086f38db2fb0607170
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -447,26 +438,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL1q5b3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwArilPzSvgIMmB5AjSBZcUYz2Y8C2KACwhwyLvwBxyqtjtnKVQMOF1yWqT5Iv9m
-        ZXdjlA1gRucLKQBzVJLOChSZUpkCqdhyli9qNc+QzRWwM4HX0XDbDiK+EJUYtb+zUsT2gehTRdC8
-        bktyPD/syZo4ub6vyPETAAD//wMAry1Q1SACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:51.965+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 7a5b32c3-62bf-4cd7-aa3e-9ffd28d8f2dd
+      - f48decb9-b357-4d79-ab95-214e63ef80ea
       Atl-Traceid:
-      - 7a5b32c362bf4cd7aa3e9ffd28d8f2dd
+      - f48decb9b3574d79ab95214e63ef80ea
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:17 GMT
+      - Wed, 30 Apr 2025 16:28:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -476,7 +463,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=150,atl-edge-internal;dur=13,atl-edge-upstream;dur=137,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=226,atl-edge;dur=194,atl-edge-internal;dur=14,atl-edge-upstream;dur=180,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="0ptdkM5p0c_2FBF3TzECDpvq8wy2m3-MMcgOuTI_ufeohrE63mYU-A==",cdn-downstream-fbl;dur=230
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -485,10 +472,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 edb5724c2fa0963fde9c6c5089b747ce.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 0ptdkM5p0c_2FBF3TzECDpvq8wy2m3-MMcgOuTI_ufeohrE63mYU-A==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4b4cb4787a07063cbd144bdf1ad062a5
+      - c96673c154360c4b933171253e71247d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -515,41 +510,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - 1239ffee-e95e-499b-b28f-4c403c5ec74c
+      - 9edcb912-e08e-4590-a45d-2cc0c599ca70
       Atl-Traceid:
-      - 1239ffeee95e499bb28f4c403c5ec74c
+      - 9edcb912e08e4590a45d2cc0c599ca70
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:18 GMT
+      - Wed, 30 Apr 2025 16:28:52 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -559,7 +541,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=320,atl-edge-internal;dur=13,atl-edge-upstream;dur=306,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=304,atl-edge;dur=272,atl-edge-internal;dur=18,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="6_F75WW2HENvPPAka7_zAY0K_edEFbm1B95Ie8Yp2lEVFDFnq6Si8w==",cdn-downstream-fbl;dur=308
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -568,13 +550,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8139bc666c011a53bdc5037ba6d5931e.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - 6_F75WW2HENvPPAka7_zAY0K_edEFbm1B95Ie8Yp2lEVFDFnq6Si8w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - fd581ea06f6d039fadec4eb69e2dab52
+      - 40fe438581a7b07a234e229a7c9f3e4f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -587,7 +577,7 @@ interactions:
       "summary": "Zap2: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/346]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/346 (346)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -595,7 +585,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "priority": {"name": "Low"}}}'
     headers:
       Accept:
@@ -607,7 +597,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1303'
+      - '1323'
       Content-Type:
       - application/json
       User-Agent:
@@ -616,18 +606,20 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue
   response:
     body:
-      string: '{"id":"16143","key":"NTEST-1659","self":"https://defectdojo.atlassian.net/rest/api/2/issue/16143"}'
+      string: '{"id":"18293","key":"NTEST-1899","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18293"}'
     headers:
       Atl-Request-Id:
-      - b22a04f8-dc3d-4733-a525-5f08f914f9f6
+      - 19a70b48-7d79-4765-b263-9d84cb9e0e09
       Atl-Traceid:
-      - b22a04f8dc3d4733a5255f08f914f9f6
+      - 19a70b487d794765b2639d84cb9e0e09
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:18 GMT
+      - Wed, 30 Apr 2025 16:28:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -637,7 +629,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=764,atl-edge-internal;dur=12,atl-edge-upstream;dur=753,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=689,atl-edge;dur=656,atl-edge-internal;dur=16,atl-edge-upstream;dur=641,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="_CMYRDPQ-F5qp1g7JPrX9PxDpof2wUiReWVRi2Pyjqz9roeICww0qg==",cdn-downstream-fbl;dur=693
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -646,10 +638,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 98d88908b69262fc69248986276dbe36.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - _CMYRDPQ-F5qp1g7JPrX9PxDpof2wUiReWVRi2Pyjqz9roeICww0qg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 56dea983b27654977627f4cb1efdd621
+      - 9ff94d0bb2f518a7c492eec93def97a6
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -673,61 +673,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1659
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1899
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU8jNxD+K9Z+ammSfUmAsFJVXUlouVJKIYB0FCGzO9mYeO0920uScvz3jvct
-        QNiroOrpJC7r8bw/83geHFhmVMRO6CgQMSiIDxjwWHcETUF3dDSDlHZkBooaJoXuQMxMCoZ2ohkV
-        CXCZdO5BaZRBfAqZAg3CVHejXBuZTq3BG9/zfK+n4HMO2kxWGZwoGhkWgdNxmPXv7/iDPn5o4FP8
-        nBmT6dB1Y5hCZGJ5J3vUcKo1o6InwLjoybg0Y27gMq1zcGsDc1ih/vFkfDbp+jvbe3hUhKCd8MHR
-        GFuuI2ogkWpV5hDjF2oEXrDd9fyu700CL/T3Qn/Y293d+wHj9myQ1onBwAsz7wzS6rtozwuatKuP
-        GHSkWGYLh6cfiE4p5x0SM22YiAzJGERA5JQspJr3rHYkxbnib4wiF8y2i/Ibek8NVe49g4VbhLUO
-        sBL5Xt8f/qTZ3/Bjim3PU/RqYYEuJ1TPba/yW2N/hVPKNXScUvEQ8yp0O86MIXBUNFsdwT1grN5j
-        xzEMkZUhSpxQ5Jij8wImfa8WZEreYUbvLHilXZS7aGBdbvvxBCTrrM4FMwYNaKfxbZH6W3FXy6lZ
-        UGXxqlmacYYBxy8yx34UKBsMl4PhG8P9SmfqTJq+DLxdDCMYLIPB/+ul7H6BRXTo7yz9nW/hcFl7
-        7AfLfvAtPFYAf3zchKPfhtOgFkzZ8qLkQOz+1fXmzX59kyaJggT5ZmMIMAHJ83L8X3e33SbYaRPs
-        tgiCVsGwTbC3GWdJm+WpJaXihXDCrl9xpW2JYlGZ0sPGmR0UrLaeyZzHI6YzTlfVOOEx9tZcYN/s
-        iFUuqMHHqCTxt5NB+USsHwW3NKfsqBc/92Vum1EEf2kPmEic0KjcRhMpwGQtf7z2SAyC3fqReFm2
-        hspeCtpAFTSgyhSTipnVOxOu1d3B294KltIEtGs1dG2E4QGXi56+T9ZkeSQXNakOnM2xCRrMc3oL
-        lhZfGQzLJq+WwW9DqD+09ZhRPc5YdMTE/MBKRpDZ7UVENYIKXC0KWXMipBjj8kJvOZwC1SUqVfXL
-        OTk6/+Xw+ObocH98fDa+GZ+e/nGK+eGUaiwIXpjMgJwg/wtDrF/CNJGCrwhyCePWKDGSfGSKkhMF
-        KZIJyTXiq/cap/g4To73hXneZ/82dMo3EXuHxV/P1DOuwDYkTFD+8lK1e1XlLVDOMbrq2/Y1EdDc
-        zjM7tG043vb8GsflmvRO6JXKzbv7fLN5GxrXcPuZRnNcNmvI1cZLX/vVPvefAq6XQrfezYJ6TRBg
-        oR5JLtVxGc0tz6GbKGSs9UokyUiWzZZphuuwMK+Dfrshha819qVSQxjPy/mXWP/bmjDDYSskV59o
-        FoRkX8o5A3LJDHKsIWcQ5QrIAafJF1sdLA6XEeUzqU049IaeO2UiRtpz+4Od68LgqCge5nUniYVV
-        uEX+VZN8h3++L9TPcOmzHIRqyBZVkKMcyAgTxcPf6Yr4XodYMDZJ7F+OUXSF/3VxoS8itX2MFtBL
-        mVHQkypxEcbUtpbhxmbh7+LV3sykvIi7tHNh7ZyLuZCLp0U6UTLOcQcYiwQHO8U2uRMsvvVZVAjj
-        Jb/KRdfIlipllYHgmrjkyteG/JlTZUCRtckWVVj79AvtTx9OyFlERct9u4y6fjBssnqSx9lKG0g1
-        5hFnkiHYtsLivOiQrVhKmdDMQA/xiAXTs1tJVdx2Y8P+aI2zrfAfAAAA///sWV1L3EAU/SuDICiY
-        mN3NursFsYu00AdpUaggwjKZTNzQ3UnIh1Gs/73nzsxOY7qxRYr4IPgQMzP3K/eee+7stZozYdIJ
-        2MsiKRUrZcUam1sVwLE0+ZUgvw5Ys0zFkq0lVyUWudlhJcDfaxVJxoUAusqY3aac1SgYUdzngCfs
-        U0oakuC3LDrDt77RoyUZdLmUivKLcSc3w+QJj2AJuQUWyFKVZMVan2FZQZjNsVoSZAKuf0h1QIZB
-        eFoxw0QYXzX8nlxkOdfW1SUym3HFWgZiblRy5eOLl+Sz89DE4FpREEgbxQgWWAvLjYkksKwRoK2W
-        tnxueX+OWkT3QcjIe5svTdP4WcPLXFcFilDe+fky1xkNJQvIXFjdC16BekU1cmqx9/VyfvHNuzjz
-        0Kh1rToleUapTNWwx+N1qvbZ3v5PJMqqyj4gDf/kOGPX6LtNro/8DMI2AFYFkF2TLaKD3a19pDfo
-        WwgdU+2ecFxDfyTNrLZv7OMeQR87DpxOxJiLJRW4bcDtHt6F+LJerzk1rZ2/4TVFnShoVrywwxEV
-        OUG9Ecn9Eh+P49F0Mo0Gk0COxCwQs/EwmQ2SI+hxm6DhmW2SUmIex9CBLoeWF99/bBkCQCFZzw7F
-        plZ8dFG9TcOUHcxCCaLH40EYHk3EdDIezSIRTQKoT7hMpuIkPtZSdkfz3eFn/Jlz3pori6+eZ16V
-        fl16DQLhDX0Cbj+vo1UqKFJeznlJgcJ53UdAE/F4iqLwc0Ux7w7Yb9/i7oT+9i3uTvhv3WJgVGyG
-        VUsFT5H6YDJJUguR6gIiPDejo0G4K5BBbPxUF1kuD6+APWL5u9LohgmrrnRJg71X284fwz5cDfuG
-        ytANlYXF93cYebWEeYeR17D4HUa2wEgXBvqYWugImeMrcOfGFOUDXYXb5wCWZBW3F/ldKX2ULOjD
-        pWC4HeD6boWCXgd6KZvzrHuij8uNehccyZPqNi0yZVieeRXX9lck8++/RO82q/7fbaYR5oRCE8a0
-        75m+69lcqaIEjMkPm0fbX15sgP7F7XAj92Bnze/OZVmvSHDLWX1LU1TzyjhOd8V0k0Ouu/dPDw+f
-        nLYHtLWPj4+/AAAA//8DAASeVFi0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18293","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18293","key":"NTEST-1899","fields":{"statuscategorychangedate":"2025-04-30T18:28:53.119+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1899/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:52.842+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tcf:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:52.908+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/346]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/346 (346)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1899/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18293/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 42d46fc3-cefc-4e0b-9ede-b5a6c28b138a
+      - d4fbb9dd-1cf8-4fcb-835a-7b709e75292e
       Atl-Traceid:
-      - 42d46fc3cefc4e0b9edeb5a6c28b138a
+      - d4fbb9dd1cf84fcb835a7b709e75292e
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:19 GMT
+      - Wed, 30 Apr 2025 16:28:53 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -737,7 +720,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=280,atl-edge-internal;dur=12,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="bznfiE2j_EAbKUuj1FeueLG9CwDNYnD5cBrSThSB61I-wu4Sj4SvZw==",cdn-downstream-fbl;dur=293,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=55,cdn-upstream-fbl;dur=291,atl-edge;dur=217,atl-edge-internal;dur=17,atl-edge-upstream;dur=201,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -746,10 +729,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 dd3ca66f64c2ab5745848b5787ca747a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - bznfiE2j_EAbKUuj1FeueLG9CwDNYnD5cBrSThSB61I-wu4Sj4SvZw==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 5d5a4e91e3c3bf16beb72b22823b6f8b
+      - 16010740c1e50149a8cac150a147a79a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -773,61 +764,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16143
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18293
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxt4rSFEmma7mjZ2BhjUEC6DCGTnKamjp1rO7Qdl/++46Rp
-        ecu9gmlXSCX28Xl//Pjce7DImUy8yNMgE9CQ7HMQiWlJloFpmXgKGWupHDSzXEnTgoTbDCxrxVMm
-        UxAqbd2BNiiD5ARyDQakXZ2NC2NVNnEGr2kQ0KCj4VMBxo6XORxrFlseg9fyuPNPt2mviwsDYoLL
-        qbW5iXw/gQnENlG3qsOsYMZwJjsSrI+erM9y7oc+N6YAvzYwgyXqH41Hp+M23e7v4lYZgvGie89g
-        bIWJmYVU6WWVQ4Ir1AiDsN8OaJsG4zCI6G5EB52dnd0fMO7ABemcWAy8NPPOIJ2+j/aCcJ32apGA
-        iTXPXeFw9wMxGROiRRJuLJexJTmHGIiakLnSs47TjpU80+KNURSSu3Yxcc3umGXav+Mw98uwNgGu
-        RDTo0sFPhv8DP2bY9iJDrw4W6HLMzMz1qrix7iuaMGGg5VWKB5hXqdvyphyBo+Pp8hDuAGMNHlqe
-        5YisHFHiRbLAHL1nMOkGtSDX6hYzemfBV9plucsG1uV2i0cg2WR1Jrm1aMB4a98Oqb+XZ42a2DnT
-        Dq+GZ7ngGHDyLHPsR4my3mDRG7wx3C90ps5k3ZdesINhhL1F2Pt/vVTdL7GIDun2gm5/C4eL2mM3
-        XHTDb+FxBfCHh5dwpE04DZsE3Vow4YvzihwRFpdXCJM01ZAi33z1EvRrAWamRFHxwutHt5sEOw2C
-        sFEwaBLsvgynos1q15FS+UJ4UZvikll8OCrCffvFreh8Q+B+ZU67a1l+7qnCFY46Ur5wG1ymXmR1
-        Adg+NGrPsePuclbBlfacfc3jqo73L/ZcrKhspqoQyZCbXLDl6nI7SGjAZB1/vPZI9MKd+pF4XrY1
-        lT0XNIEqXIMq11xpbpfvLGKt7vfe9lbwjKVgfKdhaiMcN4Sad8xduiHLQzWvSbXnvbw24foSCHYD
-        jhYd/p9PBE3QpU0IpQNXjykzo5zHh1zO9p1kCLmbXmRc96zs5LyUrXekkiMcXtiNgBNgpsKBXn15
-        x4dnvxwcXR8e7I2OTkfXo5OTP08wP7ylBguCB8ZTIMfI/9IS55dwQ5QUS4JcwoUzSqwiv3HNyLGG
-        DMmEFAYx23mNUyheJy/4zIPgE72JvOpNxN5h8Td36glXYBtSLpl4fmg1e63KW6JaYHQ13WBfUwnr
-        00XuLm0TjvsBrXFcjUnvhF6lvH53n042b0PjBm4/s3iGw2YNudp45WtvNc/9p4DrodCvZ7OwHhMk
-        OKjHSih9VEVzIwpopxo5YjMSKTJUVbNVluM4LO3roO83kUJ/TQpf6vjTcv4tN39bY24FbEXk8iPL
-        w4jsKTXjQC64RVaz5BTiQgPZFyz97KqDxREqZmKqjI0GwSDwJ1wmSKV+t7d9VRoclsXDvG4VcbCK
-        tshXNcl3+PN9qX6KQ5/jIFRDtlgFOSyADDEf3PyDLQkNWsSBcZ3E3sUIRZf4r40DfRmp62M8h07G
-        rYaO0qmPMGautRwnNgd/H492pjYTZdyVnXNn50zOpJo/LtKxVkmBM8BIpnixM2yTP8YaO59lhTBe
-        8quat61qqFK+MhBeEZ9cUmPJXwXTFjTZmGxQhY1PWmp//HBMTmMmG867YdSn4WCd1aM8TpfGQmYw
-        jyRXHMG2FZX7ZYdcxTLGpeEWOohHLJiZ3iimk6YTL+wPNzjbiv4FAAD//+xZbWvbMBD+K6JQaKF2
-        ncRpkkHpQtlgH8pGCyuUQpBluTGLZeOXuqXrf99zkqKlXtyNMko/FPLBiaS70/nuuecu12rOhAkn
-        YC+LpFSskjVrbWzVAMfKxFeC+Dpg7TIVS5ZJrioscrPDSsB9r1UkGRcC6Cpjdpty1iBhRHlfAJ6w
-        TylpyrK/YdEZ3vWNbi3JoMulVBRfjDu5OTpP3AiW0LXAAlmqkrzM9BmWl4TZHKsVQSbg+odUB2QY
-        hKc1M7Wf8VXL7+mKrODauqZCZDOu2IaB6BuVXPl44xXd2d3Q+OBakRNIG/kIFlgLq7WJJLBq4KCt
-        lm7ceeP258hFVB+4jG5v46VtWz9veVXorEASyju/WBY6oqFkAZkLq3vBa5CdqEFMLfa+Xs4vvnkX
-        Zx4Ktc5Vp6TIKZQpG/Z4nKVqn+3t/0SgrOr8A8LwT44zdoW+W+T6cG4Q9i040ksAWJeAfM3siJl1
-        toaOkHYWAieju9DHNQLHNfTb05Rr+8Y+dhw4Y57U7C5y4wVwsaTsN3WharKMU9Ha+Rtek9eJgubl
-        CyscUZET5BsR5y/x8TgeTSfTaDAJ5EjMAjEbD5PZIDmCHrcJGp7ZJikk5nEMHahyKHnx/ccNQwAo
-        JOvZptjkio8qqrdpmLKNWShB9Hg8CMOjiZhOxqNZJKJJAPUJl8lUnMTHWsruaL47/IyPOedlXFl8
-        9TzzU+U3ldfCEd7QJ+D2iyZapYI85RWcV+QonNd1BDQRj6dICr9Q5PNug/32Le526G/f4m6H/9Yt
-        BhTFpj20VPAUoQ8mkySNEKlOIMJz044aILsCGcTGT02ZF/LwChAjlr8zjSZMWHWpSxrsXG07fwz7
-        cDXsayrDvklF6LC7tMD/ji+vFknv+PIaFr/jyxZ86cKAI2SOv8DqG5N7DzQKt88BFOY1t4P8rpRe
-        5tWLS72UbLgd+fqmQkEfByVA2LoQ9HHQUd+JkSN5Ut2mZa4MkTM/xY39F8l8/Sfv5ZmR8LB+tHD/
-        Avjd+APscC33YCfjd+eyalYkeEO3HpqU9bw2dtzm9f+b1BphTih0oV38nuuZ03qYSrNimuSQSmfI
-        U2uHT8y1B7R7Hh8ffwEAAP//AwDFp6zjtBwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18293","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18293","key":"NTEST-1899","fields":{"statuscategorychangedate":"2025-04-30T18:28:53.119+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1899/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:52.842+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tcf:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:52.908+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap2: Cookie Without Secure Flag|http://localhost:8080/finding/346]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/346 (346)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap2:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1899/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18293/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - af70023d-6cd7-4ca6-88ce-4300da328452
+      - 5b43e845-8a5a-45c9-8a98-4cef341953c4
       Atl-Traceid:
-      - af70023d6cd74ca688ce4300da328452
+      - 5b43e8458a5a45c98a984cef341953c4
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:19 GMT
+      - Wed, 30 Apr 2025 16:28:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -837,7 +811,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=294,atl-edge-internal;dur=12,atl-edge-upstream;dur=282,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="xv9P4ebBNOnI9CFbiywtqmX7CFmA2tHEbKcwdZNz2fuxWc8VCfr28g==",cdn-downstream-fbl;dur=345,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=63,cdn-upstream-fbl;dur=342,atl-edge;dur=256,atl-edge-internal;dur=14,atl-edge-upstream;dur=243,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -846,10 +820,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 f4931915c262d78fa3e94b48faa4f55a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - xv9P4ebBNOnI9CFbiywtqmX7CFmA2tHEbKcwdZNz2fuxWc8VCfr28g==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 410b6006cf552252d1fc66a3900e4177
+      - 7cd31fe2c954deb3b7617666a80b550d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -882,7 +864,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - DefectDojo-2.42.0
+      - DefectDojo-2.45.3
       X-DefectDojo-Event:
       - test_added
       X-DefectDojo-Instance:
@@ -896,9 +878,9 @@ interactions:
         [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
         \   ],\n    \"Content-Length\": [\n      \"843\"\n    ],\n    \"Content-Type\":
         [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
-        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.42.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
         [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
-        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.2:43304\",\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57274\",\n
         \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
         \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
         Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\": null,
@@ -934,7 +916,112 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 10 Jan 2025 19:19:19 GMT
+      - Wed, 30 Apr 2025 16:28:54 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/128", "url_api": "http://localhost:8080/api/v2/tests/128/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      128, "url_ui": "http://localhost:8080/test/128", "url_api": "http://localhost:8080/api/v2/tests/128/"},
+      "finding_count": 2, "findings": {"new": [{"id": 345, "title": "Zap1: Cookie
+      Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/345",
+      "url_api": "http://localhost:8080/api/v2/findings/345/"}, {"id": 346, "title":
+      "Zap2: Cookie Without Secure Flag", "severity": "Low", "url_ui": "http://localhost:8080/finding/346",
+      "url_api": "http://localhost:8080/api/v2/findings/346/"}], "reactivated": [],
+      "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.45.3
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"1315\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.45.3\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.9:57288\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        2 findings for Security How-to: 1st Quarter Engagement: ZAP Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/128\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/128/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 128, \\\"url_ui\\\": \\\"http://localhost:8080/test/128\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/128/\\\"}, \\\"finding_count\\\":
+        2, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 345, \\\"title\\\": \\\"Zap1:
+        Cookie Without Secure Flag\\\", \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\":
+        \\\"http://localhost:8080/finding/345\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/345/\\\"},
+        {\\\"id\\\": 346, \\\"title\\\": \\\"Zap2: Cookie Without Secure Flag\\\",
+        \\\"severity\\\": \\\"Low\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/346\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/346/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        2,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 345,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap1: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/345/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/345\"\n        },\n
+        \       {\n          \"id\": 346,\n          \"severity\": \"Low\",\n          \"title\":
+        \"Zap2: Cookie Without Secure Flag\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/346/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/346\"\n        }\n      ],\n
+        \     \"reactivated\": [],\n      \"untouched\": []\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        128,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/128/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/128\"\n    },\n    \"title\":
+        \"Created/Updated 2 findings for Security How-to: 1st Quarter Engagement:
+        ZAP Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/128/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/128\",\n    \"user\": null\n
+        \ }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 30 Apr 2025 16:28:54 GMT
       Transfer-Encoding:
       - chunked
     status:
@@ -959,26 +1046,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQzU7DMBCE38VXmnTtun++oSJREBSkpBcQQo6zFgHHjmKnUlX13bFFBT0Ct9Xu
-        NzujOZBKetz2hgjyFkLnxXhco0YVavfuchmM9L6RNrcYyIjUje+M3P+DL7DfNQpr9B9rNN0KbcD+
-        r09WzmozoFX4O+UOe984G2EKQHPIISs2l4/F+qH8uW6GtooTEc8JGsEIXqIndsbt25iy3HfJbWXc
-        UEdRNTSm/pIQEQVsPj8tr2RIIAM2zYBmsCwZE3wieDQGuIAIR72PPWBfNu05S6FkIOhSsBiR8m9W
-        tTdWuwhyOlsoCThFrehkjpJrzTUozZaT6aLSM45spoGdGQSTHG6bXqYKUcvBhDunZFofiDlNBO3r
-        tiDH82BPzqbL9X1Jjp8AAAD//wMAuLdUGiACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:54.710+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 9945d055-7466-41cd-9a99-c589faac379c
+      - 5d5e3e86-e38c-495f-956c-3660ebe98aac
       Atl-Traceid:
-      - 9945d055746641cd9a99c589faac379c
+      - 5d5e3e86e38c495f956c3660ebe98aac
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:20 GMT
+      - Wed, 30 Apr 2025 16:28:54 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -988,7 +1071,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=143,atl-edge-internal;dur=15,atl-edge-upstream;dur=129,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="gr8dq17liX3k8U5VilCOXvexAsw6cbhlOgNIv2bbsPebfoBmwGj_AA==",cdn-downstream-fbl;dur=249,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=60,cdn-upstream-fbl;dur=246,atl-edge;dur=161,atl-edge-internal;dur=15,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -997,10 +1080,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 13926aef629bc9518d9ad769185e8c4e.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - gr8dq17liX3k8U5VilCOXvexAsw6cbhlOgNIv2bbsPebfoBmwGj_AA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 57b77ed049c042e610c0fbe63fea2576
+      - 655c566a2e9fd830438e94ccde841f90
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1024,61 +1115,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16142
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18291
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa0/jRhT9KyN/amkSe5wAWUtVtSXZli2lFAJIS1dosG+c2YxnvDNjkpTlv/eO
-        HwkQvBVUXSEFz+O+zz1z7zxY5kwmXuRpkAloSN5xEInpSJaB6Zh4BhnrqBw0s1xJ04GE2wws68Qz
-        JlMQKu3cgjZ4Bskp5BoMSFvfjQtjVTZ1Cq9pENCgp+FzAcZOVjmcaBZbHoPX8bizT/foIMSFATHF
-        5cza3ES+n8AUYpuoT6rHrGDGcCZ7EqyPlqzPcu6HPjemAL9RMIcVyh9PxmeTLt3bHeJW6YLxojvP
-        oG+FiZmFVOlVFUOCK5QIg3C3G9AuDSZhENE3Ed3rDfaHP6DfgXPSGbHoeKnmlU46eR/1Bc7RKux6
-        kYCJNc9d4nD3LTEZE6JDEm4sl7ElOYcYiJqShdLznpOOlTzX4oVeFJK7cjFxzW6ZZdq/5bDwS7c2
-        DtZHNOjT4U+G/w0/Zlj2IkOrDhZocsLM3NWquLHuK5oyYaDjVYKHGFcp2/FmHIGj49nqCG4BfQ3u
-        O57liKwcUeJFssAYvScw6QfNQa7VJ4zolQmvpct0lwVs0u0WD0CyiepccmtRgfHWth1SfyvvGjW1
-        C6YdXg3PcsHR4eRJ5FiPEmWD4XIwfKG7X6lME8m6LoNgH90IB8tw8P9aqapfYhEN0r0l3fsWBpeN
-        xX647IffwmIN8Pv7bTjSNpyGzcGULy8qDsTqX33cvtlvbrI01ZAi32w1AQagRFG1//PmdtsO9toO
-        9lsOwtaDYdvBm20/K9qsdh0plS+EF3UpLpnFh6Mi3Jc3bkXnGwL3K3XatWX5eaAKlzjqSPnSbXCZ
-        epHVBWD5UKm9wIq75qycK/U5/ZrHVYLvtvacryhsZqoQyYibXLBV3dwOEhowWMcfzz0SNNxvHomn
-        aVtT2dODNlCFa1DlmivN7eqVSWzE/cHL3gqesRSM7yRMo4TjhlCLnrlNN2R5pBYNqQ687bYJ15gX
-        7AYcLT7TGI5Nnk0DbUMoHbp8zJgZ5zw+4nL+zp2MIHfTi4ybmpWVXJRn6x2p5BiHF3Yj4BSYqXCg
-        6y/v5Oj8l8Pj66PDg/Hx2fh6fHr6xynGh11qMCF4YTIDcoL8Ly1xdgk3REmxIsglXDilxCrynmtG
-        TjRkSCakMIjZ3nOcQrGdvOALD4LPtB951ZuItcPkb3rqEVdgGVIumXh6qZ696vSWqBboXb12dU0l
-        rG8XuWvaNhyHwaDBcTUmvRJ6lfD63X082bwMjRu4/cziOQ6bDeQa5ZWtg3qe+08ON0Oh38xmYTMm
-        SHBQj5VQ+rjy5kYU0E01csRmJFJkpKpiqyzHcVja50G/20YKu2tS+FrFH6fzL7n525lwK2AnIlcf
-        WE4jcqDUnAO55BZZzZIziAsN5J1g6ReXHUyOUDETM2VsNAyGgT/lMkEq9fuD3Y+lwlGZPIzrkyIO
-        VtEO+VdJ8h3+fF+Kn+HQ5zgIxZAtaidHBZARxoObv7MVoUGHODCugzi4HOPRFf7r4kBfeurqGC+g
-        l3Groad06iOMmSstx4nNwd/Hq72ZzUTpd6Xnwuk5l3OpFg+TdKJVUuAMMJYpNnaGZfInmGNns8wQ
-        +kt+VYuuVS1ZymsF4UfikytqLPmzYNqCJhuVLaKwsUlL6Q9vT8hZzGTLfTeM+jQcrqN6EMfZyljI
-        DMaR5Ioj2Haicr+skMtYxrg03EIP8YgJM7MbxXTSdmNL/2iDs53oHwAAAP//7Flta9swEP4rolBo
-        oXadxGmSQelC2WAfykYLK5RCkGW5MYtl45e6pet/33OSoqVe3I0ySj8U8sGJpLvT+e655y7Xas6E
-        CSdgL4ukVKySNWttbNUAx8rEV4L4OmDtMhVLlkmuKixys8NKwH2vVSQZFwLoKmN2m3LWIGFEeV8A
-        nrBPKWnKsr9h0Rne9Y1uLcmgy6VUFF+MO7k5Ok/cCJbQtcACWaqSvMz0GZaXhNkcqxVBJuD6h1QH
-        ZBiEpzUztZ/xVcvv6Yqs4Nq6pkJkM67YhoHoG5Vc+XjjFd3Z3dD44FqRE0gb+QgWWAurtYkksGrg
-        oK2Wbtx54/bnyEVUH7iMbm/jpW1bP295VeisQBLKO79YFjqioWQBmQure8FrkJ2oQUwt9r5ezi++
-        eRdnHgq1zlWnpMgplCkb9nicpWqf7e3/RKCs6vwDwvBPjjN2hb5b5PpwbhD2LTiKSwBYl4B8zeyI
-        mXW2ho6QdhaCPpoc9HGNwHEN/fY05dq+sY8dB86YJzW7i9x4AVwsKftNXaiaLONUtHb+htfkdaKg
-        efnCCkdU5AT5RsT5S3w8jkfTyTQaTAI5ErNAzMbDZDZIjqDHbYKGZ7ZJCol5HEMHqhxKXnz/ccMQ
-        AArJerYpNrnio4rqbRqmbGMWShA9Hg/C8GgippPxaBaJaBJAfcJlMhUn8bGWsjua7w4/42POeRlX
-        Fl89z/xU+U3ltXCEN/QJuP2iiVapIE95BecVOQrndR0BTcTjKZLCLxT5vNtgv32Lux3627e42+G/
-        dYsBRbFpDy0VPEXog8kkSSNEqhOI8Ny0owbIrkAGsfFTU+aFPLwCxIjl70yjCRNWXeqSBjtX284f
-        wz5cDfuaytA1ld0Fh92lBf53fHm1SHrHl9ew+B1ftuBLFwYcIXP8BVbfmNx7oFG4fQ6gMK+5HeR3
-        pfQyr15c6qVkw+3I1zcVCvo4KAHC1oWgj4OO+k6MHMmT6jYtc2WInPkpbuy/SObrP3kvz4yEh/Wj
-        hfsXwO/GH2CHa7kHOxm/O5dVsyLBG7r10KSs57Wx4zav/9+k1ghzQqEL7eL3XM+c1sNUmhXTJIdU
-        OkOeWjt8Yq49oN3z+Pj4CwAA//8DAF4/bYe0HAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18291","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291","key":"NTEST-1898","fields":{"statuscategorychangedate":"2025-04-30T18:28:50.547+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:50.307+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":[],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tc7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:50.383+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 10cbb71a-88b8-4cfb-9183-7257719c19a1
+      - 1711a9c8-ae3c-4bab-ba98-6b3776d8bd95
       Atl-Traceid:
-      - 10cbb71a88b84cfb91837257719c19a1
+      - 1711a9c8ae3c4babba986b3776d8bd95
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:20 GMT
+      - Wed, 30 Apr 2025 16:28:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1088,7 +1162,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=296,atl-edge-internal;dur=17,atl-edge-upstream;dur=280,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=289,atl-edge;dur=256,atl-edge-internal;dur=15,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="AZcKi8z5hYrdNKnj0pz87DUw9PyT9PEklSJbOtrgFIuS1Qp9TczTVg==",cdn-downstream-fbl;dur=293
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1097,10 +1171,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 b3ac893abff0a2c3dda216fe4cd9157a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - AZcKi8z5hYrdNKnj0pz87DUw9PyT9PEklSJbOtrgFIuS1Qp9TczTVg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 4122e6c8e9933b662e2e6ae4c0e94fbd
+      - 4405564afc30a530a15c1b583578a5fb
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1127,41 +1209,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - a0a062a0-8207-4d2d-9010-fd176a398c96
+      - 3d7ffcf9-ae8c-47e9-9cef-0ec12fffeeda
       Atl-Traceid:
-      - a0a062a082074d2d9010fd176a398c96
+      - 3d7ffcf9ae8c47e99cef0ec12fffeeda
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:20 GMT
+      - Wed, 30 Apr 2025 16:28:55 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1171,7 +1240,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=297,atl-edge-internal;dur=14,atl-edge-upstream;dur=283,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="I_OoHJkbjVsGl105Rhgiyr8vzJFB1S7TaMx-urmTwbK1faHT3GAWHA==",cdn-downstream-fbl;dur=393,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=58,cdn-upstream-fbl;dur=390,atl-edge;dur=312,atl-edge-internal;dur=15,atl-edge-upstream;dur=298,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1180,13 +1249,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 0835ebd52ef8594cd8aa4dac9cfbd9a8.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - I_OoHJkbjVsGl105Rhgiyr8vzJFB1S7TaMx-urmTwbK1faHT3GAWHA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 424376c6d52be9c7ffab1d3d0279d5c9
+      - fc9d6dfba576883faa613e26542abfde
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1199,7 +1276,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1207,7 +1284,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "labels": ["tag1", "tag2"]}, "update": {}}'
     headers:
       Accept:
@@ -1219,27 +1296,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1316'
+      - '1336'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16142
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18291
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - b7776026-66a4-4e4c-9ddf-86356b48ea96
+      - 8cbfdc5d-2e72-455b-b242-9bacd9b824a5
       Atl-Traceid:
-      - b777602666a44e4c9ddf86356b48ea96
+      - 8cbfdc5d2e72455bb2429bacd9b824a5
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:21 GMT
+      - Wed, 30 Apr 2025 16:28:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1249,17 +1328,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=516,atl-edge-internal;dur=13,atl-edge-upstream;dur=503,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=700,atl-edge;dur=667,atl-edge-internal;dur=15,atl-edge-upstream;dur=653,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="tBDn-lTEar6M-2MPcdHGLGfg6MFucUAr6gXF5B1qL0UPdktJg1aAWg==",cdn-downstream-fbl;dur=706
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c31337642f54c5bd34bb485701d02e8a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - tBDn-lTEar6M-2MPcdHGLGfg6MFucUAr6gXF5B1qL0UPdktJg1aAWg==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - b23ab4f71becd59ea9e2975d673d1a5c
+      - 297dcf1a95dadf5bd671adc36e67b357
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1283,61 +1370,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16142
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18291
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxt4rRAiTRNd1A2NsYYFJAuQ8gkp6mpY+faDm3H5b/vOC8t
-        b7lXMO0KicY+Pu+PH597DxY5k4kXeRpkAhqSfQ4iMR3JMjAdE08hYx2Vg2aWK2k6kHCbgWWdeMpk
-        CkKlnTvQBmWQnECuwYC09dm4MFZlE2fwmgYBDXoaPhVg7HiZw7FmseUxeB2PO/90iw5CXBgQE1xO
-        rc1N5PsJTCC2ibpVPWYFM4Yz2ZNgffRkfZZzP/S5MQX4jYEZLFH/aDw6HXfp1uYQt8oQjBfdewZj
-        K0zMLKRKL6scElyhRhiEm92AdmkwDoOI7kR0qzfYHv6AcQcuSOfEYuClmXcG6fR9tBe4QKu060UC
-        JtY8d4XD3Q/EZEyIDkm4sVzGluQcYiBqQuZKz3pOO1byTIs3RlFI7trFxDW7Y5Zp/47D3C/DWgdY
-        i2jQp8OfDP8Hfsyw7UWGXh0s0OWYmZnrVXFj3Vc0YcJAx6sUDzCvUrfjTTkCR8fT5SHcAcYaPHQ8
-        yxFZOaLEi2SBOXrPYNIPGkGu1S1m9M6C19plucsGNuV2i0cgWWd1Jrm1aMB4K98Oqb+XZ42a2DnT
-        Dq+GZ7ngGHDyLHPsR4mywXAxGL4x3C90pslk1ZdBsI1hhINFOPh/vVTdL7GIDunWgm59C4eLxmM/
-        XPTDb+GxBvjDw0s40jachm2CfiOY8MV5RY4Ii8srhEmaakiRb756CTYbAWamRFHxwutHt9oE2y2C
-        sFUwbBPsvAynos1q15FS+UJ4UZfikll8OCrCffvFreh8TeB+ZU67a1l+7qrCFY46Ur5wG1ymXmR1
-        Adg+NGrPsePuclbBlfacfc3jqo73L/ZcrKhspqoQyR43uWDL+nI7SGjAZB1/vPZI0HC7eSSel21F
-        Zc8FbaAKV6DKNVea2+U7i9io+4O3vRU8YykY32mYxgjHDaHmPXOXrsnyUM0bUh14L69NuLoEgt2A
-        o8VLz7KUog7+hN7VCw1HLa/WhLbBlQ5dcabMjHIeH3I523eSPcjdKCPjpoFlW+elbLUjlRzhJMNu
-        BJwAMxUodP3lHR+e/XJwdH14sDs6Oh1dj05O/jzBwPHKGqwOHhhPgRzjYyAtcX4JN0RJsSRILFw4
-        o8Qq8hvXjBxryJBZSGEQwL3XCIbi3fKCzzwIPtF+5OqD3ICNxE6sL9gT4sCepFwy8fxQPYjVXFNC
-        XGB0Dfdgk1MJq9NF7m7wq6AOaS/YWYG6mpneicNKefUIPx1z3gbNNfZ+ZvEMJ88Gf43xytduPdz9
-        p4CbCdFvBrWwmRkkONzHSih9VEVzIwrophoJYz0fKbKnqmarLMfZWNq6C8+av9nGEJsrhvhSx5+W
-        82+5/tsYcytgIyKXH1lOI7Kr1IwDueAWKc6SU4gLDWRfsPSzqw4WR6iYiakyNhoGw8CfcJkgr/r9
-        weZVaXCvLB7mdauIg1W0Qb6qSb7Df9+X6qc4ATpCQjWkjjrIvQLIHuaDm3+wJaFBhzgwrpLYvRih
-        6BJ/ujjdl5G6PsZz6GXcaugpnfoIY+Zay3F8c/D38WhvajNRxl3ZOXd2zuRMqvnjIh1rlRQ4EIxk
-        ihc7wzb5Y6yx81lWCOMlv6p516qWKuW1gfCK+OSSGkv+Kpi2oMnaZIsqrH3SUvvjh2NyGjPZct5N
-        pj4Nh6usHuVxujQWMoN5JLniCLaNqNwvO+QqljEuDbfQQzxiwcz0RjGdtJ14Yf9fAAAA///sWW1r
-        2zAQ/iuiUGihdp3EaZJB6UK3wT6UjRZWKIWgyHJjFsvGL3VLl/++5yRFTb24G2WUfijkgxNJd6fz
-        3XPPXT49xhlJnjJhwgnYy+ZSKlbKijU2tiqAY2niK0Z8HbBmkYgFSyVXJRa52WEl4L7Xai4ZFwLo
-        KiN2m3BWI2FEcZ8DnrBPKWlqtL9h0Rne9Y3uM8mgy4VUFF+MO7kZ2lDcCJbQtUAJWaLirEj1GZYV
-        hNkcqyVBJuD6p1QHZBiEJxUzRIDxZcPv6Yos59q6ukRkM67YhoFoIpVc+njjJd3Z3dD44FqRE0gb
-        +QgWWAvLtYkksKzhoK2Wbtx54/bnyEVUH7iMbm/jpWkaP2t4meusQBLKOz9f5DqioWQGmTOre8Yr
-        MJ95jZia7X27nF589y7OPFRtnatOSZ5RKFM27PEoTdQ+29v/hUBZVtkHhOGfhGfoqn67yHXhXC/s
-        WnAMmACwKgD5muYRTWttDR07bS0ETkZ7oYtrBI5r6Len+df2jV1UOXDGPKnZbeTGC+BiQdlv6kJZ
-        pymnorXzN7wmrxMfzYoXVjiiIifIN2LRX6PjYTQYj8bz3iiQAzEJxGTYjye9+Ah63CZoeGabpJCY
-        RhF0oMqh5EX3HzcMAaCQrGc7ZJMrPqqo3qZhynZpoQTR41EvDI9GYjwaDiZzMR8FUB9zGY/FSXSs
-        pewOprv9L/iYc17KlcVXzzM/lX5deg0c4fV9Am4/r+fLRJCnvJzzkhyF87qOgCbi8RRJ4eeKfN7u
-        tt++xe12/e1b3G7337rFgKLI9IqWCp4i9MFk4rgWItEJRHhuelMDZFcgg9j4uS6yXB5eAWLE4jHT
-        aNyEVZe6pMEO2bbzx7ALV8OuDjPsGluEDrsLC/zv+PJqkfSOL69h8Tu+bMGXNgw4Qub4C6y+Mbn3
-        QHNx+xxAYVZxO9VvS+lkXp241EnJ+tuRr2sqFHRxUAKErQtBFwcddJ0YOJIn1W1SZMoQOfNTVNu/
-        lMzXf/JelhoJD+tHC/cvgN+Nf8MO13IPdlJ+dy7LekmCN3TroUlRTStjx21W/b+xrRHmhEIX2sUf
-        mZ45rSerNDimSQ6pdIY8tbb/xFx7QLtntVr9BgAA//8DAHUwqpfBHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18291","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291","key":"NTEST-1898","fields":{"statuscategorychangedate":"2025-04-30T18:28:50.547+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:50.307+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":["tag1","tag2"],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tc7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:56.277+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - b755897f-4a27-40ae-9ba7-1d632228a350
+      - 3a578414-e0df-4a52-b07b-e5f6b991a6ae
       Atl-Traceid:
-      - b755897f4a2740ae9ba71d632228a350
+      - 3a578414e0df4a52b07be5f6b991a6ae
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:21 GMT
+      - Wed, 30 Apr 2025 16:28:56 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1347,7 +1417,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=371,atl-edge-internal;dur=18,atl-edge-upstream;dur=353,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="lpoTTJ2Gqe-PjyOKOh4unTGAWtjICQmOUY-JLYe4crCLLcacZ2VDYw==",cdn-downstream-fbl;dur=346,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=65,cdn-upstream-fbl;dur=343,atl-edge;dur=259,atl-edge-internal;dur=16,atl-edge-upstream;dur=243,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1356,10 +1426,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 a9a3eef6ee6df44793fb3d5e366a7238.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - lpoTTJ2Gqe-PjyOKOh4unTGAWtjICQmOUY-JLYe4crCLLcacZ2VDYw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 45b3f6ee4e4fa29821551519f3772fcb
+      - c1b3476854148b2e46c0cfa47e1f42ca
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1386,26 +1464,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtL2nVb3mSCU3QK7V4UkTS9YDVNSpMOxth3N8Ghe1Tfjrvf
-        /37HHUgtHG4HTTh58753fDptUKH0jX23qfBaONcKkxr0ZEKa1vVa7P/BlzjsWokNuo816n6FxuPw
-        1yUra5Qe0Uj8XXKHg2utCTAFoCmkkJSby8dy/VD9TDdjV4eK8OcITWACL8GJvbb7LlxZ7ftoW2k7
-        NiFUj61uviKEhwCbz0/NK+EjyIDNEqAJLCvGeJ7xPIgBLiDAIe/CH3Co2u6cpVAx4HTJGUuhyL5Z
-        2d0YZQOY02IhBeAMlaTZHEWuVK5AKrbMZotaFTmyQgE7E3gdDbftIOILUYlR+zsrRWwfiD5VBM3r
-        tiTH88OerImT6/uKHD8BAAD//wMAA6L9HCACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:57.412+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 37ce9761-00f4-4ba2-a064-d8f94db26d32
+      - 8d44063f-23d6-4b06-9ad2-29d2f1ef8be1
       Atl-Traceid:
-      - 37ce976100f44ba2a064d8f94db26d32
+      - 8d44063f23d64b069ad229d2f1ef8be1
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:22 GMT
+      - Wed, 30 Apr 2025 16:28:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1415,7 +1489,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=140,atl-edge-internal;dur=13,atl-edge-upstream;dur=127,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="boltMrFqw6_F6ykVAQCSEfa2tFLTu4b7kX2Yx_DtimUM6SNDvVsMrw==",cdn-downstream-fbl;dur=249,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=241,atl-edge;dur=165,atl-edge-internal;dur=15,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1424,10 +1498,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5a3010bd9376613ba1249daca87b27a2.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - boltMrFqw6_F6ykVAQCSEfa2tFLTu4b7kX2Yx_DtimUM6SNDvVsMrw==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - 8e658c38c9bce4c08262a367c9a19177
+      - de50d9735dddad5eb34ca9a1ab6b4f61
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1451,61 +1533,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16142
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18291
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa2/bNhT9K4Q+bZltibKTOAKGoUvcLV2WZbHTAs2KgJGuZdYUqZJUbC/Nf9+l
-        Xm7suEMyrAgQi4/7Pvfw3nuwzJlMvMjTIBPQkLzmIBLTkSwD0zHxDDLWUTloZrmSpgMJtxlY1oln
-        TKYgVNq5A23wDJJLyDUYkLa+GxfGqmzqFN7QIKBBT8OnAoydrHK40Cy2PAav43Fnnx7QQYgLA2KK
-        y5m1uYl8P4EpxDZRH1WPWcGM4Uz2JFgfLVmf5dwPfW5MAX6jYA4rlD+fjMaTLj3YH+JW6YLxonvP
-        oG+FiZmFVOlVFUOCK5QIg3C/G9AuDSZhENGjiB70BofDH9DvwDnpjFh0vFTzQiedvI/6AudoFXa9
-        SMDEmucucbj7ipiMCdEhCTeWy9iSnEMMRE3JQul5z0nHSl5p8UwvCslduZi4YXfMMu3fcVj4pVtr
-        B+sjGvTp8CfD/4YfMyx7kaFVBws0OWFm7mpV3Fr3FU2ZMNDxKsFTjKuU7XgzjsDR8Wx1BneAvgYP
-        Hc9yRFaOKPEiWWCM3gZM+kFzkGv1ESN6YcJr6TLdZQGbdLvFFyBZR3UlubWowHitbYfU38q7Rk3t
-        gmmHV8OzXHB0ONmIHOtRomwwXA6Gz3T3K5VpImnrMggO0Y1wsAwH/6+VqvolFtEgPVjSg29hcNlY
-        7IfLfvgtLNYAf3jYhiPdhdOwOZjy5duKA7H61x+2b/abmyxNNaTIN1tNgAEoUVTt/7S5/V0HB7sO
-        DncchDsPhrsOjrb9rGiz2nWkVL4QXtSlNVe6kmgeVyHdb+25RsFsm5kqRHLCTS7Yqm4n3Mba2rdY
-        N9ditQlm8TGqSPz5ZFA9EetHwa/Uadfq5eexKlwxSuffuQ0uUy+yunDexBowWMcfTz0SNDxsHonN
-        tLVUtnmwC1RhC6pcc6W5Xb0w4EbcHzzvreAZS8H4TsI0SjhuCLXombt0TZZnatGQ6sDbbpuwxbxg
-        t+Bo8dqzLKUogz+ht90ljlqezAndBVc6dMmZMTPKeXzG5fy1OzmB3I0yMm7gVIJsUZ61O1LJEU4y
-        7FbAJTBTQVTXX97F2dUvp+c3Z6fHo/Px6GZ0efnHJTqOLWswO3hhMgNygY+BtMTZJdwQJcWKILFw
-        4ZQSq8gbrhm50JAhs5DCINh6TxEMxd7ygs88CD7RfuTyg9yAhcRKrBvsEXFgTVIumdi8VA9iNQmV
-        kBfoXb12RU4ltLeL3HXwk6AOaS84akFdzUwvxGEl3D7Cj8ec50Fzjb2fWTzHybPBX6O8snVcD3f/
-        yeFmQvSbQS1sZgYJDvexEkqfV97cigK6qUb6Ws9Hipyoqtgqy3E2lvbpp2G/ZYivFXZTqGWPx+n8
-        S67/9ibcCtiLyPV7ltOIHCs150DecYuEa8kY4kIDeS1Y+tllB5MjVMzETBkbDYNh4E+5TJAD/f5g
-        /0Op8KRMHsb1UREHq2iP/Ksk+Q7/fV+Kj3ECdISEYkgdtZMnBZATDBQ3f2crQoMOcWBsgzh+N8Kj
-        a/zp4nRfeurqGC+gl3Groad06iOMmSstx/HNwd/Hq72ZzUTpd6XnrdNzJedSLb5M0oVWSYEDwUim
-        2NgZlsmfYPKdzTJD6C/5VS26Vu3IUl4rCD8Qn1xTY8mfBdMWNFmr3CEKa5u0lH7/6oKMYyZ33HeT
-        qU/DYRvVF3GMV8ZCZjCOJFccwbYXlftlhVzGMsal4RZ6iEdMmJndKqaTXTe29P8DAAD//+xZXUvj
-        QBT9K4MgKJiYtqltF8Qt7i7sg+yisIIIZTqZ2LDtJOTDKG7/+547Mx1jtnEXWcQHwYeYmblfuffc
-        c6efHvOMJE+ZMOkE7GVzKRUrZMlqm1slwLEw+RUjvw5YvUjEgq0kVwUWudlhJcDfazWXjAsBdJUR
-        u004q1AwIr/PAE/Yp5Q0jMFvWHSGb32j50wy6HIhFeUX405uijEUHsEScguUkCUqTvOVPsPSnDCb
-        Y7UgyARc/5TqgAyD8KRkhpYwvqz5PbnIMq6tqwpkNuOKNQzEEKnk0scXL8hn56GJwbWiIJA2ihEs
-        sBYWGxNJYFEhQFstbfjc8P4ctYjug5CR9zZf6rr205oXma4KFKG887NFpjMaSmaQObO6Z7wED5tX
-        yKnZ3rfL6cV37+LMQ9fWteqUZCmlMlXDHo9Widpne/u/kCjLMv2ANPyT8Axd1283uS4m1AubAFjm
-        QHbNvIgbtrd2MeCgayF0tLV9wnEN/ZE0zdq+sYt7BF1UOXA6EWMuFlTgtgE3e3gb4otqteLUtHb+
-        htcUdeKjaf7CDkdU5AT1Roz3a3Q8jAbj0XjeGwVyICaBmAz78aQXH0GP2wQNz2yTlBLTKIIOdDm0
-        vOj+Y8MQAArJenZCNrXio4vqbRqm7JQWShA9HvXC8GgkxqPhYDIX81EA9TGX8VicRMdayu5gutv/
-        gj9zzltxZfHV88yrwq8Kr0YgvL5PwO1n1XyZCIqUl3FeUKBwXvcR0EQ8nqIo/ExRzNvT9tu3uD2u
-        v32L2+P+W7cYGBWZydVSwVOkPphMHFdCJLqACM/NHGkQ7gpkEBs/V3maycMrYI9YPFYaXTdh1ZUu
-        abCXbNv5Y9iFq2HXhBm6CTO3+P4OI6+WMO8w8hoWv8PIFhhpw0AXUwsdIXN8Be7cmKJ8oHtx+xzA
-        krTk9la/LaWLkgVduBT0twNc161Q0OlAJ2VznrVPdHG5QeeCI3lS3SZ5qgzLM6+iyv6kZP79l+jd
-        puX/u9o0wpxQaMKY9iPVdz2b+1WUgDH5YfNo+8uLDdA/vx1u5B7srPjduSyqJQluOKtvafJyWhrH
-        6eKYbnLIdff+6eH+k9P2gLZ2vV7/BgAA//8DAN/z4lDBHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18291","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291","key":"NTEST-1898","fields":{"statuscategorychangedate":"2025-04-30T18:28:50.547+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:50.307+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":["tag1","tag2"],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tc7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:56.277+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 8390bd94-fa48-495f-a119-220fdc43ef21
+      - 0cc13a8a-f808-435e-a0ca-7d38066a4d0b
       Atl-Traceid:
-      - 8390bd94fa48495fa119220fdc43ef21
+      - 0cc13a8af808435ea0ca7d38066a4d0b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:22 GMT
+      - Wed, 30 Apr 2025 16:28:57 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1515,7 +1580,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=260,atl-edge-internal;dur=23,atl-edge-upstream;dur=238,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="U9zwB_W6TivEc4e7UmyTJQokLT4YnN8Etk2qiVm7mjdvF6TDDix-eA==",cdn-downstream-fbl;dur=344,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=66,cdn-upstream-fbl;dur=341,atl-edge;dur=251,atl-edge-internal;dur=18,atl-edge-upstream;dur=232,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1524,10 +1589,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 3699bc5ea5aacbe1d32ebe3e874f0c68.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - U9zwB_W6TivEc4e7UmyTJQokLT4YnN8Etk2qiVm7mjdvF6TDDix-eA==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - e94e7c224849febc7e2f5e3d40ae24b0
+      - 4151ce2365ca08b2be05c20ba539501f
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1554,26 +1627,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQTU/DMAyG/0uubJ2Tdl+5oSExEAykdhcQQmnqiECaVE06aZr230nEBDsCN8t+
-        Xj+WD6QWHre9IZy8hdB5Ppk0qFCGxr27TAQjvNfCZhYDGZFG+86I/T/4Evudltig/1ij6VZoA/Z/
-        XbJyVpkBrcTfJXfYe+1shCkAzSCDcbm5fCzXD9XPdDO0dawIf07QCEbwEp3YGbdv45XVvku2lXFD
-        E0P1oE3zFSE8Bth8fmpeiZBABmw6BjqGZcUYL3JeRDHABUQ45n38A/aVbs9ZChUDTpecsWyR59+s
-        bG+schEs6GwhBeAUlaT5HEWhVKFAKrbMp4tazQpkMwXsTBBMMtzqXqQXohKDCXdOitQ+EHOqCNrX
-        bUmO54c9OZsm1/cVOX4CAAD//wMAXmPaeSACAAA=
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:28:58.315+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 730dcf94-26f9-4c0b-8a5b-7186929a6e4f
+      - 79387217-fbe9-40f7-a30d-b016c1f267f0
       Atl-Traceid:
-      - 730dcf9426f94c0b8a5b7186929a6e4f
+      - 79387217fbe940f7a30db016c1f267f0
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:22 GMT
+      - Wed, 30 Apr 2025 16:28:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1583,7 +1652,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=155,atl-edge-internal;dur=17,atl-edge-upstream;dur=142,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=200,atl-edge;dur=167,atl-edge-internal;dur=19,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="mZn6WeKaeIa09nAgHdMxhWaxE5mnLYDKk-q5hAQp2-ZHkzpaxEh8Yw==",cdn-downstream-fbl;dur=205
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1592,10 +1661,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 1918cab433d8a05c792c3cff85897f3c.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - mZn6WeKaeIa09nAgHdMxhWaxE5mnLYDKk-q5hAQp2-ZHkzpaxEh8Yw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 67486395996df5d4451b46725f58ae26
+      - 7c118b47c71f58ce6ae266def87e00fe
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1619,61 +1696,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16142
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18291
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWbU/rNhT+K1Y+baxt4rRAiTRNd1A2NsYYFJAuQ8gkp6mpY+faDm3H5b/vOC8t
-        b7lXMO0KicY+Pu+PH597DxY5k4kXeRpkAhqSfQ4iMR3JMjAdE08hYx2Vg2aWK2k6kHCbgWWdeMpk
-        CkKlnTvQBmWQnECuwYC09dm4MFZlE2fwmgYBDXoaPhVg7HiZw7FmseUxeB2PO/90iw5CXBgQE1xO
-        rc1N5PsJTCC2ibpVPWYFM4Yz2ZNgffRkfZZzP/S5MQX4jYEZLFH/aDw6HXfp1uYQt8oQjBfdewZj
-        K0zMLKRKL6scElyhRhiEm92AdmkwDoOI7kR0qzfYHv6AcQcuSOfEYuClmXcG6fR9tBe4QKu060UC
-        JtY8d4XD3Q/EZEyIDkm4sVzGluQcYiBqQuZKz3pOO1byTIs3RlFI7trFxDW7Y5Zp/47D3C/DWgdY
-        i2jQp8OfDP8Hfsyw7UWGXh0s0OWYmZnrVXFj3Vc0YcJAx6sUDzCvUrfjTTkCR8fT5SHcAcYaPHQ8
-        yxFZOaLEi2SBOXrPYNIPGkGu1S1m9M6C19plucsGNuV2i0cgWWd1Jrm1aMB4K98Oqb+XZ42a2DnT
-        Dq+GZ7ngGHDyLHPsR4mywXAxGL4x3C90pslk1ZdBsI1hhINFOPh/vVTdL7GIDunWgm59C4eLxmM/
-        XPTDb+GxBvjDw0s40jachm2CfiOY8MV5RY4Ii8srhEmaakiRb756CTYbAWamRFHxwutHt9oE2y2C
-        sFUwbBPsvAynos1q15FS+UJ4UZfikll8OCrCffvFreh8TeB+ZU67a1l+7qrCFY46Ur5wG1ymXmR1
-        Adg+NGrPsePuclbBlfacfc3jqo73L/ZcrKhspqoQyR43uWDL+nI7SGjAZB1/vPZI0HC7eSSel21F
-        Zc8FbaAKV6DKNVea2+U7i9io+4O3vRU8YykY32mYxgjHDaHmPXOXrsnyUM0bUh14L69NuLoEgt2A
-        o8VLz7KUog7+hN7VCw1HLa/WhLbBlQ5dcabMjHIeH3I523eSPcjdKCPjpoFlW+elbLUjlRzhJMNu
-        BJwAMxUodP3lHR+e/XJwdH14sDs6Oh1dj05O/jzBwPHKGqwOHhhPgRzjYyAtcX4JN0RJsSRILFw4
-        o8Qq8hvXjBxryJBZSGEQwL3XCIbi3fKCzzwIPtF+5OqD3ICNxE6sL9gT4sCepFwy8fxQPYjVXFNC
-        XGB0Dfdgk1MJq9NF7m7wq6AOaS/YWYG6mpneicNKefUIPx1z3gbNNfZ+ZvEMJ88Gf43xytduPdz9
-        p4CbCdFvBrWwmRkkONzHSih9VEVzIwrophoJYz0fKbKnqmarLMfZWNq6C8+av9nGEJsrhvhSx5+W
-        82+5/tsYcytgIyKXH1lOI7Kr1IwDueAWKc6SU4gLDWRfsPSzqw4WR6iYiakyNhoGw8CfcJkgr/r9
-        weZVaXCvLB7mdauIg1W0Qb6qSb7Df9+X6qc4ATpCQjWkjjrIvQLIHuaDm3+wJaFBhzgwrpLYvRih
-        6BJ/ujjdl5G6PsZz6GXcaugpnfoIY+Zay3F8c/D38WhvajNRxl3ZOXd2zuRMqvnjIh1rlRQ4EIxk
-        ihc7wzb5Y6yx81lWCOMlv6p516qWKuW1gfCK+OSSGkv+Kpi2oMnaZIsqrH3SUvvjh2NyGjPZct5N
-        pj4Nh6usHuVxujQWMoN5JLniCLaNqNwvO+QqljEuDbfQQzxiwcz0RjGdtJ14Yf9fAAAA///sWW1r
-        2zAQ/iuiUGihdp3EaZJB6UK3wT6UjRZWKIWgyHJjFsvGL3VLl/++5yRFTb24G2WUfijkgxNJd6fz
-        3XPPXT49xhlJnjJhwgnYy+ZSKlbKijU2tiqAY2niK0Z8HbBmkYgFSyVXJRa52WEl4L7Xai4ZFwLo
-        KiN2m3BWI2FEcZ8DnrBPKWlqtL9h0Rne9Y3uM8mgy4VUFF+MO7kZ2lDcCJbQtUAJWaLirEj1GZYV
-        hNkcqyVBJuD6p1QHZBiEJxUzRIDxZcPv6Yos59q6ukRkM67YhoFoIpVc+njjJd3Z3dD44FqRE0gb
-        +QgWWAvLtYkksKzhoK2Wbtx54/bnyEVUH7iMbm/jpWkaP2t4meusQBLKOz9f5DqioWQGmTOre8Yr
-        MJ95jZia7X27nF589y7OPFRtnatOSZ5RKFM27PEoTdQ+29v/hUBZVtkHhOGfhGfoqn67yHXhXC/s
-        WnAMmACwKgD5muYRTWttDR07bS0ETkZ7oYtrBI5r6Len+df2jV1UOXDGPKnZbeTGC+BiQdlv6kJZ
-        pymnorXzN7wmrxMfzYoXVjiiIifIN2LRX6PjYTQYj8bz3iiQAzEJxGTYjye9+Ah63CZoeGabpJCY
-        RhF0oMqh5EX3HzcMAaCQrGc7ZJMrPqqo3qZhynZpoQTR41EvDI9GYjwaDiZzMR8FUB9zGY/FSXSs
-        pewOprv9L/iYc17KlcVXzzM/lX5deg0c4fV9Am4/r+fLRJCnvJzzkhyF87qOgCbi8RRJ4eeKfN7u
-        tt++xe12/e1b3G7337rFgKLI9IqWCp4i9MFk4rgWItEJRHhuelMDZFcgg9j4uS6yXB5eAWLE4jHT
-        aNyEVZe6pMEO2bbzx7ALV8OuDjPsGluEDrsLC/zv+PJqkfSOL69h8Tu+bMGXNgw4Qub4C6y+Mbn3
-        QHNx+xxAYVZxO9VvS+lkXp241EnJ+tuRr2sqFHRxUAKErQtBFwcddJ0YOJIn1W1SZMoQOfNTVNu/
-        lMzXf/JelhoJD+tHC/cvgN+Nf8MO13IPdlJ+dy7LekmCN3TroUlRTStjx21W/b+xrRHmhEIX2sUf
-        mZ45rSerNDimSQ6pdIY8tbb/xFx7QLtntVr9BgAA//8DAHUwqpfBHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18291","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291","key":"NTEST-1898","fields":{"statuscategorychangedate":"2025-04-30T18:28:50.547+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:50.307+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":["tag1","tag2"],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tc7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:28:56.277+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 2cf7bd4d-a9b5-42ac-a735-5d869a49e327
+      - 5d76eea8-bad3-4227-a0b5-dd5d1d0ce69c
       Atl-Traceid:
-      - 2cf7bd4da9b542aca7355d869a49e327
+      - 5d76eea8bad34227a0b5dd5d1d0ce69c
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:23 GMT
+      - Wed, 30 Apr 2025 16:28:58 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1683,7 +1743,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=256,atl-edge-internal;dur=15,atl-edge-upstream;dur=239,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="nEkUZGs63fP425tm9sT7TwNwE879ur-A8VXfcz0JveV4mXPE1EaTUQ==",cdn-downstream-fbl;dur=369,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=64,cdn-upstream-fbl;dur=365,atl-edge;dur=278,atl-edge-internal;dur=20,atl-edge-upstream;dur=259,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1692,10 +1752,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 5b8f26c7595104a396342213c43d8b98.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - nEkUZGs63fP425tm9sT7TwNwE879ur-A8VXfcz0JveV4mXPE1EaTUQ==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - d82bd53375856ef8b8d4e294d606aabb
+      - fb121bfca2e81745d5f45f5508f5141a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1722,41 +1790,28 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA+xW32/TMBD+V6I8V03bVWOqhBBiICbQhLRuL9OETHJZb3OcYDttyrT/nXPixO5a
-        RjpgvCxP9vl+fOf77uK7EKqCiSSchYXMbyDWKhy45ezyzimgUiXodQFGRQFPSbbQulCzKEogJYMk
-        v8mHTHOmFDIxFKAjCUpHrMBoElmv0XhEH7lA47Td3MKadqfz92dz2gmWAW3PBWpNDkxAtmSayXPJ
-        CdVdOD2qpkd7xi8FLkEqxr82vqIlwioyCXXQ7MF4NB29opiTaTWZ/tsobxT+gNcqY5xTwPFhNT58
-        joBVG/FgUh1MniNiBgmWWXg/8Hlk+PUEJnUeai5NfC6ZTQIqllhozAVJ3wZ1roMgQaVRxDooEGII
-        8jRY5fJ2aKzjXBCz9kTxyDU4gN1FHIyPNi6iI/mcqVvalUJLJhRnGpLTjRNVftNmNUsZVzAIFwiS
-        yXix/gxLINCjgevRFIEnpl3sglpFlVnG5NosJXwvUQIpalmSJxUvIGPmxGAlc6UlimsTc600ZEZi
-        re87vGdW0vZsq0HAmDqGlJVcXzBeQgc4LwiwqYYpONVbh1c+DXohc9oeOCd08E6MLJg3mg1C37YX
-        xisaN5znK0hqpReePsLGxvCE8qptd9Dz3lS7YBKE3iy19bC71hxFHa6ttXXgCv2lEbRFtuc9K9yx
-        MM6zIhdkWffK77ExKZnhOhIqMnH2PlbPqcP7zglbzJ5eX9wsSUwkMPEkZPkSwh1sNZltsKtPatvN
-        77twiRx70jYTX7NvKm0J7D+j1xhodX1iWJHHjE7JUqPb7wFs+1KfNAL+7NFjrc00+9QM2zzVK2K6
-        uQDMCo40511JX95IfzPg/3sj1RMzxeqCPDSk7NO/D0eTid/0Y9crvk/XLx+wCqyym02+6j6NM7Aj
-        6vHhVEjMJeoHr5JfZdZpb7S9lfl936m1jd8JthJoBsw2/h2An9j4TexobErS/8eNGbsGFRkL1TpB
-        EizwekHeh2ppRrTN+GMj/AkAAP//vJfBboMwDIZfpeqht8K60sskVO2wwyR22rmagFrARoERoq6H
-        vvviOIFQOo01aMe6cfLFNs5vPEH2FREMO1ipUaaBHZJqzHtrzPU0mPS99UFftOyRqGtrVG8aVFGR
-        fc6gPGpIzxpyMxnkoEQDadOom/l5h9LE/BLt0P+zFFAvctaUBzldvYlnfOWN62BhgU2InOdS+DnV
-        6StjTlIDFGlZiT7kvGd1+JCkS6iyeKn0L7mQvBandc3uSSyaBbRIqckB2pW292Pfxq6chxGQdhhx
-        o4vXZqge1W4dckAGzav+F/2WNyWq4xwaGJnGthJWzp1LG7mMJyK1zfaTQ33yR1/+mqIWzGHThHF6
-        GD20XMbD8DdiYli7uDyaSyk2Pe9x96AbxGV16sZrLKIb82n4G/yG1cir+A37mZy8u/T2NrBJsZqj
-        XVHwH1BvY17jpKdE/vPeX7C0PL7yCAdUGgp9fNxNMyOLcpWgQk/7Bc/zxU3l0oYZgZMCZBv7Pcic
-        Qd0rB+1tFIM2taXQGeyiiIe7tFsY5eAywDF9q+SoL8eQv0aDOgcK1t35GwAA//8DAFZhNg1MFgAA
+      string: '{"expand":"projects","projects":[{"expand":"issuetypes","self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"},"issuetypes":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","untranslatedName":"Task","subtask":false,"hierarchyLevel":0,"expand":"fields","fields":{"summary":{"required":true,"schema":{"type":"string","system":"summary"},"name":"Summary","key":"summary","hasDefaultValue":false,"operations":["set"]},"issuetype":{"required":true,"schema":{"type":"issuetype","system":"issuetype"},"name":"Issue
+        Type","key":"issuetype","hasDefaultValue":false,"operations":[],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0}]},"parent":{"required":false,"schema":{"type":"issuelink","system":"parent"},"name":"Parent","key":"parent","hasDefaultValue":false,"operations":["set"]},"components":{"required":false,"schema":{"type":"array","items":"component","system":"components"},"name":"Components","key":"components","hasDefaultValue":false,"operations":["add","set","remove"],"allowedValues":[]},"description":{"required":false,"schema":{"type":"string","system":"description"},"name":"Description","key":"description","hasDefaultValue":false,"operations":["set"]},"project":{"required":true,"schema":{"type":"project","system":"project"},"name":"Project","key":"project","hasDefaultValue":false,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}}]},"fixVersions":{"required":false,"schema":{"type":"array","items":"version","system":"fixVersions"},"name":"Fix
+        versions","key":"fixVersions","hasDefaultValue":false,"operations":["set","add","remove"],"allowedValues":[]},"priority":{"required":false,"schema":{"type":"priority","system":"priority"},"name":"Priority","key":"priority","hasDefaultValue":true,"operations":["set"],"allowedValues":[{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/1","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/highest.svg","name":"Highest","id":"1"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/2","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/high.svg","name":"High","id":"2"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/5","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/lowest.svg","name":"Lowest","id":"5"}],"defaultValue":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/3","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/medium.svg","name":"Medium","id":"3"}},"customfield_10014":{"required":false,"schema":{"type":"any","custom":"com.pyxis.greenhopper.jira:gh-epic-link","customId":10014},"name":"Epic
+        Link","key":"customfield_10014","hasDefaultValue":false,"operations":["set"]},"labels":{"required":false,"schema":{"type":"array","items":"string","system":"labels"},"name":"Labels","key":"labels","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/1.0/labels/suggest?query=","hasDefaultValue":false,"operations":["add","set","remove"]},"attachment":{"required":false,"schema":{"type":"array","items":"attachment","system":"attachment"},"name":"Attachment","key":"attachment","hasDefaultValue":false,"operations":["set","copy"]},"issuelinks":{"required":false,"schema":{"type":"array","items":"issuelinks","system":"issuelinks"},"name":"Linked
+        Issues","key":"issuelinks","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/issue/picker?currentProjectId=&showSubTaskParent=true&showSubTasks=true&currentIssueKey=null&query=","hasDefaultValue":false,"operations":["add","copy"]},"assignee":{"required":false,"schema":{"type":"user","system":"assignee"},"name":"Assignee","key":"assignee","autoCompleteUrl":"https://defectdojo.atlassian.net/rest/api/2/user/assignable/search?project=NTEST&query=","hasDefaultValue":false,"operations":["set"]}}}]}]}'
     headers:
       Atl-Request-Id:
-      - cfe2f33d-be4d-48dd-9e23-ff5da07b67ae
+      - 858e8346-50e8-4703-a98f-c7c99136fd86
       Atl-Traceid:
-      - cfe2f33dbe4d48dd9e23ff5da07b67ae
+      - 858e834650e84703a98fc7c99136fd86
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:23 GMT
+      - Wed, 30 Apr 2025 16:28:59 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1766,7 +1821,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=285,atl-edge-internal;dur=12,atl-edge-upstream;dur=273,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="sfB47UNycbCJF_SKSgn-p9fRsGwreqlkLrKyU_AvM3lhZ9W13C3cfg==",cdn-downstream-fbl;dur=408,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=62,cdn-upstream-fbl;dur=406,atl-edge;dur=322,atl-edge-internal;dur=19,atl-edge-upstream;dur=303,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1775,13 +1830,21 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 8f3e5b5af450fbcfb7e821f6aa6b3d76.cloudfront.net (CloudFront)
       Warning:
       - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
         June 03, 2024)'
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - sfB47UNycbCJF_SKSgn-p9fRsGwreqlkLrKyU_AvM3lhZ9W13C3cfg==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - 4e3f89cf8d110cf8d8b9d04ab1ab69cf
+      - 31e3bad0a1b71f6500bd839b98b0082d
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1794,7 +1857,7 @@ interactions:
       "summary": "Zap1: Cookie Without Secure Flag", "description": "\n\n\n\n\n\n*Title*:
       [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
       Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
-      Date:* May 10, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+      Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
       Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
       / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
       https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
@@ -1802,7 +1865,7 @@ interactions:
       accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
       contains sensitive information or is a session token, then\nit should always
       be passed using an encrypted channel. Ensure that the secure\nflag is set for
-      cookies containing such sensitive information.\n\n\n\n\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+      cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
       [(admin) ()|mailto:]\n", "labels": ["tag1", "tag2", "tag3", "tag4", "tag1",
       "tag2"]}, "update": {}}'
     headers:
@@ -1815,27 +1878,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1348'
+      - '1368'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.32.3
     method: PUT
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16142
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18291
   response:
     body:
       string: ''
     headers:
       Atl-Request-Id:
-      - c316154d-ea37-4c72-a323-b2198cda0eb5
+      - 107ad6c8-57a2-4a8e-9ed4-3d22177fb852
       Atl-Traceid:
-      - c316154dea374c72a323b2198cda0eb5
+      - 107ad6c857a24a8e9ed43d22177fb852
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:24 GMT
+      - Wed, 30 Apr 2025 16:29:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1845,17 +1910,25 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=467,atl-edge-internal;dur=12,atl-edge-upstream;dur=455,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=595,atl-edge;dur=561,atl-edge-internal;dur=17,atl-edge-upstream;dur=543,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="ip2N5sqRxrpV-3-s2PkvOlcPtFLI6OpiLy05u8mJytKXIqgW306gWw==",cdn-downstream-fbl;dur=599
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
       - '*'
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c7697b9c4955dc41900ab918dddd33e0.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - ip2N5sqRxrpV-3-s2PkvOlcPtFLI6OpiLy05u8mJytKXIqgW306gWw==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 87bcf50af7a4f1a39e678c8d4db1c336
+      - 5cc5839cc7a527257deefb84300703a4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1879,61 +1952,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16142
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18291
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xW/U/jNhj+V6z8tLG2idMWepGm6QZlY2OMQQHpGEImeZv66tg526HtOP73vc5H
-        y1fuBNNOSKT26/f78eP3zoNlzmTiRZ4GmYCGZJ+DSExHsgxMx8QzyFhH5aCZ5UqaDiTcZmBZJ54x
-        mYJQaecWtEEZJCeQazAgbX02LoxV2dQZvKZBQIOehk8FGDtZ5XCsWWx5DF7H484/3aaDEBcGxBSX
-        M2tzE/l+AlOIbaI+qh6zghnDmexJsD56sj7LuR/63JgC/MbAHFaofzQZn066dHs4wq0yBONFd57B
-        2AoTMwup0qsqhwRXqBEG4bAb0C4NJmEQ0XcR3e4NdkY/YNyBC9I5sRh4aeaNQTp9H+0FLtAq7XqR
-        gIk1z13hcPc9MRkTokMSbiyXsSU5hxiImpKF0vOe046VPNPilVEUkrt2MXHNbpll2r/lsPDLsDYB
-        1iIa9OnoJ8P/gR8zbHuRoVcHC3Q5YWbuelXcWPcrmjJhoONVigeYV6nb8WYcgaPj2eoQbgFjDe47
-        nuWIrBxR4kWywBy9JzDpB40g1+ojZvTGgtfaZbnLBjbldosHINlkdSa5tWjAeGvfDqm/l2eNmtoF
-        0w6vhme54Bhw8iRz7EeJssFoORi9MtwvdKbJZN2XQbCDYYSDZTj4f71U3S+xiA7p9pJufwuHy8Zj
-        P1z2w2/hsQb4/f1zONI2nIZtgn4jmPLleUWOCIvLK4RJmmpIkW++egmGjQAzU6KoeOHlo9ttgp0W
-        QdgqGLUJ3j0Pp6LNateRUvlCeFGX4pJZfDgqwn39xa3ofEPgfmVOu2tZ/txVhSscdaR84Ta4TL3I
-        6gKwfWjUnmPH3eWsgivtOfuax1Ud757tuVhR2cxUIZI9bnLBVvXldpDQgMk6/njpkaDhTvNIPC3b
-        msqeCtpAFa5BlWuuNLerNxaxUfcHr3sreMZSML7TMI0RjhtCLXrmNt2Q5aFaNKQ68J5fm3B9CQS7
-        AUeLl55lKUUd/LgXDz/96jPwrp7pO6J5sUK0Dbx05Eo1Y2ac8/iQy/m+k+xB7gYbGTftLJu8KGXr
-        HankGOcadiPgBJipIKLrX97x4dkvB0fXhwe746PT8fX45OTPEwwcL7DBWuGByQzIMT4N0hLnl3BD
-        lBQrgjTDhTNKrCK/cc3IsYYMeYYUBuHce4luKN40L/jMg+AT7UeuPsgU2Fbsy+a6PaIR7FDKJRNP
-        D9VjWc08JeAFRtcwEbY8lbA+XeTuPr8I8bDfGw2HDcSrCeqNqKyU10/y46HndUDdIPFnFs9xDm3Q
-        2BivfO3Wo95/CriZF/1mbAubCUKCuwWxEkofVdHciAK6qUb62ExLiuypqtkqy3FSlrbuwpPmD9v4
-        Yrjmiy91/HE5/5abv60JtwK2InL5geU0IrtKzTmQC26R8Cw5hbjQQPYFSz+76mBxhIqZmCljo1Ew
-        CvwplwmyrN8fDK9Kg3tl8TCvj4o4WEVb5Kua5Dv8932pforzoKMnVEMiqYPcK4DsYT64+QdbERp0
-        iAPjOondizGKLvHTxVm/jNT1MV5AL+NWQ0/p1EcYM9dajsOcg7+PR3szm4ky7srOubNzJudSLR4W
-        6VirpMDxYCxTvNgZtsmfYI2dz7JCGC/5VS26VrVUKa8NhFfEJ5fUWPJXwbQFTTYmW1Rh45OW2h/e
-        H5PTmMmW825O9Wk4Wmf1II/TlbGQGcwjyRVHsG1F5X7ZIVexjHFpuIUe4hELZmY3iumk7QTq/gsA
-        AP//7Flta9swEP4rolBooXadxG2SQelCt8E+lI0WViiFIMtyYxbLxi91y9b/vuckRU1M3I0ySj8U
-        8sGJpLvT+e655y6b8j89xRlJnjFhwgnYyyIpFatkzVobWzXAsTLxlSC+Dli7SMWCZZKrCovc7LAS
-        cN8bFUnGhQC6ypjdpZw1SBhRPhSAJ+xTSpqK7a9ZdI53fau7TjLoaiEVxRfjTm6OphQ3giV0LRBE
-        lqokLzN9huUlYTbHakWQCbj+KdUBGQbhac0MLWB82fIHuiIruLauqRDZjCu2ZiBaSiWXPt54RXd2
-        NzQ+uFHkBNJGPoIF1sJqZSIJrBo4aKula3deu/0FchHVBy6j29t4advWz1teFTorkITy3i8WhY5o
-        KJlD5tzqnvMaPChqEFPzvW9Xs8vv3uW5hxquc9UpKXIKZcqGPR5nqdpne/u/ESjLOv+AMCQc7KCW
-        4wDdIteHc4Owb8HxYQLAugTka9JHpK2zNXRctbMQOBndhT6uETiuod+eZmPbN/YR58AZs1Gzu8iN
-        F8DFgrLf1IWqyTJORWvnb3hNXid2mpcvrHBERU6Rb8Spv8YnR/FoMp5Eg3EgR2IaiOnRMJkOkmPo
-        cZug4ZltkkJiFsfQgSqHkhc/fFwzBIBCsp7tl02u+KiiepuGKduzhRJEj8eDMDwei8n4aDSNRDQO
-        oD7hMpmI0/hES9kdzXaHX/Ax57yMK4uvnmd+qvym8lo4whv6BNx+0UTLVJCnvILzihyF87qOgCbi
-        8QxJ4ReKfN7tvd++xd3m/e1b3G3+37rFgKLYdI6WCp4h9MFkkqQRItUJRHhuOlUDZNcgg9j4uSnz
-        Qh5eA2LE4inTaPiEVZe6pMGO3Lbzx7APV8O+fjPsG2KEDrtLC/zv+PJqkfSOL69h8Tu+bMGXLgw4
-        Qub4C6y+Nbn3i6bk9jmAwrzmdsbfldLLvHpxqZeSDbcjX99UKOjjoAQIWxeCPg466jsxciRPqru0
-        zJUhcuanuLF/MJmv/+S9PDMSfq0eLdy/AH7X/hs7XMk92Mn4/YWsmiUJXtOthyZlPauNHXd5/f+G
-        uEaYEwpdaBd/5HrmtJqz0hiZJjmk0hmyae1ww1x7QLvn8fHxDwAAAP//AwBwlTg0zxwAAA==
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18291","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291","key":"NTEST-1898","fields":{"statuscategorychangedate":"2025-04-30T18:28:50.547+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:50.307+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":["tag1","tag2","tag3","tag4"],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tc7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:29:00.016+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 307802bd-ffdd-4edf-b268-f200a19c6146
+      - a7408a79-66cd-4613-8cd3-359621f5ef6b
       Atl-Traceid:
-      - 307802bdffdd4edfb268f200a19c6146
+      - a7408a7966cd46138cd3359621f5ef6b
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:24 GMT
+      - Wed, 30 Apr 2025 16:29:00 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -1943,7 +1999,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=255,atl-edge-internal;dur=17,atl-edge-upstream;dur=236,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=0,cdn-upstream-fbl;dur=295,atl-edge;dur=262,atl-edge-internal;dur=14,atl-edge-upstream;dur=248,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="DFW57-P1",cdn-rid;desc="oteCz7vKMCDJ7l25IeyPxgShC27n4LzMwuHzIiYuGY-neGV4NJSf2w==",cdn-downstream-fbl;dur=299
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -1952,10 +2008,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 223f95455b0bb3057583bfe63e0d5c7a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - oteCz7vKMCDJ7l25IeyPxgShC27n4LzMwuHzIiYuGY-neGV4NJSf2w==
+      X-Amz-Cf-Pop:
+      - DFW57-P1
       X-Arequestid:
-      - 78df6752a21632fa21c0da49c3e2f2a8
+      - 8bd987459c28bddb4cdf93d555e95d6a
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -1982,26 +2046,22 @@ interactions:
     uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA5yQUUvDMBDHv0teXbtrlrVb3mSCU3QK7V4UkTS9YDRNSpMOxth3N8XB9qi+HXe/
-        //2OO5BaeNz2hnDyEULn+XTaoEIZGvfpUhGM8F4Lm1oMZEIa7Tsj9v/gS+x3WmKD/muNpluhDdj/
-        dcnKWWUGtBJ/l9xh77WzEc4AshRSSMrN9XO5fqrO083Q1rEi/HWEJjCBt+jEzrh9G6+s9t1oWxk3
-        NDFUD9o0PxHCY4AWxal5I8IIUqDzBLIElhWlnM04i2KAK4hwzPv4B+wr3V6yGVQUeLbklKV5cWZl
-        e2eViyDL8oUUgHNUMpsVKJhSTIFUdDmbL2qVM6S5AnohCGY03OtejC9EJQYTHpwUY/tAzKkiaN+3
-        JTleHvbi7Di5fazI8RsAAP//AwChwkSoIAIAAA==
+      string: '{"baseUrl":"https://defectdojo.atlassian.net","displayUrl":"https://defectdojo.atlassian.net","displayUrlServicedeskHelpCenter":"https://defectdojo.atlassian.net","displayUrlConfluence":"https://defectdojo.atlassian.net","version":"1001.0.0-SNAPSHOT","versionNumbers":[1001,0,0],"deploymentType":"Cloud","buildNumber":100283,"buildDate":"2025-04-29T22:58:24.000+0200","serverTime":"2025-04-30T18:29:01.059+0200","scmInfo":"0bc1b6ccc33af448636c49e0141bd2e25a26f3ec","serverTitle":"Jira","defaultLocale":{"locale":"en_US"},"serverTimeZone":"Etc/UTC"}'
     headers:
       Atl-Request-Id:
-      - 352871f4-76d8-4713-8312-aa0bc0737297
+      - fa0a704c-e173-48d4-8022-26c7ce7046a9
       Atl-Traceid:
-      - 352871f476d847138312aa0bc0737297
+      - fa0a704ce17348d4802226c7ce7046a9
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:24 GMT
+      - Wed, 30 Apr 2025 16:29:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2011,7 +2071,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=163,atl-edge-internal;dur=14,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-cache-miss,cdn-pop;desc="ORD56-P1",cdn-rid;desc="Qfa0hs5vepFX9o8yfTAAAWJPX_bmvOc5gWOtGiVkt_7DpEwYKOZPcA==",cdn-downstream-fbl;dur=241,cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=57,cdn-upstream-fbl;dur=239,atl-edge;dur=162,atl-edge-internal;dur=14,atl-edge-upstream;dur=149,atl-edge-pop;desc="aws-us-east-1"
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2020,10 +2080,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 7b64a70fe0edcfd6cd8e281be975ea8a.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - Qfa0hs5vepFX9o8yfTAAAWJPX_bmvOc5gWOtGiVkt_7DpEwYKOZPcA==
+      X-Amz-Cf-Pop:
+      - ORD56-P1
       X-Arequestid:
-      - b483465211ec10f4fe256e296c30ee04
+      - 97357c05a4b58f731936fb0076531214
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
@@ -2047,61 +2115,44 @@ interactions:
       User-Agent:
       - python-requests/2.32.3
     method: GET
-    uri: https://defectdojo.atlassian.net/rest/api/2/issue/16142
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/18291
   response:
     body:
-      string: !!binary |
-        H4sIAAAAAAAAA7xWa08jNxT9K9Z8ammSGU8eZEeqqi2Eli2lFAJISxEyMzcTbzz2rO0hSVn+e6/n
-        kQAhW0HVFRITP+773ON778EiZzLxIk+DTEBDcsBBJKYlWQamZeIpZKylctDMciVNCxJuM7CsFU+Z
-        TEGotHUH2uAZJKeQazAgbX03LoxV2cQpvKFBQIOOhs8FGDte5nCiWWx5DF7L484+HdBeiAsDYoLL
-        qbW5iXw/gQnENlGfVIdZwYzhTHYkWB8tWZ/l3A99bkwBfqNgBkuUPx6PzsZtOugPcat0wXjRvWfQ
-        t8LEzEKq9LKKIcEVSoRB2G8HtE2DcRhE9F1EB53e7vAH9DtwTjojFh0v1bzRSSfvo77AOVqFXS8S
-        MLHmuUsc7r4nJmNCtEjCjeUytiTnEANREzJXetZx0rGS51q80otCclcuJm7YHbNM+3cc5n7p1trB
-        +ogGXTr8yfC/4ccMy15kaNXBAk2OmZm5WhW31v2KJkwYaHmV4CHGVcq2vClH4Oh4ujyCO0Bfg4eW
-        ZzkiK0eUeJEsMEbvGUy6QXOQa/UJI3pjwmvpMt1lAZt0u8UjkKyjOpfcWlRgvJVth9TfyrtGTeyc
-        aYdXw7NccHQ4eRY51qNEWW+46A1f6e5XKtNEsqpLL9hFN8LeIuz9v1aq6pdYRIN0sKCDb2Fw0Vjs
-        hotu+C0s1gB/eNiEI92G07A5mPDFRcWBWP2r682b3eYmS1MNKfLNRhNgAEoUVfu/bK6/7WCw7WB3
-        y0G49WC47eDdpp8VbVa7jpTKF8KL2rTmSlcSzeMqpPuNPdcomG0zVYVI9rnJBVvW7YTbc2bx6ako
-        +/WtXz0I6yfAr9Rp19jlzz1VuNSXrl66DS5TL7K6cLZRqb1AzLj2rrOhAYN1/PHSI0HD3eaReJ62
-        FZU9P9gGqnAFqlxzpbldvjEFjbjfe91bwTOWgvGdhGmUcNwQat4xd+maLI/UvCHVnrfZNuEK84Ld
-        gqPFK8+ylKIMftyLh59u9el5mz3jiObFDNFt4KVDl6opM6Ocx0dczg7cyT7kbrCRcQOuEnLz8my1
-        I5Uc4VzDbgWcAjMVYHX9yzs5Ov/l8Pjm6HBvdHw2uhmdnv5xio5jAxvMFV4YT4Gc4NMgLXF2CTdE
-        SbEkSDNcOKXEKvKBa0ZONGTIM6QwCMbOS3RDsdO84AsPgs+0G7n8IFNgWbEu63Z7QiNYoZRLJp5f
-        qseympLKlhDoXb12JU8lrG4XuevnFyEedjvDfr+BeDVBvRGVlfDqSX469LwOqGsk/sziGc6hDRob
-        5ZWtvXrU+08ON/Oi34xtYTNBSHBdECuh9HHlza0ooJ1qJLP1tKTIvqqKrbIcJ2VpX34o+iu++Fph
-        nwutuORpOv+S67+dMbcCdiJy9ZHlNCJ7Ss04kEtukX4tOYO40EAOBEu/uOxgcoSKmZgqY6NhMAz8
-        CZcJcqTf7fWvS4X7ZfIwrk+KOFhFO+RfJcl3+O/7UvwM50FHTyiGRFI7uV8A2cdAcfN3tiQ0aBEH
-        xlUQe5cjPLrCTxtn/dJTV8d4Dp2MWw0dpVMfYcxcaTkOcw7+Pl7tTG0mSr8rPRdOz7mcSTV/nKQT
-        rZICx4ORTLGxMyyTP8bkO5tlhtBf8quat63akqW8VhBeE59cUWPJnwXTFjRZq9wiCmubtJT++P6E
-        nMVMbrnv5lSfhsNVVI/iOFsaC5nBOJJccQTbTlTulxVyGcsYl4Zb6CAeMWFmequYTrbdQNl/AAAA
-        ///sWV1L3EAU/SuDICiYGHeju1sQu9gW+iAtChVEWGYnEzd0dxLyYZTW/95zZ2bHGHZskSI+CD7E
-        zMz9yr3nnjv7VP6nxzwjyVMmTDoBe9lcSsUqWbPW5lYNcKxMfqXIrz3WLjKxYCvJVYVFbnZYCfD3
-        Ws0l40IAXWXCbjPOGhSMKO8LwBP2KSUNfwg7Fp3hW9/oqZMMulxIRfnFuJObYyiFR7CE3AJBZJlK
-        83Klz7C8JMzmWK0IMgHXP6XaI8MgPKuZISmML1t+Ty6ygmvrmgqZzbhiHQMxUiq5DPHFK/LZeWhi
-        cK0oCKSNYgQLrIXV2kQSWDUI0EZLOz53vD9HLaL7IGTkvc2Xtm3DvOVVoasCRSjvwmJR6IyGkhlk
-        zqzuGa/ByuYNcmq28+1yevE9uDgL0MN1rTolRU6pTNWww5NVpnbZzu5vJMqyzj8gDQkHe8jkOEC/
-        yfl40UHcBcC6BLJrZkZMsb/Vx4cj30LsSGz/hOMa+iNp0rV5o497RD7iHDmdiDEXCypw24C7PbwP
-        8VWzWnFqWlt/w2uKOrHTvHxhhyMqcoJ6I0b8NTk+TIbj0Xh+MIrkUEwiMTkcpJOD9Ah63CZoeGab
-        pJSYJgl0oMuh5SX3HzuGAFBI1rPzsqmVEF1Ub9MwZWe2WILo8eQgjo9GYjw6HE7mYj6KoD7lMh2L
-        k+RYS9keTrcHX/BnzgUrriy+BoF5VYVNFbQIRDAICbjDopkvM0GRCgrOKwoUzus+ApqIx1MURVgo
-        inl/9n77FveH97dvcX/4f+sWA6MSM8daKniK1AeTSdNGiEwXEOG5mTMNwl2BDGLj56bMC7l/BewR
-        i8dKo8snrLrSJQ32ym0zf4x9uBr75s3YzZulxfd3GHm1hHmHkdew+B1GNsBIHwZ8TC12hMzxFbhz
-        Y4ryF92S2+cIluQ1t3f8fSk+Shb5cCkabAY4361Q5HXAS9mcZ/0TPi439C44kifVbVbmyrA88ypp
-        7A9M5t9/id5tXv+/q08jzAmFJoxpP3J917O+bUUJGJN/rR9tf3mxAfrHuP213L2tFb87l1WzJMEd
-        Z/UtTVlPa+M4XSPTTQ657t4/PTx4ctoe0NY+PDz8AQAA//8DAML5trvPHAAA
+      string: '{"expand":"renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations,customfield_10010.requestTypePractice","id":"18291","self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291","key":"NTEST-1898","fields":{"statuscategorychangedate":"2025-04-30T18:28:50.547+0200","issuetype":{"self":"https://defectdojo.atlassian.net/rest/api/2/issuetype/10002","id":"10002","description":"A
+        small, distinct piece of work.","iconUrl":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10318?size=medium","name":"Task","subtask":false,"avatarId":10318,"hierarchyLevel":0},"timespent":null,"customfield_10030":null,"customfield_10031":null,"project":{"self":"https://defectdojo.atlassian.net/rest/api/2/project/10000","id":"10000","key":"NTEST","name":"Unittests","projectTypeKey":"software","simplified":false,"avatarUrls":{"48x48":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407","24x24":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=small","16x16":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=xsmall","32x32":"https://defectdojo.atlassian.net/rest/api/2/universal_avatar/view/type/project/avatar/10407?size=medium"}},"customfield_10032":null,"customfield_10033":null,"fixVersions":[],"aggregatetimespent":null,"statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"},"customfield_10035":null,"resolution":null,"customfield_10036":null,"customfield_10037":null,"customfield_10027":null,"customfield_10028":null,"customfield_10029":null,"resolutiondate":null,"workratio":-1,"watches":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/watchers","watchCount":1,"isWatching":true},"lastViewed":null,"created":"2025-04-30T18:28:50.307+0200","customfield_10020":null,"customfield_10021":null,"customfield_10022":null,"customfield_10023":null,"priority":{"self":"https://defectdojo.atlassian.net/rest/api/2/priority/4","iconUrl":"https://defectdojo.atlassian.net/images/icons/priorities/low.svg","name":"Low","id":"4"},"labels":["tag1","tag2","tag3","tag4"],"customfield_10016":null,"customfield_10017":null,"customfield_10018":{"hasEpicLinkFieldDependency":false,"showField":false,"nonEditableReason":{"reason":"PLUGIN_LICENSE_ERROR","message":"The
+        Parent Link is only available to Jira Premium users."}},"customfield_10019":"0|i00tc7:","timeestimate":null,"aggregatetimeoriginalestimate":null,"versions":[],"issuelinks":[],"assignee":null,"updated":"2025-04-30T18:29:00.016+0200","status":{"self":"https://defectdojo.atlassian.net/rest/api/2/status/10000","description":"","iconUrl":"https://defectdojo.atlassian.net/","name":"Backlog","id":"10000","statusCategory":{"self":"https://defectdojo.atlassian.net/rest/api/2/statuscategory/2","id":2,"key":"new","colorName":"blue-gray","name":"To
+        Do"}},"components":[],"customfield_10050":null,"customfield_10051":null,"timeoriginalestimate":null,"customfield_10053":null,"description":"\n\n\n\n\n\n*Title*:
+        [Zap1: Cookie Without Secure Flag|http://localhost:8080/finding/345]\n\n*Defect
+        Dojo link:* http://localhost:8080/finding/345 (345)\n\n*Severity:* Low\n\n\n*Due
+        Date:* Aug. 28, 2025\n\n\n\n*CWE:* [CWE-614|https://cwe.mitre.org/data/definitions/614.html]\n\n\n\n*CVE:*
+        Unknown\n\n\n\n\n*Product/Engagement/Test:* [Security How-to|http://localhost:8080/product/2]
+        / [1st Quarter Engagement|http://localhost:8080/engagement/1] / [ZAP Scan|http://localhost:8080/test/128]\n\n\n\n\n\n\n\n\n*Systems/Endpoints*:\n\n*
+        https://mainsite.com/dashboard\n* https://mainsite.com\n\n\n\n\n\n\n\n*Description*:\nA
+        cookie has been set without the secure flag, which means that the cookie can\nbe
+        accessed via unencrypted connections.\n\n\n\n\n*Mitigation*:\nWhenever a cookie
+        contains sensitive information or is a session token, then\nit should always
+        be passed using an encrypted channel. Ensure that the secure\nflag is set
+        for cookies containing such sensitive information.\n\n\n\n\n\n*Impact*:\nNone\n\n\n\n\n\n*References*:\nhttp://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\n\n\n\n*Reporter:*
+        [(admin) ()|mailto:]\n","customfield_10010":null,"customfield_10055":null,"customfield_10056":null,"customfield_10014":null,"timetracking":{},"customfield_10015":null,"customfield_10005":null,"customfield_10049":null,"customfield_10006":null,"customfield_10007":null,"security":null,"customfield_10008":null,"attachment":[],"customfield_10009":null,"aggregatetimeestimate":null,"summary":"Zap1:
+        Cookie Without Secure Flag","creator":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"subtasks":[],"customfield_10040":null,"customfield_10041":null,"customfield_10042":null,"reporter":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5d3878b170e3c90c952f91f6","accountId":"5d3878b170e3c90c952f91f6","emailAddress":"cody@defectdojo.com","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","24x24":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","16x16":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png","32x32":"https://secure.gravatar.com/avatar/4e018ad14467c87539bcb7052ffaef8c?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FCM-0.png"},"displayName":"Cody
+        Maffucci","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"customfield_10043":null,"aggregateprogress":{"progress":0,"total":0},"customfield_10044":null,"customfield_10045":null,"customfield_10001":null,"customfield_10046":null,"customfield_10002":[],"customfield_10003":null,"customfield_10047":null,"customfield_10004":null,"customfield_10048":null,"customfield_10038":null,"customfield_10039":null,"environment":null,"duedate":null,"progress":{"progress":0,"total":0},"votes":{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1898/votes","votes":0,"hasVoted":false},"comment":{"comments":[],"self":"https://defectdojo.atlassian.net/rest/api/2/issue/18291/comment","maxResults":0,"total":0,"startAt":0},"worklog":{"startAt":0,"maxResults":20,"total":0,"worklogs":[]}}}'
     headers:
       Atl-Request-Id:
-      - 1c2bdf51-6cf5-4bed-a634-b6e6bb9411bb
+      - de6bfce1-0fe6-4b4e-98ca-c5361642cd69
       Atl-Traceid:
-      - 1c2bdf516cf54beda634b6e6bb9411bb
+      - de6bfce10fe64b4e98cac5361642cd69
       Cache-Control:
       - no-cache, no-store, no-transform
+      Connection:
+      - keep-alive
       Content-Encoding:
       - gzip
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 10 Jan 2025 19:19:25 GMT
+      - Wed, 30 Apr 2025 16:29:01 GMT
       Nel:
       - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
         "endpoint-1"}'
@@ -2111,7 +2162,7 @@ interactions:
       Server:
       - AtlassianEdge
       Server-Timing:
-      - atl-edge;dur=288,atl-edge-internal;dur=15,atl-edge-upstream;dur=276,atl-edge-pop;desc="aws-us-east-1"
+      - cdn-upstream-layer;desc="EDGE",cdn-upstream-dns;dur=0,cdn-upstream-connect;dur=21,cdn-upstream-fbl;dur=445,atl-edge;dur=359,atl-edge-internal;dur=16,atl-edge-upstream;dur=343,atl-edge-pop;desc="aws-us-east-1",cdn-cache-miss,cdn-pop;desc="ORD58-P1",cdn-rid;desc="vwXJeG_2e-9tj9QurSF7LWDmd-_g05YKsT-4awjxu0V9_oHRSJyuLg==",cdn-downstream-fbl;dur=450
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
       Timing-Allow-Origin:
@@ -2120,10 +2171,18 @@ interactions:
       - chunked
       Vary:
       - Accept-Encoding
+      Via:
+      - 1.1 c8780798b589dc6b55523ca0a9bc3c02.cloudfront.net (CloudFront)
       X-Aaccountid:
       - 5d3878b170e3c90c952f91f6
+      X-Amz-Cf-Id:
+      - vwXJeG_2e-9tj9QurSF7LWDmd-_g05YKsT-4awjxu0V9_oHRSJyuLg==
+      X-Amz-Cf-Pop:
+      - ORD58-P1
       X-Arequestid:
-      - cf701a693e9db2934111abb49540128e
+      - 436a2b899fc1478df1686158d488f7c4
+      X-Cache:
+      - Miss from cloudfront
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:


### PR DESCRIPTION
Initially, we saw that tests were failing in #12218 on the jira tests, so I had asserted that the issue was with the jira client based on the stack traces there found in the test. As it turns out, testing the jira instance creation and finding push flows manually on urllib 2.4.0 was a success, so that meant the unit tests may be the issue. Sure enough, rerecording the tests allowed for successful tests execution 

Big thanks to @dogboat for doing the testing to figure out the jira client is not the issue here!

[sc-11031]