### PR TITLE
cvssv3: backport tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pip-delete-this-directory.txt
 .ruff_cache
 nosetests.xml
 coverage.xml
+selenium_page_source.html
 
 # Translations
 *.mo


### PR DESCRIPTION
While working on #12440 I decided to add the test cases from there also to the current bugfix branch to capture the old behaviour of the "old" RegEx based `cvssv_validator`.

This also helps us with understanding #8264 