### PR TITLE
Consistent "Close old findings" between UI and API

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -535,13 +535,13 @@ class ImportScanForm(forms.Form):
     # If 'close_old_findings_product_scope' is selected, the backend will ensure that both flags are set.
     close_old_findings = forms.BooleanField(help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
                                                         "If service has been set, only the findings for this service will be closed. "
-                                                        "This only affects findings within the same engagement.",
-                                            label="Close old findings within this engagement",
+                                                        "This affects findings within the same engagement by default.",
+                                            label="Close old findings",
                                             required=False,
                                             initial=False)
     close_old_findings_product_scope = forms.BooleanField(help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
                                                         "If service has been set, only the findings for this service will be closed. "
-                                                        "This only affects findings within the same product.",
+                                                        "This affects findings within the same product.",
                                             label="Close old findings within this product",
                                             required=False,
                                             initial=False)


### PR DESCRIPTION
**Description**

If we look at the import scan result screen in the UI:

<img width="322" height="88" alt="image" src="https://github.com/user-attachments/assets/bf61cddd-affc-4dfb-96e0-fa7ceba9e990" />

If we look at the API description for the same fields:

<img width="1370" height="133" alt="image" src="https://github.com/user-attachments/assets/b2b704bf-49ed-4e1b-9359-1a055fa2425d" />

I found this confusing the first time I saw and it made me check the code to make sure they were setting the same fields (and they are).

This PR tries to put them in sync, by rephrasing the ones in the UI (as those seem the furthest from the actual variable intent).

I think it could be done the other way around or even switching the field to choices field (`Do not close`, `Close at engagement level`, `Close at product level`) but those would impact API consumers...

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.