### PR TITLE
finding groups: filter by product if applicable

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1975,6 +1975,7 @@ class FindingFilter(FindingFilterHelper, FindingTagFilter):
         self.set_related_object_fields(*args, **kwargs)
 
     def set_related_object_fields(self, *args: list, **kwargs: dict):
+        finding_group_query = Finding_Group.objects.all()
         if self.pid is not None:
             del self.form.fields["test__engagement__product"]
             del self.form.fields["test__engagement__product__prod_type"]
@@ -1983,6 +1984,7 @@ class FindingFilter(FindingFilterHelper, FindingTagFilter):
                 product_id=self.pid,
             ).all()
             self.form.fields["test"].queryset = get_authorized_tests(Permissions.Test_View, product=self.pid).prefetch_related("test_type")
+            finding_group_query = Finding_Group.objects.filter(test__engagement__product_id=self.pid)
         else:
             self.form.fields[
                 "test__engagement__product__prod_type"].queryset = get_authorized_product_types(Permissions.Product_Type_View)
@@ -1992,7 +1994,7 @@ class FindingFilter(FindingFilterHelper, FindingTagFilter):
         if self.form.fields.get("test__engagement__product"):
             self.form.fields["test__engagement__product"].queryset = get_authorized_products(Permissions.Product_View)
         if self.form.fields.get("finding_group", None):
-            self.form.fields["finding_group"].queryset = get_authorized_finding_groups(Permissions.Finding_Group_View)
+            self.form.fields["finding_group"].queryset = get_authorized_finding_groups(Permissions.Finding_Group_View, queryset=finding_group_query)
         self.form.fields["reporter"].queryset = get_authorized_users(Permissions.Finding_View)
         self.form.fields["reviewers"].queryset = self.form.fields["reporter"].queryset
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -150,7 +150,7 @@ class ViewTest(View):
         findings = Finding.objects.filter(test=test).order_by("numerical_severity")
         filter_string_matching = get_system_setting("filter_string_matching", False)
         finding_filter_class = FindingFilterWithoutObjectLookups if filter_string_matching else FindingFilter
-        findings = finding_filter_class(request.GET, queryset=findings)
+        findings = finding_filter_class(request.GET, pid=test.engagement.product.id, queryset=findings)
         paged_findings = get_page_items_and_count(request, prefetch_for_findings(findings.qs), 25, prefix="findings")
 
         return {


### PR DESCRIPTION
Partly fixes: #10268

This PR limits the list of Finding Group options in the Finding Filter to those groups that belong to the Product the user is viewing.
This also applies to when viewing findings by Test or by Enagement. In that case Finding Groups from the whole product will be shown. This is because currently the FindingFilter class is not aware of which Engagement or Test is being viewed. It only has the Product as context via `self.pid`. I didn't want to refactor too many things and I think limiting the list to the Product context is already a good improvement.