### PR TITLE
Qualys: do not use access_path as endpoints

### DIFF
--- a/dojo/tools/qualys_webapp/parser.py
+++ b/dojo/tools/qualys_webapp/parser.py
@@ -194,9 +194,6 @@ def get_unique_vulnerabilities(
         url = vuln.findtext("URL")
         if url is not None:
             urls.append(str(url))
-        access_path = vuln.find("ACCESS_PATH")
-        if access_path is not None:
-            urls += [url.text for url in access_path.iter("URL")]
         payloads = vuln.find("PAYLOADS")
         req_resps = get_request_response(payloads) if payloads is not None else [[], []]
 
@@ -258,9 +255,6 @@ def get_vulnerabilities(
         url = vuln.findtext("URL")
         if url is not None:
             urls.append(str(url))
-        access_path = vuln.find("ACCESS_PATH")
-        if access_path is not None:
-            urls += [url.text for url in access_path.iter("URL")]
         payloads = vuln.find("PAYLOADS")
         req_resps = get_request_response(payloads) if payloads is not None else [[], []]
 


### PR DESCRIPTION

**Description**

Couple of bugfixes:
- fix(qualys_was_parser): do not use access_path as endpoints, because they aren't
- fix(qualys_was_parser): update import paths for settings: to reflect current module structure

**Test results**

Passed all unittests for qualys_webapp_parser


