### PR TITLE
SAML Login: Respect `next` parameter

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -98,6 +98,8 @@
         </style>
     </head>
     <body class="{% dojo_body_class %}">
+        {% block pre_wrapper %}
+        {% endblock %}
         <div id="wrapper">
             {% block navigation %}
                 <!-- Navigation -->

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -99,7 +99,7 @@
     </head>
     <body class="{% dojo_body_class %}">
         {% block pre_wrapper %}
-        {% endblock %}
+        {% endblock pre_wrapper %}
         <div id="wrapper">
             {% block navigation %}
                 <!-- Navigation -->

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -97,7 +97,7 @@
 
                 {% if SAML2_ENABLED is True %}
                     <div class="col-sm-offset-1 col-sm-2">
-                        <a id="oauth-login-saml" rel="nofollow" data-method="post" href="/saml2/login" style="color: rgb(255,255,255)" class="btn btn-success" type="button">{{ SAML2_LOGIN_BUTTON_TEXT }}</a>
+                        <a id="oauth-login-saml" rel="nofollow" data-method="post" href="/saml2/login?next={{ request.GET.next }}" style="color: rgb(255,255,255)" class="btn btn-success" type="button">{{ SAML2_LOGIN_BUTTON_TEXT }}</a>
                     </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
When logging in with SAML, the `next` parameter is not respected like it is for other SSO providers
[sc-11368]