### PR TITLE
Session Warning: Prevent timeout overflow for large session ages

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -1120,7 +1120,7 @@
 
                         setTimeout(() => {
                             $('#sessionTimeoutModal').modal('show');
-                        }, timeout * 1000);
+                        }, Math.min(timeout, 2147483) * 1000); // Do not allow a buffer overflow here
 
                     }  
                     session_notifcation();


### PR DESCRIPTION
For session ages greater than 24 days, the `setTimeout` function will overflow and display to popup immediately on each request

[sc-11334]
