### PR TITLE
helm chart publisher: use proper ref for checkout

### DIFF
--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: master
+          ref: ${{ inputs.release_number }}
           fetch-depth: 0
 
       # This action is deprecated. Not sure if it is even being used anymore...


### PR DESCRIPTION
The helm chart publish step had a hardcoded `ref: master` on the checkout step.

Now that we have the `nightly-dev` builds merged and enabled, this means the wrong ref is checked out for the helm cart publishing. It overwrites the latest release info in the helm chart.

This PR fixes the checkout ref.

For now I have disabled the `nightly-dev` builds and I've regenerated the helm-chart for 2.46.0:  
- https://github.com/DefectDojo/django-DefectDojo/actions/runs/14864126991/job/41736476121
- https://github.com/DefectDojo/django-DefectDojo/commit/e10b8fe3e41295e0f616c84ad86bd3589adbfb54

Thanks @kiblik for raising this and working together on a fix.