### PR TITLE
Fix Jira FindingText

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -637,13 +637,13 @@ def jira_description(obj):
         kwargs["finding"] = obj
         jira_instance = get_jira_instance(obj)
         if jira_instance:
-            loggin.debug("Adding findind_text to the jira description")
+            logger.debug("Adding findind_text to the jira description")
             kwargs["finding_text"] = getattr(jira_instance, "finding_text", None)
     elif isinstance(obj, Finding_Group):
         kwargs["finding_group"] = obj
         jira_instance = get_jira_instance(obj)
         if jira_instance:
-            loggin.debug("Adding findind_text to the jira description")
+            logger.debug("Adding findind_text to the jira description")
             kwargs["finding_text"] = getattr(jira_instance, "finding_text", None)
 
     description = render_to_string(template, kwargs)

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -635,8 +635,16 @@ def jira_description(obj):
     kwargs = {}
     if isinstance(obj, Finding):
         kwargs["finding"] = obj
+        jira_instance = get_jira_instance(obj)
+        if jira_instance:
+            loggin.debug("Adding findind_text to the jira description")
+            kwargs["finding_text"] = getattr(jira_instance, "finding_text", None)
     elif isinstance(obj, Finding_Group):
         kwargs["finding_group"] = obj
+        jira_instance = get_jira_instance(obj)
+        if jira_instance:
+            loggin.debug("Adding findind_text to the jira description")
+            kwargs["finding_text"] = getattr(jira_instance, "finding_text", None)
 
     description = render_to_string(template, kwargs)
     logger.debug("rendered description: %s", description)

--- a/dojo/templates/issue-trackers/jira_full/jira-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-description.tpl
@@ -94,4 +94,9 @@
 {{ finding.references|safe }}
 {% endif %}
 
+{% if finding_text %}
+*Finding Text*:
+{{ finding_text|safe}}
+{% endif %}
+
 *Reporter:* [{{ finding.reporter|full_name}} ({{ finding.reporter.email }})|mailto:{{ finding.reporter.email }}]

--- a/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
@@ -88,5 +88,10 @@ h3. [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}]
 {{ finding.references|safe }}
 {% endif %}
 
+{% if finding_text %}
+*Finding Text*:
+{{ finding_text|safe}}
+{% endif %}
+
 *Reporter:* [{{ finding.reporter|full_name}} ({{ finding.reporter.email }})|mailto:{{ finding.reporter.email }}]
 {% endfor %}

--- a/dojo/templates/issue-trackers/jira_limited/jira-description.tpl
+++ b/dojo/templates/issue-trackers/jira_limited/jira-description.tpl
@@ -9,4 +9,9 @@
 
 *Product/Engagement/Test:* [{{ finding.test.engagement.product.name }}|{{ product_url|full_url }}] / [{{ finding.test.engagement.name }}|{{ engagement_url|full_url }}] / [{{ finding.test }}|{{ test_url|full_url }}]
 
+{% if finding_text %}
+*Finding Text*:
+{{ finding_text|safe}}
+{% endif %}
+
 *Reporter:* [{{ finding.reporter|full_name}} ({{ finding.reporter.email }})|mailto:{{ finding.reporter.email }}]

--- a/dojo/templates/issue-trackers/jira_limited/jira-finding-group-description.tpl
+++ b/dojo/templates/issue-trackers/jira_limited/jira-finding-group-description.tpl
@@ -25,3 +25,8 @@ Findings:
 {% if finding_group.test.engagement.commit_hash %}
 *Commit hash:* {{ finding_group.test.engagement.commit_hash }}
 {% endif %}
+
+{% if finding_text %}
+*Finding Text*:
+{{ finding_text|safe}}
+{% endif %}


### PR DESCRIPTION
**Description**

[Fixes 12610](https://github.com/DefectDojo/django-DefectDojo/issues/12610). Add the `finding_text` attribute from the Jira instance to the issue description field and update the templates to properly display it.


**Test results**

![image](https://github.com/user-attachments/assets/3a45dab5-528e-435e-8969-598969ccd16c)
If no text is configured, no message is displayed.


