### PR TITLE
view_test: use subquery for finding counts

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -95,6 +95,7 @@ from dojo.product_announcements import (
     LargeScanSizeProductAnnouncement,
     ScanTypeProductAnnouncement,
 )
+from dojo.query_utils import build_count_subquery
 from dojo.risk_acceptance.helper import prefetch_for_expiration
 from dojo.tools.factory import get_scan_types_sorted
 from dojo.user.queries import get_authorized_users
@@ -105,7 +106,6 @@ from dojo.utils import (
     add_error_message_to_response,
     add_success_message_to_response,
     async_delete,
-    build_count_subquery,
     calculate_grade,
     generate_file_response_from_file_path,
     get_cal_event,

--- a/dojo/finding/queries.py
+++ b/dojo/finding/queries.py
@@ -1,16 +1,27 @@
+import logging
+from functools import partial
+
 from crum import get_current_user
-from django.db.models import Exists, OuterRef, Q
+from django.db.models import Exists, OuterRef, Q, Value
+from django.db.models.functions import Coalesce
+from django.db.models.query import Prefetch, QuerySet
 
 from dojo.authorization.authorization import get_roles_for_permission, user_has_global_permission
 from dojo.models import (
+    IMPORT_UNTOUCHED_FINDING,
+    Endpoint_Status,
     Finding,
     Product_Group,
     Product_Member,
     Product_Type_Group,
     Product_Type_Member,
     Stub_Finding,
+    Test_Import_Finding_Action,
     Vulnerability_Id,
 )
+from dojo.query_utils import build_count_subquery
+
+logger = logging.getLogger(__name__)
 
 
 def get_authorized_groups(permission, user=None):
@@ -146,3 +157,70 @@ def get_authorized_vulnerability_ids(permission, queryset=None, user=None):
         | Q(finding__test__engagement__product__member=True)
         | Q(finding__test__engagement__product__prod_type__authorized_group=True)
         | Q(finding__test__engagement__product__authorized_group=True))
+
+
+def prefetch_for_findings(findings, prefetch_type="all", *, exclude_untouched=True):
+    """
+    Unified prefetch function for findings across the application.
+
+    Args:
+        findings: QuerySet of findings to prefetch
+        prefetch_type: "all" or "open" - controls risk acceptance prefetching
+        exclude_untouched: Whether to exclude untouched import actions
+
+    """
+    if not isinstance(findings, QuerySet):
+        logger.debug("unable to prefetch because query was already executed")
+        return findings
+
+    # Base prefetches - always needed
+    prefetched_findings = findings.prefetch_related(
+        "reviewers",
+        "jira_issue__jira_project__jira_instance",
+        "test__test_type",
+        "test__engagement__jira_project__jira_instance",
+        "test__engagement__product__jira_project_set__jira_instance",
+        "found_by",
+        "reporter",
+    )
+
+    # Conditional prefetches for non-open findings
+    if prefetch_type != "open":
+        prefetched_findings = prefetched_findings.prefetch_related(
+            "risk_acceptance_set",
+            "risk_acceptance_set__accepted_findings",
+            "original_finding",
+            "duplicate_finding",
+        )
+
+    # Import actions - configurable filtering
+    if exclude_untouched:
+        prefetched_findings = prefetched_findings.prefetch_related(
+            Prefetch(
+                "test_import_finding_action_set",
+                queryset=Test_Import_Finding_Action.objects.exclude(action=IMPORT_UNTOUCHED_FINDING),
+            ),
+        )
+    else:
+        prefetched_findings = prefetched_findings.prefetch_related("test_import_finding_action_set")
+
+    # Standard prefetches
+    prefetched_findings = prefetched_findings.prefetch_related(
+        "notes",
+        "tags",
+        "endpoints",
+        "status_finding",
+        "finding_group_set",
+        "finding_group_set__jira_issue",  # Include both variants
+        "test__engagement__product__members",
+        "test__engagement__product__prod_type__members",
+        "vulnerability_id_set",
+    )
+
+    # Endpoint counts using optimized subqueries
+    base_status = Endpoint_Status.objects.filter(finding_id=OuterRef("pk"))
+    count_subquery = partial(build_count_subquery, group_field="finding_id")
+    return prefetched_findings.annotate(
+        active_endpoint_count=Coalesce(count_subquery(base_status.filter(mitigated=False)), Value(0)),
+        mitigated_endpoint_count=Coalesce(count_subquery(base_status.filter(mitigated=True)), Value(0)),
+    )

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -13,7 +13,7 @@ from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.authorization.authorization_decorators import user_is_authorized
 from dojo.authorization.roles_permissions import Permissions
 from dojo.filters import FindingFilter, FindingFilterWithoutObjectLookups
-from dojo.finding.views import prefetch_for_findings
+from dojo.finding.queries import prefetch_for_findings
 from dojo.forms import DeleteFindingGroupForm, EditFindingGroupForm, FindingBulkUpdateForm
 from dojo.models import Engagement, Finding, Finding_Group, GITHUB_PKey, Product
 from dojo.utils import Product_Tab, add_breadcrumb, get_page_items, get_setting, get_system_setting, get_words_for_field

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -107,6 +107,7 @@ from dojo.product_type.queries import (
     get_authorized_members_for_product_type,
     get_authorized_product_types,
 )
+from dojo.query_utils import build_count_subquery
 from dojo.templatetags.display_tags import asvs_calc_level
 from dojo.tool_config.factory import create_API
 from dojo.tools.factory import get_api_scan_configuration_hints
@@ -117,7 +118,6 @@ from dojo.utils import (
     add_external_issue,
     add_field_errors_to_response,
     async_delete,
-    build_count_subquery,
     calculate_finding_age,
     get_enabled_notifications_list,
     get_open_findings_burndown,

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -35,10 +35,10 @@ from dojo.product_type.queries import (
     get_authorized_members_for_product_type,
     get_authorized_product_types,
 )
+from dojo.query_utils import build_count_subquery
 from dojo.utils import (
     add_breadcrumb,
     async_delete,
-    build_count_subquery,
     get_page_items,
     get_setting,
     get_system_setting,

--- a/dojo/query_utils.py
+++ b/dojo/query_utils.py
@@ -1,0 +1,10 @@
+from django.db.models import Count, IntegerField, Subquery
+from django.db.models.query import QuerySet
+
+
+def build_count_subquery(model_qs: QuerySet, group_field: str) -> Subquery:
+    """Return a Subquery that yields one aggregated count per `group_field`."""
+    return Subquery(
+        model_qs.values(group_field).annotate(c=Count("*")).values("c")[:1],  # one row per group_field
+        output_field=IntegerField(),
+    )

--- a/dojo/search/views.py
+++ b/dojo/search/views.py
@@ -14,8 +14,7 @@ from dojo.endpoint.queries import get_authorized_endpoints
 from dojo.endpoint.views import prefetch_for_endpoints
 from dojo.engagement.queries import get_authorized_engagements
 from dojo.filters import FindingFilter, FindingFilterWithoutObjectLookups
-from dojo.finding.queries import get_authorized_findings, get_authorized_vulnerability_ids
-from dojo.finding.views import prefetch_for_findings
+from dojo.finding.queries import get_authorized_findings, get_authorized_vulnerability_ids, prefetch_for_findings
 from dojo.forms import SimpleSearchForm
 from dojo.models import Engagement, Finding, Finding_Template, Languages, Product, Test
 from dojo.product.queries import get_authorized_app_analysis, get_authorized_products

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -30,7 +30,7 @@ from django.contrib import messages
 from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
 from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import Paginator
-from django.db.models import Case, Count, IntegerField, Q, Subquery, Sum, Value, When
+from django.db.models import Case, Count, IntegerField, Q, Sum, Value, When
 from django.db.models.query import QuerySet
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -2682,11 +2682,3 @@ def parse_cvss_data(cvss_vector_string: str) -> dict:
         }
     logger.debug("No valid CVSS3 vector found in %s", cvss_vector_string)
     return {}
-
-
-def build_count_subquery(model_qs: QuerySet, group_field: str) -> Subquery:
-    """Return a Subquery that yields one aggregated count per `group_field`."""
-    return Subquery(
-        model_qs.values(group_field).annotate(c=Count("*")).values("c")[:1],  # one row per group_field
-        output_field=IntegerField(),
-    )


### PR DESCRIPTION
On [Slack](https://owasp.slack.com/archives/C2P5BA8MN/p1752548817067239) a user reported an exception involving an invalid Postgres query in Defect Dojo 2.47.3.

```
4448] ERROR:  column "dojo_finding.title" must appear in the GROUP BY clause or be used in an aggregate function at characte │
│ r 29                                                                                                                                                      │
│ 2025-07-14 15:05:54.553 GMT [4448] STATEMENT:  SELECT "dojo_finding"."id", "dojo_finding"."title", "dojo_finding"."date", "dojo_finding"."sla_start_date" │
│ , "dojo_finding"."sla_expiration_date", "dojo_finding"."cwe", "dojo_finding"."cve", "dojo_finding"."epss_score", "dojo_finding"."epss_percentile", "dojo_ │
│ finding"."cvssv3", "dojo_finding"."cvssv3_score", "dojo_finding"."url", "dojo_finding"."severity", "dojo_finding"."description", "dojo_finding"."mitigati │
│ on", "dojo_finding"."impact", "dojo_finding"."steps_to_reproduce", "dojo_finding"."severity_justification", "dojo_finding"."refs", "dojo_finding"."test_i │
│ d", "dojo_finding"."active", "dojo_finding"."verified", "dojo_finding"."false_p", "dojo_finding"."duplicate", "dojo_finding"."duplicate_finding_id", "doj │
│ o_finding"."out_of_scope", "dojo_finding"."risk_accepted", "dojo_finding"."under_review", "dojo_finding"."last_status_update", "dojo_finding"."review_req │
│ uested_by_id", "dojo_finding"."under_defect_review", "dojo_finding"."defect_review_requested_by_id", "dojo_finding"."is_mitigated", "dojo_finding"."threa │
│ d_id", "dojo_finding"."mitigated", "dojo_finding"."mitigated_by_id", "dojo_finding"."reporter_id", "dojo_finding"."numerical_severity", "dojo_finding"."l │
│ ast_reviewed", "dojo_finding"."last_reviewed_by_id", "dojo_finding"."param", "dojo_finding"."payload", "dojo_finding"."hash_code", "dojo_finding"."line", │
│  "dojo_finding"."file_path", "dojo_finding"."component_name", "dojo_finding"."component_version", "dojo_finding"."static_finding", "dojo_finding"."dynami │
│ c_finding", "dojo_finding"."created", "dojo_finding"."scanner_confidence", "dojo_finding"."sonarqube_issue_id", "dojo_finding"."unique_id_from_tool", "do │
│ jo_finding"."vuln_id_from_tool", "dojo_finding"."sast_source_object", "dojo_finding"."sast_sink_object", "dojo_finding"."sast_source_line", "dojo_finding │
│ "."sast_source_file_path", "dojo_finding"."nb_occurences", "dojo_finding"."publish_date", "dojo_finding"."service", "dojo_finding"."planned_remediation_d │
│ ate", "dojo_finding"."planned_remediation_version", "dojo_finding"."effort_for_fixing", COUNT("dojo_endpoint_status"."id") FILTER (WHERE NOT "dojo_endpoi │
│ nt_status"."mitigated") AS "active_endpoint_count", COUNT("dojo_endpoint_status"."id") FILTER (WHERE "dojo_endpoint_status"."mitigated") AS "mitigated_en │
│ dpoint_count" FROM "dojo_finding" LEFT OUTER JOIN "dojo_endpoint_status" ON ("dojo_finding"."id" = "dojo_endpoint_status"."finding_id") GROUP BY "dojo_fi │
│ nding"."id" ORDER BY "dojo_finding"."numerical_severity" ASC LIMIT 21
```

This code hasn't been changed since a long time, so it's unclear why this pops up now. It could be related to a very specific dataset or data that was create long ago and was migrated over time in Django migrations.

Either way, this code is using the old aggrgation via group by constructs. In 2.48.0 via #12575 these were changed into subquery counts. This was not done for `view_test` where a list of findings is also rendered. This used its own almost identical copy of `prefetch_for_findings` which still used the old construct. This PR changes `view_test` to use that existing and optimized `prefetch_for_findings` method that doesn't use aggregation via group by anymore.