### PR TITLE
trivy: map status field

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/file/trivy.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/trivy.md
@@ -4,7 +4,7 @@ toc_hide: true
 ---
 JSON report of [trivy scanner](https://github.com/aquasecurity/trivy).
 
-The status field in Trivy is mapped to the Defect Dojo status flags in the following way:
+The [status](https://trivy.dev/latest/docs/configuration/filtering/) field in Trivy is mapped to the Defect Dojo status flags in the following way:
 
 | Trivy Status         | Active | Verified | Mitigated | False Positive | Remarks                                                                                                         |
 |----------------------|--------|----------|-----------|---------------|-----------------------------------------------------------------------------------------------------------------|
@@ -19,6 +19,7 @@ The status field in Trivy is mapped to the Defect Dojo status flags in the follo
 
 The status field contains the status as assigned by the OS/Package vendor such as Red Hat, Debian, etc.
 As s Defect Dojo user you still have to asses the appropiate action in your product context.
+If you want to exclude certain status from being imported into Defect Dojo, please [filter them in the export from Trivy](https://trivy.dev/latest/docs/configuration/filtering/)
 
 ### Sample Scan Data
 Sample Trivy scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/trivy).

--- a/docs/content/en/connecting_your_tools/parsers/file/trivy.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/trivy.md
@@ -6,20 +6,20 @@ JSON report of [trivy scanner](https://github.com/aquasecurity/trivy).
 
 The [status](https://trivy.dev/latest/docs/configuration/filtering/) field in Trivy is mapped to the Defect Dojo status flags in the following way:
 
-| Trivy Status         | Active | Verified | Mitigated | False Positive | Remarks                                                                                                         |
-|----------------------|--------|----------|-----------|---------------|-----------------------------------------------------------------------------------------------------------------|
-| unknown              | True   | False    | False     |               | use default value for active which is usually True                                                              |
-| not_affected         | False  | True     | True      | True          | false positive is the most appropriate status for not affected as out of scope might be interpreted as something else |
-| affected             | True   | True     | False     |               | standard case                                                                                                   |
-| fixed                | True   | True     | False     |               | fixed in this context means that there is a fix available by patching/updating/upgrading the package but it's still active and verified |
-| under_investigation  | True   | False    | False     |               | no status flag in Defect Dojo to capture this, but verified is False                                            |
-| will_not_fix         | True   | True     | False     |               | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to risk accept this finding |
-| fix_deferred         | True   | True     | False     |               | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to (temporarily) risk accept this finding |
-| end_of_life          | True   | True     | False     |               | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to (temporarily) risk accept
+| Trivy Status         | Active | Verified | Mitigated | Remarks                                                                                                         |
+|----------------------|--------|----------|-----------|-----------------------------------------------------------------------------------------------------------------|
+| unknown              | True   | False    | False     | use default value for active which is usually True                                                              |
+| not_affected         | False  | True     | True      | false positive is the most appropriate status for not affected as out of scope might be interpreted as something else |
+| affected             | True   | True     | False     | standard case                                                                                                   |
+| fixed                | True   | True     | False     | fixed in this context means that there is a fix available by patching/updating/upgrading the package but it's still active and verified |
+| under_investigation  | True   | False    | False     | no status flag in Defect Dojo to capture this, but verified is False                                            |
+| will_not_fix         | True   | True     | False     | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to risk accept this finding |
+| fix_deferred         | True   | True     | False     | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to (temporarily) risk accept this finding |
+| end_of_life          | True   | True     | False     | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to (temporarily) risk accept
 
 The status field contains the status as assigned by the OS/Package vendor such as Red Hat, Debian, etc.
-It is recommended to assess the appropriate action in your Product's context
+It is recommended to assess the appropriate action in your Product's context.
 If you want to exclude certain status from being imported into Defect Dojo, please [filter them in the export from Trivy](https://trivy.dev/latest/docs/configuration/filtering/)
 
 ### Sample Scan Data
-Sample Trivy scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/trivy).
+Sample Trivy scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/trivy)

--- a/docs/content/en/connecting_your_tools/parsers/file/trivy.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/trivy.md
@@ -4,5 +4,21 @@ toc_hide: true
 ---
 JSON report of [trivy scanner](https://github.com/aquasecurity/trivy).
 
+The status field in Trivy is mapped to the Defect Dojo status flags in the following way:
+
+| Trivy Status         | Active | Verified | Mitigated | False Positive | Remarks                                                                                                         |
+|----------------------|--------|----------|-----------|---------------|-----------------------------------------------------------------------------------------------------------------|
+| unknown              | True   | False    | False     |               | use default value for active which is usually True                                                              |
+| not_affected         | False  | True     | True      | True          | false positive is the most appropriate status for not affected as out of scope might be interpreted as something else |
+| affected             | True   | True     | False     |               | standard case                                                                                                   |
+| fixed                | True   | True     | False     |               | fixed in this context means that there is a fix available by patching/updating/upgrading the package but it's still active and verified |
+| under_investigation  | True   | False    | False     |               | no status flag in Defect Dojo to capture this, but verified is False                                            |
+| will_not_fix         | True   | True     | False     |               | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to risk accept this finding |
+| fix_deferred         | True   | True     | False     |               | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to (temporarily) risk accept this finding |
+| end_of_life          | True   | True     | False     |               | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to (temporarily) risk accept
+
+The status field contains the status as assigned by the OS/Package vendor such as Red Hat, Debian, etc.
+As s Defect Dojo user you still have to asses the appropiate action in your product context.
+
 ### Sample Scan Data
 Sample Trivy scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/trivy).

--- a/docs/content/en/connecting_your_tools/parsers/file/trivy.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/trivy.md
@@ -18,7 +18,7 @@ The [status](https://trivy.dev/latest/docs/configuration/filtering/) field in Tr
 | end_of_life          | True   | True     | False     |               | no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor; we can't set active to False as the user needs to (temporarily) risk accept
 
 The status field contains the status as assigned by the OS/Package vendor such as Red Hat, Debian, etc.
-As s Defect Dojo user you still have to asses the appropiate action in your product context.
+It is recommended to assess the appropriate action in your Product's context
 If you want to exclude certain status from being imported into Defect Dojo, please [filter them in the export from Trivy](https://trivy.dev/latest/docs/configuration/filtering/)
 
 ### Sample Scan Data

--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -104,7 +104,6 @@ class TrivyParser:
                 # false positive is the most appropriate status for not affected as out of scope might be interpreted as something else
                 "active": False,
                 "verified": True,
-                "false_p": True,
                 "is_mitigated": True,
             },
             "affected": {

--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -66,6 +66,86 @@ class TrivyParser:
             return "High"
         return "Critical"
 
+    def convert_trivy_status(self, trivy_status: str) -> dict:
+        """
+        Determine status fields based on Trivy status
+
+        From: https://trivy.dev/v0.54/docs/configuration/filtering/
+
+        Trivy has a Status field based on VEX vulnerability statuses. Please not these are statuses based on the vulnerability advisories by OS vendors such as Debian, RHEL, etc.
+
+        - `unknown`
+        - `not_affected`: this package is not affected by this vulnerability on this platform
+        - `affected`: this package is affected by this vulnerability on this platform, but there is no patch released yet
+        - `fixed`: this vulnerability is fixed on this platform
+        - `under_investigation`: it is currently unknown whether or not this vulnerability affects this package on this platform, and it is under investigation
+        - `will_not_fix`: this package is affected by this vulnerability on this platform, but there is currently no intention to fix it (this would primarily be for flaws that are of Low or Moderate impact that pose no significant risk to customers)
+        - `fix_deferred`: this package is affected by this vulnerability on this platform, and may be fixed in the future
+        - `end_of_life`: this package has been identified to contain the impacted component, but analysis to determine whether it is affected or not by this vulnerability was not performed
+
+
+        Note that vulnerabilities with the `unknown`, `not_affected` or `under_investigation` status are not detected.
+        These are only defined for comprehensiveness, and you will not have the opportunity to specify these statuses.
+
+        Some statuses are supported in limited distributions.
+
+        |     OS     | Fixed | Affected | Under Investigation | Will Not Fix | Fix Deferred | End of Life |
+        |:----------:|:-----:|:--------:|:-------------------:|:------------:|:------------:|:-----------:|
+        |   Debian   |   ✓   |    ✓     |                     |              |      ✓       |      ✓      |
+        |    RHEL    |   ✓   |    ✓     |          ✓          |      ✓       |      ✓       |      ✓      |
+        | Other OSes |   ✓   |    ✓     |                     |              |              |             |
+        """
+        status_mapping = {
+            "unknown": {
+                # use default value for active which is usually True
+                "verified": False,
+            },
+            "not_affected": {
+                # false positive is the most appropriate status for not affected as out of scope might be interpreted as something else
+                "active": False,
+                "verified": True,
+                "false_p": True,
+                "is_mitigated": True,
+            },
+            "affected": {
+                # standard case
+                "active": True,
+                "verified": True,
+            },
+            "fixed": {
+                # fixed in this context means that there is a fix available by patching/updating/upgrading the package
+                # but it's still active and verified
+                "active": True,
+                "verified": True,
+            },
+            "under_investigation": {
+                # no status flag in Defect Dojo to capture this, but verified is False
+                "active": True,
+                "verified": False,
+            },
+            "will_not_fix": {
+                # no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor
+                # we can't set active to False as the user needs to risk accept this finding
+                "active": True,
+                "verified": True,
+            },
+            "fix_deferred": {
+                # no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor
+                # we can't set active to False as the user needs to (temporarily) risk accept this finding
+                "active": True,
+                "verified": True,
+            },
+            "end_of_life": {
+                # no different from affected as Defect Dojo doesn't have a flag to capture will_not_fix by OS/Package Vendor
+                # we can't set active to False as the user needs to (temporarily) risk accept this finding
+                "active": True,
+                "verified": True,
+            },
+        }
+
+        # default is to fallback to default Defect Dojo behaviour which takes scan parameters into account
+        return status_mapping.get(trivy_status, {})
+
     def get_findings(self, scan_file, test):
         scan_data = scan_file.read()
 
@@ -194,6 +274,8 @@ class TrivyParser:
                 package_version = vuln.get("InstalledVersion", "")
                 references = "\n".join(vuln.get("References", []))
                 mitigation = vuln.get("FixedVersion", "")
+                impact = vuln.get("Status", "")
+                status_fields = self.convert_trivy_status(vuln.get("Status", ""))
                 cwe = int(vuln["CweIDs"][0].split("-")[1]) if len(vuln.get("CweIDs", [])) > 0 else 0
                 vul_type = target_data.get("Type", "")
                 title = f"{vuln_id} {package_name} {package_version}"
@@ -212,6 +294,7 @@ class TrivyParser:
                     file_path=file_path,
                     references=references,
                     description=description,
+                    impact=impact,
                     mitigation=mitigation,
                     component_name=package_name,
                     component_version=package_version,
@@ -220,6 +303,7 @@ class TrivyParser:
                     dynamic_finding=False,
                     tags=[vul_type, target_class],
                     service=service_name,
+                    **status_fields,
                 )
 
                 if vuln_id:

--- a/unittests/scans/trivy/all_statuses.json
+++ b/unittests/scans/trivy/all_statuses.json
@@ -1,0 +1,603 @@
+{
+    "SchemaVersion": 2,
+    "CreatedAt": "2024-01-15T08:58:29.82753744Z",
+    "ArtifactName": "",
+    "ArtifactType": "container_image",
+    "Metadata": {
+      "OS": {
+        "Family": "debian",
+        "Name": "10.13"
+      },
+      "ImageID": "sha256:22ae3921bdaac434bb4cb92dbbc209e46b1f3f70e9fa0b5fbbb43ce7d452c72d",
+      "DiffIDs": [
+        "sha256:b2dba74777543b60e1a5be6da44e67659f51b8df1e96922205a5dde6b92dda3c",
+        "sha256:f1186e5061f20658954f6bfdfaead0abc5ed2371d70f707da05206e868a226ab",
+        "sha256:fe0fb3ab4a0f7be72784fcab5ef9c8fda65ea9b1067e8f7cdf293c12bcd25c13",
+        "sha256:c45660adde371317a1eafb102ee1d33b059328ec73a01b5c2461c4d04a40ecec",
+        "sha256:e01a454893a9a11115c598e5dec158ded8bd41326046c993c81b76b6a963590b",
+        "sha256:cb81227abde588a006a8b7ceac6034a303813efadc2c711fabf7b224649d183f",
+        "sha256:f8a91dd5fc84e4e5a1f261cf306ba1de28894524326d86eec0d74e9c0d22baec",
+        "sha256:3c777d951de2c488f73618f92b2adee8bd5de6f77e36bab51d57583bc487b99b",
+        "sha256:0d5f5a015e5d65973cce1dbab5aa60ce0836dbf2b3c9eabcb6efc89db1db3221",
+        "sha256:baa0956fea600c916f370870566aca1edf9a5ffc7facf51cfb1286e774f6e0e2",
+        "sha256:2f08eba9a3eddbb1e9dc2b70a25a1a3860807dac0d42c1e40fd890bbafbfba29",
+        "sha256:bf7d7d997f27e713b44ac0e763a38c46f9698e71e2243b0ffa80405d62d8c5e0"
+      ],
+      "RepoTags": [
+        ""
+      ],
+      "RepoDigests": [
+        ""
+      ],
+      "ImageConfig": {
+        "architecture": "amd64",
+        "created": "2024-01-15T08:56:27.807609822Z",
+        "history": [
+          {
+            "created": "2023-04-12T00:20:15Z",
+            "created_by": "/bin/sh -c #(nop) ADD file:40953ed6e6f96703b2e0c13288437c2aaf8b3df33dbc423686290cbe0e595a5e in / "
+          },
+          {
+            "created": "2023-04-12T00:20:15Z",
+            "created_by": "/bin/sh -c #(nop)  CMD [\"bash\"]",
+            "empty_layer": true
+          },
+          {
+            "created": "2023-04-12T07:52:41Z",
+            "created_by": "/bin/sh -c set -eux; \tapt-get update; \tapt-get install -y --no-install-recommends \t\tca-certificates \t\tcurl \t\tnetbase \t\twget \t; \trm -rf /var/lib/apt/lists/*"
+          },
+          {
+            "created": "2023-04-12T07:52:47Z",
+            "created_by": "/bin/sh -c set -ex; \tif ! command -v gpg \u003e /dev/null; then \t\tapt-get update; \t\tapt-get install -y --no-install-recommends \t\t\tgnupg \t\t\tdirmngr \t\t; \t\trm -rf /var/lib/apt/lists/*; \tfi"
+          },
+          {
+            "created": "2023-04-12T07:53:05Z",
+            "created_by": "/bin/sh -c apt-get update \u0026\u0026 apt-get install -y --no-install-recommends \t\tgit \t\tmercurial \t\topenssh-client \t\tsubversion \t\t\t\tprocps \t\u0026\u0026 rm -rf /var/lib/apt/lists/*"
+          },
+          {
+            "created": "2023-04-12T07:54:04Z",
+            "created_by": "/bin/sh -c set -ex; \tapt-get update; \tapt-get install -y --no-install-recommends \t\tautoconf \t\tautomake \t\tbzip2 \t\tdpkg-dev \t\tfile \t\tg++ \t\tgcc \t\timagemagick \t\tlibbz2-dev \t\tlibc6-dev \t\tlibcurl4-openssl-dev \t\tlibdb-dev \t\tlibevent-dev \t\tlibffi-dev \t\tlibgdbm-dev \t\tlibglib2.0-dev \t\tlibgmp-dev \t\tlibjpeg-dev \t\tlibkrb5-dev \t\tliblzma-dev \t\tlibmagickcore-dev \t\tlibmagickwand-dev \t\tlibmaxminddb-dev \t\tlibncurses5-dev \t\tlibncursesw5-dev \t\tlibpng-dev \t\tlibpq-dev \t\tlibreadline-dev \t\tlibsqlite3-dev \t\tlibssl-dev \t\tlibtool \t\tlibwebp-dev \t\tlibxml2-dev \t\tlibxslt-dev \t\tlibyaml-dev \t\tmake \t\tpatch \t\tunzip \t\txz-utils \t\tzlib1g-dev \t\t\t\t$( \t\t\tif apt-cache show 'default-libmysqlclient-dev' 2\u003e/dev/null | grep -q '^Version:'; then \t\t\t\techo 'default-libmysqlclient-dev'; \t\t\telse \t\t\t\techo 'libmysqlclient-dev'; \t\t\tfi \t\t) \t; \trm -rf /var/lib/apt/lists/*"
+          },
+          {
+            "created": "2023-04-12T09:05:40Z",
+            "created_by": "/bin/sh -c groupadd --gid 1000 node   \u0026\u0026 useradd --uid 1000 --gid node --shell /bin/bash --create-home node"
+          },
+          {
+            "created": "2023-04-12T09:11:56Z",
+            "created_by": "/bin/sh -c #(nop)  ENV NODE_VERSION=14.21.3",
+            "empty_layer": true
+          },
+          {
+            "created": "2023-04-12T09:12:09Z",
+            "created_by": "/bin/sh -c ARCH= \u0026\u0026 dpkgArch=\"$(dpkg --print-architecture)\"   \u0026\u0026 case \"${dpkgArch##*-}\" in     amd64) ARCH='x64';;     ppc64el) ARCH='ppc64le';;     s390x) ARCH='s390x';;     arm64) ARCH='arm64';;     armhf) ARCH='armv7l';;     i386) ARCH='x86';;     *) echo \"unsupported architecture\"; exit 1 ;;   esac   \u0026\u0026 set -ex   \u0026\u0026 for key in     4ED778F539E3634C779C87C6D7062848A1AB005C     141F07595B7B3FFE74309A937405533BE57C7D57     74F12602B6F1C4E913FAA37AD3A89613643B6201     61FC681DFB92A079F1685E77973F295594EC4689     8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600     C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8     890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4     C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C     108F52B48DB57BB0CC439B2997B01419BD92F80A   ; do       gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys \"$key\" ||       gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \"$key\" ;   done   \u0026\u0026 curl -fsSLO --compressed \"https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz\"   \u0026\u0026 curl -fsSLO --compressed \"https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc\"   \u0026\u0026 gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc   \u0026\u0026 grep \" node-v$NODE_VERSION-linux-$ARCH.tar.xz\\$\" SHASUMS256.txt | sha256sum -c -   \u0026\u0026 tar -xJf \"node-v$NODE_VERSION-linux-$ARCH.tar.xz\" -C /usr/local --strip-components=1 --no-same-owner   \u0026\u0026 rm \"node-v$NODE_VERSION-linux-$ARCH.tar.xz\" SHASUMS256.txt.asc SHASUMS256.txt   \u0026\u0026 ln -s /usr/local/bin/node /usr/local/bin/nodejs   \u0026\u0026 node --version   \u0026\u0026 npm --version"
+          },
+          {
+            "created": "2023-04-12T09:12:09Z",
+            "created_by": "/bin/sh -c #(nop)  ENV YARN_VERSION=1.22.19",
+            "empty_layer": true
+          },
+          {
+            "created": "2023-04-12T09:12:12Z",
+            "created_by": "/bin/sh -c set -ex   \u0026\u0026 for key in     6A010C5166006599AA17F08146C2130DFD2497F5   ; do     gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys \"$key\" ||     gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \"$key\" ;   done   \u0026\u0026 curl -fsSLO --compressed \"https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz\"   \u0026\u0026 curl -fsSLO --compressed \"https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc\"   \u0026\u0026 gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz   \u0026\u0026 mkdir -p /opt   \u0026\u0026 tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/   \u0026\u0026 ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn   \u0026\u0026 ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg   \u0026\u0026 rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz   \u0026\u0026 yarn --version"
+          },
+          {
+            "created": "2023-04-12T09:12:12Z",
+            "created_by": "/bin/sh -c #(nop) COPY file:4d192565a7220e135cab6c77fbc1c73211b69f3d9fb37e62857b2c6eb9363d51 in /usr/local/bin/ "
+          },
+          {
+            "created": "2023-04-12T09:12:12Z",
+            "created_by": "/bin/sh -c #(nop)  ENTRYPOINT [\"docker-entrypoint.sh\"]",
+            "empty_layer": true
+          },
+          {
+            "created": "2023-04-12T09:12:12Z",
+            "created_by": "/bin/sh -c #(nop)  CMD [\"node\"]",
+            "empty_layer": true
+          },
+          {
+            "created": "2024-01-15T08:56:23Z",
+            "created_by": "WORKDIR /usr/src/app/",
+            "comment": "buildkit.dockerfile.v0"
+          },
+          {
+            "created": "2024-01-15T08:56:23Z",
+            "created_by": "COPY src/ /usr/src/app/ # buildkit",
+            "comment": "buildkit.dockerfile.v0"
+          },
+          {
+            "created": "2024-01-15T08:56:27Z",
+            "created_by": "RUN /bin/sh -c npm install # buildkit",
+            "comment": "buildkit.dockerfile.v0"
+          },
+          {
+            "created": "2024-01-15T08:56:27Z",
+            "created_by": "EXPOSE map[3000/tcp:{}]",
+            "comment": "buildkit.dockerfile.v0",
+            "empty_layer": true
+          },
+          {
+            "created": "2024-01-15T08:56:27Z",
+            "created_by": "CMD [\"node\" \"index.js\"]",
+            "comment": "buildkit.dockerfile.v0",
+            "empty_layer": true
+          }
+        ],
+        "os": "linux",
+        "rootfs": {
+          "type": "layers",
+          "diff_ids": [
+            "sha256:b2dba74777543b60e1a5be6da44e67659f51b8df1e96922205a5dde6b92dda3c",
+            "sha256:f1186e5061f20658954f6bfdfaead0abc5ed2371d70f707da05206e868a226ab",
+            "sha256:fe0fb3ab4a0f7be72784fcab5ef9c8fda65ea9b1067e8f7cdf293c12bcd25c13",
+            "sha256:c45660adde371317a1eafb102ee1d33b059328ec73a01b5c2461c4d04a40ecec",
+            "sha256:e01a454893a9a11115c598e5dec158ded8bd41326046c993c81b76b6a963590b",
+            "sha256:cb81227abde588a006a8b7ceac6034a303813efadc2c711fabf7b224649d183f",
+            "sha256:f8a91dd5fc84e4e5a1f261cf306ba1de28894524326d86eec0d74e9c0d22baec",
+            "sha256:3c777d951de2c488f73618f92b2adee8bd5de6f77e36bab51d57583bc487b99b",
+            "sha256:0d5f5a015e5d65973cce1dbab5aa60ce0836dbf2b3c9eabcb6efc89db1db3221",
+            "sha256:baa0956fea600c916f370870566aca1edf9a5ffc7facf51cfb1286e774f6e0e2",
+            "sha256:2f08eba9a3eddbb1e9dc2b70a25a1a3860807dac0d42c1e40fd890bbafbfba29",
+            "sha256:bf7d7d997f27e713b44ac0e763a38c46f9698e71e2243b0ffa80405d62d8c5e0"
+          ]
+        },
+        "config": {
+          "Cmd": [
+            "node",
+            "index.js"
+          ],
+          "Entrypoint": [
+            "docker-entrypoint.sh"
+          ],
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "NODE_VERSION=14.21.3",
+            "YARN_VERSION=1.22.19"
+          ],
+          "WorkingDir": "/usr/src/app/",
+          "ArgsEscaped": true
+        }
+      }
+    },
+    "Results": [
+      {
+        "Target": "noppaknopsta/example-app:main-159 (debian 10.13)",
+        "Class": "os-pkgs",
+        "Type": "debian",
+        "Vulnerabilities": [
+          {
+            "VulnerabilityID": "CVE-2011-3374",
+            "PkgID": "apt@1.8.2.3",
+            "PkgName": "apt",
+            "InstalledVersion": "1.8.2.3",
+            "Status": "unknown",
+            "Layer": {
+              "DiffID": "sha256:b2dba74777543b60e1a5be6da44e67659f51b8df1e96922205a5dde6b92dda3c"
+            },
+            "SeveritySource": "debian",
+            "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2011-3374",
+            "DataSource": {
+              "ID": "debian",
+              "Name": "Debian Security Tracker",
+              "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+            },
+            "Title": "It was found that apt-key in apt, all versions, do not correctly valid ...",
+            "Description": "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.",
+            "Severity": "LOW",
+            "CweIDs": [
+              "CWE-347"
+            ],
+            "VendorSeverity": {
+              "debian": 1,
+              "nvd": 1
+            },
+            "CVSS": {
+              "nvd": {
+                "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
+                "V3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+                "V2Score": 4.3,
+                "V3Score": 3.7
+              }
+            },
+            "References": [
+              "https://access.redhat.com/security/cve/cve-2011-3374",
+              "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=642480",
+              "https://people.canonical.com/~ubuntu-security/cve/2011/CVE-2011-3374.html",
+              "https://seclists.org/fulldisclosure/2011/Sep/221",
+              "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+              "https://snyk.io/vuln/SNYK-LINUX-APT-116518",
+              "https://ubuntu.com/security/CVE-2011-3374"
+            ],
+            "PublishedDate": "2019-11-26T00:15:11.03Z",
+            "LastModifiedDate": "2021-02-09T16:08:18.683Z"
+          },
+          {
+            "VulnerabilityID": "CVE-2019-18276",
+            "PkgID": "bash@5.0-4",
+            "PkgName": "bash",
+            "InstalledVersion": "5.0-4",
+            "Status": "not_affected",
+            "Layer": {
+              "DiffID": "sha256:b2dba74777543b60e1a5be6da44e67659f51b8df1e96922205a5dde6b92dda3c"
+            },
+            "SeveritySource": "debian",
+            "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2019-18276",
+            "DataSource": {
+              "ID": "debian",
+              "Name": "Debian Security Tracker",
+              "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+            },
+            "Title": "bash: when effective UID is not equal to its real UID the saved UID is not dropped",
+            "Description": "An issue was discovered in disable_priv_mode in shell.c in GNU Bash through 5.0 patch 11. By default, if Bash is run with its effective UID not equal to its real UID, it will drop privileges by setting its effective UID to its real UID. However, it does so incorrectly. On Linux and other systems that support \"saved UID\" functionality, the saved UID is not dropped. An attacker with command execution in the shell can use \"enable -f\" for runtime loading of a new builtin, which can be a shared object that calls setuid() and therefore regains privileges. However, binaries running with an effective UID of 0 are unaffected.",
+            "Severity": "LOW",
+            "CweIDs": [
+              "CWE-273"
+            ],
+            "VendorSeverity": {
+              "cbl-mariner": 3,
+              "debian": 1,
+              "nvd": 3,
+              "oracle-oval": 1,
+              "photon": 3,
+              "redhat": 1,
+              "ubuntu": 1
+            },
+            "CVSS": {
+              "nvd": {
+                "V2Vector": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+                "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "V2Score": 7.2,
+                "V3Score": 7.8
+              },
+              "redhat": {
+                "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "V3Score": 7.8
+              }
+            },
+            "References": [
+              "http://packetstormsecurity.com/files/155498/Bash-5.0-Patch-11-Privilege-Escalation.html",
+              "https://access.redhat.com/security/cve/CVE-2019-18276",
+              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18276",
+              "https://github.com/bminor/bash/commit/951bdaad7a18cc0dc1036bba86b18b90874d39ff",
+              "https://linux.oracle.com/cve/CVE-2019-18276.html",
+              "https://linux.oracle.com/errata/ELSA-2021-1679.html",
+              "https://lists.apache.org/thread.html/rf9fa47ab66495c78bb4120b0754dd9531ca2ff0430f6685ac9b07772%40%3Cdev.mina.apache.org%3E",
+              "https://nvd.nist.gov/vuln/detail/CVE-2019-18276",
+              "https://security.gentoo.org/glsa/202105-34",
+              "https://security.netapp.com/advisory/ntap-20200430-0003/",
+              "https://ubuntu.com/security/notices/USN-5380-1",
+              "https://www.cve.org/CVERecord?id=CVE-2019-18276",
+              "https://www.oracle.com/security-alerts/cpuapr2022.html",
+              "https://www.youtube.com/watch?v=-wGtxJ8opa8"
+            ],
+            "PublishedDate": "2019-11-28T01:15:10.603Z",
+            "LastModifiedDate": "2023-11-07T03:06:25.3Z"
+          },
+          {
+            "VulnerabilityID": "TEMP-0841856-B18BAF",
+            "PkgID": "bash@5.0-4",
+            "PkgName": "bash",
+            "InstalledVersion": "5.0-4",
+            "Status": "affected",
+            "Layer": {
+              "DiffID": "sha256:b2dba74777543b60e1a5be6da44e67659f51b8df1e96922205a5dde6b92dda3c"
+            },
+            "SeveritySource": "debian",
+            "PrimaryURL": "https://security-tracker.debian.org/tracker/TEMP-0841856-B18BAF",
+            "DataSource": {
+              "ID": "debian",
+              "Name": "Debian Security Tracker",
+              "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+            },
+            "Title": "[Privilege escalation possible to other user than root]",
+            "Severity": "LOW",
+            "VendorSeverity": {
+              "debian": 1
+            }
+          },
+          {
+            "VulnerabilityID": "CVE-2018-1000876",
+            "PkgID": "binutils@2.31.1-16",
+            "PkgName": "binutils",
+            "InstalledVersion": "2.31.1-16",
+            "Status": "fixed",
+            "Layer": {
+              "DiffID": "sha256:e01a454893a9a11115c598e5dec158ded8bd41326046c993c81b76b6a963590b"
+            },
+            "SeveritySource": "debian",
+            "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-1000876",
+            "DataSource": {
+              "ID": "debian",
+              "Name": "Debian Security Tracker",
+              "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+            },
+            "Title": "integer overflow leads to heap-based buffer overflow in objdump",
+            "Description": "binutils version 2.32 and earlier contains a Integer Overflow vulnerability in objdump, bfd_get_dynamic_reloc_upper_bound,bfd_canonicalize_dynamic_reloc that can result in Integer overflow trigger heap overflow. Successful exploitation allows execution of arbitrary code.. This attack appear to be exploitable via Local. This vulnerability appears to have been fixed in after commit 3a551c7a1b80fca579461774860574eabfd7f18f.",
+            "Severity": "LOW",
+            "CweIDs": [
+              "CWE-190",
+              "CWE-787"
+            ],
+            "VendorSeverity": {
+              "amazon": 2,
+              "debian": 1,
+              "nvd": 3,
+              "oracle-oval": 2,
+              "photon": 3,
+              "redhat": 2,
+              "ubuntu": 1
+            },
+            "CVSS": {
+              "nvd": {
+                "V2Vector": "AV:L/AC:L/Au:N/C:P/I:P/A:P",
+                "V3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "V2Score": 4.6,
+                "V3Score": 7.8
+              },
+              "redhat": {
+                "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "V3Score": 7.8
+              }
+            },
+            "References": [
+              "http://lists.opensuse.org/opensuse-security-announce/2019-10/msg00072.html",
+              "http://lists.opensuse.org/opensuse-security-announce/2019-11/msg00008.html",
+              "http://www.securityfocus.com/bid/106304",
+              "https://access.redhat.com/errata/RHSA-2019:2075",
+              "https://access.redhat.com/security/cve/CVE-2018-1000876",
+              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000876",
+              "https://linux.oracle.com/cve/CVE-2018-1000876.html",
+              "https://linux.oracle.com/errata/ELSA-2019-2075.html",
+              "https://nvd.nist.gov/vuln/detail/CVE-2018-1000876",
+              "https://sourceware.org/bugzilla/show_bug.cgi?id=23994",
+              "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git%3Bh=3a551c7a1b80fca579461774860574eabfd7f18f",
+              "https://ubuntu.com/security/notices/USN-4336-1",
+              "https://ubuntu.com/security/notices/USN-4336-2",
+              "https://usn.ubuntu.com/4336-1/",
+              "https://www.cve.org/CVERecord?id=CVE-2018-1000876"
+            ],
+            "PublishedDate": "2018-12-20T17:29:01.033Z",
+            "LastModifiedDate": "2023-11-07T02:51:14.47Z"
+          },
+          {
+            "VulnerabilityID": "CVE-2018-12697",
+            "PkgID": "binutils@2.31.1-16",
+            "PkgName": "binutils",
+            "InstalledVersion": "2.31.1-16",
+            "Status": "under_investigation",
+            "Layer": {
+              "DiffID": "sha256:e01a454893a9a11115c598e5dec158ded8bd41326046c993c81b76b6a963590b"
+            },
+            "SeveritySource": "debian",
+            "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-12697",
+            "DataSource": {
+              "ID": "debian",
+              "Name": "Debian Security Tracker",
+              "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+            },
+            "Title": "binutils: NULL pointer dereference in work_stuff_copy_to_from in cplus-dem.c.",
+            "Description": "A NULL pointer dereference (aka SEGV on unknown address 0x000000000000) was discovered in work_stuff_copy_to_from in cplus-dem.c in GNU libiberty, as distributed in GNU Binutils 2.30. This can occur during execution of objdump.",
+            "Severity": "LOW",
+            "CweIDs": [
+              "CWE-476"
+            ],
+            "VendorSeverity": {
+              "amazon": 2,
+              "debian": 1,
+              "nvd": 3,
+              "oracle-oval": 2,
+              "photon": 3,
+              "redhat": 1,
+              "ubuntu": 1
+            },
+            "CVSS": {
+              "nvd": {
+                "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+                "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "V2Score": 5,
+                "V3Score": 7.5
+              },
+              "redhat": {
+                "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+                "V3Score": 3.3
+              }
+            },
+            "References": [
+              "http://www.securityfocus.com/bid/104538",
+              "https://access.redhat.com/errata/RHSA-2019:2075",
+              "https://access.redhat.com/security/cve/CVE-2018-12697",
+              "https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/1763102",
+              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12697",
+              "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85454",
+              "https://linux.oracle.com/cve/CVE-2018-12697.html",
+              "https://linux.oracle.com/errata/ELSA-2019-2075.html",
+              "https://nvd.nist.gov/vuln/detail/CVE-2018-12697",
+              "https://security.gentoo.org/glsa/201908-01",
+              "https://sourceware.org/bugzilla/show_bug.cgi?id=23057",
+              "https://ubuntu.com/security/notices/USN-4326-1",
+              "https://ubuntu.com/security/notices/USN-4336-1",
+              "https://ubuntu.com/security/notices/USN-4336-2",
+              "https://usn.ubuntu.com/4326-1/",
+              "https://usn.ubuntu.com/4336-1/",
+              "https://www.cve.org/CVERecord?id=CVE-2018-12697"
+            ],
+            "PublishedDate": "2018-06-23T23:29:00.22Z",
+            "LastModifiedDate": "2019-08-03T13:15:17.257Z"
+          },
+          {
+            "VulnerabilityID": "CVE-2018-12698",
+            "PkgID": "binutils@2.31.1-16",
+            "PkgName": "binutils",
+            "InstalledVersion": "2.31.1-16",
+            "Status": "will_not_fix",
+            "Layer": {
+              "DiffID": "sha256:e01a454893a9a11115c598e5dec158ded8bd41326046c993c81b76b6a963590b"
+            },
+            "SeveritySource": "debian",
+            "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-12698",
+            "DataSource": {
+              "ID": "debian",
+              "Name": "Debian Security Tracker",
+              "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+            },
+            "Title": "binutils: excessive memory consumption in demangle_template in cplus-dem.c",
+            "Description": "demangle_template in cplus-dem.c in GNU libiberty, as distributed in GNU Binutils 2.30, allows attackers to trigger excessive memory consumption (aka OOM) during the \"Create an array for saving the template argument values\" XNEWVEC call. This can occur during execution of objdump.",
+            "Severity": "LOW",
+            "VendorSeverity": {
+              "debian": 1,
+              "nvd": 3,
+              "photon": 3,
+              "redhat": 1,
+              "ubuntu": 1
+            },
+            "CVSS": {
+              "nvd": {
+                "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+                "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "V2Score": 5,
+                "V3Score": 7.5
+              },
+              "redhat": {
+                "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+                "V3Score": 3.3
+              }
+            },
+            "References": [
+              "http://www.securityfocus.com/bid/104539",
+              "https://access.redhat.com/security/cve/CVE-2018-12698",
+              "https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/1763102",
+              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12698",
+              "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85454",
+              "https://nvd.nist.gov/vuln/detail/CVE-2018-12698",
+              "https://security.gentoo.org/glsa/201908-01",
+              "https://sourceware.org/bugzilla/show_bug.cgi?id=23057",
+              "https://ubuntu.com/security/notices/USN-4326-1",
+              "https://ubuntu.com/security/notices/USN-4336-1",
+              "https://ubuntu.com/security/notices/USN-4336-2",
+              "https://usn.ubuntu.com/4326-1/",
+              "https://usn.ubuntu.com/4336-1/",
+              "https://www.cve.org/CVERecord?id=CVE-2018-12698"
+            ],
+            "PublishedDate": "2018-06-23T23:29:00.283Z",
+            "LastModifiedDate": "2019-10-03T00:03:26.223Z"
+          },
+          {
+            "VulnerabilityID": "CVE-2018-12699",
+            "PkgID": "binutils@2.31.1-16",
+            "PkgName": "binutils",
+            "InstalledVersion": "2.31.1-16",
+            "Status": "fix_deferred",
+            "Layer": {
+              "DiffID": "sha256:e01a454893a9a11115c598e5dec158ded8bd41326046c993c81b76b6a963590b"
+            },
+            "SeveritySource": "debian",
+            "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-12699",
+            "DataSource": {
+              "ID": "debian",
+              "Name": "Debian Security Tracker",
+              "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+            },
+            "Title": "binutils: heap-based buffer overflow in finish_stab in stabs.c",
+            "Description": "finish_stab in stabs.c in GNU Binutils 2.30 allows attackers to cause a denial of service (heap-based buffer overflow) or possibly have unspecified other impact, as demonstrated by an out-of-bounds write of 8 bytes. This can occur during execution of objdump.",
+            "Severity": "LOW",
+            "CweIDs": [
+              "CWE-787"
+            ],
+            "VendorSeverity": {
+              "debian": 1,
+              "nvd": 4,
+              "photon": 4,
+              "redhat": 1,
+              "ubuntu": 1
+            },
+            "CVSS": {
+              "nvd": {
+                "V2Vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "V2Score": 7.5,
+                "V3Score": 9.8
+              },
+              "redhat": {
+                "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L",
+                "V3Score": 3.3
+              }
+            },
+            "References": [
+              "http://www.securityfocus.com/bid/104540",
+              "https://access.redhat.com/security/cve/CVE-2018-12699",
+              "https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/1763102",
+              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12699",
+              "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85454",
+              "https://nvd.nist.gov/vuln/detail/CVE-2018-12699",
+              "https://security.gentoo.org/glsa/201908-01",
+              "https://sourceware.org/bugzilla/show_bug.cgi?id=23057",
+              "https://ubuntu.com/security/notices/USN-4336-1",
+              "https://ubuntu.com/security/notices/USN-4336-2",
+              "https://usn.ubuntu.com/4336-1/",
+              "https://www.cve.org/CVERecord?id=CVE-2018-12699"
+            ],
+            "PublishedDate": "2018-06-23T23:29:00.33Z",
+            "LastModifiedDate": "2019-08-03T13:15:17.587Z"
+          },
+          {
+            "VulnerabilityID": "CVE-2018-12934",
+            "PkgID": "binutils@2.31.1-16",
+            "PkgName": "binutils",
+            "InstalledVersion": "2.31.1-16",
+            "Status": "end_of_life",
+            "Layer": {
+              "DiffID": "sha256:e01a454893a9a11115c598e5dec158ded8bd41326046c993c81b76b6a963590b"
+            },
+            "SeveritySource": "debian",
+            "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2018-12934",
+            "DataSource": {
+              "ID": "debian",
+              "Name": "Debian Security Tracker",
+              "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+            },
+            "Title": "binutils: Uncontrolled Resource Consumption in remember_Ktype in cplus-dem.c",
+            "Description": "remember_Ktype in cplus-dem.c in GNU libiberty, as distributed in GNU Binutils 2.30, allows attackers to trigger excessive memory consumption (aka OOM). This can occur during execution of cxxfilt.",
+            "Severity": "LOW",
+            "CweIDs": [
+              "CWE-770"
+            ],
+            "VendorSeverity": {
+              "debian": 1,
+              "nvd": 3,
+              "photon": 3,
+              "redhat": 1,
+              "ubuntu": 1
+            },
+            "CVSS": {
+              "nvd": {
+                "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:P",
+                "V3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "V2Score": 5,
+                "V3Score": 7.5
+              },
+              "redhat": {
+                "V3Vector": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+                "V3Score": 5.5
+              }
+            },
+            "References": [
+              "https://access.redhat.com/security/cve/CVE-2018-12934",
+              "https://bugs.launchpad.net/ubuntu/+source/binutils/+bug/1763101",
+              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12934",
+              "https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85453",
+              "https://nvd.nist.gov/vuln/detail/CVE-2018-12934",
+              "https://sourceware.org/bugzilla/show_bug.cgi?id=23059",
+              "https://ubuntu.com/security/notices/USN-4326-1",
+              "https://ubuntu.com/security/notices/USN-4336-1",
+              "https://ubuntu.com/security/notices/USN-4336-2",
+              "https://usn.ubuntu.com/4326-1/",
+              "https://usn.ubuntu.com/4336-1/",
+              "https://www.cve.org/CVERecord?id=CVE-2018-12934"
+            ],
+            "PublishedDate": "2018-06-28T14:29:00.683Z",
+            "LastModifiedDate": "2020-04-21T22:15:13.15Z"
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -230,3 +230,73 @@ Number  Content
             parser = TrivyParser()
             findings = parser.get_findings(test_file, Test())
             self.assertEqual(len(findings), 37)
+
+    def test_all_statuses(self):
+        with sample_path("all_statuses.json").open(encoding="utf-8") as test_file:
+            parser = TrivyParser()
+            findings = parser.get_findings(test_file, Test())
+            self.assertEqual(len(findings), 8)
+
+            with self.subTest("unknown"):
+                finding = findings[0]
+                self.assertEqual(True, finding.active)
+                self.assertEqual(False, finding.verified)
+                self.assertEqual(False, finding.false_p)
+                self.assertEqual(False, finding.out_of_scope)
+                self.assertEqual(False, finding.is_mitigated)
+
+            with self.subTest("not_affected"):
+                finding = findings[1]
+                self.assertEqual(False, finding.active)
+                self.assertEqual(True, finding.verified)
+                self.assertEqual(True, finding.false_p)
+                self.assertEqual(False, finding.out_of_scope)
+                self.assertEqual(True, finding.is_mitigated)
+
+            with self.subTest("affected"):
+                finding = findings[2]
+                self.assertEqual(True, finding.active)
+                self.assertEqual(True, finding.verified)
+                self.assertEqual(False, finding.false_p)
+                self.assertEqual(False, finding.out_of_scope)
+                self.assertEqual(False, finding.is_mitigated)
+
+            with self.subTest("fixed"):
+                finding = findings[3]
+                self.assertEqual(True, finding.active)
+                self.assertEqual(True, finding.verified)
+                self.assertEqual(False, finding.false_p)
+                self.assertEqual(False, finding.out_of_scope)
+                self.assertEqual(False, finding.is_mitigated)
+
+            with self.subTest("under_investigation"):
+                finding = findings[4]
+                self.assertEqual(True, finding.active)
+                self.assertEqual(False, finding.verified)
+                self.assertEqual(False, finding.false_p)
+                self.assertEqual(False, finding.out_of_scope)
+                self.assertEqual(False, finding.is_mitigated)
+
+            with self.subTest("will_not_fix"):
+                finding = findings[5]
+                self.assertEqual(True, finding.active)
+                self.assertEqual(True, finding.verified)
+                self.assertEqual(False, finding.false_p)
+                self.assertEqual(False, finding.out_of_scope)
+                self.assertEqual(False, finding.is_mitigated)
+
+            with self.subTest("fix_deferred"):
+                finding = findings[6]
+                self.assertEqual(True, finding.active)
+                self.assertEqual(True, finding.verified)
+                self.assertEqual(False, finding.false_p)
+                self.assertEqual(False, finding.out_of_scope)
+                self.assertEqual(False, finding.is_mitigated)
+
+            with self.subTest("end_of_life"):
+                finding = findings[7]
+                self.assertEqual(True, finding.active)
+                self.assertEqual(True, finding.verified)
+                self.assertEqual(False, finding.false_p)
+                self.assertEqual(False, finding.out_of_scope)
+                self.assertEqual(False, finding.is_mitigated)

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -249,7 +249,7 @@ Number  Content
                 finding = findings[1]
                 self.assertEqual(False, finding.active)
                 self.assertEqual(True, finding.verified)
-                self.assertEqual(True, finding.false_p)
+                self.assertEqual(False, finding.false_p)
                 self.assertEqual(False, finding.out_of_scope)
                 self.assertEqual(True, finding.is_mitigated)
 


### PR DESCRIPTION
Trivy has a "status" field for triaging which is currently unmapped:
"status": "affected" or "not_affected" or "fix_deferred" or "will_not_fix"

This would be useful information to handle.

see: https://trivy.dev/latest/docs/configuration/filtering/


"Affected": the package is affected by the flaw on this platform
"Not affected": the package, which ships on this platform, is not affected by the flaw
"Fix deferred": the package is affected by the flaw on this platform, and may be fixed in the future
"Under investigation": it is currently unknown whether the flaw affects the package on this platform, and is under investigation
"Will not fix": the package is affected by the flaw on this platform, but there is no current intention to fix it (primarily for flaws that are of Low or Moderate impact that pose no significant risk to customers)​

This PR stores the Trivy `status` value in the `Impact` field.

It also tries to map the `status`  to Defect Dojo status flags. This is not trivial as the `status` of the vulnerability in the Trivy report is set by the OS/Package vendor. If they state `will_not_fix` it doesn't automatically mean Defect Dojo needs to close the finding on import.

The ` trivy.md`  file in this PR contains a table with status flag mappings.

[sc-11484]