### PR TITLE
defender: fix no vulnerabilities check

### DIFF
--- a/dojo/tools/ms_defender/parser.py
+++ b/dojo/tools/ms_defender/parser.py
@@ -34,9 +34,8 @@ class MSDefenderParser:
                 input_zip = zipfile.ZipFile(file.name, "r")
             else:
                 input_zip = zipfile.ZipFile(file, "r")
+
             zipdata = {name: input_zip.read(name) for name in input_zip.namelist()}
-            if zipdata.get("vulnerabilities/") is None:
-                return []
             vulnerabilityfiles = []
             machinefiles = []
             for content in list(zipdata):
@@ -44,6 +43,11 @@ class MSDefenderParser:
                     vulnerabilityfiles.append(content)
                 if "machines/" in content and content != "machines/":
                     machinefiles.append(content)
+
+            if len(vulnerabilityfiles) == 0:
+                logger.debug("No vulnerabilities.json files found in the vulnerabilities/ folder")
+                return []
+
             vulnerabilities = []
             machines = {}
             for vulnerabilityfile in vulnerabilityfiles:


### PR DESCRIPTION
The check to bail out early expects a `vulnerabilities/` folder entry to always be present in the zip file if there are files in that folder. We've seen that this is not always the case as some zips do not contain entries for folders, only entries for actual files.
This PR changes the "bail out check" to work well in both scenario's.

Raised by user on Slack: https://owasp.slack.com/archives/C2P5BA8MN/p1747126211915059