### PR TITLE
Bug Fix: improve Kiuwan SCA parser to support multi component findings

### DIFF
--- a/dojo/tools/kiuwan_sca/parser.py
+++ b/dojo/tools/kiuwan_sca/parser.py
@@ -1,7 +1,10 @@
 import hashlib
 import json
+import logging
 
 from dojo.models import Finding
+
+logger = logging.getLogger(__name__)
 
 __author__ = "mwager"
 
@@ -37,50 +40,53 @@ class KiuwanSCAParser:
             if row["muted"] is True:
                 continue
 
-            finding = Finding(test=test)
-            finding.unique_id_from_tool = row["id"]
-            finding.cve = row["cve"]
-            finding.description = row["description"]
-            finding.severity = self.SEVERITY[row["securityRisk"]]
+            components = row.get("components", [])
+            if not components:
+                logger.warning("WARNING: Insights Finding from kiuwan does not have a related component - Skipping.")
+                continue
 
-            if "components" in row and len(row["components"]) > 0:
-                finding.component_name = row["components"][0]["artifact"]
-                finding.component_version = row["components"][0]["version"]
-                finding.title = finding.component_name + " v" + str(finding.component_version)
+            # We want one unique finding in DD for each component affected:
+            for component in components:
+                finding = Finding(test=test)
+                finding.unique_id_from_tool = row["id"]
+                finding.cve = row["cve"]
+                finding.description = row["description"]
+                finding.severity = self.SEVERITY[row["securityRisk"]]
 
-            if not finding.title:
-                finding.title = row["cve"]
+                finding.component_name = component.get("artifact", "Unknown")
+                finding.component_version = component.get("version", "Unknown")
+                finding.title = f"{finding.component_name} v{finding.component_version}"
 
-            if "cwe" in row and "CWE-" in row["cwe"]:
-                finding.cwe = int(row["cwe"].replace("CWE-", ""))
+                if "cwe" in row and "CWE-" in row["cwe"]:
+                    finding.cwe = int(row["cwe"].replace("CWE-", ""))
 
-            if "epss_score" in row:
-                finding.epss_score = row["epss_score"]
-            if "epss_percentile" in row:
-                finding.epss_percentile = row["epss_percentile"]
+                if "epss_score" in row:
+                    finding.epss_score = row["epss_score"]
+                if "epss_percentile" in row:
+                    finding.epss_percentile = row["epss_percentile"]
 
-            if "cVSSv3BaseScore" in row:
-                finding.cvssv3_score = float(row["cVSSv3BaseScore"])
+                if "cVSSv3BaseScore" in row:
+                    finding.cvssv3_score = float(row["cVSSv3BaseScore"])
 
-            finding.references = "See Kiuwan Web UI"
-            finding.mitigation = "See Kiuwan Web UI"
-            finding.static_finding = True
+                finding.references = "See Kiuwan Web UI"
+                finding.mitigation = "See Kiuwan Web UI"
+                finding.static_finding = True
 
-            key = hashlib.sha256(
-                (
-                    finding.description
-                    + "|"
-                    + finding.severity
-                    + "|"
-                    + finding.component_name
-                    + "|"
-                    + finding.component_version
-                    + "|"
-                    + str(finding.cwe)
-                ).encode("utf-8"),
-            ).hexdigest()
+                key = hashlib.sha256(
+                    (
+                        finding.description
+                        + "|"
+                        + finding.severity
+                        + "|"
+                        + finding.component_name
+                        + "|"
+                        + finding.component_version
+                        + "|"
+                        + str(finding.cwe)
+                    ).encode("utf-8"),
+                ).hexdigest()
 
-            if key not in dupes:
-                dupes[key] = finding
+                if key not in dupes:
+                    dupes[key] = finding
 
         return list(dupes.values())


### PR DESCRIPTION
This PR enhances the Kiuwan SCA Parser by modifying the logic to create one finding per component, instead of taking only the first component from the components array.

Motivation

In the current implementation, for a given CVE from a Kiuwan SCA scan, only the first component listed is used to create a finding. However, many CVEs in Kiuwan are related to multiple components. This leads to loss of detail and incomplete representation of risks in DefectDojo.

**Test results**

- Manual test with real-world Kiuwan JSON input shows that all findings are now preserved and properly associated with the correct component.

This checklist is for your information.

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.