### PR TITLE
legacy reimport: make matching on title case-insensitive

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -404,7 +404,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             # If you have use cases going through this section, you're advised to create a deduplication configuration for your parser
             logger.warning("Legacy reimport. In case of issue, you're advised to create a deduplication configuration in order not to go through this section")
             return Finding.objects.filter(
-                    title=unsaved_finding.title,
+                    title__iexact=unsaved_finding.title,
                     test=self.test,
                     severity=unsaved_finding.severity,
                     numerical_severity=Finding.get_numerical_severity(unsaved_finding.severity)).order_by("id")

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -220,7 +220,7 @@ def match_finding_to_existing_findings(finding, product=None, engagement=None, t
         return (
             Finding.objects.filter(
                 **custom_filter,
-                title=finding.title,
+                title__iexact=finding.title,
                 severity=finding.severity,
                 numerical_severity=Finding.get_numerical_severity(finding.severity),
             ).order_by("id")


### PR DESCRIPTION
In some scenario's the reimporter will fall back to the legacy dedupe algorithm that looks at the `title` and `severity` of existing findings. Although this is not a preferred situation, it happens when no dedupe hash field configuration is present for the parser.

At the time of writing this is the case for the OpenVAS parser. This can lead to false negative matching behavior as reported in #12378. This is because Defect Dojo uses `titlecase` to format the title of a finding before saving. So existing findings will can have a different `title` from the findings being processed by the reimporter because the latter are not saved yet.  Since Postgres is performing case sensitive comparisons by default, we have to explicitly make the comparison case insensitive with this PR.

There are no tests cases covering this I believe. Adding a test case is doable, for example using an OpenVAS report. However we  will probably add hash code config soon for OpenVAS rendering the test case useless. I think we should accept that we don't have explicit test cases for this "corner" or "legacy" scenario. I do think it's beneficial to merge this fix as it might be something first time users / PoC users run into for certain less used scan formats.