### PR TITLE
post processing: check for finding being None

### DIFF
--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -106,7 +106,7 @@ def dojo_model_from_id(_func=None, *, model=Finding, parameter=0):
                     try:
                         instance = model.objects.get(id=model_or_id)
                     except model.DoesNotExist:
-                        logger.debug("error instantiating model_or_id: %s for model: %s: DoesNotExist", model_or_id, model)
+                        logger.warning("error instantiating model_or_id: %s for model: %s: DoesNotExist", model_or_id, model)
                         instance = None
                     args = list(args)
                     args[parameter] = instance

--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -351,6 +351,10 @@ def add_findings_to_auto_group(name, findings, group_by, *, create_finding_group
 def post_process_finding_save(finding, dedupe_option=True, rules_option=True, product_grading_option=True,  # noqa: FBT002
              issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):  # noqa: FBT002 - this is bit hard to fix nice have this universally fixed
 
+    if not finding:
+        logger.warning("post_process_finding_save called with finding==None, skipping post processing")
+        return
+
     system_settings = System_Settings.objects.get()
 
     # STEP 1 run all status changing tasks sequentially to avoid race conditions


### PR DESCRIPTION
Fixes #11958 

Sometimes during unit tests we see that the `finding` is already deleted once the `post_process_finding_save` is being executed.
This can also happen in real life if a finding is deleted manually or by the duplicate delete job.
This PR add a check so that the logs aren't polluted with stacktraces. There is still logging at the `warning` level as it's not 100% expected/intended to have this happening.