### PR TITLE
Bugfix: fix gap between component header and filter body

### DIFF
--- a/dojo/templates/dojo/components.html
+++ b/dojo/templates/dojo/components.html
@@ -16,9 +16,9 @@
                     </div>
                 </h3>
             </div>
-        </div>
-        <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
-            {% include "dojo/filter_snippet.html" with form=filter.form %}
+            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+                {% include "dojo/filter_snippet.html" with form=filter.form %}
+            </div>
         </div>
         <div class="clearfix">
             {% include "dojo/paging_snippet.html" with page=result page_size=True %}

--- a/dojo/templates/dojo/product_components.html
+++ b/dojo/templates/dojo/product_components.html
@@ -14,9 +14,9 @@
                         </div>
                     </h3>
             </div>
-        </div>
-        <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
-            {% include "dojo/filter_snippet.html" with form=filter.form %}
+            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+                {% include "dojo/filter_snippet.html" with form=filter.form %}
+            </div>
         </div>
         <div class="clearfix">
             {% include "dojo/paging_snippet.html" with page=result page_size=True %}


### PR DESCRIPTION
**Description**
If you show the filter options, there is a gap between the component panel header and the filter content. This gap is not present in similar views, such as Open Findings. This issue occurs because the `is-filters` `<div>` is not a child of the `panel panel-default` `<div>` like it is in the other views.

![image](https://github.com/user-attachments/assets/1ed892bb-e677-4999-aae7-147c6c84e015)


This PR moves the filters on both HTML component pages into the correct `<div>`.