### PR TITLE
Tags: Add support for comma separation for multipart forms (import/reimport)

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -225,9 +225,11 @@ class TagListSerializerField(serializers.ListField):
                 self.fail("not_a_str")
             # Run the children validation
             self.child.run_validation(s)
-            # Validate the tag to ensure it doesn't contain invalid characters
-            tag_validator(s, exception_class=RestFrameworkValidationError)
+            # Split the tags up in any way we need to
             substrings = re.findall(r'(?:"[^"]*"|[^",]+)', s)
+            # Validate the tag to ensure it doesn't contain invalid characters
+            for sub in substrings:
+                tag_validator(sub, exception_class=RestFrameworkValidationError)
             data_safe.extend(substrings)
 
         return tagulous.utils.render_tags(data_safe)

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -481,12 +481,6 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         self.assertEqual(expected_http_status_code, response.status_code, response.content[:1000])
         return json.loads(response.content)
 
-    def multipart_import_scan(self, payload, expected_http_status_code):
-        logger.debug("import_scan payload %s", payload)
-        response = self.client.post(reverse("importscan-list"), data=payload, format="multipart")
-        self.assertEqual(expected_http_status_code, response.status_code, response.content[:1000])
-        return json.loads(response.content)
-
     def reimport_scan(self, payload, expected_http_status_code):
         logger.debug("reimport_scan payload %s", payload)
         response = self.client.post(reverse("reimportscan-list"), payload)

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -480,10 +480,10 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         response = self.client.post(reverse("importscan-list"), payload)
         self.assertEqual(expected_http_status_code, response.status_code, response.content[:1000])
         return json.loads(response.content)
-    
+
     def multipart_import_scan(self, payload, expected_http_status_code):
         logger.debug("import_scan payload %s", payload)
-        response = self.client.post(reverse("importscan-list"), data=payload,  format="multipart")
+        response = self.client.post(reverse("importscan-list"), data=payload, format="multipart")
         self.assertEqual(expected_http_status_code, response.status_code, response.content[:1000])
         return json.loads(response.content)
 

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -480,6 +480,12 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         response = self.client.post(reverse("importscan-list"), payload)
         self.assertEqual(expected_http_status_code, response.status_code, response.content[:1000])
         return json.loads(response.content)
+    
+    def multipart_import_scan(self, payload, expected_http_status_code):
+        logger.debug("import_scan payload %s", payload)
+        response = self.client.post(reverse("importscan-list"), data=payload,  format="multipart")
+        self.assertEqual(expected_http_status_code, response.status_code, response.content[:1000])
+        return json.loads(response.content)
 
     def reimport_scan(self, payload, expected_http_status_code):
         logger.debug("reimport_scan payload %s", payload)

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -163,10 +163,6 @@ class TagTests(DojoAPITestCase):
     def test_finding_patch_remove_tags_non_existent(self):
         return self.test_finding_put_remove_tags_non_existent()
 
-    def test_finding_create_tags_with_commas(self):
-        tags = ["one,two"]
-        self.create_finding_with_tags(tags, expected_status_code=400)
-
     def test_finding_create_tags_with_spaces(self):
         tags = ["one two"]
         self.create_finding_with_tags(tags, expected_status_code=400)
@@ -211,6 +207,25 @@ class TagTests(DojoAPITestCase):
         self.assertEqual(len(tags), len(response.get("tags")))
         for tag in tags:
             self.assertIn(tag, response["tags"])
+
+    def test_import_reimport_multipart_tags(self):
+        with (self.zap_sample5_filename).open(encoding="utf-8") as testfile:
+            data = {
+                "engagement": [1],
+                "file": [testfile],
+                "scan_type": ["ZAP Scan"],
+                "tags": ["bug,security", "urgent"],
+            }
+            response = self.multipart_import_scan(data, 201)
+            # Make sure the serializer returns the correct tags
+            success_tags = ["bug", "security", "urgent"]
+            self.assertEqual(response["tags"], success_tags)
+            # Check that the test has the same issue
+            test_id = response["test"]
+            response = self.get_test_api(test_id)
+            self.assertEqual(len(success_tags), len(response.get("tags")))
+            for tag in success_tags:
+                self.assertIn(tag, response["tags"])
 
 
 class InheritedTagsTests(DojoAPITestCase):

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -208,7 +208,7 @@ class TagTests(DojoAPITestCase):
         for tag in tags:
             self.assertIn(tag, response["tags"])
 
-    def test_import_reimport_multipart_tags(self):
+    def test_import_multipart_tags(self):
         with (self.zap_sample5_filename).open(encoding="utf-8") as testfile:
             data = {
                 "engagement": [1],

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -214,9 +214,9 @@ class TagTests(DojoAPITestCase):
                 "engagement": [1],
                 "file": [testfile],
                 "scan_type": ["ZAP Scan"],
-                "tags": ["bug,security", "urgent"],
+                "tags": ["bug,security", "urgent"], # Attempting to mimic the two "tag" fields (-F 'tags=tag1' -F 'tags=tag2')
             }
-            response = self.multipart_import_scan(data, 201)
+            response = self.import_scan(data, 201)
             # Make sure the serializer returns the correct tags
             success_tags = ["bug", "security", "urgent"]
             self.assertEqual(response["tags"], success_tags)

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -214,7 +214,7 @@ class TagTests(DojoAPITestCase):
                 "engagement": [1],
                 "file": [testfile],
                 "scan_type": ["ZAP Scan"],
-                "tags": ["bug,security", "urgent"], # Attempting to mimic the two "tag" fields (-F 'tags=tag1' -F 'tags=tag2')
+                "tags": ["bug,security", "urgent"],  # Attempting to mimic the two "tag" fields (-F 'tags=tag1' -F 'tags=tag2')
             }
             response = self.import_scan(data, 201)
             # Make sure the serializer returns the correct tags


### PR DESCRIPTION
When attempting to attach multiple tags during a reimport through the swagger docs page, the curl request that is generated places all submitted tags in the same form field in a comma separated list. In the recent changes from #1294, commas are not longer allowed. This PR allowed for tag enforcement in lists, but not when a string is passed. Unfortunately correcting the generated curl request is not really feasible, so we must return to approach of splitting all tags from the API by commas.

Slack Context: https://defectdojo-workspace.slack.com/archives/C2P5BA8MN/p1747055360228049 
[sc-11116]