### PR TITLE
fix: secret must be optional in all containers

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -131,6 +131,7 @@ spec:
             name: {{ $fullName }}
         - secretRef:
             name: {{ $fullName }}
+            optional: true
         env:
         - name: DD_DATABASE_PASSWORD
           valueFrom:


### PR DESCRIPTION
## :warning: Note on feature completeness :warning:

We are narrowing the scope of acceptable enhancements to DefectDojo in preparation for v3. Learn more here:
https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/CONTRIBUTING.md

**Description**

When secret is not being created, job initializer still fails to start all containers since one of them is missing the `optional: true` statement.

**Test results**

Tested locally

**Documentation**

n/a

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
