### PR TITLE
twistlock json: safely get fields

### DIFF
--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -149,23 +149,23 @@ def get_item(vulnerability, test):
 
     # create the finding object
     finding = Finding(
-        title=vulnerability["id"]
+        title=vulnerability.get("id", "Unknown Vulnerability")
         + ": "
-        + vulnerability["packageName"]
+        + vulnerability.get("packageName", "Unknown Package")
         + " - "
-        + vulnerability["packageVersion"],
+        + str(vulnerability.get("packageVersion", "")),
         test=test,
         severity=severity,
-        description=vulnerability["description"]
+        description=vulnerability.get("description", "")
         + "<p> Vulnerable Package: "
-        + vulnerability["packageName"]
+        + vulnerability.get("packageName", "")
         + "</p><p> Current Version: "
-        + str(vulnerability["packageVersion"])
+        + str(vulnerability.get("packageVersion", ""))
         + "</p>",
-        mitigation=status.title(),
+        mitigation=status.title() if isinstance(status, str) else "",
         references=vulnerability.get("link"),
-        component_name=vulnerability["packageName"],
-        component_version=vulnerability["packageVersion"],
+        component_name=vulnerability.get("packageName", ""),
+        component_version=vulnerability.get("packageVersion", ""),
         false_p=False,
         duplicate=False,
         out_of_scope=False,
@@ -173,7 +173,7 @@ def get_item(vulnerability, test):
         severity_justification=f"{vector} (CVSS v3 base score: {cvss})\n\n{riskFactors}",
         impact=severity,
     )
-    finding.unsaved_vulnerability_ids = [vulnerability["id"]]
+    finding.unsaved_vulnerability_ids = [vulnerability["id"]] if "id" in vulnerability else None
     finding.description = finding.description.strip()
 
     return finding

--- a/unittests/scans/twistlock/one_vuln_no_link_no_description.json
+++ b/unittests/scans/twistlock/one_vuln_no_link_no_description.json
@@ -21,7 +21,6 @@
                 {
                     "id": "PRISMA-2021-0013",
                     "status": "fixed in 1.1.1",
-                    "description": "marked package prior to 1.1.1 are vulnerable to  Regular Expression Denial of Service (ReDoS). The regex within src/rules.js file have multiple unused capture groups which could lead to a denial of service attack if user input is reachable.  Origin: https://github.com/markedjs/marked/commit/bd4f8c464befad2b304d51e33e89e567326e62e0",
                     "severity": "medium",
                     "packageName": "marked",
                     "packageVersion": "0.3.9",

--- a/unittests/tools/test_twistlock_parser.py
+++ b/unittests/tools/test_twistlock_parser.py
@@ -20,8 +20,8 @@ class TestTwistlockParser(DojoTestCase):
         self.assertEqual(1, len(findings[0].unsaved_vulnerability_ids))
         self.assertEqual("CVE-2013-7459", findings[0].unsaved_vulnerability_ids[0])
 
-    def test_parse_file_with_no_link(self):
-        testfile = (get_unit_tests_scans_path("twistlock") / "one_vuln_no_link.json").open(encoding="utf-8")
+    def test_parse_file_with_no_link_no_description(self):
+        testfile = (get_unit_tests_scans_path("twistlock") / "one_vuln_no_link_no_description.json").open(encoding="utf-8")
         parser = TwistlockParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()


### PR DESCRIPTION
Make the twistlock parser safer by not directly referencing dict entries, fixes #12694