### PR TITLE
tags: prevent validation from removing tags

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -341,6 +341,7 @@ class ProductForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
 
 class DeleteProductForm(forms.ModelForm):
@@ -608,6 +609,7 @@ class ImportScanForm(forms.Form):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
     # date can only be today or in the past, not the future
     def clean_scan_date(self):
@@ -717,6 +719,7 @@ class ReImportScanForm(forms.Form):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
     # date can only be today or in the past, not the future
     def clean_scan_date(self):
@@ -1033,6 +1036,7 @@ class EngForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
     class Meta:
         model = Engagement
@@ -1091,6 +1095,7 @@ class TestForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
 
 class DeleteTestForm(forms.ModelForm):
@@ -1190,6 +1195,7 @@ class AddFindingForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
     class Meta:
         model = Finding
@@ -1270,6 +1276,7 @@ class AdHocFindingForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
     class Meta:
         model = Finding
@@ -1330,6 +1337,7 @@ class PromoteFindingForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
     class Meta:
         model = Finding
@@ -1455,6 +1463,7 @@ class FindingForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
     def _post_clean(self):
         super()._post_clean()
@@ -1534,6 +1543,7 @@ class ApplyFindingTemplateForm(forms.Form):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
     class Meta:
         fields = ["title", "cwe", "vulnerability_ids", "cvssv3", "severity", "description", "mitigation", "impact", "references", "tags"]
@@ -1567,6 +1577,7 @@ class FindingTemplateForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
 
 class DeleteFindingTemplateForm(forms.ModelForm):
@@ -1623,6 +1634,7 @@ class FindingBulkUpdateForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
     class Meta:
         model = Finding
@@ -1676,6 +1688,7 @@ class EditEndpointForm(forms.ModelForm):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
 
 class AddEndpointForm(forms.Form):
@@ -1742,6 +1755,7 @@ class AddEndpointForm(forms.Form):
 
     def clean_tags(self):
         tag_validator(self.cleaned_data.get("tags"))
+        return self.cleaned_data.get("tags")
 
 
 class DeleteEndpointForm(forms.ModelForm):

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2677,4 +2677,5 @@ def tag_validator(value: str | list[str], exception_class: Callable = Validation
         error_messages.append(f"Value must be a string or list of strings: {value} - {type(value)}.")
 
     if error_messages:
+        logger.debug(f"Tag validation failed: {error_messages}")
         raise exception_class(error_messages)

--- a/tests/finding_test.py
+++ b/tests/finding_test.py
@@ -119,8 +119,6 @@ class FindingTest(BaseTestCase):
         driver.find_element(By.ID, "id_cvssv3").send_keys("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H")
         # finding Vulnerability Ids
         driver.find_element(By.ID, "id_vulnerability_ids").send_keys("\nREF-3\nREF-4\n")
-        # Select the first element with class 'select2-search__field'
-        driver.find_element(By.CLASS_NAME, "select2-search__field").send_keys("tag1\t")
         # "Click" the Done button to Edit the finding
         driver.find_element(By.XPATH, "//input[@name='_Finished']").click()
         # Query the site to determine if the finding has been added
@@ -132,7 +130,6 @@ class FindingTest(BaseTestCase):
         self.assertTrue(self.is_text_present_on_page(text="REF-3"))
         self.assertTrue(self.is_text_present_on_page(text="REF-4"))
         self.assertTrue(self.is_text_present_on_page(text="Additional Vulnerability Ids"))
-        self.assertTrue(self.is_text_present_on_page(text="Search tag1"))
 
     def test_add_image(self):
         # The Name of the Finding created by test_add_product_finding => 'App Vulnerable to XSS'

--- a/tests/finding_test.py
+++ b/tests/finding_test.py
@@ -119,6 +119,8 @@ class FindingTest(BaseTestCase):
         driver.find_element(By.ID, "id_cvssv3").send_keys("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H")
         # finding Vulnerability Ids
         driver.find_element(By.ID, "id_vulnerability_ids").send_keys("\nREF-3\nREF-4\n")
+        # id_tags it the hidden input field, so it doesn't have autcompletion and tabbing functionality
+        driver.find_element(By.ID, "id_tags").send_keys("tag1, tag2")
         # "Click" the Done button to Edit the finding
         driver.find_element(By.XPATH, "//input[@name='_Finished']").click()
         # Query the site to determine if the finding has been added
@@ -130,6 +132,8 @@ class FindingTest(BaseTestCase):
         self.assertTrue(self.is_text_present_on_page(text="REF-3"))
         self.assertTrue(self.is_text_present_on_page(text="REF-4"))
         self.assertTrue(self.is_text_present_on_page(text="Additional Vulnerability Ids"))
+        self.assertTrue(self.is_text_present_on_page(text="Search tag1"))
+        self.assertTrue(self.is_text_present_on_page(text="Search tag2"))
 
     def test_add_image(self):
         # The Name of the Finding created by test_add_product_finding => 'App Vulnerable to XSS'

--- a/tests/finding_test.py
+++ b/tests/finding_test.py
@@ -119,8 +119,8 @@ class FindingTest(BaseTestCase):
         driver.find_element(By.ID, "id_cvssv3").send_keys("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H")
         # finding Vulnerability Ids
         driver.find_element(By.ID, "id_vulnerability_ids").send_keys("\nREF-3\nREF-4\n")
-        # id_tags it the hidden input field, so it doesn't have autcompletion and tabbing functionality
-        driver.find_element(By.ID, "id_tags").send_keys("tag1, tag2")
+        # Select the first element with class 'select2-search__field'
+        driver.find_element(By.CLASS_NAME, "select2-search__field").send_keys("tag1\t")
         # "Click" the Done button to Edit the finding
         driver.find_element(By.XPATH, "//input[@name='_Finished']").click()
         # Query the site to determine if the finding has been added
@@ -133,7 +133,6 @@ class FindingTest(BaseTestCase):
         self.assertTrue(self.is_text_present_on_page(text="REF-4"))
         self.assertTrue(self.is_text_present_on_page(text="Additional Vulnerability Ids"))
         self.assertTrue(self.is_text_present_on_page(text="Search tag1"))
-        self.assertTrue(self.is_text_present_on_page(text="Search tag2"))
 
     def test_add_image(self):
         # The Name of the Finding created by test_add_product_finding => 'App Vulnerable to XSS'


### PR DESCRIPTION
Fixes #12394 where any save action via the UI will clear the `tags` field on the saved object.

Any `clean_<fieldname>` method in Django must return the cleaned value of the field. If nothing is returned, the field will become empty. https://docs.djangoproject.com/en/5.2/ref/forms/validation/

Confirmed validation is working OK:
![image](https://github.com/user-attachments/assets/ae00c5c4-7bf6-4b1d-b40e-450f8655f96e)

I tried to add a simple smoke test for the tags field in the UI tests, but it's not trivial as the tags field is dynamically generated on the client-side.

REST API validation and modification of objects is working fine (has test cases)