### PR TITLE
ui: fix "retrieve my username" typo

### DIFF
--- a/dojo/locale/en/LC_MESSAGES/django.po
+++ b/dojo/locale/en/LC_MESSAGES/django.po
@@ -3198,7 +3198,7 @@ msgid ""
 msgstr ""
 
 #: dojo/templates/dojo/forgot_username.html
-msgid "Retreive my username"
+msgid "Retrieve my username"
 msgstr ""
 
 #: dojo/templates/dojo/forgot_username_done.html

--- a/dojo/templates/login/forgot_username.html
+++ b/dojo/templates/login/forgot_username.html
@@ -9,7 +9,7 @@
         {% include "dojo/form_fields.html" with form=form %}
         <div class="form-group">
         <div class="col-sm-offset-1 col-sm-1">
-            <button id="reset-password" class="btn btn-success">{% translate 'Retreive my username' %}</button>
+            <button id="reset-password" class="btn btn-success">{% translate 'Retrieve my username' %}</button>
         </div>
         </div>
     </fieldset>


### PR DESCRIPTION
**Description**

Just fix a typo in the UI when going to the clicking on "I forgot my username" from the login UI

**Test results**

No test here.

**Documentation**

N/A