### PR TITLE
add postgres 17 upgrade steps to 2.39.0 upgrade notes

### DIFF
--- a/docs/content/en/open_source/upgrading/2.39.md
+++ b/docs/content/en/open_source/upgrading/2.39.md
@@ -15,13 +15,15 @@ There are lots of online guides to be found such as https://hub.docker.com/r/tia
 There's also the [official documentation on `pg_upgrade`](https://www.postgresql.org/docs/current/pgupgrade.html), but this doesn't work out of the box when using Docker containers.
 
 Sometimes it's easier to just perform the upgrade manually, which would look something like the steps below.
-It may need some tuning to your specific needs and docker compose setup.
+It may need some tuning to your specific needs and docker compose setup. The guide is loosely based on https://simplebackups.com/blog/docker-postgres-backup-restore-guide-with-examples.
+If you already have a valid backup of the postgres 16 database, you can start at step 4.
 
 ---
 
 ## 0. Backup
 
-Always back up your data before starting.
+Always back up your data before starting and save it somewhere.
+Make sure the backup and restore is tested before continuing the steps below where the docker volume containing the database will be removed.
 
 ## 1. Start the Old Postgres Container
 


### PR DESCRIPTION
A major version postgres update such as in 2.39.0 is non-trivial. This PR adds some notes to help users make the upgrade work.