### PR TITLE
Make KEV data visible on findings listing

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1797,6 +1797,7 @@ class FindingFilterHelper(FilterSet):
         self.form.fields["on"].widget = date_input_widget
         self.form.fields["before"].widget = date_input_widget
         self.form.fields["after"].widget = date_input_widget
+        self.form.fields["kev_date"].widget = date_input_widget
         self.form.fields["mitigated_on"].widget = date_input_widget
         self.form.fields["mitigated_before"].widget = date_input_widget
         self.form.fields["mitigated_after"].widget = date_input_widget

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1760,6 +1760,7 @@ class FindingFilterHelper(FilterSet):
             "is an upper bound. Leaving one empty will skip that bound (e.g., leaving the lower bound "
             'input empty will filter only on the upper bound -- filtering on "less than or equal").'
         ))
+    kev_date = DateFilter(field_name="kev_date", lookup_expr="exact", label="Added to KEV On")
 
     o = OrderingFilter(
         # tuple-mapping retains order
@@ -1776,6 +1777,9 @@ class FindingFilterHelper(FilterSet):
             ("service", "service"),
             ("epss_score", "epss_score"),
             ("epss_percentile", "epss_percentile"),
+            ("known_exploited", "known_exploited"),
+            ("ransomware_used", "ransomware_used"),
+            ("kev_date", "kev_date"),
         ),
         field_labels={
             "numerical_severity": "Severity",
@@ -1786,6 +1790,9 @@ class FindingFilterHelper(FilterSet):
             "test__engagement__product__name": "Product Name",
             "epss_score": "EPSS Score",
             "epss_percentile": "EPSS Percentile",
+            "known_exploited": "Known Exploited",
+            "ransomware_used": "Ransomware Used",
+            "kev_date": "Date added to KEV",
         },
     )
 

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -451,6 +451,8 @@ def get_finding_filterset_fields(*, metrics=False, similar=False, filter_string_
         "known_exploited",
         "ransomware_used",
         "kev_date",
+        "kev_before",
+        "kev_after",
     ])
 
     if similar:
@@ -1761,6 +1763,8 @@ class FindingFilterHelper(FilterSet):
             'input empty will filter only on the upper bound -- filtering on "less than or equal").'
         ))
     kev_date = DateFilter(field_name="kev_date", lookup_expr="exact", label="Added to KEV On")
+    kev_before = DateFilter(field_name="kev_date", lookup_expr="lt", label="Added to KEV Before")
+    kev_after = DateFilter(field_name="kev_date", lookup_expr="gt", label="Added to KEV After")
 
     o = OrderingFilter(
         # tuple-mapping retains order
@@ -1805,6 +1809,8 @@ class FindingFilterHelper(FilterSet):
         self.form.fields["before"].widget = date_input_widget
         self.form.fields["after"].widget = date_input_widget
         self.form.fields["kev_date"].widget = date_input_widget
+        self.form.fields["kev_before"].widget = date_input_widget
+        self.form.fields["kev_after"].widget = date_input_widget
         self.form.fields["mitigated_on"].widget = date_input_widget
         self.form.fields["mitigated_before"].widget = date_input_widget
         self.form.fields["mitigated_after"].widget = date_input_widget

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -448,6 +448,9 @@ def get_finding_filterset_fields(*, metrics=False, similar=False, filter_string_
         "epss_score_range",
         "epss_percentile",
         "epss_percentile_range",
+        "known_exploited",
+        "ransomware_used",
+        "kev_date",
     ])
 
     if similar:

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -336,6 +336,15 @@
                                     <th scope="col">
                                         {% trans "EPSS Percentile" %}
                                     </th>
+                                    <th scope="col">
+                                        {% trans "Known Exploited" %}
+                                    </th>
+                                    <th scope="col">
+                                        {% trans "Used in Ransomware" %}
+                                    </th>
+                                    <th scope="col">
+                                        {% trans "KEV" %}
+                                    </th>
                                     <th class="nowrap" scope="col">
                                         {% if filter_name == 'Closed' %}
                                             {% comment %} The display field is translated in the function. No need to translate here as well{% endcomment %}
@@ -618,6 +627,15 @@
                                         <td class="nowrap text-right">
                                             {{ finding.epss_percentile|format_epss }}
                                         </td>
+                                        <td class="nowrap text-right">
+                                            {{ finding.known_exploited|yesno|capfirst }}
+                                        </td>
+                                        <td class="nowrap text-right">
+                                            {{ finding.ransomware_used|yesno|capfirst }}
+                                        </td>
+                                        <td class="nowrap text-right">
+                                            {{ finding.kev_date|date }}
+                                        </td>
                                         {% if filter_name == 'Closed' %}
                                         <td class="nowrap" data-order="{{ finding.mitigated|date:"U" }}">
                                             {{ finding.mitigated|date }}
@@ -765,6 +783,14 @@
                     { "data": "cve" },
                     { "data": "epss_score", "type": "num", "render": percentSort },
                     { "data": "epss_percentile", "type": "num", "render": percentSort },
+                    { "data": "known_exploited", },
+                    { "data": "used_ransomware", },
+                    { "data": "kev_date", render: function(data, type, row, meta) {
+                        if(type === 'sort') {
+                            return data && Date.parse(data)
+                        }
+                        return data;
+                    }},
                     { "data": "found_date", render: function (data, type, row, meta) {
                         if(type === 'sort') {
                             var api = new $.fn.dataTable.Api(meta.settings);

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -343,7 +343,7 @@
                                         {% trans "Used in Ransomware" %}
                                     </th>
                                     <th scope="col">
-                                        {% trans "KEV" %}
+                                        {% trans "Date Added to KEV" %}
                                     </th>
                                     <th class="nowrap" scope="col">
                                         {% if filter_name == 'Closed' %}


### PR DESCRIPTION
This PR displays KEV-related data (known exploited/used in ransomware/kev added date) stored on the Finding model to the Finding listing pages (all/open/closed/risk accepted). It also adds basic filtering against those fields.

Listing page view:
<img width="591" height="457" alt="Screenshot 2025-07-15 at 1 17 32 PM" src="https://github.com/user-attachments/assets/4f2bbd20-0a90-4845-8545-6f8d4b606427" />

Filter view:
<img width="1025" height="163" alt="Screenshot 2025-07-15 at 1 07 35 PM" src="https://github.com/user-attachments/assets/15f8180d-30a2-437a-b0bf-d4595c9390cc" />
