### PR TITLE
Async Delete: Correct instances of multiple audit log entries for delete

### DIFF
--- a/dojo/endpoint/signals.py
+++ b/dojo/endpoint/signals.py
@@ -19,7 +19,7 @@ def endpoint_post_delete(sender, instance, using, origin, **kwargs):
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label="dojo", model="endpoint"),
                 object_id=instance.id,
-            ).order_by('-id').first():
+            ).order_by("-id").first():
                 description = _('The endpoint "%(name)s" was deleted by %(user)s') % {
                                 "name": str(instance), "user": le.actor}
         create_notification(event="endpoint_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing

--- a/dojo/endpoint/signals.py
+++ b/dojo/endpoint/signals.py
@@ -13,16 +13,15 @@ from dojo.notifications.helper import create_notification
 @receiver(post_delete, sender=Endpoint)
 def endpoint_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
+        description = _('The endpoint "%(name)s" was deleted') % {"name": str(instance)}
         if settings.ENABLE_AUDITLOG:
-            le = LogEntry.objects.get(
+            if le := LogEntry.objects.filter(
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label="dojo", model="endpoint"),
                 object_id=instance.id,
-            )
-            description = _('The endpoint "%(name)s" was deleted by %(user)s') % {
+            ).order_by('-id').first():
+                description = _('The endpoint "%(name)s" was deleted by %(user)s') % {
                                 "name": str(instance), "user": le.actor}
-        else:
-            description = _('The endpoint "%(name)s" was deleted') % {"name": str(instance)}
         create_notification(event="endpoint_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
                             title=_("Deletion of %(name)s") % {"name": str(instance)},
                             description=description,

--- a/dojo/engagement/signals.py
+++ b/dojo/engagement/signals.py
@@ -39,16 +39,15 @@ def engagement_pre_save(sender, instance, **kwargs):
 @receiver(post_delete, sender=Engagement)
 def engagement_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
+        description = _('The engagement "%(name)s" was deleted') % {"name": instance.name}
         if settings.ENABLE_AUDITLOG:
-            le = LogEntry.objects.get(
+            if le := LogEntry.objects.filter(
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label="dojo", model="engagement"),
                 object_id=instance.id,
-            )
-            description = _('The engagement "%(name)s" was deleted by %(user)s') % {
+            ).order_by('-id').first():
+                description = _('The engagement "%(name)s" was deleted by %(user)s') % {
                                 "name": instance.name, "user": le.actor}
-        else:
-            description = _('The engagement "%(name)s" was deleted') % {"name": instance.name}
         create_notification(event="engagement_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
                             title=_("Deletion of %(name)s") % {"name": instance.name},
                             description=description,

--- a/dojo/engagement/signals.py
+++ b/dojo/engagement/signals.py
@@ -45,7 +45,7 @@ def engagement_post_delete(sender, instance, using, origin, **kwargs):
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label="dojo", model="engagement"),
                 object_id=instance.id,
-            ).order_by('-id').first():
+            ).order_by("-id").first():
                 description = _('The engagement "%(name)s" was deleted by %(user)s') % {
                                 "name": instance.name, "user": le.actor}
         create_notification(event="engagement_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing

--- a/dojo/finding_group/signals.py
+++ b/dojo/finding_group/signals.py
@@ -13,16 +13,15 @@ from dojo.notifications.helper import create_notification
 @receiver(post_delete, sender=Finding_Group)
 def finding_group_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
+        description = _('The finding group "%(name)s" was deleted') % {"name": instance.name}
         if settings.ENABLE_AUDITLOG:
-            le = LogEntry.objects.get(
+            if le := LogEntry.objects.filter(
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label="dojo", model="finding_group"),
                 object_id=instance.id,
-            )
-            description = _('The finding group "%(name)s" was deleted by %(user)s') % {
+            ).order_by('-id').first():
+                description = _('The finding group "%(name)s" was deleted by %(user)s') % {
                                 "name": instance.name, "user": le.actor}
-        else:
-            description = _('The finding group "%(name)s" was deleted') % {"name": instance.name}
         create_notification(event="finding_group_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
                             title=_("Deletion of %(name)s") % {"name": instance.name},
                             description=description,

--- a/dojo/finding_group/signals.py
+++ b/dojo/finding_group/signals.py
@@ -19,7 +19,7 @@ def finding_group_post_delete(sender, instance, using, origin, **kwargs):
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label="dojo", model="finding_group"),
                 object_id=instance.id,
-            ).order_by('-id').first():
+            ).order_by("-id").first():
                 description = _('The finding group "%(name)s" was deleted by %(user)s') % {
                                 "name": instance.name, "user": le.actor}
         create_notification(event="finding_group_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing

--- a/dojo/product/signals.py
+++ b/dojo/product/signals.py
@@ -23,16 +23,15 @@ def product_post_save(sender, instance, created, **kwargs):
 
 @receiver(post_delete, sender=Product)
 def product_post_delete(sender, instance, **kwargs):
+    description = _('The product "%(name)s" was deleted') % {"name": instance.name}
     if settings.ENABLE_AUDITLOG:
-        le = LogEntry.objects.get(
+        if le := LogEntry.objects.filter(
             action=LogEntry.Action.DELETE,
             content_type=ContentType.objects.get(app_label="dojo", model="product"),
             object_id=instance.id,
-        )
-        description = _('The product "%(name)s" was deleted by %(user)s') % {
+        ).order_by('-id').first():
+            description = _('The product "%(name)s" was deleted by %(user)s') % {
                             "name": instance.name, "user": le.actor}
-    else:
-        description = _('The product "%(name)s" was deleted') % {"name": instance.name}
     create_notification(event="product_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
                         title=_("Deletion of %(name)s") % {"name": instance.name},
                         description=description,

--- a/dojo/product/signals.py
+++ b/dojo/product/signals.py
@@ -29,7 +29,7 @@ def product_post_delete(sender, instance, **kwargs):
             action=LogEntry.Action.DELETE,
             content_type=ContentType.objects.get(app_label="dojo", model="product"),
             object_id=instance.id,
-        ).order_by('-id').first():
+        ).order_by("-id").first():
             description = _('The product "%(name)s" was deleted by %(user)s') % {
                             "name": instance.name, "user": le.actor}
     create_notification(event="product_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing

--- a/dojo/product_type/signals.py
+++ b/dojo/product_type/signals.py
@@ -29,7 +29,7 @@ def product_type_post_delete(sender, instance, **kwargs):
             action=LogEntry.Action.DELETE,
             content_type=ContentType.objects.get(app_label="dojo", model="product_type"),
             object_id=instance.id,
-        ).order_by('-id').first():
+        ).order_by("-id").first():
             description = _('The product type "%(name)s" was deleted by %(user)s') % {
                             "name": instance.name, "user": le.actor}
     create_notification(event="product_type_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing

--- a/dojo/product_type/signals.py
+++ b/dojo/product_type/signals.py
@@ -23,16 +23,15 @@ def product_type_post_save(sender, instance, created, **kwargs):
 
 @receiver(post_delete, sender=Product_Type)
 def product_type_post_delete(sender, instance, **kwargs):
+    description = _('The product type "%(name)s" was deleted') % {"name": instance.name}
     if settings.ENABLE_AUDITLOG:
-        le = LogEntry.objects.get(
+        if le := LogEntry.objects.filter(
             action=LogEntry.Action.DELETE,
             content_type=ContentType.objects.get(app_label="dojo", model="product_type"),
             object_id=instance.id,
-        )
-        description = _('The product type "%(name)s" was deleted by %(user)s') % {
+        ).order_by('-id').first():
+            description = _('The product type "%(name)s" was deleted by %(user)s') % {
                             "name": instance.name, "user": le.actor}
-    else:
-        description = _('The product type "%(name)s" was deleted') % {"name": instance.name}
     create_notification(event="product_type_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
                         title=_("Deletion of %(name)s") % {"name": instance.name},
                         description=description,

--- a/dojo/test/signals.py
+++ b/dojo/test/signals.py
@@ -16,16 +16,15 @@ from dojo.notifications.helper import create_notification
 @receiver(post_delete, sender=Test)
 def test_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
+        description = _('The test "%(name)s" was deleted') % {"name": str(instance)}
         if settings.ENABLE_AUDITLOG:
-            le = LogEntry.objects.get(
+            if le := LogEntry.objects.filter(
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label="dojo", model="test"),
                 object_id=instance.id,
-            )
-            description = _('The test "%(name)s" was deleted by %(user)s') % {
+            ).order_by('-id').first():
+                description = _('The test "%(name)s" was deleted by %(user)s') % {
                                 "name": str(instance), "user": le.actor}
-        else:
-            description = _('The test "%(name)s" was deleted') % {"name": str(instance)}
         create_notification(event="test_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
                             title=_("Deletion of %(name)s") % {"name": str(instance)},
                             description=description,

--- a/dojo/test/signals.py
+++ b/dojo/test/signals.py
@@ -22,7 +22,7 @@ def test_post_delete(sender, instance, using, origin, **kwargs):
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label="dojo", model="test"),
                 object_id=instance.id,
-            ).order_by('-id').first():
+            ).order_by("-id").first():
                 description = _('The test "%(name)s" was deleted by %(user)s') % {
                                 "name": str(instance), "user": le.actor}
         create_notification(event="test_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2344,7 +2344,7 @@ class async_delete:
                 ).delete()
                 # Now delete the object again
                 obj.delete()
-    
+
     @dojo_async_task
     @app.task
     def delete(self, obj, **kwargs):

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2333,7 +2333,16 @@ class async_delete:
                 logger.debug("ASYNC_DELETE: object has already been deleted elsewhere. Skipping")
                 # The id must be None
                 # The object has already been deleted elsewhere
-
+            except LogEntry.MultipleObjectsReturned:
+                # Delete the log entrys first, then delete
+                LogEntry.objects.filter(
+                    content_type=ContentType.objects.get_for_model(obj.__class__),
+                    object_pk=str(obj.pk),
+                    action=LogEntry.Action.DELETE,
+                ).delete()
+                # Now delete the object again
+                obj.delete()
+    
     @dojo_async_task
     @app.task
     def delete(self, obj, **kwargs):

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -18,6 +18,7 @@ import crum
 import hyperlink
 import vobject
 from asteval import Interpreter
+from auditlog.models import LogEntry
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from dateutil.parser import parse
@@ -25,6 +26,7 @@ from dateutil.relativedelta import MO, SU, relativedelta
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db.models import Case, Count, IntegerField, Q, Sum, Value, When


### PR DESCRIPTION
Correcting the following:
```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/celery/app/trace.py", line 453, in trace_task
    R = retval = fun(*args, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/utils.py", line 2331, in delete_chunk
    obj.delete()
  File "/app/dojo/models.py", line 1614, in delete
    super().delete(*args, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 1273, in delete
    return collector.delete()
           ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/deletion.py", line 508, in delete
    signals.post_delete.send(
  File "/usr/local/lib/python3.11/site-packages/django/dispatch/dispatcher.py", line 189, in send
    response = receiver(signal=self, sender=sender, **named)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/engagement/signals.py", line 43, in engagement_post_delete
    le = LogEntry.objects.get(
         ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 652, in get
    raise self.model.MultipleObjectsReturned(
auditlog.models.LogEntry.MultipleObjectsReturned: get() returned more than one LogEntry -- it returned 2!
```