### PR TITLE
 Add Simple Metrics API endpoint

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -3089,3 +3089,19 @@ class NotificationWebhooksSerializer(serializers.ModelSerializer):
     class Meta:
         model = Notification_Webhooks
         fields = "__all__"
+
+
+class SimpleMetricsSerializer(serializers.Serializer):
+    """
+    Serializer for simple metrics data grouped by product type.
+    """
+    product_type_id = serializers.IntegerField(read_only=True)
+    product_type_name = serializers.CharField(read_only=True)
+    Total = serializers.IntegerField(read_only=True)
+    S0 = serializers.IntegerField(read_only=True)  # Critical
+    S1 = serializers.IntegerField(read_only=True)  # High  
+    S2 = serializers.IntegerField(read_only=True)  # Medium
+    S3 = serializers.IntegerField(read_only=True)  # Low
+    S4 = serializers.IntegerField(read_only=True)  # Info
+    Opened = serializers.IntegerField(read_only=True)
+    Closed = serializers.IntegerField(read_only=True)

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -58,6 +58,7 @@ from dojo.api_v2.views import (
     ReImportScanView,
     RiskAcceptanceViewSet,
     RoleViewSet,
+    SimpleMetricsViewSet,
     SLAConfigurationViewset,
     SonarqubeIssueTransitionViewSet,
     SonarqubeIssueViewSet,
@@ -143,6 +144,7 @@ v2_api.register(r"jira_projects", JiraProjectViewSet, basename="jira_project")
 v2_api.register(r"languages", LanguageViewSet, basename="languages")
 v2_api.register(r"language_types", LanguageTypeViewSet, basename="language_type")
 v2_api.register(r"metadata", DojoMetaViewSet, basename="metadata")
+v2_api.register(r"metrics/simple", SimpleMetricsViewSet, basename="simple_metrics")
 v2_api.register(r"network_locations", NetworkLocationsViewset, basename="network_locations")
 v2_api.register(r"notes", NotesViewSet, basename="notes")
 v2_api.register(r"note_type", NoteTypeViewSet, basename="note_type")

--- a/unittests/test_apiv2_simple_metrics.py
+++ b/unittests/test_apiv2_simple_metrics.py
@@ -1,0 +1,84 @@
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from unittests.dojo_test_case import DojoAPITestCase
+
+
+class SimpleMetricsAPITest(DojoAPITestCase):
+
+    """Test the Simple Metrics APIv2 endpoint."""
+
+    fixtures = ["dojo_testdata.json"]
+
+    def setUp(self):
+        token = Token.objects.get(user__username="admin")
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+
+    def test_simple_metrics_get(self):
+        """Test GET request to simple metrics endpoint"""
+        r = self.client.get(reverse("simple_metrics-list"), format="json")
+        self.assertEqual(r.status_code, 200)
+        # Check that it returns a list
+        self.assertIsInstance(r.json(), list)
+
+    def test_simple_metrics_get_with_date(self):
+        """Test GET request with date parameter"""
+        # Test with current month/year
+        current_date = timezone.now().strftime('%Y-%m-%d')
+        r = self.client.get(
+            reverse("simple_metrics-list"),
+            {"date": current_date},
+            format="json"
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertIsInstance(r.json(), list)
+
+    def test_simple_metrics_get_with_invalid_date(self):
+        """Test GET request with invalid date parameter"""
+        r = self.client.get(
+            reverse("simple_metrics-list"),
+            {"date": "invalid-date"},
+            format="json"
+        )
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("error", r.json())
+
+    def test_simple_metrics_response_structure(self):
+        """Test that response has expected structure"""
+        r = self.client.get(reverse("simple_metrics-list"), format="json")
+        self.assertEqual(r.status_code, 200)
+        
+        data = r.json()
+        if data:  # If there's any data
+            # Check first item structure
+            item = data[0]
+            expected_fields = [
+                'product_type_id', 'product_type_name', 'Total',
+                'S0', 'S1', 'S2', 'S3', 'S4',
+                'Opened', 'Closed'
+            ]
+            for field in expected_fields:
+                self.assertIn(field, item)
+                # Numeric fields should be integers
+                if field in ['product_type_id', 'Total', 'S0', 'S1', 
+                           'S2', 'S3', 'S4', 'Opened', 'Closed']:
+                    self.assertIsInstance(item[field], int)
+
+    def test_simple_metrics_post_not_allowed(self):
+        """Test that POST method is not allowed"""
+        r = self.client.post(reverse("simple_metrics-list"), {}, format="json")
+        self.assertEqual(r.status_code, 405)  # Method not allowed
+
+    def test_simple_metrics_with_specific_month(self):
+        """Test with a specific month/year"""
+        # Test with January 2024
+        r = self.client.get(
+            reverse("simple_metrics-list"),
+            {"date": "2024-01-15"},  # Any day in January 2024
+            format="json"
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertIsInstance(r.json(), list)


### PR DESCRIPTION
**Description**

This PR implements a new REST API endpoint `/api/v2/metrics/simple` that provides programmatic access to DefectDojo's simple metrics functionality. The API endpoint replicates the exact business logic of the existing UI `/metrics/simple` endpoint, enabling automated reporting and dashboard integration.

**Test results**
- Created 6 test methods in 'dojo/unittests/test_apiv2_simple_metrics'
----------------------------------------------------------------------
Ran 6 tests in 1.223s

**Documentation**
- Updated OpenAPI schema documentation


**Checklist**

- [X] Make sure to rebase your PR against the very latest `dev`.
- [X] Features/Changes should be submitted against the `dev`.
- [X] Bugfixes should be submitted against the `bugfix` branch.
- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [X] Your code is flake8 compliant.
- [X] Your code is python 3.11 compliant.
- [] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [X] Add applicable tests to the unit tests.
- [X] Add the proper label to categorize your PR.

Response
```
[
  {
    "product_type_id": 2,
    "product_type_name": "Platform A",
    "Total": 25,
    "S0": 13,
    "S1": 2,
    "S2": 10,
    "S3": 0,
    "S4": 0,
    "Opened": 25,
    "Closed": 0
  },
  {
    "product_type_id": 1,
    "product_type_name": "Research and Development",
    "Total": 7,
    "S0": 1,
    "S1": 3,
    "S2": 3,
    "S3": 0,
    "S4": 0,
    "Opened": 7,
    "Closed": 0
  }
]
```