### PR TITLE
jira: truncate description if max length exceeded

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -648,7 +648,7 @@ def jira_description(obj, **kwargs):
 
     description = render_to_string(template, kwargs)
     defect_dojo_obj_url = get_full_url(obj.get_absolute_url())
-    max_length = getattr(settings, "JIRA_DESCRIPTION_MAX_LENGTH", 32768)
+    max_length = getattr(settings, "JIRA_DESCRIPTION_MAX_LENGTH", 32767)
     suffix = f"\n\nIssue Description Too Long: See [DefectDojo|{defect_dojo_obj_url}] for full description."
     if len(description) > max_length:
         # suffix can be longer after rendering do to urlenocoding, so we take twice the length of the suffix as a buffer

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -226,7 +226,7 @@ env = environ.FileAwareEnv(
     DD_MAX_REQRESP_FROM_API=(int, -1),
     DD_MAX_AUTOCOMPLETE_WORDS=(int, 20000),
     DD_JIRA_SSL_VERIFY=(bool, True),
-    DD_JIRA_DESCRIPTION_MAX_LENGTH=(int, 32768),
+    DD_JIRA_DESCRIPTION_MAX_LENGTH=(int, 32767),
     # When interacting with jira tickets that attached finding groups, we should no be opening any findings
     # on the DefectDojo side because jira has no way of knowing if a finding really should be reopened or not
     DD_JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN=(bool, False),


### PR DESCRIPTION
Fixes #6668 and [sc-11551]

JIRA has a max length of `32768` for the `description` field. This PR truncates accordingly and provides a hint to check the full description in JIRA (and links to the finding) in JIRA.

Example with 50.000 'A' characters added to the description as a test of what it looks like:

![image](https://github.com/user-attachments/assets/5b9abd59-0262-4dbd-9d4d-158bde96a5b6)
