### PR TITLE
easymde: enable native/browser spell checker

### DIFF
--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -76,6 +76,7 @@
                 if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -123,6 +123,7 @@
             if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                 var mde = new EasyMDE({
                     spellChecker: false,
+                    inputStyle: "contenteditable",
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/add_group.html
+++ b/dojo/templates/dojo/add_group.html
@@ -49,6 +49,7 @@
             if(!$(elem).hasClass('select2-search__field')) {
                 var mde = new EasyMDE({
                     spellChecker: false,
+                    inputStyle: "contenteditable",
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/add_risk_acceptance.html
+++ b/dojo/templates/dojo/add_risk_acceptance.html
@@ -51,6 +51,7 @@
 
             var mde = new EasyMDE({
                 spellChecker: false,
+                inputStyle: "contenteditable",
                 element: elem,
                 autofocus: false,
                 forceSync: true,

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -77,6 +77,7 @@
                 if (elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -53,6 +53,7 @@
                 if (elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -183,6 +183,7 @@
                 if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/edit_presets.html
+++ b/dojo/templates/dojo/edit_presets.html
@@ -39,6 +39,7 @@
                 if(!$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -53,6 +53,7 @@
               if(!$(elem).hasClass('select2-search__field')) {
                 var mde = new EasyMDE({
                     spellChecker: false,
+                    inputStyle: "contenteditable",
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/edit_product_type.html
+++ b/dojo/templates/dojo/edit_product_type.html
@@ -41,6 +41,7 @@
                 if(!$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -73,6 +73,7 @@
                 if(!$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/new_params.html
+++ b/dojo/templates/dojo/new_params.html
@@ -39,6 +39,7 @@
                 if(!$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -50,6 +50,7 @@
                 if(!$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/new_product_type.html
+++ b/dojo/templates/dojo/new_product_type.html
@@ -40,6 +40,7 @@
                 if(!$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -57,6 +57,7 @@
                 if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
+                        inputStyle: "contenteditable",
                         element: elem,
                         autofocus: false,
                         forceSync: true,

--- a/dojo/templates/dojo/view_risk_acceptance.html
+++ b/dojo/templates/dojo/view_risk_acceptance.html
@@ -367,6 +367,7 @@
 
             var mde = new EasyMDE({
                 spellChecker: false,
+                inputStyle: "contenteditable",
                 element: elem,
                 autofocus: false,
                 forceSync: true,


### PR DESCRIPTION
Fixes #12363 

To make native spell checking work with EasyMDE text fields, we need to DISABLE spell checking on the field.
This was already done, but we also need to change the `inputStyle` to `contenteditable`.
This wasn't clear to a lot of people including me: https://github.com/Ionaru/easy-markdown-editor/issues/617, for which I raised https://github.com/Ionaru/easy-markdown-editor/pull/619

The change to `contenteditable` doesn't seem to have a noticable effect, I can still create/edit findings and other objects. Just to be safe I added it to 2.47.0 and not the first upcoming `bugfix` release.

