### PR TITLE
cobalt api: add note about v1 api keys only

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/api/cobalt.md
+++ b/docs/content/en/connecting_your_tools/parsers/api/cobalt.md
@@ -7,6 +7,7 @@ All parsers which using API have common basic configuration step but with differ
 
 In `Tool Configuration`, select `Tool Type` to "Cobalt.io" and `Authentication Type` "API Key".
 Paste your Cobalt.io API token in the `API Key` field and the desired org token in the `Extras` field.
+Currently Defect Dojo only support [V1 API Keys](https://github.com/DefectDojo/django-DefectDojo/issues/12572).
 
 In `Add API Scan Configuration` provide the ID
 of the asset from which to import findings in the field `Service key 1`.


### PR DESCRIPTION
Make it clear users need to use a V1 API Key for now.