### PR TITLE
Fix helm chart for nightly-dev builds

### DIFF
--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -22,6 +22,21 @@ on:
         description: 'Release number'
         required: true
 
+      make_draft:
+        type: boolean
+        description: 'Mark as draft release?'
+        default: true
+
+      make_prerelease:
+        type: boolean
+        description: 'Mark as pre-release?'
+        default: false
+
+      make_latest:
+        type: boolean
+        description: 'Mark as latest?'
+        default: false
+
 jobs:
   release-chart:
     runs-on: ubuntu-latest
@@ -78,8 +93,9 @@ jobs:
           name: '${{ inputs.release_number }} 🌈'
           tag_name: ${{ inputs.release_number }}
           body: Run the release drafter to populate the release notes.
-          draft: true
-          prerelease: false
+          draft: ${{ inputs.make_draft }}
+          prerelease: ${{ inputs.make_prerelease }}
+          make_latest: ${{ inputs.make_latest }}
           files: ./build/defectdojo-${{ env.chart_version }}.tgz
           token: ${{ secrets.GITHUB_TOKEN }}
         env:

--- a/.github/workflows/release-x-nightly.yml
+++ b/.github/workflows/release-x-nightly.yml
@@ -77,5 +77,6 @@ jobs:
     uses: ./.github/workflows/release-x-manual-helm-chart.yml
     with:
       release_number: ${{ inputs.tag-to-apply }}
+      make_draft: false
+      make_prerelease: true
     secrets: inherit
-


### PR DESCRIPTION
The nightly-dev builds currently end up incorrectly in the helm chart due to the `-dev` suffix not being detected.
The change in this PR works OK for version numbers with and without this suffix.

To make the heml chart downloads work, the `nightly-dev` release must be a published release. Otherwise github changes the artifact download urls to something like `https://github.com/DefectDojo/django-DefectDojo/releases/download/untagged-8327861234712346718234671236748129392146712394123412367841678234/<helm-chart.tgz>`

Added to `2.47.1` as I won't be available during `2.47.0`.