### PR TITLE
add risk acceptance: display more fields in findings dropdown 

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -1243,11 +1243,14 @@ def add_risk_acceptance(request, eid, fid=None):
         risk_acceptance_title_suggestion = f"Accept: {finding}"
         form = RiskAcceptanceForm(initial={"owner": request.user, "name": risk_acceptance_title_suggestion})
 
-    finding_choices = Finding.objects.filter(duplicate=False, test__engagement=eng).filter(NOT_ACCEPTED_FINDINGS_QUERY).order_by("title")
+    finding_choices = Finding.objects.filter(duplicate=False, test__engagement=eng).filter(NOT_ACCEPTED_FINDINGS_QUERY).prefetch_related("test", "finding_group_set").order_by("test__id", "numerical_severity", "title")
 
     form.fields["accepted_findings"].queryset = finding_choices
     if fid:
+        # Set the initial selected finding
         form.fields["accepted_findings"].initial = {fid}
+        # Change the label for each finding in the dropdown
+        form.fields["accepted_findings"].label_from_instance = lambda obj: f"({obj.test.scan_type}) - ({obj.severity}) - {obj.title} - {obj.date} - {obj.status()} - {obj.finding_group})"
     product_tab = Product_Tab(eng.product, title="Risk Acceptance", tab="engagements")
     product_tab.setEngagement(eng)
 


### PR DESCRIPTION
When adding a Risk Acceptance, the dropdown used to select findings only displays the finding title. But all findings from the engagement are in there making it sometimes hard to select the correct findings.

This PR displays some more fields in the dropdown:
- Test scan_Type
- Severity
- Title
- Status
- Date
- Finding Group

It also orders the findings by Test, Severity, Title.

The Add Risk Acceptance page is in need of an improvement to use a proper tabel with bulk select, but this PR is a low hanging fruit until that bigger change it implemented.


![image](https://github.com/user-attachments/assets/b45ab345-7b5b-4991-b597-433b3ff4955f)
