### PR TITLE
Feature/asvs 5.0 benchmark

### DIFF
--- a/dojo/fixtures/benchmark_category.json
+++ b/dojo/fixtures/benchmark_category.json
@@ -375,5 +375,226 @@
       "created": "2019-03-27T15:18:24.276Z",
       "updated": "2019-03-27T15:18:24.276Z"
     }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 30,
+    "fields": {
+      "type": 3,
+      "name": "V1 Encoding and Sanitization",
+      "objective": "This chapter addresses the most common web application security weaknesses related to the unsafe processing of untrusted data. Such weaknesses can result in various technical vulnerabilities, where untrusted data is interpreted according to the syntax rules of the relevant interpreter.\n\nFor modern web applications, it is always best to use safer APIs, such as parameterized queries, auto-escaping, or templating frameworks. Otherwise, carefully performed output encoding, escaping, or sanitization becomes critical to the application's security.\n\nInput validation serves as a defense-in-depth mechanism to protect against unexpected or dangerous content. However, since its primary purpose is to ensure that incoming content matches functional and business expectations, requirements related to this can be found in the \"Validation and Business Logic\" chapter.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP LDAP Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html)\n* [OWASP Cross Site Scripting Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)\n* [OWASP DOM Based Cross Site Scripting Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html)\n* [OWASP XML External Entity Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html)\n* [OWASP Web Security Testing Guide: Client-Side Testing](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/11-Client-side_Testing)\n* [OWASP Java Encoding Project](https://owasp.org/owasp-java-encoder/)\n* [DOMPurify - Client-side HTML Sanitization Library](https://github.com/cure53/DOMPurify)\n* [RFC4180 - Common Format and MIME Type for Comma-Separated Values (CSV) Files](https://datatracker.ietf.org/doc/html/rfc4180#section-2)\n\nFor more information, specifically on deserialization or parsing issues, please see:\n\n* [OWASP Deserialization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html)\n* [An Exploration of JSON Interoperability Vulnerabilities](https://bishopfox.com/blog/json-interoperability-vulnerabilities)\n* [Orange Tsai - A New Era of SSRF Exploiting URL Parser In Trending Programming Languages](https://www.blackhat.com/docs/us-17/thursday/us-17-Tsai-A-New-Era-Of-SSRF-Exploiting-URL-Parser-In-Trending-Programming-Languages.pdf)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 31,
+    "fields": {
+      "type": 3,
+      "name": "V2 Validation and Business Logic",
+      "objective": "This chapter aims to ensure that a verified application meets the following high-level goals:\n\n* Input received by the application matches business or functional expectations.\n* The business logic flow is sequential, processed in order, and cannot be bypassed.\n* Business logic includes limits and controls to detect and prevent automated attacks, such as continuous small funds transfers or adding a million friends one at a time.\n* High-value business logic flows have considered abuse cases and malicious actors, and have protections against spoofing, tampering, information disclosure, and elevation of privilege attacks.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP Web Security Testing Guide: Input Validation Testing](https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/README.html)\n* [OWASP Web Security Testing Guide: Business Logic Testing](https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/10-Business_Logic_Testing/README)\n* Anti-automation can be achieved in many ways, including the use of the [OWASP Automated Threats to Web Applications](https://owasp.org/www-project-automated-threats-to-web-applications/)\n* [OWASP Input Validation Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html)\n* [JSON Schema](https://json-schema.org/specification.html)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 32,
+    "fields": {
+      "type": 3,
+      "name": "V3 Web Frontend Security",
+      "objective": "This category focuses on requirements designed to protect against attacks executed via a web frontend. These requirements do not apply to machine-to-machine solutions.",
+      "references": "## References\n\nFor more information, see also:\n\n* [Set-Cookie __Host- prefix details](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#cookie_prefixes)\n* [OWASP Content Security Policy Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)\n* [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/)\n* [OWASP Cross-Site Request Forgery Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)\n* [HSTS Browser Preload List submission form](https://hstspreload.org/)\n* [OWASP DOM Clobbering Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/DOM_Clobbering_Prevention_Cheat_Sheet.html)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 33,
+    "fields": {
+      "type": 3,
+      "name": "V4 API and Web Service",
+      "objective": "Several considerations apply specifically to applications that expose APIs for use by web browsers or other consumers (commonly using JSON, XML, or GraphQL). This chapter covers the relevant security configurations and mechanisms that should be applied.\n\nNote that authentication, session management, and input validation concerns from other chapters also apply to APIs, so this chapter cannot be taken out of context or tested in isolation.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP REST Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/REST_Security_Cheat_Sheet.html)\n* Resources on GraphQL Authorization from [graphql.org](https://graphql.org/learn/authorization/) and [Apollo](https://www.apollographql.com/docs/apollo-server/security/authentication/#authorization-methods).\n* [OWASP Web Security Testing Guide: GraphQL Testing](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL)\n* [OWASP Web Security Testing Guide: Testing WebSockets](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/11-Client-side_Testing/10-Testing_WebSockets)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 34,
+    "fields": {
+      "type": 3,
+      "name": "V5 File Handling",
+      "objective": "The use of files can present a variety of risks to the application, including denial of service, unauthorized access, and storage exhaustion. This chapter includes requirements to address these risks.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP File Upload Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/File_Upload_Cheat_Sheet.html)\n* [Example of using symlinks for arbitrary file read](https://hackerone.com/reports/1439593)\n* [Explanation of \"Magic Bytes\" from Wikipedia](https://en.wikipedia.org/wiki/List_of_file_signatures)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 35,
+    "fields": {
+      "type": 3,
+      "name": "V6 Authentication",
+      "objective": "Authentication is the process of establishing or confirming the authenticity of an individual or device. It involves verifying claims made by a person or about a device, ensuring resistance to impersonation, and preventing the recovery or interception of passwords.\n\n[NIST SP 800-63](https://pages.nist.gov/800-63-3/) is a modern, evidence-based standard that is valuable for organizations worldwide, but is particularly relevant to US agencies and those interacting with US agencies.\n\nWhile many of the requirements in this chapter are based on the second section of the standard (known as NIST SP 800-63B \"Digital Identity Guidelines - Authentication and Lifecycle Management\"), the chapter focuses on common threats and frequently exploited authentication weaknesses. It does not attempt to comprehensively cover every point in the standard. For cases where full NIST SP 800-63 compliance is necessary, please refer to NIST SP 800-63.\n\nAdditionally, NIST SP 800-63 terminology may sometimes differ, and this chapter often uses more commonly understood terminology to improve clarity.\n\nA common feature of more advanced applications is the ability to adapt authentication stages required based on various risk factors. This feature is covered in the \"Authorization\" chapter, since these mechanisms also need to be considered for authorization decisions.",
+      "references": "## References\n\nFor more information, see also:\n\n* [NIST SP 800-63 - Digital Identity Guidelines](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63-3.pdf)\n* [NIST SP 800-63B - Authentication and Lifecycle Management](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63b.pdf)\n* [NIST SP 800-63 FAQ](https://pages.nist.gov/800-63-FAQ/)\n* [OWASP Web Security Testing Guide: Testing for Authentication](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/04-Authentication_Testing)\n* [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)\n* [OWASP Forgot Password Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Forgot_Password_Cheat_Sheet.html)\n* [OWASP Choosing and Using Security Questions Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Choosing_and_Using_Security_Questions_Cheat_Sheet.html)\n* [CISA Guidance on \"Number Matching\"](https://www.cisa.gov/sites/default/files/publications/fact-sheet-implement-number-matching-in-mfa-applications-508c.pdf)\n* [Details on the FIDO Alliance](https://fidoalliance.org/)\n",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 36,
+    "fields": {
+      "type": 3,
+      "name": "V7 Session Management",
+      "objective": "Session management mechanisms allow applications to correlate user and device interactions over time, even when using stateless communication protocols (such as HTTP). Modern applications may use multiple session tokens with distinct characteristics and purposes. A secure session management system is one that prevents attackers from obtaining, utilizing, or otherwise abusing a victim's session. Applications maintaining sessions must ensure that the following high-level session management requirements are met:\n\n* Sessions are unique to each individual and cannot be guessed or shared.\n* Sessions are invalidated when no longer required and are timed out during periods of inactivity.\n\nMany of the requirements in this chapter relate to selected [NIST SP 800-63 Digital Identity Guidelines](https://pages.nist.gov/800-63-4/) controls, focusing on common threats and commonly exploited authentication weaknesses.\n\nNote that requirements for specific implementation details of certain session management mechanisms can be found elsewhere:\n\n* HTTP Cookies are a common mechanism for securing session tokens. Specific security requirements for cookies can be found in the \"Web Frontend Security\" chapter.\n* Self-contained tokens are frequently used as a way of maintaining sessions. Specific security requirements can be found in the \"Self-contained Tokens\" chapter.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP Web Security Testing Guide: Session Management Testing](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/06-Session_Management_Testing)\n* [OWASP Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 37,
+    "fields": {
+      "type": 3,
+      "name": "V8 Authorization",
+      "objective": "Authorization ensures that access is granted only to permitted consumers (users, servers, and other clients). To enforce the Principle of Least Privilege (POLP), verified applications must meet the following high-level requirements:\n\n* Document authorization rules, including decision-making factors and environmental contexts.\n* Consumers should have access only to resources permitted by their defined entitlements.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP Web Security Testing Guide: Authorization](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/05-Authorization_Testing)\n* [OWASP Authorization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 38,
+    "fields": {
+      "type": 3,
+      "name": "V9 Self-contained Tokens",
+      "objective": "The concept of a self-contained token is mentioned in the original RFC 6749 OAuth 2.0 from 2012. It refers to a token containing data or claims on which a receiving service will rely to make security decisions. This should be differentiated from a simple token containing only an identifier, which a receiving service uses to look up data locally. The most common examples of self-contained tokens are JSON Web Tokens (JWTs) and SAML assertions.\n\nThe use of self-contained tokens has become very widespread, even outside of OAuth and OIDC. At the same time, the security of this mechanism relies on the ability to validate the integrity of the token and to ensure that the token is valid for a particular context. There are many pitfalls with this process, and this chapter provides specific details of the mechanisms that applications should have in place to prevent them.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP JSON Web Token Cheat Sheet for Java Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/JSON_Web_Token_for_Java_Cheat_Sheet.html) (but has useful general guidance)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 39,
+    "fields": {
+      "type": 3,
+      "name": "V10 OAuth and OIDC",
+      "objective": "OAuth2 (referred to as OAuth in this chapter) is an industry-standard framework for delegated authorization. For example, using OAuth, a client application can obtain access to APIs (server resources) on a user's behalf, provided the user has authorized the client application to do so.\n\nBy itself, OAuth is not designed for user authentication. The OpenID Connect (OIDC) framework extends OAuth by adding a user identity layer on top of OAuth. OIDC provides support for features including standardized user information, Single Sign-On (SSO), and session management. As OIDC is an extension of OAuth, the OAuth requirements in this chapter also apply to OIDC.\n\nThe following roles are defined in OAuth:\n\n* The OAuth client is the application that attempts to obtain access to server resources (e.g., by calling an API using the issued access token). The OAuth client is often a server-side application.\n    * A confidential client is a client capable of maintaining the confidentiality of the credentials it uses to authenticate itself with the authorization server.\n    * A public client is not capable of maintaining the confidentiality of credentials for authenticating with the authorization server. Therefore, instead of authenticating itself (e.g., using 'client_id' and 'client_secret' parameters), it only identifies itself (using a 'client_id' parameter).\n* The OAuth resource server (RS) is the server API exposing resources to OAuth clients.\n* The OAuth authorization server (AS) is a server application that issues access tokens to OAuth clients. These access tokens allow OAuth clients to access RS resources, either on behalf of an end-user or on the OAuth client's own behalf. The AS is often a separate application, but (if appropriate) it may be integrated into a suitable RS.\n* The resource owner (RO) is the end-user who authorizes OAuth clients to obtain limited access to resources hosted on the resource server on their behalf. The resource owner consents to this delegated authorization by interacting with the authorization server.\n\nThe following roles are defined in OIDC:\n\n* The relying party (RP) is the client application requesting end-user authentication through the OpenID Provider. It assumes the role of an OAuth client.\n* The OpenID Provider (OP) is an OAuth AS that is capable of authenticating the end-user and provides OIDC claims to an RP. The OP may be the identity provider (IdP), but in federated scenarios, the OP and the identity provider (where the end-user authenticates) may be different server applications.\n\nOAuth and OIDC were initially designed for third-party applications. Today, they are often used by first-party applications as well. However, when used in first-party scenarios, such as authentication and session management, the protocol adds some complexity, which may introduce new security challenges.\n\nOAuth and OIDC can be used for many types of applications, but the focus for ASVS and the requirements in this chapter is on web applications and APIs.\n\nSince OAuth and OIDC can be considered logic on top of web technologies, general requirements from other chapters always apply, and this chapter cannot be taken out of context.\n\nThis chapter addresses best current practices for OAuth2 and OIDC aligned with specifications found at <https://oauth.net/2/> and <https://openid.net/developers/specs/>. Even if RFCs are considered mature, they are updated frequently. Thus, it is important to align with the latest versions when applying the requirements in this chapter. See the references section for more details.\n\nGiven the complexity of the area, it is vitally important for a secure OAuth or OIDC solution to use well-known industry-standard authorization servers and apply the recommended security configuration.\n\nTerminology used in this chapter aligns with OAuth RFCs and OIDC specifications, but note that OIDC terminology is only used for OIDC-specific requirements; otherwise, OAuth terminology is used.\n\nIn the context of OAuth and OIDC, the term \"token\" in this chapter refers to:\n\n* Access tokens, which shall only be consumed by the RS and can either be reference tokens that are validated using introspection or self-contained tokens that are validated using some key material.\n* Refresh tokens, which shall only be consumed by the authorization server that issued the token.\n* OIDC ID Tokens, which shall only be consumed by the client that triggered the authorization flow.\n\nThe risk levels for some of the requirements in this chapter depend on whether the client is a confidential client or regarded as a public client. Since using strong client authentication mitigates many attack vectors, a few requirements might be relaxed when using a confidential client for L1 applications.",
+      "references": "## References\n\nFor more information on OAuth, please see:\n\n* [oauth.net](https://oauth.net/)\n* [OWASP OAuth 2.0 Protocol Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/OAuth2_Cheat_Sheet.html)\n\nFor OAuth-related requirements in ASVS following published and in draft status RFC-s are used:\n\n* [RFC6749 The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)\n* [RFC6750 The OAuth 2.0 Authorization Framework: Bearer Token Usage](https://datatracker.ietf.org/doc/html/rfc6750)\n* [RFC6819 OAuth 2.0 Threat Model and Security Considerations](https://datatracker.ietf.org/doc/html/rfc6819)\n* [RFC7636 Proof Key for Code Exchange by OAuth Public Clients](https://datatracker.ietf.org/doc/html/rfc7636)\n* [RFC7591 OAuth 2.0 Dynamic Client Registration Protocol](https://datatracker.ietf.org/doc/html/rfc7591)\n* [RFC8628 OAuth 2.0 Device Authorization Grant](https://datatracker.ietf.org/doc/html/rfc8628)\n* [RFC8707 Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc8707)\n* [RFC9068 JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/html/rfc9068)\n* [RFC9126 OAuth 2.0 Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126)\n* [RFC9207 OAuth 2.0 Authorization Server Issuer Identification](https://datatracker.ietf.org/doc/html/rfc9207)\n* [RFC9396 OAuth 2.0 Rich Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9396)\n* [RFC9449 OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)\n* [RFC9700 Best Current Practice for OAuth 2.0 Security](https://datatracker.ietf.org/doc/html/rfc9700)\n* [draft OAuth 2.0 for Browser-Based Applications](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps)<!-- recheck on release -->\n* [draft The OAuth 2.1 Authorization Framework](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12)<!-- recheck on release -->\n\nFor more information on OpenID Connect, please see:\n\n* [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)\n* [FAPI 2.0 Security Profile](https://openid.net/specs/fapi-security-profile-2_0-final.html)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 40,
+    "fields": {
+      "type": 3,
+      "name": "V11 Cryptography",
+      "objective": "The objective of this chapter is to define best practices for the general use of cryptography, as well as to instill a fundamental understanding of cryptographic principles and inspire a shift toward more resilient and modern approaches. It encourages the following:\n\n* Implementing robust cryptographic systems that fail securely, adapt to evolving threats, and are future-proof.\n* Utilizing cryptographic mechanisms that are both secure and aligned with industry best practices.\n* Maintaining a secure cryptographic key management system with appropriate access controls and auditing.\n* Regularly evaluating the cryptographic landscape to assess new risks and adapt algorithms accordingly.\n* Discovering and managing cryptographic use cases throughout the application's lifecycle to ensure that all cryptographic assets are accounted for and secured.\n\nIn addition to outlining general principles and best practices, this document also provides more in-depth technical information about the requirements in Appendix C - Cryptography Standards. This includes algorithms and modes that are considered \"approved\" for the purposes of the requirements in this chapter.\n\nRequirements that use cryptography to solve a separate problem, such as secrets management or communications security, will be in different parts of the standard.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP Web Security Testing Guide: Testing for Weak Cryptography](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography)\n* [OWASP Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)\n* [FIPS 140-3](https://csrc.nist.gov/pubs/fips/140-3/final)\n* [NIST SP 800-57](https://csrc.nist.gov/publications/detail/sp/800-57-part-1/rev-5/final)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 41,
+    "fields": {
+      "type": 3,
+      "name": "V12 Secure Communication",
+      "objective": "This chapter includes requirements related to the specific mechanisms that should be in place to protect data in transit, both between an end-user client and a backend service, as well as between internal and backend services.\n\nThe general concepts promoted by this chapter include:\n\n* Ensuring that communications are encrypted externally, and ideally internally as well.\n* Configuring encryption mechanisms using the latest guidance, including preferred algorithms and ciphers.\n* Using signed certificates to ensure that communications are not being intercepted by unauthorized parties.\n\nIn addition to outlining general principles and best practices, the ASVS also provides more in-depth technical information about cryptographic strength in Appendix C - Cryptography Standards.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP - Transport Layer Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html)\n* [Mozilla's Server Side TLS configuration guide](https://wiki.mozilla.org/Security/Server_Side_TLS)\n* [Mozilla's tool to generate known good TLS configurations](https://ssl-config.mozilla.org/).\n* [O-Saft - OWASP Project to validate TLS configuration](https://owasp.org/www-project-o-saft/)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 42,
+    "fields": {
+      "type": 3,
+      "name": "V13 Configuration",
+      "objective": "The application's default configuration must be secure for use on the Internet.\n\nThis chapter provides guidance on the various configurations necessary to achieve this, including those applied during development, build, and deployment.\n\nTopics covered include preventing data leakage, securely managing communication between components, and protecting secrets.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP Web Security Testing Guide: Configuration and Deployment Management Testing](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 43,
+    "fields": {
+      "type": 3,
+      "name": "V14 Data Protection",
+      "objective": "Applications cannot account for all usage patterns and user behaviors, and should therefore implement controls to limit unauthorized access to sensitive data on client devices.\n\nThis chapter includes requirements related to defining what data needs to be protected, how it should be protected, and specific mechanisms to implement or pitfalls to avoid.\n\nAnother consideration for data protection is bulk extraction, modification, or excessive usage. Each system's requirements are likely to be very different, so determining what is \"abnormal\" must consider the threat model and business risk. From an ASVS perspective, detecting these issues is handled in the \"Security Logging and Error Handling\" chapter, and setting limits is handled in the \"Validation and Business Logic\" chapter.",
+      "references": "## References\n\nFor more information, see also:\n\n* [Consider using the Security Headers website to check security and anti-caching header fields](https://securityheaders.com/)\n* [Documentation about anti-caching headers by Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching)\n* [OWASP Secure Headers project](https://owasp.org/www-project-secure-headers/)\n* [OWASP Privacy Risks Project](https://owasp.org/www-project-top-10-privacy-risks/)\n* [OWASP User Privacy Protection Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/User_Privacy_Protection_Cheat_Sheet.html)\n* [Australian Privacy Principle 11 - Security of personal information](https://www.oaic.gov.au/privacy/australian-privacy-principles/australian-privacy-principles-guidelines/chapter-11-app-11-security-of-personal-information)\n* [European Union General Data Protection Regulation (GDPR) overview](https://www.edps.europa.eu/data-protection_en)\n* [European Union Data Protection Supervisor - Internet Privacy Engineering Network](https://www.edps.europa.eu/data-protection/ipen-internet-privacy-engineering-network_en)\n* [Information on the \"Clear-Site-Data\" header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data)\n* [White paper on Web Cache Deception](https://www.blackhat.com/docs/us-17/wednesday/us-17-Gil-Web-Cache-Deception-Attack-wp.pdf)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 44,
+    "fields": {
+      "type": 3,
+      "name": "V15 Secure Coding and Architecture",
+      "objective": "Many ASVS requirements either relate to a particular area of security, such as authentication or authorization, or pertain to a particular type of application functionality, such as logging or file handling.\n\nThis chapter provides general security requirements to consider when designing and developing applications. These requirements focus not only on clean architecture and code quality but also on specific architecture and coding practices necessary for application security.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP Prototype Pollution Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html)\n* [OWASP Mass Assignment Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Mass_Assignment_Cheat_Sheet.html)\n* [OWASP CycloneDX Bill of Materials Specification](https://owasp.org/www-project-cyclonedx/)\n* [OWASP Web Security Testing Guide: Testing for HTTP Parameter Pollution](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/07-Input_Validation_Testing/04-Testing_for_HTTP_Parameter_Pollution)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 45,
+    "fields": {
+      "type": 3,
+      "name": "V16 Security Logging and Error Handling",
+      "objective": "Security logs are distinct from error or performance logs and are used to record security-relevant events such as authentication decisions, access control decisions, and attempts to bypass security controls, such as input validation or business logic validation. Their purpose is to support detection, response, and investigation by providing high-signal, structured data for analysis tools like SIEMs.\n\nLogs should not include sensitive personal data unless legally required, and any logged data must be protected as a high-value asset. Logging must not compromise privacy or system security. Applications must also fail securely, avoiding unnecessary disclosure or disruption.\n\nFor detailed implementation guidance, refer to the OWASP Cheat Sheets in the references section.",
+      "references": "## References\n\nFor more information, see also:\n\n* [OWASP Web Security Testing Guide: Testing for Error Handling](https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/08-Testing_for_Error_Handling/README)\n* [OWASP Authentication Cheat Sheet section about error messages](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#authentication-and-error-messages)\n* [OWASP Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html)\n* [OWASP Application Logging Vocabulary Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Vocabulary_Cheat_Sheet.html)",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
+  },
+  {
+    "model": "dojo.benchmark_category",
+    "pk": 46,
+    "fields": {
+      "type": 3,
+      "name": "V17 WebRTC",
+      "objective": "Web Real-Time Communication (WebRTC) enables real-time voice, video, and data exchange in modern applications. As adoption increases, securing WebRTC infrastructure becomes critical. This section provides security requirements for stakeholders who develop, host, or integrate WebRTC systems.\n\nThe WebRTC market can be broadly categorized into three segments:\n\n1. Product Developers: Proprietary and open-source vendors that create and supply WebRTC products and solutions. Their focus is on developing robust and secure WebRTC technologies that can be used by others.\n\n2. Communication Platforms as a Service (CPaaS): Providers that offer APIs, SDKs, and the necessary infrastructure or platforms to enable WebRTC functionalities. CPaaS providers may use products from the first category or develop their own WebRTC software to offer these services.\n\n3. Service Providers: Organizations that leverage products from product developers or CPaaS providers, or develop their own WebRTC solutions. They create and implement applications for online conferencing, healthcare, e-learning, and other domains where real-time communication is crucial.\n\nThe security requirements outlined here are primarily focused on Product Developers, CPaaS, and Service Providers who:\n\n* Utilize open-source solutions to build their WebRTC applications.\n* Use commercial WebRTC products as part of their infrastructure.\n* Use internally developed WebRTC solutions or integrate various components into a cohesive service offering.\n\nIt is important to note that these security requirements do not apply to developers who exclusively use SDKs and APIs provided by CPaaS vendors. For such developers, the CPaaS providers are typically responsible for most of the underlying security concerns within their platforms, and a generic security standard like ASVS may not fully address their needs.",
+      "references": "## References\n\nFor more information, see also:\n\n* The WebRTC DTLS ClientHello DoS is best documented at [Enable Security's blog post aimed at security professionals](https://www.enablesecurity.com/blog/novel-dos-vulnerability-affecting-webrtc-media-servers/) and the associated [white paper aimed at WebRTC developers](https://www.enablesecurity.com/blog/webrtc-hello-race-conditions-paper/)\n* [RFC 3550 - RTP: A Transport Protocol for Real-Time Applications](https://www.rfc-editor.org/rfc/rfc3550)\n* [RFC 3711 - The Secure Real-time Transport Protocol (SRTP)](https://datatracker.ietf.org/doc/html/rfc3711)\n* [RFC 5764 - Datagram Transport Layer Security (DTLS) Extension to Establish Keys for the Secure Real-time Transport Protocol (SRTP))](https://datatracker.ietf.org/doc/html/rfc5764)\n* [RFC 8825 - Overview: Real-Time Protocols for Browser-Based Applications](https://www.rfc-editor.org/info/rfc8825)\n* [RFC 8826 - Security Considerations for WebRTC](https://www.rfc-editor.org/info/rfc8826)\n* [RFC 8827 - WebRTC Security Architecture](https://www.rfc-editor.org/info/rfc8827)\n* [DTLS-SRTP Protection Profiles](https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml)\n",
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z"
+    }
   }
 ]

--- a/dojo/fixtures/benchmark_requirement.json
+++ b/dojo/fixtures/benchmark_requirement.json
@@ -8566,5 +8566,6215 @@
       "cwe_mapping": [],
       "testing_guide": []
     }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 478,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.1.1",
+      "objective": "Verify that input is decoded or unescaped into a canonical form only once, it is only decoded when encoded data in that form is expected, and that this is done before processing the input further, for example it is not performed after input validation or sanitization.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 479,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.1.2",
+      "objective": "Verify that the application performs output encoding and escaping either as a final step before being used by the interpreter for which it is intended or by the interpreter itself.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 480,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.1",
+      "objective": "Verify that output encoding for an HTTP response, HTML document, or XML document is relevant for the context required, such as encoding the relevant characters for HTML elements, HTML attributes, HTML comments, CSS, or HTTP header fields, to avoid changing the message or document structure.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 481,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.2",
+      "objective": "Verify that when dynamically building URLs, untrusted data is encoded according to its context (e.g., URL encoding or base64url encoding for query or path parameters). Ensure that only safe URL protocols are permitted (e.g., disallow javascript: or data:).",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 482,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.3",
+      "objective": "Verify that output encoding or escaping is used when dynamically building JavaScript content (including JSON), to avoid changing the message or document structure (to avoid JavaScript and JSON injection).",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 483,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.4",
+      "objective": "Verify that data selection or database queries (e.g., SQL, HQL, NoSQL, Cypher) use parameterized queries, ORMs, entity frameworks, or are otherwise protected from SQL Injection and other database injection attacks. This is also relevant when writing stored procedures.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 484,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.5",
+      "objective": "Verify that the application protects against OS command injection and that operating system calls use parameterized OS queries or use contextual command line output encoding.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 485,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.6",
+      "objective": "Verify that the application protects against LDAP injection vulnerabilities, or that specific security controls to prevent LDAP injection have been implemented.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 486,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.7",
+      "objective": "Verify that the application is protected against XPath injection attacks by using query parameterization or precompiled queries.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 487,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.8",
+      "objective": "Verify that LaTeX processors are configured securely (such as not using the \"--shell-escape\" flag) and an allowlist of commands is used to prevent LaTeX injection attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 488,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.9",
+      "objective": "Verify that the application escapes special characters in regular expressions (typically using a backslash) to prevent them from being misinterpreted as metacharacters.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 489,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.2.10",
+      "objective": "Verify that the application is protected against CSV and Formula Injection. The application must follow the escaping rules defined in RFC 4180 sections 2.6 and 2.7 when exporting CSV content. Additionally, when exporting to CSV or other spreadsheet formats (such as XLS, XLSX, or ODF), special characters (including '=', '+', '-', '@', '\\t' (tab), and '\\0' (null character)) must be escaped with a single quote if they appear as the first character in a field value.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 490,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.1",
+      "objective": "Verify that all untrusted HTML input from WYSIWYG editors or similar is sanitized using a well-known and secure HTML sanitization library or framework feature.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 491,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.2",
+      "objective": "Verify that the application avoids the use of eval() or other dynamic code execution features such as Spring Expression Language (SpEL). Where there is no alternative, any user input being included must be sanitized before being executed.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 492,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.3",
+      "objective": "Verify that data being passed to a potentially dangerous context is sanitized beforehand to enforce safety measures, such as only allowing characters which are safe for this context and trimming input which is too long.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 493,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.4",
+      "objective": "Verify that user-supplied Scalable Vector Graphics (SVG) scriptable content is validated or sanitized to contain only tags and attributes (such as draw graphics) that are safe for the application, e.g., do not contain scripts and foreignObject.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 494,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.5",
+      "objective": "Verify that the application sanitizes or disables user-supplied scriptable or expression template language content, such as Markdown, CSS or XSL stylesheets, BBCode, or similar.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 495,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.6",
+      "objective": "Verify that the application protects against Server-side Request Forgery (SSRF) attacks, by validating untrusted data against an allowlist of protocols, domains, paths and ports and sanitizing potentially dangerous characters before using the data to call another service.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 496,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.7",
+      "objective": "Verify that the application protects against template injection attacks by not allowing templates to be built based on untrusted input. Where there is no alternative, any untrusted input being included dynamically during template creation must be sanitized or strictly validated.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 497,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.8",
+      "objective": "Verify that the application appropriately sanitizes untrusted input before use in Java Naming and Directory Interface (JNDI) queries and that JNDI is configured securely to prevent JNDI injection attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 498,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.9",
+      "objective": "Verify that the application sanitizes content before it is sent to memcache to prevent injection attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 499,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.10",
+      "objective": "Verify that format strings which might resolve in an unexpected or malicious way when used are sanitized before being processed.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 500,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.11",
+      "objective": "Verify that the application sanitizes user input before passing to mail systems to protect against SMTP or IMAP injection.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 501,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.3.12",
+      "objective": "Verify that regular expressions are free from elements causing exponential backtracking, and ensure untrusted input is sanitized to mitigate ReDoS or Runaway Regex attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 502,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.4.1",
+      "objective": "Verify that the application uses memory-safe string, safer memory copy and pointer arithmetic to detect or prevent stack, buffer, or heap overflows.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 503,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.4.2",
+      "objective": "Verify that sign, range, and input validation techniques are used to prevent integer overflows.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 504,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.4.3",
+      "objective": "Verify that dynamically allocated memory and resources are released, and that references or pointers to freed memory are removed or set to null to prevent dangling pointers and use-after-free vulnerabilities.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 505,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.5.1",
+      "objective": "Verify that the application configures XML parsers to use a restrictive configuration and that unsafe features such as resolving external entities are disabled to prevent XML eXternal Entity (XXE) attacks.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 506,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.5.2",
+      "objective": "Verify that deserialization of untrusted data enforces safe input handling, such as using an allowlist of object types or restricting client-defined object types, to prevent deserialization attacks. Deserialization mechanisms that are explicitly defined as insecure must not be used with untrusted input.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 507,
+    "fields": {
+      "category": 30,
+      "objective_number": "1.5.3",
+      "objective": "Verify that different parsers used in the application for the same data type (e.g., JSON parsers, XML parsers, URL parsers), perform parsing in a consistent way and use the same character encoding mechanism to avoid issues such as JSON Interoperability vulnerabilities or different URI or file parsing behavior being exploited in Remote File Inclusion (RFI) or Server-side Request Forgery (SSRF) attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 508,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.1.1",
+      "objective": "Verify that the application's documentation defines input validation rules for how to check the validity of data items against an expected structure. This could be common data formats such as credit card numbers, email addresses, telephone numbers, or it could be an internal data format.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 509,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.1.2",
+      "objective": "Verify that the application's documentation defines how to validate the logical and contextual consistency of combined data items, such as checking that suburb and ZIP code match.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 510,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.1.3",
+      "objective": "Verify that expectations for business logic limits and validations are documented, including both per-user and globally across the application.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 511,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.2.1",
+      "objective": "Verify that input is validated to enforce business or functional expectations for that input. This should either use positive validation against an allow list of values, patterns, and ranges, or be based on comparing the input to an expected structure and logical limits according to predefined rules. For L1, this can focus on input which is used to make specific business or security decisions. For L2 and up, this should apply to all input.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 512,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.2.2",
+      "objective": "Verify that the application is designed to enforce input validation at a trusted service layer. While client-side validation improves usability and should be encouraged, it must not be relied upon as a security control.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 513,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.2.3",
+      "objective": "Verify that the application ensures that combinations of related data items are reasonable according to the pre-defined rules.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 514,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.3.1",
+      "objective": "Verify that the application will only process business logic flows for the same user in the expected sequential step order and without skipping steps.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 515,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.3.2",
+      "objective": "Verify that business logic limits are implemented per the application's documentation to avoid business logic flaws being exploited.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 516,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.3.3",
+      "objective": "Verify that transactions are being used at the business logic level such that either a business logic operation succeeds in its entirety or it is rolled back to the previous correct state.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 517,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.3.4",
+      "objective": "Verify that business logic level locking mechanisms are used to ensure that limited quantity resources (such as theater seats or delivery slots) cannot be double-booked by manipulating the application's logic.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 518,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.3.5",
+      "objective": "Verify that high-value business logic flows require multi-user approval to prevent unauthorized or accidental actions. This could include but is not limited to large monetary transfers, contract approvals, access to classified information, or safety overrides in manufacturing.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 519,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.4.1",
+      "objective": "Verify that anti-automation controls are in place to protect against excessive calls to application functions that could lead to data exfiltration, garbage-data creation, quota exhaustion, rate-limit breaches, denial-of-service, or overuse of costly resources.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 520,
+    "fields": {
+      "category": 31,
+      "objective_number": "2.4.2",
+      "objective": "Verify that business logic flows require realistic human timing, preventing excessively rapid transaction submissions.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 521,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.1.1",
+      "objective": "Verify that application documentation states the expected security features that browsers using the application must support (such as HTTPS, HTTP Strict Transport Security (HSTS), Content Security Policy (CSP), and other relevant HTTP security mechanisms). It must also define how the application must behave when some of these features are not available (such as warning the user or blocking access).",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 522,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.2.1",
+      "objective": "Verify that security controls are in place to prevent browsers from rendering content or functionality in HTTP responses in an incorrect context (e.g., when an API, a user-uploaded file or other resource is requested directly). Possible controls could include: not serving the content unless HTTP request header fields (such as Sec-Fetch-\\*) indicate it is the correct context, using the sandbox directive of the Content-Security-Policy header field or using the attachment disposition type in the Content-Disposition header field.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 523,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.2.2",
+      "objective": "Verify that content intended to be displayed as text, rather than rendered as HTML, is handled using safe rendering functions (such as createTextNode or textContent) to prevent unintended execution of content such as HTML or JavaScript.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 524,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.2.3",
+      "objective": "Verify that the application avoids DOM clobbering when using client-side JavaScript by employing explicit variable declarations, performing strict type checking, avoiding storing global variables on the document object, and implementing namespace isolation.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 525,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.3.1",
+      "objective": "Verify that cookies have the 'Secure' attribute set, and if the '\\__Host-' prefix is not used for the cookie name, the '__Secure-' prefix must be used for the cookie name.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 526,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.3.2",
+      "objective": "Verify that each cookie's 'SameSite' attribute value is set according to the purpose of the cookie, to limit exposure to user interface redress attacks and browser-based request forgery attacks, commonly known as cross-site request forgery (CSRF).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 527,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.3.3",
+      "objective": "Verify that cookies have the '__Host-' prefix for the cookie name unless they are explicitly designed to be shared with other hosts.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 528,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.3.4",
+      "objective": "Verify that if the value of a cookie is not meant to be accessible to client-side scripts (such as a session token), the cookie must have the 'HttpOnly' attribute set and the same value (e. g. session token) must only be transferred to the client via the 'Set-Cookie' header field.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 529,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.3.5",
+      "objective": "Verify that when the application writes a cookie, the cookie name and value length combined are not over 4096 bytes. Overly large cookies will not be stored by the browser and therefore not sent with requests, preventing the user from using application functionality which relies on that cookie.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 530,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.4.1",
+      "objective": "Verify that a Strict-Transport-Security header field is included on all responses to enforce an HTTP Strict Transport Security (HSTS) policy. A maximum age of at least 1 year must be defined, and for L2 and up, the policy must apply to all subdomains as well.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 531,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.4.2",
+      "objective": "Verify that the Cross-Origin Resource Sharing (CORS) Access-Control-Allow-Origin header field is a fixed value by the application, or if the Origin HTTP request header field value is used, it is validated against an allowlist of trusted origins. When 'Access-Control-Allow-Origin: *' needs to be used, verify that the response does not include any sensitive information.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 532,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.4.3",
+      "objective": "Verify that HTTP responses include a Content-Security-Policy response header field which defines directives to ensure the browser only loads and executes trusted content or resources, in order to limit execution of malicious JavaScript. As a minimum, a global policy must be used which includes the directives object-src 'none' and base-uri 'none' and defines either an allowlist or uses nonces or hashes. For an L3 application, a per-response policy with nonces or hashes must be defined.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 533,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.4.4",
+      "objective": "Verify that all HTTP responses contain an 'X-Content-Type-Options: nosniff' header field. This instructs browsers not to use content sniffing and MIME type guessing for the given response, and to require the response's Content-Type header field value to match the destination resource. For example, the response to a request for a style is only accepted if the response's Content-Type is 'text/css'. This also enables the use of the Cross-Origin Read Blocking (CORB) functionality by the browser.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 534,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.4.5",
+      "objective": "Verify that the application sets a referrer policy to prevent leakage of technically sensitive data to third-party services via the 'Referer' HTTP request header field. This can be done using the Referrer-Policy HTTP response header field or via HTML element attributes. Sensitive data could include path and query data in the URL, and for internal non-public applications also the hostname.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 535,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.4.6",
+      "objective": "Verify that the web application uses the frame-ancestors directive of the Content-Security-Policy header field for every HTTP response to ensure that it cannot be embedded by default and that embedding of specific resources is allowed only when necessary. Note that the X-Frame-Options header field, although supported by browsers, is obsolete and may not be relied upon.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 536,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.4.7",
+      "objective": "Verify that the Content-Security-Policy header field specifies a location to report violations.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 537,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.4.8",
+      "objective": "Verify that all HTTP responses that initiate a document rendering (such as responses with Content-Type text/html), include the Cross‑Origin‑Opener‑Policy header field with the same-origin directive or the same-origin-allow-popups directive as required. This prevents attacks that abuse shared access to Window objects, such as tabnabbing and frame counting.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 538,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.5.1",
+      "objective": "Verify that, if the application does not rely on the CORS preflight mechanism to prevent disallowed cross-origin requests to use sensitive functionality, these requests are validated to ensure they originate from the application itself. This may be done by using and validating anti-forgery tokens or requiring extra HTTP header fields that are not CORS-safelisted request-header fields. This is to defend against browser-based request forgery attacks, commonly known as cross-site request forgery (CSRF).",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 539,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.5.2",
+      "objective": "Verify that, if the application relies on the CORS preflight mechanism to prevent disallowed cross-origin use of sensitive functionality, it is not possible to call the functionality with a request which does not trigger a CORS-preflight request. This may require checking the values of the 'Origin' and 'Content-Type' request header fields or using an extra header field that is not a CORS-safelisted header-field.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 540,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.5.3",
+      "objective": "Verify that HTTP requests to sensitive functionality use appropriate HTTP methods such as POST, PUT, PATCH, or DELETE, and not methods defined by the HTTP specification as \"safe\" such as HEAD, OPTIONS, or GET. Alternatively, strict validation of the Sec-Fetch-* request header fields can be used to ensure that the request did not originate from an inappropriate cross-origin call, a navigation request, or a resource load (such as an image source) where this is not expected.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 541,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.5.4",
+      "objective": "Verify that separate applications are hosted on different hostnames to leverage the restrictions provided by same-origin policy, including how documents or scripts loaded by one origin can interact with resources from another origin and hostname-based restrictions on cookies.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 542,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.5.5",
+      "objective": "Verify that messages received by the postMessage interface are discarded if the origin of the message is not trusted, or if the syntax of the message is invalid.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 543,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.5.6",
+      "objective": "Verify that JSONP functionality is not enabled anywhere across the application to avoid Cross-Site Script Inclusion (XSSI) attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 544,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.5.7",
+      "objective": "Verify that data requiring authorization is not included in script resource responses, like JavaScript files, to prevent Cross-Site Script Inclusion (XSSI) attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 545,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.5.8",
+      "objective": "Verify that authenticated resources (such as images, videos, scripts, and other documents) can be loaded or embedded on behalf of the user only when intended. This can be accomplished by strict validation of the Sec-Fetch-* HTTP request header fields to ensure that the request did not originate from an inappropriate cross-origin call, or by setting a restrictive Cross-Origin-Resource-Policy HTTP response header field to instruct the browser to block returned content.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 546,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.6.1",
+      "objective": "Verify that client-side assets, such as JavaScript libraries, CSS, or web fonts, are only hosted externally (e.g., on a Content Delivery Network) if the resource is static and versioned and Subresource Integrity (SRI) is used to validate the integrity of the asset. If this is not possible, there should be a documented security decision to justify this for each resource.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 547,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.7.1",
+      "objective": "Verify that the application only uses client-side technologies which are still supported and considered secure. Examples of technologies which do not meet this requirement include NSAPI plugins, Flash, Shockwave, ActiveX, Silverlight, NACL, or client-side Java applets.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 548,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.7.2",
+      "objective": "Verify that the application will only automatically redirect the user to a different hostname or domain (which is not controlled by the application) where the destination appears on an allowlist.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 549,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.7.3",
+      "objective": "Verify that the application shows a notification when the user is being redirected to a URL outside of the application's control, with an option to cancel the navigation.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 550,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.7.4",
+      "objective": "Verify that the application's top-level domain (e.g., site.tld) is added to the public preload list for HTTP Strict Transport Security (HSTS). This ensures that the use of TLS for the application is built directly into the main browsers, rather than relying only on the Strict-Transport-Security response header field.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 551,
+    "fields": {
+      "category": 32,
+      "objective_number": "3.7.5",
+      "objective": "Verify that the application behaves as documented (such as warning the user or blocking access) if the browser used to access the application does not support the expected security features.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 552,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.1.1",
+      "objective": "Verify that every HTTP response with a message body contains a Content-Type header field that matches the actual content of the response, including the charset parameter to specify safe character encoding (e.g., UTF-8, ISO-8859-1) according to IANA Media Types, such as \"text/\", \"/+xml\" and \"/xml\".",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 553,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.1.2",
+      "objective": "Verify that only user-facing endpoints (intended for manual web-browser access) automatically redirect from HTTP to HTTPS, while other services or endpoints do not implement transparent redirects. This is to avoid a situation where a client is erroneously sending unencrypted HTTP requests, but since the requests are being automatically redirected to HTTPS, the leakage of sensitive data goes undiscovered.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 554,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.1.3",
+      "objective": "Verify that any HTTP header field used by the application and set by an intermediary layer, such as a load balancer, a web proxy, or a backend-for-frontend service, cannot be overridden by the end-user. Example headers might include X-Real-IP, X-Forwarded-*, or X-User-ID.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 555,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.1.4",
+      "objective": "Verify that only HTTP methods that are explicitly supported by the application or its API (including OPTIONS during preflight requests) can be used and that unused methods are blocked.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 556,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.1.5",
+      "objective": "Verify that per-message digital signatures are used to provide additional assurance on top of transport protections for requests or transactions which are highly sensitive or which traverse a number of systems.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 557,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.2.1",
+      "objective": "Verify that all application components (including load balancers, firewalls, and application servers) determine boundaries of incoming HTTP messages using the appropriate mechanism for the HTTP version to prevent HTTP request smuggling. In HTTP/1.x, if a Transfer-Encoding header field is present, the Content-Length header must be ignored per RFC 2616. When using HTTP/2 or HTTP/3, if a Content-Length header field is present, the receiver must ensure that it is consistent with the length of the DATA frames.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 558,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.2.2",
+      "objective": "Verify that when generating HTTP messages, the Content-Length header field does not conflict with the length of the content as determined by the framing of the HTTP protocol, in order to prevent request smuggling attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 559,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.2.3",
+      "objective": "Verify that the application does not send nor accept HTTP/2 or HTTP/3 messages with connection-specific header fields such as Transfer-Encoding to prevent response splitting and header injection attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 560,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.2.4",
+      "objective": "Verify that the application only accepts HTTP/2 and HTTP/3 requests where the header fields and values do not contain any CR (\\r), LF (\\n), or CRLF (\\r\\n) sequences, to prevent header injection attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 561,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.2.5",
+      "objective": "Verify that, if the application (backend or frontend) builds and sends requests, it uses validation, sanitization, or other mechanisms to avoid creating URIs (such as for API calls) or HTTP request header fields (such as Authorization or Cookie), which are too long to be accepted by the receiving component. This could cause a denial of service, such as when sending an overly long request (e.g., a long cookie header field), which results in the server always responding with an error status.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 562,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.3.1",
+      "objective": "Verify that a query allowlist, depth limiting, amount limiting, or query cost analysis is used to prevent GraphQL or data layer expression Denial of Service (DoS) as a result of expensive, nested queries.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 563,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.3.2",
+      "objective": "Verify that GraphQL introspection queries are disabled in the production environment unless the GraphQL API is meant to be used by other parties.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 564,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.4.1",
+      "objective": "Verify that WebSocket over TLS (WSS) is used for all WebSocket connections.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 565,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.4.2",
+      "objective": "Verify that, during the initial HTTP WebSocket handshake, the Origin header field is checked against a list of origins allowed for the application.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 566,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.4.3",
+      "objective": "Verify that, if the application's standard session management cannot be used, dedicated tokens are being used for this, which comply with the relevant Session Management security requirements.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 567,
+    "fields": {
+      "category": 33,
+      "objective_number": "4.4.4",
+      "objective": "Verify that dedicated WebSocket session management tokens are initially obtained or validated through the previously authenticated HTTPS session when transitioning an existing HTTPS session to a WebSocket channel.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 568,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.1.1",
+      "objective": "Verify that the documentation defines the permitted file types, expected file extensions, and maximum size (including unpacked size) for each upload feature. Additionally, ensure that the documentation specifies how files are made safe for end-users to download and process, such as how the application behaves when a malicious file is detected.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 569,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.2.1",
+      "objective": "Verify that the application will only accept files of a size which it can process without causing a loss of performance or a denial of service attack.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 570,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.2.2",
+      "objective": "Verify that when the application accepts a file, either on its own or within an archive such as a zip file, it checks if the file extension matches an expected file extension and validates that the contents correspond to the type represented by the extension. This includes, but is not limited to, checking the initial 'magic bytes', performing image re-writing, and using specialized libraries for file content validation. For L1, this can focus just on files which are used to make specific business or security decisions. For L2 and up, this must apply to all files being accepted.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 571,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.2.3",
+      "objective": "Verify that the application checks compressed files (e.g., zip, gz, docx, odt) against maximum allowed uncompressed size and against maximum number of files before uncompressing the file.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 572,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.2.4",
+      "objective": "Verify that a file size quota and maximum number of files per user are enforced to ensure that a single user cannot fill up the storage with too many files, or excessively large files.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 573,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.2.5",
+      "objective": "Verify that the application does not allow uploading compressed files containing symlinks unless this is specifically required (in which case it will be necessary to enforce an allowlist of the files that can be symlinked to).",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 574,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.2.6",
+      "objective": "Verify that the application rejects uploaded images with a pixel size larger than the maximum allowed, to prevent pixel flood attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 575,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.3.1",
+      "objective": "Verify that files uploaded or generated by untrusted input and stored in a public folder, are not executed as server-side program code when accessed directly with an HTTP request.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 576,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.3.2",
+      "objective": "Verify that when the application creates file paths for file operations, instead of user-submitted filenames, it uses internally generated or trusted data, or if user-submitted filenames or file metadata must be used, strict validation and sanitization must be applied. This is to protect against path traversal, local or remote file inclusion (LFI, RFI), and server-side request forgery (SSRF) attacks.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 577,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.3.3",
+      "objective": "Verify that server-side file processing, such as file decompression, ignores user-provided path information to prevent vulnerabilities such as zip slip.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 578,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.4.1",
+      "objective": "Verify that the application validates or ignores user-submitted filenames, including in a JSON, JSONP, or URL parameter and specifies a filename in the Content-Disposition header field in the response.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 579,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.4.2",
+      "objective": "Verify that file names served (e.g., in HTTP response header fields or email attachments) are encoded or sanitized (e.g., following RFC 6266) to preserve document structure and prevent injection attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 580,
+    "fields": {
+      "category": 34,
+      "objective_number": "5.4.3",
+      "objective": "Verify that files obtained from untrusted sources are scanned by antivirus scanners to prevent serving of known malicious content.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 581,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.1.1",
+      "objective": "Verify that application documentation defines how controls such as rate limiting, anti-automation, and adaptive response, are used to defend against attacks such as credential stuffing and password brute force. The documentation must make clear how these controls are configured and prevent malicious account lockout.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 582,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.1.2",
+      "objective": "Verify that a list of context-specific words is documented in order to prevent their use in passwords. The list could include permutations of organization names, product names, system identifiers, project codenames, department or role names, and similar.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 583,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.1.3",
+      "objective": "Verify that, if the application includes multiple authentication pathways, these are all documented together with the security controls and authentication strength which must be consistently enforced across them.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 584,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.1",
+      "objective": "Verify that user set passwords are at least 8 characters in length although a minimum of 15 characters is strongly recommended.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 585,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.2",
+      "objective": "Verify that users can change their password.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 586,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.3",
+      "objective": "Verify that password change functionality requires the user's current and new password.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 587,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.4",
+      "objective": "Verify that passwords submitted during account registration or password change are checked against an available set of, at least, the top 3000 passwords which match the application's password policy, e.g. minimum length.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 588,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.5",
+      "objective": "Verify that passwords of any composition can be used, without rules limiting the type of characters permitted. There must be no requirement for a minimum number of upper or lower case characters, numbers, or special characters.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 589,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.6",
+      "objective": "Verify that password input fields use type=password to mask the entry. Applications may allow the user to temporarily view the entire masked password, or the last typed character of the password.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 590,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.7",
+      "objective": "Verify that \"paste\" functionality, browser password helpers, and external password managers are permitted.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 591,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.8",
+      "objective": "Verify that the application verifies the user's password exactly as received from the user, without any modifications such as truncation or case transformation.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 592,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.9",
+      "objective": "Verify that passwords of at least 64 characters are permitted.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 593,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.10",
+      "objective": "Verify that a user's password stays valid until it is discovered to be compromised or the user rotates it. The application must not require periodic credential rotation.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 594,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.11",
+      "objective": "Verify that the documented list of context specific words is used to prevent easy to guess passwords being created.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 595,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.2.12",
+      "objective": "Verify that passwords submitted during account registration or password changes are checked against a set of breached passwords.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 596,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.3.1",
+      "objective": "Verify that controls to prevent attacks such as credential stuffing and password brute force are implemented according to the application's security documentation.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 597,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.3.2",
+      "objective": "Verify that default user accounts (e.g., \"root\", \"admin\", or \"sa\") are not present in the application or are disabled.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 598,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.3.3",
+      "objective": "Verify that either a multi-factor authentication mechanism or a combination of single-factor authentication mechanisms, must be used in order to access the application. For L3, one of the factors must be a hardware-based authentication mechanism which provides compromise and impersonation resistance against phishing attacks while verifying the intent to authenticate by requiring a user-initiated action (such as a button press on a FIDO hardware key or a mobile phone). Relaxing any of the considerations in this requirement requires a fully documented rationale and a comprehensive set of mitigating controls.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 599,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.3.4",
+      "objective": "Verify that, if the application includes multiple authentication pathways, there are no undocumented pathways and that security controls and authentication strength are enforced consistently.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 600,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.3.5",
+      "objective": "Verify that users are notified of suspicious authentication attempts (successful or unsuccessful). This may include authentication attempts from an unusual location or client, partially successful authentication (only one of multiple factors), an authentication attempt after a long period of inactivity or a successful authentication after several unsuccessful attempts.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 601,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.3.6",
+      "objective": "Verify that email is not used as either a single-factor or multi-factor authentication mechanism.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 602,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.3.7",
+      "objective": "Verify that users are notified after updates to authentication details, such as credential resets or modification of the username or email address.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 603,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.3.8",
+      "objective": "Verify that valid users cannot be deduced from failed authentication challenges, such as by basing on error messages, HTTP response codes, or different response times. Registration and forgot password functionality must also have this protection.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 604,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.4.1",
+      "objective": "Verify that system generated initial passwords or activation codes are securely randomly generated, follow the existing password policy, and expire after a short period of time or after they are initially used. These initial secrets must not be permitted to become the long term password.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 605,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.4.2",
+      "objective": "Verify that password hints or knowledge-based authentication (so-called \"secret questions\") are not present.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 606,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.4.3",
+      "objective": "Verify that a secure process for resetting a forgotten password is implemented, that does not bypass any enabled multi-factor authentication mechanisms.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 607,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.4.4",
+      "objective": "Verify that if a multi-factor authentication factor is lost, evidence of identity proofing is performed at the same level as during enrollment.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 608,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.4.5",
+      "objective": "Verify that renewal instructions for authentication mechanisms which expire are sent with enough time to be carried out before the old authentication mechanism expires, configuring automated reminders if necessary.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 609,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.4.6",
+      "objective": "Verify that administrative users can initiate the password reset process for the user, but that this does not allow them to change or choose the user's password. This prevents a situation where they know the user's password.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 610,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.5.1",
+      "objective": "Verify that lookup secrets, out-of-band authentication requests or codes, and time-based one-time passwords (TOTPs) are only successfully usable once.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 611,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.5.2",
+      "objective": "Verify that, when being stored in the application's backend, lookup secrets with less than 112 bits of entropy (19 random alphanumeric characters or 34 random digits) are hashed with an approved password storage hashing algorithm that incorporates a 32-bit random salt. A standard hash function can be used if the secret has 112 bits of entropy or more.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 612,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.5.3",
+      "objective": "Verify that lookup secrets, out-of-band authentication code, and time-based one-time password seeds, are generated using a Cryptographically Secure Pseudorandom Number Generator (CSPRNG) to avoid predictable values.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 613,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.5.4",
+      "objective": "Verify that lookup secrets and out-of-band authentication codes have a minimum of 20 bits of entropy (typically 4 random alphanumeric characters or 6 random digits is sufficient).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 614,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.5.5",
+      "objective": "Verify that out-of-band authentication requests, codes, or tokens, as well as time-based one-time passwords (TOTPs) have a defined lifetime. Out of band requests must have a maximum lifetime of 10 minutes and for TOTP a maximum lifetime of 30 seconds.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 615,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.5.6",
+      "objective": "Verify that any authentication factor (including physical devices) can be revoked in case of theft or other loss.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 616,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.5.7",
+      "objective": "Verify that biometric authentication mechanisms are only used as secondary factors together with either something you have or something you know.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 617,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.5.8",
+      "objective": "Verify that time-based one-time passwords (TOTPs) are checked based on a time source from a trusted service and not from an untrusted or client provided time.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 618,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.6.1",
+      "objective": "Verify that authentication mechanisms using the Public Switched Telephone Network (PSTN) to deliver One-time Passwords (OTPs) via phone or SMS are offered only when the phone number has previously been validated, alternate stronger methods (such as Time based One-time Passwords) are also offered, and the service provides information on their security risks to users. For L3 applications, phone and SMS must not be available as options.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 619,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.6.2",
+      "objective": "Verify that out-of-band authentication requests, codes, or tokens are bound to the original authentication request for which they were generated and are not usable for a previous or subsequent one.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 620,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.6.3",
+      "objective": "Verify that a code based out-of-band authentication mechanism is protected against brute force attacks by using rate limiting. Consider also using a code with at least 64 bits of entropy.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 621,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.6.4",
+      "objective": "Verify that, where push notifications are used for multi-factor authentication, rate limiting is used to prevent push bombing attacks. Number matching may also mitigate this risk.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 622,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.7.1",
+      "objective": "Verify that the certificates used to verify cryptographic authentication assertions are stored in a way protects them from modification.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 623,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.7.2",
+      "objective": "Verify that the challenge nonce is at least 64 bits in length, and statistically unique or unique over the lifetime of the cryptographic device.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 624,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.8.1",
+      "objective": "Verify that, if the application supports multiple identity providers (IdPs), the user's identity cannot be spoofed via another supported identity provider (eg. by using the same user identifier). The standard mitigation would be for the application to register and identify the user using a combination of the IdP ID (serving as a namespace) and the user's ID in the IdP.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 625,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.8.2",
+      "objective": "Verify that the presence and integrity of digital signatures on authentication assertions (for example on JWTs or SAML assertions) are always validated, rejecting any assertions that are unsigned or have invalid signatures.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 626,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.8.3",
+      "objective": "Verify that SAML assertions are uniquely processed and used only once within the validity period to prevent replay attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 627,
+    "fields": {
+      "category": 35,
+      "objective_number": "6.8.4",
+      "objective": "Verify that, if an application uses a separate Identity Provider (IdP) and expects specific authentication strength, methods, or recentness for specific functions, the application verifies this using the information returned by the IdP. For example, if OIDC is used, this might be achieved by validating ID Token claims such as 'acr', 'amr', and 'auth_time' (if present). If the IdP does not provide this information, the application must have a documented fallback approach that assumes that the minimum strength authentication mechanism was used (for example, single-factor authentication using username and password).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 628,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.1.1",
+      "objective": "Verify that the user's session inactivity timeout and absolute maximum session lifetime are documented, are appropriate in combination with other controls, and that the documentation includes justification for any deviations from NIST SP 800-63B re-authentication requirements.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 629,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.1.2",
+      "objective": "Verify that the documentation defines how many concurrent (parallel) sessions are allowed for one account as well as the intended behaviors and actions to be taken when the maximum number of active sessions is reached.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 630,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.1.3",
+      "objective": "Verify that all systems that create and manage user sessions as part of a federated identity management ecosystem (such as SSO systems) are documented along with controls to coordinate session lifetimes, termination, and any other conditions that require re-authentication.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 631,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.2.1",
+      "objective": "Verify that the application performs all session token verification using a trusted, backend service.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 632,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.2.2",
+      "objective": "Verify that the application uses either self-contained or reference tokens that are dynamically generated for session management, i.e. not using static API secrets and keys.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 633,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.2.3",
+      "objective": "Verify that if reference tokens are used to represent user sessions, they are unique and generated using a cryptographically secure pseudo-random number generator (CSPRNG) and possess at least 128 bits of entropy.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 634,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.2.4",
+      "objective": "Verify that the application generates a new session token on user authentication, including re-authentication, and terminates the current session token.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 635,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.3.1",
+      "objective": "Verify that there is an inactivity timeout such that re-authentication is enforced according to risk analysis and documented security decisions.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 636,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.3.2",
+      "objective": "Verify that there is an absolute maximum session lifetime such that re-authentication is enforced according to risk analysis and documented security decisions.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 637,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.4.1",
+      "objective": "Verify that when session termination is triggered (such as logout or expiration), the application disallows any further use of the session. For reference tokens or stateful sessions, this means invalidating the session data at the application backend. Applications using self-contained tokens will need a solution such as maintaining a list of terminated tokens, disallowing tokens produced before a per-user date and time or rotating a per-user signing key.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 638,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.4.2",
+      "objective": "Verify that the application terminates all active sessions when a user account is disabled or deleted (such as an employee leaving the company).",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 639,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.4.3",
+      "objective": "Verify that the application gives the option to terminate all other active sessions after a successful change or removal of any authentication factor (including password change via reset or recovery and, if present, an MFA settings update).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 640,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.4.4",
+      "objective": "Verify that all pages that require authentication have easy and visible access to logout functionality.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 641,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.4.5",
+      "objective": "Verify that application administrators are able to terminate active sessions for an individual user or for all users.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 642,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.5.1",
+      "objective": "Verify that the application requires full re-authentication before allowing modifications to sensitive account attributes which may affect authentication such as email address, phone number, MFA configuration, or other information used in account recovery.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 643,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.5.2",
+      "objective": "Verify that users are able to view and (having authenticated again with at least one factor) terminate any or all currently active sessions.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 644,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.5.3",
+      "objective": "Verify that the application requires further authentication with at least one factor or secondary verification before performing highly sensitive transactions or operations.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 645,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.6.1",
+      "objective": "Verify that session lifetime and termination between Relying Parties (RPs) and Identity Providers (IdPs) behave as documented, requiring re-authentication as necessary such as when the maximum time between IdP authentication events is reached.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 646,
+    "fields": {
+      "category": 36,
+      "objective_number": "7.6.2",
+      "objective": "Verify that creation of a session requires either the user's consent or an explicit action, preventing the creation of new application sessions without user interaction.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 647,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.1.1",
+      "objective": "Verify that authorization documentation defines rules for restricting function-level and data-specific access based on consumer permissions and resource attributes.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 648,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.1.2",
+      "objective": "Verify that authorization documentation defines rules for field-level access restrictions (both read and write) based on consumer permissions and resource attributes. Note that these rules might depend on other attribute values of the relevant data object, such as state or status.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 649,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.1.3",
+      "objective": "Verify that the application's documentation defines the environmental and contextual attributes (including but not limited to, time of day, user location, IP address, or device) that are used in the application to make security decisions, including those pertaining to authentication and authorization.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 650,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.1.4",
+      "objective": "Verify that authentication and authorization documentation defines how environmental and contextual factors are used in decision-making, in addition to function-level, data-specific, and field-level authorization. This should include the attributes evaluated, thresholds for risk, and actions taken (e.g., allow, challenge, deny, step-up authentication).",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 651,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.2.1",
+      "objective": "Verify that the application ensures that function-level access is restricted to consumers with explicit permissions.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 652,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.2.2",
+      "objective": "Verify that the application ensures that data-specific access is restricted to consumers with explicit permissions to specific data items to mitigate insecure direct object reference (IDOR) and broken object level authorization (BOLA).",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 653,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.2.3",
+      "objective": "Verify that the application ensures that field-level access is restricted to consumers with explicit permissions to specific fields to mitigate broken object property level authorization (BOPLA).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 654,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.2.4",
+      "objective": "Verify that adaptive security controls based on a consumer's environmental and contextual attributes (such as time of day, location, IP address, or device) are implemented for authentication and authorization decisions, as defined in the application's documentation. These controls must be applied when the consumer tries to start a new session and also during an existing session.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 655,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.3.1",
+      "objective": "Verify that the application enforces authorization rules at a trusted service layer and doesn't rely on controls that an untrusted consumer could manipulate, such as client-side JavaScript.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 656,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.3.2",
+      "objective": "Verify that changes to values on which authorization decisions are made are applied immediately. Where changes cannot be applied immediately, (such as when relying on data in self-contained tokens), there must be mitigating controls to alert when a consumer performs an action when they are no longer authorized to do so and revert the change. Note that this alternative would not mitigate information leakage.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 657,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.3.3",
+      "objective": "Verify that access to an object is based on the originating subject's (e.g. consumer's) permissions, not on the permissions of any intermediary or service acting on their behalf. For example, if a consumer calls a web service using a self-contained token for authentication, and the service then requests data from a different service, the second service will use the consumer's token, rather than a machine-to-machine token from the first service, to make permission decisions.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 658,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.4.1",
+      "objective": "Verify that multi-tenant applications use cross-tenant controls to ensure consumer operations will never affect tenants with which they do not have permissions to interact.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 659,
+    "fields": {
+      "category": 37,
+      "objective_number": "8.4.2",
+      "objective": "Verify that access to administrative interfaces incorporates multiple layers of security, including continuous consumer identity verification, device security posture assessment, and contextual risk analysis, ensuring that network location or trusted endpoints are not the sole factors for authorization even though they may reduce the likelihood of unauthorized access.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 660,
+    "fields": {
+      "category": 38,
+      "objective_number": "9.1.1",
+      "objective": "Verify that self-contained tokens are validated using their digital signature or MAC to protect against tampering before accepting the token's contents.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 661,
+    "fields": {
+      "category": 38,
+      "objective_number": "9.1.2",
+      "objective": "Verify that only algorithms on an allowlist can be used to create and verify self-contained tokens, for a given context. The allowlist must include the permitted algorithms, ideally only either symmetric or asymmetric algorithms, and must not include the 'None' algorithm. If both symmetric and asymmetric must be supported, additional controls will be needed to prevent key confusion.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 662,
+    "fields": {
+      "category": 38,
+      "objective_number": "9.1.3",
+      "objective": "Verify that key material that is used to validate self-contained tokens is from trusted pre-configured sources for the token issuer, preventing attackers from specifying untrusted sources and keys. For JWTs and other JWS structures, headers such as 'jku', 'x5u', and 'jwk' must be validated against an allowlist of trusted sources.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 663,
+    "fields": {
+      "category": 38,
+      "objective_number": "9.2.1",
+      "objective": "Verify that, if a validity time span is present in the token data, the token and its content are accepted only if the verification time is within this validity time span. For example, for JWTs, the claims 'nbf' and 'exp' must be verified.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 664,
+    "fields": {
+      "category": 38,
+      "objective_number": "9.2.2",
+      "objective": "Verify that the service receiving a token validates the token to be the correct type and is meant for the intended purpose before accepting the token's contents. For example, only access tokens can be accepted for authorization decisions and only ID Tokens can be used for proving user authentication.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 665,
+    "fields": {
+      "category": 38,
+      "objective_number": "9.2.3",
+      "objective": "Verify that the service only accepts tokens which are intended for use with that service (audience). For JWTs, this can be achieved by validating the 'aud' claim against an allowlist defined in the service.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 666,
+    "fields": {
+      "category": 38,
+      "objective_number": "9.2.4",
+      "objective": "Verify that, if a token issuer uses the same private key for issuing tokens to different audiences, the issued tokens contain an audience restriction that uniquely identifies the intended audiences. This will prevent a token from being reused with an unintended audience. If the audience identifier is dynamically provisioned, the token issuer must validate these audiences in order to make sure that they do not result in audience impersonation.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 667,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.1.1",
+      "objective": "Verify that tokens are only sent to components that strictly need them. For example, when using a backend-for-frontend pattern for browser-based JavaScript applications, access and refresh tokens shall only be accessible for the backend.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 668,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.1.2",
+      "objective": "Verify that the client only accepts values from the authorization server (such as the authorization code or ID Token) if these values result from an authorization flow that was initiated by the same user agent session and transaction. This requires that client-generated secrets, such as the proof key for code exchange (PKCE) 'code_verifier', 'state' or OIDC 'nonce', are not guessable, are specific to the transaction, and are securely bound to both the client and the user agent session in which the transaction was started.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 669,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.2.1",
+      "objective": "Verify that, if the code flow is used, the OAuth client has protection against browser-based request forgery attacks, commonly known as cross-site request forgery (CSRF), which trigger token requests, either by using proof key for code exchange (PKCE) functionality or checking the 'state' parameter that was sent in the authorization request.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 670,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.2.2",
+      "objective": "Verify that, if the OAuth client can interact with more than one authorization server, it has a defense against mix-up attacks. For example, it could require that the authorization server return the 'iss' parameter value and validate it in the authorization response and the token response.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 671,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.2.3",
+      "objective": "Verify that the OAuth client only requests the required scopes (or other authorization parameters) in requests to the authorization server.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 672,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.3.1",
+      "objective": "Verify that the resource server only accepts access tokens that are intended for use with that service (audience). The audience may be included in a structured access token (such as the 'aud' claim in JWT), or it can be checked using the token introspection endpoint.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 673,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.3.2",
+      "objective": "Verify that the resource server enforces authorization decisions based on claims from the access token that define delegated authorization. If claims such as 'sub', 'scope', and 'authorization_details' are present, they must be part of the decision.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 674,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.3.3",
+      "objective": "Verify that if an access control decision requires identifying a unique user from an access token (JWT or related token introspection response), the resource server identifies the user from claims that cannot be reassigned to other users. Typically, it means using a combination of 'iss' and 'sub' claims.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 675,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.3.4",
+      "objective": "Verify that, if the resource server requires specific authentication strength, methods, or recentness, it verifies that the presented access token satisfies these constraints. For example, if present, using the OIDC 'acr', 'amr' and 'auth_time' claims respectively.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 676,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.3.5",
+      "objective": "Verify that the resource server prevents the use of stolen access tokens or replay of access tokens (from unauthorized parties) by requiring sender-constrained access tokens, either Mutual TLS for OAuth 2 or OAuth 2 Demonstration of Proof of Possession (DPoP).",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 677,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.1",
+      "objective": "Verify that the authorization server validates redirect URIs based on a client-specific allowlist of pre-registered URIs using exact string comparison.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 678,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.2",
+      "objective": "Verify that, if the authorization server returns the authorization code in the authorization response, it can be used only once for a token request. For the second valid request with an authorization code that has already been used to issue an access token, the authorization server must reject a token request and revoke any issued tokens related to the authorization code.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 679,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.3",
+      "objective": "Verify that the authorization code is short-lived. The maximum lifetime can be up to 10 minutes for L1 and L2 applications and up to 1 minute for L3 applications.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 680,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.4",
+      "objective": "Verify that for a given client, the authorization server only allows the usage of grants that this client needs to use. Note that the grants 'token' (Implicit flow) and 'password' (Resource Owner Password Credentials flow) must no longer be used.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 681,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.5",
+      "objective": "Verify that the authorization server mitigates refresh token replay attacks for public clients, preferably using sender-constrained refresh tokens, i.e., Demonstrating Proof of Possession (DPoP) or Certificate-Bound Access Tokens using mutual TLS (mTLS). For L1 and L2 applications, refresh token rotation may be used. If refresh token rotation is used, the authorization server must invalidate the refresh token after usage, and revoke all refresh tokens for that authorization if an already used and invalidated refresh token is provided.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 682,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.6",
+      "objective": "Verify that, if the code grant is used, the authorization server mitigates authorization code interception attacks by requiring proof key for code exchange (PKCE). For authorization requests, the authorization server must require a valid 'code_challenge' value and must not accept a 'code_challenge_method' value of 'plain'. For a token request, it must require validation of the 'code_verifier' parameter.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 683,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.7",
+      "objective": "Verify that if the authorization server supports unauthenticated dynamic client registration, it mitigates the risk of malicious client applications. It must validate client metadata such as any registered URIs, ensure the user's consent, and warn the user before processing an authorization request with an untrusted client application.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 684,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.8",
+      "objective": "Verify that refresh tokens have an absolute expiration, including if sliding refresh token expiration is applied.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 685,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.9",
+      "objective": "Verify that refresh tokens and reference access tokens can be revoked by an authorized user using the authorization server user interface, to mitigate the risk of malicious clients or stolen tokens.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 686,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.10",
+      "objective": "Verify that confidential client is authenticated for client-to-authorized server backchannel requests such as token requests, pushed authorization requests (PAR), and token revocation requests.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 687,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.11",
+      "objective": "Verify that the authorization server configuration only assigns the required scopes to the OAuth client.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 688,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.12",
+      "objective": "Verify that for a given client, the authorization server only allows the 'response_mode' value that this client needs to use. For example, by having the authorization server validate this value against the expected values or by using pushed authorization request (PAR) or JWT-secured Authorization Request (JAR).",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 689,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.13",
+      "objective": "Verify that grant type 'code' is always used together with pushed authorization requests (PAR).",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 690,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.14",
+      "objective": "Verify that the authorization server issues only sender-constrained (Proof-of-Possession) access tokens, either with certificate-bound access tokens using mutual TLS (mTLS) or DPoP-bound access tokens (Demonstration of Proof of Possession).",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 691,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.15",
+      "objective": "Verify that, for a server-side client (which is not executed on the end-user device), the authorization server ensures that the 'authorization_details' parameter value is from the client backend and that the user has not tampered with it. For example, by requiring the usage of pushed authorization request (PAR) or JWT-secured Authorization Request (JAR).",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 692,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.4.16",
+      "objective": "Verify that the client is confidential and the authorization server requires the use of strong client authentication methods (based on public-key cryptography and resistant to replay attacks), such as mutual TLS ('tls_client_auth', 'self_signed_tls_client_auth') or private key JWT ('private_key_jwt').",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 693,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.5.1",
+      "objective": "Verify that the client (as the relying party) mitigates ID Token replay attacks. For example, by ensuring that the 'nonce' claim in the ID Token matches the 'nonce' value sent in the authentication request to the OpenID Provider (in OAuth2 refereed to as the authorization request sent to the authorization server).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 694,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.5.2",
+      "objective": "Verify that the client uniquely identifies the user from ID Token claims, usually the 'sub' claim, which cannot be reassigned to other users (for the scope of an identity provider).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 695,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.5.3",
+      "objective": "Verify that the client rejects attempts by a malicious authorization server to impersonate another authorization server through authorization server metadata. The client must reject authorization server metadata if the issuer URL in the authorization server metadata does not exactly match the pre-configured issuer URL expected by the client.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 696,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.5.4",
+      "objective": "Verify that the client validates that the ID Token is intended to be used for that client (audience) by checking that the 'aud' claim from the token is equal to the 'client_id' value for the client.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 697,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.5.5",
+      "objective": "Verify that, when using OIDC back-channel logout, the relying party mitigates denial of service through forced logout and cross-JWT confusion in the logout flow. The client must verify that the logout token is correctly typed with a value of 'logout+jwt', contains the 'event' claim with the correct member name, and does not contain a 'nonce' claim. Note that it is also recommended to have a short expiration (e.g., 2 minutes).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 698,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.6.1",
+      "objective": "Verify that the OpenID Provider only allows values 'code', 'ciba', 'id_token', or 'id_token code' for response mode. Note that 'code' is preferred over 'id_token code' (the OIDC Hybrid flow), and 'token' (any Implicit flow) must not be used.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 699,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.6.2",
+      "objective": "Verify that the OpenID Provider mitigates denial of service through forced logout. By obtaining explicit confirmation from the end-user or, if present, validating parameters in the logout request (initiated by the relying party), such as the 'id_token_hint'.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 700,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.7.1",
+      "objective": "Verify that the authorization server ensures that the user consents to each authorization request. If the identity of the client cannot be assured, the authorization server must always explicitly prompt the user for consent.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 701,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.7.2",
+      "objective": "Verify that when the authorization server prompts for user consent, it presents sufficient and clear information about what is being consented to. When applicable, this should include the nature of the requested authorizations (typically based on scope, resource server, Rich Authorization Requests (RAR) authorization details), the identity of the authorized application, and the lifetime of these authorizations.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 702,
+    "fields": {
+      "category": 39,
+      "objective_number": "10.7.3",
+      "objective": "Verify that the user can review, modify, and revoke consents which the user has granted through the authorization server.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 703,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.1.1",
+      "objective": "Verify that there is a documented policy for management of cryptographic keys and a cryptographic key lifecycle that follows a key management standard such as NIST SP 800-57. This should include ensuring that keys are not overshared (for example, with more than two entities for shared secrets and more than one entity for private keys).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 704,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.1.2",
+      "objective": "Verify that a cryptographic inventory is performed, maintained, regularly updated, and includes all cryptographic keys, algorithms, and certificates used by the application. It must also document where keys can and cannot be used in the system, and the types of data that can and cannot be protected using the keys.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 705,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.1.3",
+      "objective": "Verify that cryptographic discovery mechanisms are employed to identify all instances of cryptography in the system, including encryption, hashing, and signing operations.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 706,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.1.4",
+      "objective": "Verify that a cryptographic inventory is maintained. This must include a documented plan that outlines the migration path to new cryptographic standards, such as post-quantum cryptography, in order to react to future threats.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 707,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.2.1",
+      "objective": "Verify that industry-validated implementations (including libraries and hardware-accelerated implementations) are used for cryptographic operations.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 708,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.2.2",
+      "objective": "Verify that the application is designed with crypto agility such that random number, authenticated encryption, MAC, or hashing algorithms, key lengths, rounds, ciphers and modes can be reconfigured, upgraded, or swapped at any time, to protect against cryptographic breaks. Similarly, it must also be possible to replace keys and passwords and re-encrypt data. This will allow for seamless upgrades to post-quantum cryptography (PQC), once high-assurance implementations of approved PQC schemes or standards are widely available.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 709,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.2.3",
+      "objective": "Verify that all cryptographic primitives utilize a minimum of 128-bits of security based on the algorithm, key size, and configuration. For example, a 256-bit ECC key provides roughly 128 bits of security where RSA requires a 3072-bit key to achieve 128 bits of security.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 710,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.2.4",
+      "objective": "Verify that all cryptographic operations are constant-time, with no 'short-circuit' operations in comparisons, calculations, or returns, to avoid leaking information.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 711,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.2.5",
+      "objective": "Verify that all cryptographic modules fail securely, and errors are handled in a way that does not enable vulnerabilities, such as Padding Oracle attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 712,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.3.1",
+      "objective": "Verify that insecure block modes (e.g., ECB) and weak padding schemes (e.g., PKCS#1 v1.5) are not used.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 713,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.3.2",
+      "objective": "Verify that only approved ciphers and modes such as AES with GCM are used.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 714,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.3.3",
+      "objective": "Verify that encrypted data is protected against unauthorized modification preferably by using an approved authenticated encryption method or by combining an approved encryption method with an approved MAC algorithm.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 715,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.3.4",
+      "objective": "Verify that nonces, initialization vectors, and other single-use numbers are not used for more than one encryption key and data-element pair. The method of generation must be appropriate for the algorithm being used.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 716,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.3.5",
+      "objective": "Verify that any combination of an encryption algorithm and a MAC algorithm is operating in encrypt-then-MAC mode.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 717,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.4.1",
+      "objective": "Verify that only approved hash functions are used for general cryptographic use cases, including digital signatures, HMAC, KDF, and random bit generation. Disallowed hash functions, such as MD5, must not be used for any cryptographic purpose.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 718,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.4.2",
+      "objective": "Verify that passwords are stored using an approved, computationally intensive, key derivation function (also known as a \"password hashing function\"), with parameter settings configured based on current guidance. The settings should balance security and performance to make brute-force attacks sufficiently challenging for the required level of security.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 719,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.4.3",
+      "objective": "Verify that hash functions used in digital signatures, as part of data authentication or data integrity are collision resistant and have appropriate bit-lengths. If collision resistance is required, the output length must be at least 256 bits. If only resistance to second pre-image attacks is required, the output length must be at least 128 bits.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 720,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.4.4",
+      "objective": "Verify that the application uses approved key derivation functions with key stretching parameters when deriving secret keys from passwords. The parameters in use must balance security and performance to prevent brute-force attacks from compromising the resulting cryptographic key.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 721,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.5.1",
+      "objective": "Verify that all random numbers and strings which are intended to be non-guessable must be generated using a cryptographically secure pseudo-random number generator (CSPRNG) and have at least 128 bits of entropy. Note that UUIDs do not respect this condition.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 722,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.5.2",
+      "objective": "Verify that the random number generation mechanism in use is designed to work securely, even under heavy demand.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 723,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.6.1",
+      "objective": "Verify that only approved cryptographic algorithms and modes of operation are used for key generation and seeding, and digital signature generation and verification. Key generation algorithms must not generate insecure keys vulnerable to known attacks, for example, RSA keys which are vulnerable to Fermat factorization.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 724,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.6.2",
+      "objective": "Verify that approved cryptographic algorithms are used for key exchange (such as Diffie-Hellman) with a focus on ensuring that key exchange mechanisms use secure parameters. This will prevent attacks on the key establishment process which could lead to adversary-in-the-middle attacks or cryptographic breaks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 725,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.7.1",
+      "objective": "Verify that full memory encryption is in use that protects sensitive data while it is in use, preventing access by unauthorized users or processes.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 726,
+    "fields": {
+      "category": 40,
+      "objective_number": "11.7.2",
+      "objective": "Verify that data minimization ensures the minimal amount of data is exposed during processing, and ensure that data is encrypted immediately after use or as soon as feasible.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 727,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.1.1",
+      "objective": "Verify that only the latest recommended versions of the TLS protocol are enabled, such as TLS 1.2 and TLS 1.3. The latest version of the TLS protocol must be the preferred option.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 728,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.1.2",
+      "objective": "Verify that only recommended cipher suites are enabled, with the strongest cipher suites set as preferred. L3 applications must only support cipher suites which provide forward secrecy.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 729,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.1.3",
+      "objective": "Verify that the application validates that mTLS client certificates are trusted before using the certificate identity for authentication or authorization.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 730,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.1.4",
+      "objective": "Verify that proper certification revocation, such as Online Certificate Status Protocol (OCSP) Stapling, is enabled and configured.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 731,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.1.5",
+      "objective": "Verify that Encrypted Client Hello (ECH) is enabled in the application's TLS settings to prevent exposure of sensitive metadata, such as the Server Name Indication (SNI), during TLS handshake processes.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 732,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.2.1",
+      "objective": "Verify that TLS is used for all connectivity between a client and external facing, HTTP-based services, and does not fall back to insecure or unencrypted communications.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 733,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.2.2",
+      "objective": "Verify that external facing services use publicly trusted TLS certificates.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 734,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.3.1",
+      "objective": "Verify that an encrypted protocol such as TLS is used for all inbound and outbound connections to and from the application, including monitoring systems, management tools, remote access and SSH, middleware, databases, mainframes, partner systems, or external APIs. The server must not fall back to insecure or unencrypted protocols.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 735,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.3.2",
+      "objective": "Verify that TLS clients validate certificates received before communicating with a TLS server.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 736,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.3.3",
+      "objective": "Verify that TLS or another appropriate transport encryption mechanism used for all connectivity between internal, HTTP-based services within the application, and does not fall back to insecure or unencrypted communications.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 737,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.3.4",
+      "objective": "Verify that TLS connections between internal services use trusted certificates. Where internally generated or self-signed certificates are used, the consuming service must be configured to only trust specific internal CAs and specific self-signed certificates.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 738,
+    "fields": {
+      "category": 41,
+      "objective_number": "12.3.5",
+      "objective": "Verify that services communicating internally within a system (intra-service communications) use strong authentication to ensure that each endpoint is verified. Strong authentication methods, such as TLS client authentication, must be employed to ensure identity, using public-key infrastructure and mechanisms that are resistant to replay attacks. For microservice architectures, consider using a service mesh to simplify certificate management and enhance security.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 739,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.1.1",
+      "objective": "Verify that all communication needs for the application are documented. This must include external services which the application relies upon and cases where an end user might be able to provide an external location to which the application will then connect.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 740,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.1.2",
+      "objective": "Verify that for each service the application uses, the documentation defines the maximum number of concurrent connections (e.g., connection pool limits) and how the application behaves when that limit is reached, including any fallback or recovery mechanisms, to prevent denial of service conditions.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 741,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.1.3",
+      "objective": "Verify that the application documentation defines resource‑management strategies for every external system or service it uses (e.g., databases, file handles, threads, HTTP connections). This should include resource‑release procedures, timeout settings, failure handling, and where retry logic is implemented, specifying retry limits, delays, and back‑off algorithms. For synchronous HTTP request–response operations it should mandate short timeouts and either disable retries or strictly limit retries to prevent cascading delays and resource exhaustion.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 742,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.1.4",
+      "objective": "Verify that the application's documentation defines the secrets that are critical for the security of the application and a schedule for rotating them, based on the organization's threat model and business requirements.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 743,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.2.1",
+      "objective": "Verify that communications between backend application components that don't support the application's standard user session mechanism, including APIs, middleware, and data layers, are authenticated. Authentication must use individual service accounts, short-term tokens, or certificate-based authentication and not unchanging credentials such as passwords, API keys, or shared accounts with privileged access.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 744,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.2.2",
+      "objective": "Verify that communications between backend application components, including local or operating system services, APIs, middleware, and data layers, are performed with accounts assigned the least necessary privileges.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 745,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.2.3",
+      "objective": "Verify that if a credential has to be used for service authentication, the credential being used by the consumer is not a default credential (e.g., root/root or admin/admin).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 746,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.2.4",
+      "objective": "Verify that an allowlist is used to define the external resources or systems with which the application is permitted to communicate (e.g., for outbound requests, data loads, or file access). This allowlist can be implemented at the application layer, web server, firewall, or a combination of different layers.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 747,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.2.5",
+      "objective": "Verify that the web or application server is configured with an allowlist of resources or systems to which the server can send requests or load data or files from.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 748,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.2.6",
+      "objective": "Verify that where the application connects to separate services, it follows the documented configuration for each connection, such as maximum parallel connections, behavior when maximum allowed connections is reached, connection timeouts, and retry strategies.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 749,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.3.1",
+      "objective": "Verify that a secrets management solution, such as a key vault, is used to securely create, store, control access to, and destroy backend secrets. These could include passwords, key material, integrations with databases and third-party systems, keys and seeds for time-based tokens, other internal secrets, and API keys. Secrets must not be included in application source code or included in build artifacts. For an L3 application, this must involve a hardware-backed solution such as an HSM.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 750,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.3.2",
+      "objective": "Verify that access to secret assets adheres to the principle of least privilege.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 751,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.3.3",
+      "objective": "Verify that all cryptographic operations are performed using an isolated security module (such as a vault or hardware security module) to securely manage and protect key material from exposure outside of the security module.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 752,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.3.4",
+      "objective": "Verify that secrets are configured to expire and be rotated based on the application's documentation.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 753,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.4.1",
+      "objective": "Verify that the application is deployed either without any source control metadata, including the .git or .svn folders, or in a way that these folders are inaccessible both externally and to the application itself.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 754,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.4.2",
+      "objective": "Verify that debug modes are disabled for all components in production environments to prevent exposure of debugging features and information leakage.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 755,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.4.3",
+      "objective": "Verify that web servers do not expose directory listings to clients unless explicitly intended.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 756,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.4.4",
+      "objective": "Verify that using the HTTP TRACE method is not supported in production environments, to avoid potential information leakage.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 757,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.4.5",
+      "objective": "Verify that documentation (such as for internal APIs) and monitoring endpoints are not exposed unless explicitly intended.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 758,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.4.6",
+      "objective": "Verify that the application does not expose detailed version information of backend components.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 759,
+    "fields": {
+      "category": 42,
+      "objective_number": "13.4.7",
+      "objective": "Verify that the web tier is configured to only serve files with specific file extensions to prevent unintentional information, configuration, and source code leakage.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 760,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.1.1",
+      "objective": "Verify that all sensitive data created and processed by the application has been identified and classified into protection levels. This includes data that is only encoded and therefore easily decoded, such as Base64 strings or the plaintext payload inside a JWT. Protection levels need to take into account any data protection and privacy regulations and standards which the application is required to comply with.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 761,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.1.2",
+      "objective": "Verify that all sensitive data protection levels have a documented set of protection requirements. This must include (but not be limited to) requirements related to general encryption, integrity verification, retention, how the data is to be logged, access controls around sensitive data in logs, database-level encryption, privacy and privacy-enhancing technologies to be used, and other confidentiality requirements.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 762,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.2.1",
+      "objective": "Verify that sensitive data is only sent to the server in the HTTP message body or header fields, and that the URL and query string do not contain sensitive information, such as an API key or session token.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 763,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.2.2",
+      "objective": "Verify that the application prevents sensitive data from being cached in server components, such as load balancers and application caches, or ensures that the data is securely purged after use.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 764,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.2.3",
+      "objective": "Verify that defined sensitive data is not sent to untrusted parties (e.g., user trackers) to prevent unwanted collection of data outside of the application's control.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 765,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.2.4",
+      "objective": "Verify that controls around sensitive data related to encryption, integrity verification, retention, how the data is to be logged, access controls around sensitive data in logs, privacy and privacy-enhancing technologies, are implemented as defined in the documentation for the specific data's protection level.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 766,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.2.5",
+      "objective": "Verify that caching mechanisms are configured to only cache responses which have the expected content type for that resource and do not contain sensitive, dynamic content. The web server should return a 404 or 302 response when a non-existent file is accessed rather than returning a different, valid file. This should prevent Web Cache Deception attacks.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 767,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.2.6",
+      "objective": "Verify that the application only returns the minimum required sensitive data for the application's functionality. For example, only returning some of the digits of a credit card number and not the full number. If the complete data is required, it should be masked in the user interface unless the user specifically views it.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 768,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.2.7",
+      "objective": "Verify that sensitive information is subject to data retention classification, ensuring that outdated or unnecessary data is deleted automatically, on a defined schedule, or as the situation requires.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 769,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.2.8",
+      "objective": "Verify that sensitive information is removed from the metadata of user-submitted files unless storage is consented to by the user.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 770,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.3.1",
+      "objective": "Verify that authenticated data is cleared from client storage, such as the browser DOM, after the client or session is terminated. The 'Clear-Site-Data' HTTP response header field may be able to help with this but the client-side should also be able to clear up if the server connection is not available when the session is terminated.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 771,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.3.2",
+      "objective": "Verify that the application sets sufficient anti-caching HTTP response header fields (i.e., Cache-Control: no-store) so that sensitive data is not cached in browsers.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 772,
+    "fields": {
+      "category": 43,
+      "objective_number": "14.3.3",
+      "objective": "Verify that data stored in browser storage (such as localStorage, sessionStorage, IndexedDB, or cookies) does not contain sensitive data, with the exception of session tokens.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 773,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.1.1",
+      "objective": "Verify that application documentation defines risk based remediation time frames for 3rd party component versions with vulnerabilities and for updating libraries in general, to minimize the risk from these components.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 774,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.1.2",
+      "objective": "Verify that an inventory catalog, such as software bill of materials (SBOM), is maintained of all third-party libraries in use, including verifying that components come from pre-defined, trusted, and continually maintained repositories.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 775,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.1.3",
+      "objective": "Verify that the application documentation identifies functionality which is time-consuming or resource-demanding. This must include how to prevent a loss of availability due to overusing this functionality and how to avoid a situation where building a response takes longer than the consumer's timeout. Potential defenses may include asynchronous processing, using queues, and limiting parallel processes per user and per application.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 776,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.1.4",
+      "objective": "Verify that application documentation highlights third-party libraries which are considered to be \"risky components\".",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 777,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.1.5",
+      "objective": "Verify that application documentation highlights parts of the application where \"dangerous functionality\" is being used.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 778,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.2.1",
+      "objective": "Verify that the application only contains components which have not breached the documented update and remediation time frames.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 779,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.2.2",
+      "objective": "Verify that the application has implemented defenses against loss of availability due to functionality which is time-consuming or resource-demanding, based on the documented security decisions and strategies for this.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 780,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.2.3",
+      "objective": "Verify that the production environment only includes functionality that is required for the application to function, and does not expose extraneous functionality such as test code, sample snippets, and development functionality.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 781,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.2.4",
+      "objective": "Verify that third-party components and all of their transitive dependencies are included from the expected repository, whether internally owned or an external source, and that there is no risk of a dependency confusion attack.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 782,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.2.5",
+      "objective": "Verify that the application implements additional protections around parts of the application which are documented as containing \"dangerous functionality\" or using third-party libraries considered to be \"risky components\". This could include techniques such as sandboxing, encapsulation, containerization or network level isolation to delay and deter attackers who compromise one part of an application from pivoting elsewhere in the application.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 783,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.3.1",
+      "objective": "Verify that the application only returns the required subset of fields from a data object. For example, it should not return an entire data object, as some individual fields should not be accessible to users.",
+      "references": "",
+      "level_1": true,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 784,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.3.2",
+      "objective": "Verify that where the application backend makes calls to external URLs, it is configured to not follow redirects unless it is intended functionality.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 785,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.3.3",
+      "objective": "Verify that the application has countermeasures to protect against mass assignment attacks by limiting allowed fields per controller and action, e.g., it is not possible to insert or update a field value when it was not intended to be part of that action.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 786,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.3.4",
+      "objective": "Verify that all proxying and middleware components transfer the user's original IP address correctly using trusted data fields that cannot be manipulated by the end user, and the application and web server use this correct value for logging and security decisions such as rate limiting, taking into account that even the original IP address may not be reliable due to dynamic IPs, VPNs, or corporate firewalls.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 787,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.3.5",
+      "objective": "Verify that the application explicitly ensures that variables are of the correct type and performs strict equality and comparator operations. This is to avoid type juggling or type confusion vulnerabilities caused by the application code making an assumption about a variable type.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 788,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.3.6",
+      "objective": "Verify that JavaScript code is written in a way that prevents prototype pollution, for example, by using Set() or Map() instead of object literals.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 789,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.3.7",
+      "objective": "Verify that the application has defenses against HTTP parameter pollution attacks, particularly if the application framework makes no distinction about the source of request parameters (query string, body parameters, cookies, or header fields).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 790,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.4.1",
+      "objective": "Verify that shared objects in multi-threaded code (such as caches, files, or in-memory objects accessed by multiple threads) are accessed safely by using thread-safe types and synchronization mechanisms like locks or semaphores to avoid race conditions and data corruption.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 791,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.4.2",
+      "objective": "Verify that checks on a resource's state, such as its existence or permissions, and the actions that depend on them are performed as a single atomic operation to prevent time-of-check to time-of-use (TOCTOU) race conditions. For example, checking if a file exists before opening it, or verifying a user’s access before granting it.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 792,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.4.3",
+      "objective": "Verify that locks are used consistently to avoid threads getting stuck, whether by waiting on each other or retrying endlessly, and that locking logic stays within the code responsible for managing the resource to ensure locks cannot be inadvertently or maliciously modified by external classes or code.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 793,
+    "fields": {
+      "category": 44,
+      "objective_number": "15.4.4",
+      "objective": "Verify that resource allocation policies prevent thread starvation by ensuring fair access to resources, such as by leveraging thread pools, allowing lower-priority threads to proceed within a reasonable timeframe.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 794,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.1.1",
+      "objective": "Verify that an inventory exists documenting the logging performed at each layer of the application's technology stack, what events are being logged, log formats, where that logging is stored, how it is used, how access to it is controlled, and for how long logs are kept.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 795,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.2.1",
+      "objective": "Verify that each log entry includes necessary metadata (such as when, where, who, what) that would allow for a detailed investigation of the timeline when an event happens.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 796,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.2.2",
+      "objective": "Verify that time sources for all logging components are synchronized, and that timestamps in security event metadata use UTC or include an explicit time zone offset. UTC is recommended to ensure consistency across distributed systems and to prevent confusion during daylight saving time transitions.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 797,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.2.3",
+      "objective": "Verify that the application only stores or broadcasts logs to the files and services that are documented in the log inventory.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 798,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.2.4",
+      "objective": "Verify that logs can be read and correlated by the log processor that is in use, preferably by using a common logging format.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 799,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.2.5",
+      "objective": "Verify that when logging sensitive data, the application enforces logging based on the data's protection level. For example, it may not be allowed to log certain data, such as credentials or payment details. Other data, such as session tokens, may only be logged by being hashed or masked, either in full or partially.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 800,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.3.1",
+      "objective": "Verify that all authentication operations are logged, including successful and unsuccessful attempts. Additional metadata, such as the type of authentication or factors used, should also be collected.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 801,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.3.2",
+      "objective": "Verify that failed authorization attempts are logged. For L3, this must include logging all authorization decisions, including logging when sensitive data is accessed (without logging the sensitive data itself).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 802,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.3.3",
+      "objective": "Verify that the application logs the security events that are defined in the documentation and also logs attempts to bypass the security controls, such as input validation, business logic, and anti-automation.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 803,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.3.4",
+      "objective": "Verify that the application logs unexpected errors and security control failures such as backend TLS failures.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 804,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.4.1",
+      "objective": "Verify that all logging components appropriately encode data to prevent log injection.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 805,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.4.2",
+      "objective": "Verify that logs are protected from unauthorized access and cannot be modified.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 806,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.4.3",
+      "objective": "Verify that logs are securely transmitted to a logically separate system for analysis, detection, alerting, and escalation. The aim is to ensure that if the application is breached, the logs are not compromised.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 807,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.5.1",
+      "objective": "Verify that a generic message is returned to the consumer when an unexpected or security-sensitive error occurs, ensuring no exposure of sensitive internal system data such as stack traces, queries, secret keys, and tokens.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 808,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.5.2",
+      "objective": "Verify that the application continues to operate securely when external resource access fails, for example, by using patterns such as circuit breakers or graceful degradation.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 809,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.5.3",
+      "objective": "Verify that the application fails gracefully and securely, including when an exception occurs, preventing fail-open conditions such as processing a transaction despite errors resulting from validation logic.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 810,
+    "fields": {
+      "category": 45,
+      "objective_number": "16.5.4",
+      "objective": "Verify that a \"last resort\" error handler is defined which will catch all unhandled exceptions. This is both to avoid losing error details that must go to log files and to ensure that an error does not take down the entire application process, leading to a loss of availability.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 811,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.1.1",
+      "objective": "Verify that the Traversal Using Relays around NAT (TURN) service only allows access to IP addresses that are not reserved for special purposes (e.g., internal networks, broadcast, loopback). Note that this applies to both IPv4 and IPv6 addresses.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 812,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.1.2",
+      "objective": "Verify that the Traversal Using Relays around NAT (TURN) service is not susceptible to resource exhaustion when legitimate users attempt to open a large number of ports on the TURN server.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 813,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.2.1",
+      "objective": "Verify that the key for the Datagram Transport Layer Security (DTLS) certificate is managed and protected based on the documented policy for management of cryptographic keys.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 814,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.2.2",
+      "objective": "Verify that the media server is configured to use and support approved Datagram Transport Layer Security (DTLS) cipher suites and a secure protection profile for the DTLS Extension for establishing keys for the Secure Real-time Transport Protocol (DTLS-SRTP).",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 815,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.2.3",
+      "objective": "Verify that Secure Real-time Transport Protocol (SRTP) authentication is checked at the media server to prevent Real-time Transport Protocol (RTP) injection attacks from leading to either a Denial of Service condition or audio or video media insertion into media streams.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 816,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.2.4",
+      "objective": "Verify that the media server is able to continue processing incoming media traffic when encountering malformed Secure Real-time Transport Protocol (SRTP) packets.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 817,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.2.5",
+      "objective": "Verify that the media server is able to continue processing incoming media traffic during a flood of Secure Real-time Transport Protocol (SRTP) packets from legitimate users.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 818,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.2.6",
+      "objective": "Verify that the media server is not susceptible to the \"ClientHello\" Race Condition vulnerability in Datagram Transport Layer Security (DTLS) by checking if the media server is publicly known to be vulnerable or by performing the race condition test.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 819,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.2.7",
+      "objective": "Verify that any audio or video recording mechanisms associated with the media server are able to continue processing incoming media traffic during a flood of Secure Real-time Transport Protocol (SRTP) packets from legitimate users.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 820,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.2.8",
+      "objective": "Verify that the Datagram Transport Layer Security (DTLS) certificate is checked against the Session Description Protocol (SDP) fingerprint attribute, terminating the media stream if the check fails, to ensure the authenticity of the media stream.",
+      "references": "",
+      "level_1": false,
+      "level_2": false,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 821,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.3.1",
+      "objective": "Verify that the signaling server is able to continue processing legitimate incoming signaling messages during a flood attack. This should be achieved by implementing rate limiting at the signaling level.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
+  },
+  {
+    "model": "dojo.benchmark_requirement",
+    "pk": 822,
+    "fields": {
+      "category": 46,
+      "objective_number": "17.3.2",
+      "objective": "Verify that the signaling server is able to continue processing legitimate signaling messages when encountering malformed signaling message that could cause a denial of service condition. This could include implementing input validation, safely handling integer overflows, preventing buffer overflows, and employing other robust error-handling techniques.",
+      "references": "",
+      "level_1": false,
+      "level_2": true,
+      "level_3": true,
+      "enabled": true,
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "cwe_mapping": [],
+      "testing_guide": []
+    }
   }
 ]

--- a/dojo/fixtures/benchmark_type.json
+++ b/dojo/fixtures/benchmark_type.json
@@ -22,5 +22,17 @@
       "updated": "2019-03-27T10:44:17.930Z",
       "enabled": true
     }
+  },
+  {
+    "model": "dojo.benchmark_type",
+    "pk": 3,
+    "fields": {
+      "name": "OWASP ASVS",
+      "version": "v. 5.0.0",
+      "benchmark_source": "OWASP ASVS",
+      "created": "2025-05-30T09:35:00.000Z",
+      "updated": "2025-05-30T09:35:00.000Z",
+      "enabled": true
+    }
   }
 ]

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -71,6 +71,7 @@ from dojo.forms import (
 from dojo.models import (
     App_Analysis,
     Benchmark_Product_Summary,
+    Benchmark_Type,
     BurpRawRequestResponse,
     DojoMeta,
     Endpoint,
@@ -90,7 +91,6 @@ from dojo.models import (
     System_Settings,
     Test,
     Test_Type,
-    Benchmark_Type,
 )
 from dojo.product.queries import (
     get_authorized_global_groups_for_product,

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -148,7 +148,7 @@ def product(request):
     prod_list.object_list = prefetch_for_product(prod_list.object_list)
 
     # Get benchmark types for the template
-    benchmark_type = Benchmark_Type.objects.filter(enabled=True).order_by("name")
+    benchmark_types = Benchmark_Type.objects.filter(enabled=True).order_by("name")
 
     add_breadcrumb(title=_("Product List"), top_level=not len(request.GET), request=request)
 
@@ -157,7 +157,7 @@ def product(request):
         "prod_filter": prod_filter,
         "name_words": sorted(set(name_words)),
         "enable_table_filtering": get_system_setting("enable_ui_table_based_searching"),
-        "benchmark_type": benchmark_type,
+        "benchmark_types": benchmark_types,
         "user": request.user})
 
 

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -90,6 +90,7 @@ from dojo.models import (
     System_Settings,
     Test,
     Test_Type,
+    Benchmark_Type,
 )
 from dojo.product.queries import (
     get_authorized_global_groups_for_product,
@@ -146,6 +147,9 @@ def product(request):
     # perform annotation/prefetching by replacing the queryset in the page with an annotated/prefetched queryset.
     prod_list.object_list = prefetch_for_product(prod_list.object_list)
 
+    # Get benchmark types for the template
+    benchmark_type = Benchmark_Type.objects.filter(enabled=True).order_by("name")
+
     add_breadcrumb(title=_("Product List"), top_level=not len(request.GET), request=request)
 
     return render(request, "dojo/product.html", {
@@ -153,6 +157,7 @@ def product(request):
         "prod_filter": prod_filter,
         "name_words": sorted(set(name_words)),
         "enable_table_filtering": get_system_setting("enable_ui_table_based_searching"),
+        "benchmark_type": benchmark_type,
         "user": request.user})
 
 
@@ -294,6 +299,7 @@ def view_product(request, pid):
         "system_settings": system_settings,
         "benchmarks_percents": benchAndPercent,
         "benchmarks": benchmarks,
+        "benchmark_type": product_tab.benchmark_type,
         "product_members": product_members,
         "global_product_members": global_product_members,
         "product_type_members": product_type_members,

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -162,7 +162,7 @@
                                         {% if prod|has_object_permission:"Benchmark_Edit" %}
                                           {% if system_settings.enable_benchmark and benchmark_type %}
                                             <li role="separator" class="divider"></li>
-                                            {% for bt in benchmark_type %}
+                                            {% for bt in benchmark_types %}
                                               <li role="presentation">
                                                 <a title="{{ bt.name }}" href="{% url 'view_product_benchmark' prod.id bt.id %}">
                                                   <span class="fa-solid fa-list-ul"></span> {{ bt.name }} {{ bt.version }}


### PR DESCRIPTION
## Description  📋

### 🐞 Bug fix  
* **Symptom:** The Benchmark-Type dropdown on the product page always showed a single entry, **“OWASP ASVS v3.1”**, even though **v4.0.1** (and other types) were already loaded in the DB.  
* **Root cause:** The view didn’t pass the full list of enabled `Benchmark_Type` records to the template.  
* **Fix:** `dojo/product/views.py` now fetches `Benchmark_Type.objects.filter(enabled=True)` and exposes it in the context → the dropdown lists *all* enabled benchmarks.

### ✨ Feature / Enhancement
* **Added OWASP ASVS 5.0**:
Includes the latest ASVS 5.0 as a selectable benchmark, with new categories and initial requirements.
* **Why**:
Previously, only the old ASVS 3.1 was visible in the dropdown, even though 4.0.1 was already in the database. ASVS 3.1 is quite outdated, so it’s nice to have more up-to-date standards available.
* **What changed**:
The dropdown now shows all available ASVS versions (including 5.0), so you can map findings to the most current requirements.

---

## Screenshots  🖼️

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/326eaa3c-756f-474c-a0ab-19a144e1aa52) | <img width="237" alt="image" src="https://github.com/user-attachments/assets/caea3020-991d-430e-bd62-6995859ea387" /> |

Additional screenshots of the new ASVS 5.0 benchmark page:  
<img width="1344" alt="image" src="https://github.com/user-attachments/assets/ae8b1d9d-3ec1-4e3e-b279-d7f8bdb551aa" />

---

## References  🔗

Place any external links here (PDF, CSV, official page, etc.):

* [Official ASVS page](https://owasp.org/www-project-application-security-verification-standard/)
* [Official OWASP ASVS 5.0 PDF](https://github.com/OWASP/ASVS/raw/v5.0.0/5.0/OWASP_Application_Security_Verification_Standard_5.0.0_en.pdf)
* [CSV source used for import](https://github.com/OWASP/ASVS/releases/download/v5.0.0_release/OWASP_Application_Security_Verification_Standard_5.0.0_en.csv)

---

## Test results

1. Loaded fixtures on a fresh database (`manage.py loaddata …`).  
2. Verified the dropdown now lists **ASVS 3.1, ASVS 4.0.1, ASVS 5.0**.  
3. Created a dummy product → mapped findings to new v5.0 requirements without issues.
