### PR TITLE
login next param: set default for sso redirects

### DIFF
--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -149,7 +149,7 @@ def login_view(request):
             return HttpResponseRedirect("/saml2/login")
         try:
             return HttpResponseRedirect("{}?{}".format(reverse("social:begin", args=[social_auth]),
-                                                   urlencode({"next": request.GET.get("next")})))
+                                                   urlencode({"next": request.GET.get("next", "/dashboard")})))
         except:
             return HttpResponseRedirect(reverse("social:begin", args=[social_auth]))
     else:


### PR DESCRIPTION
In certain SSO scenario's the user can end up with a `/login` url without any `next` parameter. This would result in a ` NoneType`  error. This PR fixes this by sending users to `/dashboard`  by default. Inspired by #6907