### PR TITLE
Bugfix: fixed wrong panel-footer margin in detailed metrics

### DIFF
--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -568,11 +568,10 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                </div>
-            
-                <div class="panel-footer">
-                    <i title="Weeks are only displayed if findings are available." class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
-                    <small>Weeks are only displayed if findings are available.</small>
+                    <div class="panel-footer">
+                        <i title="Weeks are only displayed if findings are available." class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
+                        <small>Weeks are only displayed if findings are available.</small>
+                    </div>
                 </div>
             </div>
 
@@ -622,12 +621,12 @@
                             {% endfor %}
                         </tbody>
                     </table>
-                </div>
                     <div class="panel-footer">
                         <i title="Weeks are only displayed if findings are available."
                            class="text-info fa-solid fa-circle-info" aria-hidden="true"></i>
                         <small>Weeks are only displayed if findings are available.</small>
                     </div>
+                </div>
             </div>
 
             <div class="col-md-6">


### PR DESCRIPTION
Hi,

The footer for "Week to Week by Severity" and "Critical Week to Week" in detailed metrics displays a gap that is not present in the other metrics.

Note: Please disregard the rounded corners in the image — they are part of a small experiment. This issue also occurs in the unmodified version.
![image](https://github.com/user-attachments/assets/9d53df4e-502c-48a6-842b-6d84cf14d9ba)



The issue is cause by closing the "panel panel-default" `<div>` too early.
