### PR TITLE
add option to group findings by `vuln_id_from_tool`

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -255,6 +255,9 @@ def get_group_by_group_name(finding, finding_group_by_option):
             group_name = f"Filepath {finding.file_path}"
     elif finding_group_by_option == "finding_title":
         group_name = finding.title
+    elif finding_group_by_option == "vuln_id_from_tool":
+        if finding.vuln_id_from_tool:
+            group_name = f"Vulnerability ID {finding.vuln_id_from_tool}" if finding.vuln_id_from_tool else "None"
     else:
         msg = f"Invalid group_by option {finding_group_by_option}"
         raise ValueError(msg)

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3433,7 +3433,8 @@ class Finding_Group(TimeStampedModel):
     GROUP_BY_OPTIONS = [("component_name", "Component Name"),
                         ("component_name+component_version", "Component Name + Version"),
                         ("file_path", "File path"),
-                        ("finding_title", "Finding Title")]
+                        ("finding_title", "Finding Title"),
+                        ("vuln_id_from_tool", "Vulnerability ID from Tool")]
 
     name = models.CharField(max_length=255, blank=False, null=False)
     test = models.ForeignKey(Test, on_delete=models.CASCADE)


### PR DESCRIPTION
based  on #12684
In this PR we're adding grouping by the vuln_id_from_tool field, as suggested in the discussion, as a viable static option for the grouping dropdown.