### PR TITLE
Optimize `view_engineer` to use DB-side aggregation and cut load time

### DIFF
--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -3,15 +3,12 @@ import collections
 import logging
 import operator
 from calendar import monthrange
-from collections import OrderedDict
 from datetime import date, datetime, timedelta
-from functools import reduce
-from operator import itemgetter
 
 from dateutil.relativedelta import relativedelta
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.db.models import Case, Count, IntegerField, Q, Sum, Value, When
+from django.db.models import Case, Count, F, IntegerField, Q, Sum, Value, When
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -35,7 +32,7 @@ from dojo.metrics.utils import (
     identify_view,
     severity_count,
 )
-from dojo.models import Dojo_User, Engagement, Finding, Product, Product_Type, Risk_Acceptance, Test
+from dojo.models import Dojo_User, Finding, Product, Product_Type, Risk_Acceptance
 from dojo.product.queries import get_authorized_products
 from dojo.product_type.queries import get_authorized_product_types
 from dojo.utils import (
@@ -671,307 +668,247 @@ and root can view others metrics
 """
 
 
-# noinspection DjangoOrm
 @cache_page(60 * 5)  # cache for 5 minutes
 @vary_on_cookie
 def view_engineer(request, eid):
     user = get_object_or_404(Dojo_User, pk=eid)
-    if not (request.user.is_superuser
-            or request.user.username == user.username):
+    if not (request.user.is_superuser or request.user.username == user.username):
         raise PermissionDenied
-    now = timezone.now()
 
-    if get_system_setting("enforce_verified_status", True) or get_system_setting("enforce_verified_status_metrics", True):
-        findings = Finding.objects.filter(reporter=user, verified=True)
-    else:
-        findings = Finding.objects.filter(reporter=user)
+    now = timezone.now()
+    tz = now.tzinfo
+
+    # ---------------
+    # Base query-sets
+    reporter_findings = Finding.objects.filter(reporter=user)
+    if get_system_setting("enforce_verified_status", True) or get_system_setting(
+        "enforce_verified_status_metrics", True,
+    ):
+        reporter_findings = reporter_findings.filter(verified=True)
 
     closed_findings = Finding.objects.filter(mitigated_by=user)
-    open_findings = findings.exclude(mitigated__isnull=False)
-    open_month = findings.filter(date__year=now.year, date__month=now.month)
-    accepted_month = [finding for ra in Risk_Acceptance.objects.filter(
-        created__range=[datetime(now.year,
-                                 now.month, 1,
-                                 tzinfo=timezone.get_current_timezone()),
-                        datetime(now.year,
-                                 now.month,
-                                 monthrange(now.year,
-                                            now.month)[1],
-                                 tzinfo=timezone.get_current_timezone())],
-        owner=user)
-                      for finding in ra.accepted_findings.all()]
-    closed_month = [f for f in closed_findings
-                        if f.mitigated and f.mitigated.year == now.year and f.mitigated.month == now.month]
+    open_findings = (
+        reporter_findings.filter(mitigated__isnull=True)
+        .select_related("test__engagement__product__prod_type", "reporter")
+        .prefetch_related("risk_acceptance")
+    )
+
+    # --------------------
+    # Month & week buckets
+    month_start = datetime(now.year, now.month, 1, tzinfo=tz)
+    month_end = month_start.replace(day=monthrange(now.year, now.month)[1])
+
+    open_month = reporter_findings.filter(date__range=[month_start, month_end])
+    closed_month = closed_findings.filter(mitigated__range=[month_start, month_end])
+    accepted_month = (
+        Finding.objects.filter(
+            risk_acceptance__owner=user,
+            risk_acceptance__created__range=[month_start, month_end],
+        ).distinct()
+    )
+
+    week_start = (now - timedelta(days=now.weekday())).replace(hour=0, minute=0, second=0, microsecond=0)
+    open_week = reporter_findings.filter(date__range=[week_start, now])
+    closed_week = closed_findings.filter(mitigated__range=[week_start, now])
+    accepted_week = (
+        Finding.objects.filter(
+            risk_acceptance__owner=user,
+            risk_acceptance__created__range=[week_start, now],
+        ).distinct()
+    )
 
     o_dict, open_count = count_findings(open_month)
     c_dict, closed_count = count_findings(closed_month)
     a_dict, accepted_count = count_findings(accepted_month)
-    day_list = [now - relativedelta(weeks=1,
-                                    weekday=x,
-                                    hour=0,
-                                    minute=0,
-                                    second=0)
-                for x in range(now.weekday())]
-    day_list.append(now)
-
-    q_objects = (Q(date=d) for d in day_list)
-    open_week = findings.filter(reduce(operator.or_, q_objects))
-
-    accepted_week = [finding for ra in Risk_Acceptance.objects.filter(
-        owner=user, created__range=[day_list[0], day_list[-1]])
-                     for finding in ra.accepted_findings.all()]
-
-    q_objects = (Q(mitigated=d) for d in day_list)
-    # closed_week= findings.filter(reduce(operator.or_, q_objects))
-    closed_week = [f for f in closed_findings if f.mitigated and f.mitigated >= day_list[0]]
-
     o_week_dict, open_week_count = count_findings(open_week)
     c_week_dict, closed_week_count = count_findings(closed_week)
     a_week_dict, accepted_week_count = count_findings(accepted_week)
 
-    stuff = []
-    o_stuff = []
-    a_stuff = []
-    findings_this_period(findings, 1, stuff, o_stuff, a_stuff)
-    # findings_this_period no longer fits the need for accepted findings
-    # however will use its week finding output to use here
-    for month in a_stuff:
-        month_start = datetime.strptime(
-            month[0].strip(), "%b %Y")
-        month_end = datetime(month_start.year,
-                             month_start.month,
-                             monthrange(
-                                 month_start.year,
-                                 month_start.month)[1],
-                             tzinfo=timezone.get_current_timezone())
-        for finding in [finding for ra in Risk_Acceptance.objects.filter(
-                created__range=[month_start, month_end], owner=user)
-                        for finding in ra.accepted_findings.all()]:
-            if finding.severity == "Critical":
-                month[1] += 1
-            if finding.severity == "High":
-                month[2] += 1
-            if finding.severity == "Medium":
-                month[3] += 1
-            if finding.severity == "Low":
-                month[4] += 1
+    # --------------------------
+    # Historic series for charts
+    stuff, o_stuff, a_stuff = [], [], []
+    findings_this_period(reporter_findings, 1, stuff, o_stuff, a_stuff)
 
-        month[5] = sum(month[1:])
-    week_stuff = []
-    week_o_stuff = []
-    week_a_stuff = []
-    findings_this_period(findings, 0, week_stuff, week_o_stuff, week_a_stuff)
+    week_stuff, week_o_stuff, week_a_stuff = [], [], []
+    findings_this_period(reporter_findings, 0, week_stuff, week_o_stuff, week_a_stuff)
 
-    # findings_this_period no longer fits the need for accepted findings
-    # however will use its week finding output to use here
-    for week in week_a_stuff:
-        wk_range = week[0].split("-")
-        week_start = datetime.strptime(
-            wk_range[0].strip() + " " + str(now.year), "%b %d %Y")
-        week_end = datetime.strptime(
-            wk_range[1].strip() + " " + str(now.year), "%b %d %Y")
+    ras_owner_qs = Risk_Acceptance.objects.filter(owner=user)
+    _augment_series_with_accepted(a_stuff, ras_owner_qs, period="month", tz=tz)
+    _augment_series_with_accepted(week_a_stuff, ras_owner_qs, period="week", tz=tz)
 
-        for finding in [finding for ra in Risk_Acceptance.objects.filter(
-                created__range=[week_start, week_end], owner=user)
-                        for finding in ra.accepted_findings.all()]:
-            if finding.severity == "Critical":
-                week[1] += 1
-            if finding.severity == "High":
-                week[2] += 1
-            if finding.severity == "Medium":
-                week[3] += 1
-            if finding.severity == "Low":
-                week[4] += 1
+    chart_data = [["Date", "S0", "S1", "S2", "S3", "Total"], *o_stuff]
+    a_chart_data = [["Date", "S0", "S1", "S2", "S3", "Total"], *a_stuff]
+    week_chart_data = [["Date", "S0", "S1", "S2", "S3", "Total"], *week_o_stuff]
+    week_a_chart_data = [["Date", "S0", "S1", "S2", "S3", "Total"], *week_a_stuff]
 
-        week[5] = sum(week[1:])
+    # --------------
+    # Product tables
+    products = list(get_authorized_products(Permissions.Product_Type_View).only("id", "name"))
+    update, total_update = _product_stats(products)
 
-    products = get_authorized_products(Permissions.Product_Type_View)
-    vulns = {}
-    for product in products:
-        f_count = 0
-        engs = Engagement.objects.filter(product=product)
-        for eng in engs:
-            tests = Test.objects.filter(engagement=eng)
-            for test in tests:
-                f_count += findings.filter(test=test,
-                                           mitigated__isnull=True,
-                                           active=True).count()
-        vulns[product.id] = f_count
-    od = OrderedDict(sorted(vulns.items(), key=itemgetter(1)))
-    items = list(od.items())
-    items.reverse()
-    top = items[: 10]
-    update = []
-    for t in top:
-        product = t[0]
-        z_count = 0
-        o_count = 0
-        t_count = 0
-        h_count = 0
-        engs = Engagement.objects.filter(
-            product=Product.objects.get(id=product))
-        for eng in engs:
-            tests = Test.objects.filter(engagement=eng)
-            for test in tests:
-                z_count += findings.filter(
-                    test=test,
-                    mitigated__isnull=True,
-                    severity="Critical",
-                ).count()
-                o_count += findings.filter(
-                    test=test,
-                    mitigated__isnull=True,
-                    severity="High",
-                ).count()
-                t_count += findings.filter(
-                    test=test,
-                    mitigated__isnull=True,
-                    severity="Medium",
-                ).count()
-                h_count += findings.filter(
-                    test=test,
-                    mitigated__isnull=True,
-                    severity="Low",
-                ).count()
-        prod = Product.objects.get(id=product)
-        all_findings_link = "<a href='{}'>{}</a>".format(
-            reverse("product_open_findings", args=(prod.id,)), escape(prod.name))
-        update.append([all_findings_link, z_count, o_count, t_count, h_count,
-                       z_count + o_count + t_count + h_count])
-    total_update = []
-    for i in items:
-        product = i[0]
-        z_count = 0
-        o_count = 0
-        t_count = 0
-        h_count = 0
-        engs = Engagement.objects.filter(
-            product=Product.objects.get(id=product))
-        for eng in engs:
-            tests = Test.objects.filter(engagement=eng)
-            for test in tests:
-                z_count += findings.filter(
-                    test=test,
-                    mitigated__isnull=True,
-                    severity="Critical").count()
-                o_count += findings.filter(
-                    test=test,
-                    mitigated__isnull=True,
-                    severity="High").count()
-                t_count += findings.filter(
-                    test=test,
-                    mitigated__isnull=True,
-                    severity="Medium").count()
-                h_count += findings.filter(
-                    test=test,
-                    mitigated__isnull=True,
-                    severity="Low").count()
-        prod = Product.objects.get(id=product)
-        all_findings_link = "<a href='{}'>{}</a>".format(
-            reverse("product_open_findings", args=(prod.id,)), escape(prod.name))
-        total_update.append([all_findings_link, z_count, o_count, t_count,
-                             h_count, z_count + o_count + t_count + h_count])
+    # ----------------------------------
+    # Age buckets for open critical/high
+    high_crit_open = reporter_findings.filter(
+        mitigated__isnull=True,
+        active=True,
+        risk_acceptance=None,
+        severity__in=["Critical", "High"],
+    )
+    age_buckets = _age_buckets(high_crit_open)
 
-    neg_length = len(stuff)
-    findz = findings.filter(mitigated__isnull=True, active=True,
-                            risk_acceptance=None)
-    findz = findz.filter(Q(severity="Critical") | Q(severity="High"))
-    less_thirty = 0
-    less_sixty = 0
-    less_nine = 0
-    more_nine = 0
-    for finding in findz:
-        elapsed = date.today() - finding.date
-        if elapsed <= timedelta(days=30):
-            less_thirty += 1
-        elif elapsed <= timedelta(days=60):
-            less_sixty += 1
-        elif elapsed <= timedelta(days=90):
-            less_nine += 1
-        else:
-            more_nine += 1
-
-    # Data for the monthly charts
-    chart_data = [["Date", "S0", "S1", "S2", "S3", "Total"]]
-    for thing in o_stuff:
-        chart_data.insert(1, thing)
-
-    a_chart_data = [["Date", "S0", "S1", "S2", "S3", "Total"]]
-    for thing in a_stuff:
-        a_chart_data.insert(1, thing)
-
-    # Data for the weekly charts
-    week_chart_data = [["Date", "S0", "S1", "S2", "S3", "Total"]]
-    for thing in week_o_stuff:
-        week_chart_data.insert(1, thing)
-
-    week_a_chart_data = [["Date", "S0", "S1", "S2", "S3", "Total"]]
-    for thing in week_a_stuff:
-        week_a_chart_data.insert(1, thing)
-
-    details = []
-    for find in open_findings:
-        team = find.test.engagement.product.prod_type.name
-        name = find.test.engagement.product.name
-        severity = find.severity
-        description = find.title
-        life = date.today() - find.date
-        life = life.days
-        status = "Active"
-        if find.risk_accepted:
-            status = "Accepted"
-        detail = [team, name, severity, description, life, status, find.reporter]
-        details.append(detail)
-
-    details = sorted(details, key=itemgetter(2))
+    # -------------
+    # Details table
+    details = sorted(
+        (
+            [
+                f.test.engagement.product.prod_type.name,
+                f.test.engagement.product.name,
+                f.severity,
+                f.title,
+                (date.today() - f.date).days,
+                "Accepted" if f.risk_accepted else "Active",
+                f.reporter,
+            ]
+            for f in open_findings
+        ),
+        key=operator.itemgetter(2),
+    )
 
     add_breadcrumb(title=f"{user.get_full_name()} Metrics", top_level=False, request=request)
 
-    return render(request, "dojo/view_engineer.html", {
-        "open_month": open_month,
-        "a_month": accepted_month,
-        "low_a_month": accepted_count["low"],
-        "medium_a_month": accepted_count["med"],
-        "high_a_month": accepted_count["high"],
-        "critical_a_month": accepted_count["crit"],
-        "closed_month": closed_month,
-        "low_open_month": open_count["low"],
-        "medium_open_month": open_count["med"],
-        "high_open_month": open_count["high"],
-        "critical_open_month": open_count["crit"],
-        "low_c_month": closed_count["low"],
-        "medium_c_month": closed_count["med"],
-        "high_c_month": closed_count["high"],
-        "critical_c_month": closed_count["crit"],
-        "week_stuff": week_stuff,
-        "week_a_stuff": week_a_stuff,
-        "a_total": a_stuff,
-        "total": stuff,
-        "sub": neg_length,
-        "update": update,
-        "lt": less_thirty,
-        "ls": less_sixty,
-        "ln": less_nine,
-        "mn": more_nine,
-        "chart_data": chart_data,
-        "a_chart_data": a_chart_data,
-        "week_chart_data": week_chart_data,
-        "week_a_chart_data": week_a_chart_data,
-        "name": f"{user.get_full_name()} Metrics",
-        "metric": True,
-        "total_update": total_update,
-        "details": details,
-        "open_week": open_week,
-        "closed_week": closed_week,
-        "accepted_week": accepted_week,
-        "a_dict": a_dict,
-        "o_dict": o_dict,
-        "c_dict": c_dict,
-        "o_week_dict": o_week_dict,
-        "a_week_dict": a_week_dict,
-        "c_week_dict": c_week_dict,
-        "open_week_count": open_week_count,
-        "accepted_week_count": accepted_week_count,
-        "closed_week_count": closed_week_count,
-        "user": request.user,
-    })
+    return render(
+        request,
+        "dojo/view_engineer.html",
+        {
+            # month
+            "open_month": open_month,
+            "a_month": accepted_month,
+            "low_a_month": accepted_count["low"],
+            "medium_a_month": accepted_count["med"],
+            "high_a_month": accepted_count["high"],
+            "critical_a_month": accepted_count["crit"],
+            "closed_month": closed_month,
+            "low_open_month": open_count["low"],
+            "medium_open_month": open_count["med"],
+            "high_open_month": open_count["high"],
+            "critical_open_month": open_count["crit"],
+            "low_c_month": closed_count["low"],
+            "medium_c_month": closed_count["med"],
+            "high_c_month": closed_count["high"],
+            "critical_c_month": closed_count["crit"],
+            # week
+            "week_stuff": week_stuff,
+            "week_a_stuff": week_a_stuff,
+            # series
+            "a_total": a_stuff,
+            "total": stuff,
+            "sub": len(stuff),
+            # product tables
+            "update": update,
+            "total_update": total_update,
+            # aged buckets
+            "lt": age_buckets["lt"],
+            "ls": age_buckets["ls"],
+            "ln": age_buckets["ln"],
+            "mn": age_buckets["mn"],
+            # charts
+            "chart_data": chart_data,
+            "a_chart_data": a_chart_data,
+            "week_chart_data": week_chart_data,
+            "week_a_chart_data": week_a_chart_data,
+            # misc
+            "name": f"{user.get_full_name()} Metrics",
+            "metric": True,
+            "details": details,
+            "open_week": open_week,
+            "closed_week": closed_week,
+            "accepted_week": accepted_week,
+            "a_dict": a_dict,
+            "o_dict": o_dict,
+            "c_dict": c_dict,
+            "o_week_dict": o_week_dict,
+            "a_week_dict": a_week_dict,
+            "c_week_dict": c_week_dict,
+            "open_week_count": open_week_count,
+            "accepted_week_count": accepted_week_count,
+            "closed_week_count": closed_week_count,
+            "user": request.user,
+        },
+    )
+
+
+def _age_buckets(qs):
+    """Return aged high/critical finding counts in one SQL round-trip."""
+    today = date.today()
+    return qs.aggregate(
+        lt=Count("id", filter=Q(date__gte=today - timedelta(days=30))),
+        ls=Count("id", filter=Q(date__lte=today - timedelta(days=30), date__gt=today - timedelta(days=60))),
+        ln=Count("id", filter=Q(date__lte=today - timedelta(days=60), date__gt=today - timedelta(days=90))),
+        mn=Count("id", filter=Q(date__lte=today - timedelta(days=90))),
+    )
+
+
+def _augment_series_with_accepted(series: list[list], ras_qs, *, period: str, tz):
+    """Mutate `series` in-place, adding per-severity counts for accepted findings."""
+    if not series:  # no buckets to augment
+        return
+
+    first_ra = ras_qs.first()
+    if first_ra is None:  # engineer has no risk acceptances at all
+        return
+
+    owner = first_ra.owner
+    sev_idx = {"Critical": 1, "High": 2, "Medium": 3, "Low": 4}
+
+    for bucket in series:
+        if period == "month":
+            start = datetime.strptime(bucket[0].strip(), "%b %Y").replace(tzinfo=tz)
+            end = start.replace(day=monthrange(start.year, start.month)[1])
+        else:  # "week"
+            wk_a, wk_b = (d.strip() for d in bucket[0].split("-"))
+            year = timezone.now().year
+            start = datetime.strptime(f"{wk_a} {year}", "%b %d %Y").replace(tzinfo=tz)
+            end = datetime.strptime(f"{wk_b} {year}", "%b %d %Y").replace(tzinfo=tz)
+
+        accepted = (
+            Finding.objects.filter(risk_acceptance__owner=owner, risk_acceptance__created__range=[start, end])
+            .values("severity")
+            .annotate(cnt=Count("id"))
+        )
+
+        for row in accepted:
+            bucket[sev_idx[row["severity"]]] += row["cnt"]
+
+        bucket[5] = sum(bucket[1:])
+
+
+def _product_stats(products) -> tuple[list, list]:
+    """
+    Return two tables:
+    * `update` - top-10 products by open findings
+    * `total_update` - all authorized products
+    """
+    counts = (
+        Finding.objects.filter(test__engagement__product__in=products, mitigated__isnull=True, active=True)
+        .values(pid=F("test__engagement__product"))
+        .annotate(
+            critical=Count("id", filter=Q(severity="Critical")),
+            high=Count("id", filter=Q(severity="High")),
+            medium=Count("id", filter=Q(severity="Medium")),
+            low=Count("id", filter=Q(severity="Low")),
+            total=Count("id"),
+        )
+    )
+    by_id = {c["pid"]: c for c in counts}
+    top10 = sorted(by_id.items(), key=lambda kv: kv[1]["total"], reverse=True)[:10]
+
+    def row(prod_id):
+        prod = next(p for p in products if p.id == prod_id)
+        link = f"<a href='{reverse('product_open_findings', args=(prod.id,))}'>{escape(prod.name)}</a>"
+        data = by_id[prod_id]
+        return [link, data["critical"], data["high"], data["medium"], data["low"], data["total"]]
+
+    update = [row(pid) for pid, _ in top10]
+    total_update = [row(p.id) for p in products if p.id in by_id]
+
+    return update, total_update

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -27,7 +27,7 @@ from django.contrib import messages
 from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
-from django.db.models import Case, Count, IntegerField, Q, Sum, Value, When
+from django.db.models import Case, Count, F, IntegerField, Q, Sum, Value, When
 from django.db.models.query import QuerySet
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -575,40 +575,31 @@ def set_duplicate_reopen(new_finding, existing_finding):
     existing_finding.save()
 
 
-def count_findings(findings):
-    product_count = {}
-    finding_count = {"low": 0, "med": 0, "high": 0, "crit": 0}
-    for f in findings:
-        product = f.test.engagement.product
-        if product in product_count:
-            product_count[product][4] += 1
-            if f.severity == "Low":
-                product_count[product][3] += 1
-                finding_count["low"] += 1
-            if f.severity == "Medium":
-                product_count[product][2] += 1
-                finding_count["med"] += 1
-            if f.severity == "High":
-                product_count[product][1] += 1
-                finding_count["high"] += 1
-            if f.severity == "Critical":
-                product_count[product][0] += 1
-                finding_count["crit"] += 1
-        else:
-            product_count[product] = [0, 0, 0, 0, 0]
-            product_count[product][4] += 1
-            if f.severity == "Low":
-                product_count[product][3] += 1
-                finding_count["low"] += 1
-            if f.severity == "Medium":
-                product_count[product][2] += 1
-                finding_count["med"] += 1
-            if f.severity == "High":
-                product_count[product][1] += 1
-                finding_count["high"] += 1
-            if f.severity == "Critical":
-                product_count[product][0] += 1
-                finding_count["crit"] += 1
+def count_findings(findings: QuerySet) -> tuple[dict["Product", list[int]], dict[str, int]]:
+    agg = (
+        findings.values(prod_id=F("test__engagement__product_id"))
+        .annotate(
+            crit=Count("id", filter=Q(severity="Critical")),
+            high=Count("id", filter=Q(severity="High")),
+            med=Count("id", filter=Q(severity="Medium")),
+            low=Count("id", filter=Q(severity="Low")),
+            total=Count("id"),
+        )
+    )
+    rows = list(agg)
+
+    from dojo.models import Product  # imported lazily to avoid circulars
+
+    products = Product.objects.in_bulk([r["prod_id"] for r in rows])
+    product_count = {
+        products[r["prod_id"]]: [r["crit"], r["high"], r["med"], r["low"], r["total"]] for r in rows
+    }
+    finding_count = {
+        "low": sum(r["low"] for r in rows),
+        "med": sum(r["med"] for r in rows),
+        "high": sum(r["high"] for r in rows),
+        "crit": sum(r["crit"] for r in rows),
+    }
     return product_count, finding_count
 
 


### PR DESCRIPTION

> Initially inspired by [#12575](https://github.com/DefectDojo/django-DefectDojo/issues/12575)  

---

#### ✨  Key Points
* **Full rewrite of `view_engineer`**
  * replaces Python loops with SQL `COUNT` / `CASE` / `Subquery`
  * helper functions: `_age_buckets`, `_product_stats`, `_augment_series_with_accepted`
  * preserves the 5-minute `@cache_page` (But now it **can be removed** and I guess - should be removed)
* **One SQL round-trip per metric**
  * month/week open / closed / accepted
  * product severity tables
  * age buckets for high/critical
* **Targeted ORM tuning**
  * lean `select_related` & `prefetch_related`
  * dead imports & paths removed
* **No template or migration changes**

---

#### 🚀  Performance on our dataset
**I cannot run it on the our production dataset for now, but I excpect huge improvement**

| Env            | Before | After | Δ |
|----------------|--------|-------|---|
| dev | **12.7s** | **32 ms** | –99.7 % |
| prod | **≈ 190s** | - | - |

<details>
<summary>Screenshots</summary>

| Before | After |
|:--:|:--:|
| <img width="479" alt="Screenshot 2025-06-14 at 23 31 00" src="https://github.com/user-attachments/assets/b1a8323d-3216-420d-b761-1b3c598069a2" /> | <img width="481" alt="Screenshot 2025-06-14 at 23 30 29" src="https://github.com/user-attachments/assets/9496e552-bf9a-467d-8d67-3583fd59c7fc" />|

</details>
