### PR TITLE
Dojo Meta: Migrate to `filterset_class` + Add case Insensitive filters

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -52,6 +52,7 @@ from dojo.engagement.services import close_engagement, reopen_engagement
 from dojo.filters import (
     ApiAppAnalysisFilter,
     ApiCredentialsFilter,
+    ApiDojoMetaFilter,
     ApiEndpointFilter,
     ApiEngagementFilter,
     ApiFindingFilter,
@@ -1643,14 +1644,7 @@ class DojoMetaViewSet(
     serializer_class = serializers.MetaSerializer
     queryset = DojoMeta.objects.none()
     filter_backends = (DjangoFilterBackend,)
-    filterset_fields = [
-        "id",
-        "product",
-        "endpoint",
-        "finding",
-        "name",
-        "value",
-    ]
+    filterset_class = ApiDojoMetaFilter
     permission_classes = (
         IsAuthenticated,
         permissions.UserHasDojoMetaPermission,

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -66,6 +66,7 @@ from dojo.models import (
     Development_Environment,
     Dojo_Group,
     Dojo_User,
+    DojoMeta,
     Endpoint,
     Endpoint_Status,
     Engagement,
@@ -1360,6 +1361,22 @@ class ProductFilterWithoutObjectLookups(ProductFilterHelper):
         fields = [
             "name", "name_exact", "business_criticality", "platform",
             "lifecycle", "origin", "external_audience", "internet_accessible",
+        ]
+
+
+class ApiDojoMetaFilter(DojoFilter):
+    name_exact = CharFilter(field_name="name", lookup_expr="iexact")
+    value_exact = CharFilter(field_name="value", lookup_expr="iexact")
+
+    class Meta:
+        model = DojoMeta
+        fields = [
+            "id",
+            "product",
+            "endpoint",
+            "finding",
+            "name",
+            "value",
         ]
 
 

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1365,8 +1365,8 @@ class ProductFilterWithoutObjectLookups(ProductFilterHelper):
 
 
 class ApiDojoMetaFilter(DojoFilter):
-    name_exact = CharFilter(field_name="name", lookup_expr="iexact")
-    value_exact = CharFilter(field_name="value", lookup_expr="iexact")
+    name_case_insensitive = CharFilter(field_name="name", lookup_expr="iexact")
+    value_case_insensitive = CharFilter(field_name="value", lookup_expr="iexact")
 
     class Meta:
         model = DojoMeta


### PR DESCRIPTION
Adds filters to the `metadata` endpoint that can filter on `name` and `value` in a case insensitive way

[sc-11313]