### PR TITLE
jira push: log inactive/verified message to debug

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -658,7 +658,7 @@ class ViewFinding(View):
         ) = jira_helper.can_be_pushed_to_jira(finding)
         # Check the error code
         if error_code:
-            logger.error(error_code)
+            logger.debug(error_code)
 
         return {
             "can_be_pushed_to_jira": can_be_pushed_to_jira,


### PR DESCRIPTION
In #11738 we reduced the noise for when a push to jira was triggered for findings that were not active or not verified. 

There was one place left where this message was still logged on `ERROR` level. Since this is a normal scenario, logging to `DEBUG` is sufficient. User triggering this action via the UI are still getting a msg as feedback. 

Reported via Slack: https://owasp.slack.com/archives/C2P5BA8MN/p1746205059640759