### PR TITLE
excel export: enhance handling of finding groups, better logging

### DIFF
--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -944,6 +944,7 @@ class ExcelExportView(View):
 
         row_num = 1
         for finding in findings:
+            logger.debug(f"processing finding: {finding.id}")
             if row_num == 1:
                 col_num = 1
                 for key in dir(finding):
@@ -955,7 +956,7 @@ class ExcelExportView(View):
                             cell.font = font_bold
                             col_num += 1
                     except Exception as exc:
-                        logger.error("Error in attribute: " + str(exc))
+                        logger.warning(f"Error in attribute: {key}" + str(exc))
                         cell = worksheet.cell(row=row_num, column=col_num, value=key)
                         col_num += 1
                         continue
@@ -1007,7 +1008,7 @@ class ExcelExportView(View):
                             worksheet.cell(row=row_num, column=col_num, value=value)
                             col_num += 1
                     except Exception as exc:
-                        logger.error("Error in attribute: " + str(exc))
+                        logger.warning(f"Error in attribute: {key}" + str(exc))
                         worksheet.cell(row=row_num, column=col_num, value="Value not supported")
                         col_num += 1
                         continue

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -816,7 +816,7 @@ class CSVExportView(View):
         writer = csv.writer(response)
         allowed_attributes = get_attributes()
         excludes_list = get_excludes()
-        allowed_foreign_keys = get_attributes()
+        allowed_foreign_keys = get_foreign_keys()
         first_row = True
 
         for finding in findings:
@@ -940,7 +940,7 @@ class ExcelExportView(View):
         self.font_bold = font_bold
         allowed_attributes = get_attributes()
         excludes_list = get_excludes()
-        allowed_foreign_keys = get_attributes()
+        allowed_foreign_keys = get_foreign_keys()
 
         row_num = 1
         for finding in findings:


### PR DESCRIPTION
Enhance logging for errors during Excel exports. Or rather they are warnings, so we log them at `warning` level from now on.

Inspired by #11911

Added later: Some more testing lead me to what I believe is a copy-and-paste error where `get_foreign_keys()` was not called. 

So the PR now also fixes the conversion problem and outputs finding group values correctly:

![image](https://github.com/user-attachments/assets/504facc9-a529-4365-8fbb-be7c2d6ca04c)
