### PR TITLE
Simple metrics closed per month query improvement

### DIFF
--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -200,6 +200,9 @@ def simple_metrics(request):
                                        false_p=False,
                                        duplicate=False,
                                        out_of_scope=False,
+                                       active=False,
+                                       is_mitigated=True,
+                                       mitigated__isnull=False,
                                        mitigated__month=now.month,
                                        mitigated__year=now.year,
                                        )


### PR DESCRIPTION
Small improvement after #12595 to make sure only the right findings are counted / no corner cases with `mitigated==null` happening