### PR TITLE
integration tests: sync suite between GHA and entrypoint

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,10 +31,17 @@ jobs:
           "tests/search_test.py",
           "tests/file_test.py",
           "tests/dedupe_test.py",
+          "tests/announcement_banner_test.py",
+          "tests/close_old_findings_dedupe_test.py",
+          "tests/close_old_findings_test.py",
+          "tests/false_positive_history_test.py",
           "tests/check_various_pages.py",
+          # "tests/import_scanner_test.py",
+          # "tests/zap.py",
           "tests/notifications_test.py",
           "tests/tool_config.py",
           "openapi-validatator",
+
         ]
         os: [alpine, debian]
       fail-fast: false

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -288,6 +288,14 @@ else
     #     echo "Error: Zap integration test failed"; exit 1
     # fi
 
+    test="Notifications tests"
+    echo "Running: $test"
+    if python3 tests/notifications_test.py ; then
+        success "$test"
+    else
+        fail "$test"
+    fi
+
     test="Tool Config integration tests"
     echo "Running: $test"
     if python3 tests/tool_config.py ; then


### PR DESCRIPTION
I noticed the integration test suite in GHA and the container entrypoint were slightly out of sync.