### PR TITLE
reuse Sarif base parser for snyk and mayhem parsers

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/file/snyk_code.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/snyk_code.md
@@ -2,8 +2,7 @@
 title: "Snyk Code"
 toc_hide: true
 ---
-Snyk output file (snyk test \--json \> snyk.json) can be imported in
-JSON format. Only SCA (Software Composition Analysis) report is supported (SAST report not supported yet).
+Snyk output file (snyk code test \--sarif \> snyk.json) can be imported in JSON SARIF format. 
 
 ### Sample Scan Data
 Sample Snyk Code scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/snyk_code).

--- a/dojo/tools/mayhem/parser.py
+++ b/dojo/tools/mayhem/parser.py
@@ -7,7 +7,6 @@ from dojo.tools.sarif.parser import (
     SarifParser,
     get_codeFlowsDescription,
     get_snippet,
-    get_title,
 )
 
 logger = logging.getLogger(__name__)
@@ -37,7 +36,7 @@ class MayhemParser(SarifParser):
     def get_finding_title(self, result, rule, location):
         """Get and clean the title text for Mayhem SARIF reports."""
         # Get the default title first
-        title = get_title(result, rule)
+        title = super().get_finding_title(result, rule, location)
 
         if not title:
             return ""

--- a/dojo/tools/mayhem/parser.py
+++ b/dojo/tools/mayhem/parser.py
@@ -1,24 +1,11 @@
-import json
 import logging
 import re
 
-import dateutil.parser
 from django.utils.translation import gettext as _
 
-from dojo.models import Finding
-from dojo.tools.parser_test import ParserTest
 from dojo.tools.sarif.parser import (
     SarifParser,
-    cve_try,
-    cvss_to_severity,
     get_codeFlowsDescription,
-    get_fingerprints_hashes,
-    get_properties_tags,
-    get_references,
-    get_result_cwes_properties,
-    get_rule_cwes,
-    get_rules,
-    get_severity,
     get_snippet,
     get_title,
 )
@@ -43,290 +30,102 @@ class MayhemParser(SarifParser):
     def get_description_for_scan_types(self, scan_type):
         return "Mayhem SARIF reports from code or API runs."
 
-    # Due to mixing of class methods and package functions, we need to override some of these methods
-    # without changing their behavior. __get_items_from_run is name mangled in the parent class,
-    # so inherited methods cannot access the version here in MayhemParser.
-    def get_findings(self, filehandle, test):
-        """For simple interface of parser contract we just aggregate everything"""
-        tree = json.load(filehandle)
-        items = []
-        # for each runs we just aggregate everything
-        for run in tree.get("runs", []):
-            items.extend(self.__get_items_from_run(run))
-        return items
+    def get_finding_type(self):
+        """Mayhem findings are dynamic, not static"""
+        return (False, True)
 
-    def get_tests(self, scan_type, handle):
-        tree = json.load(handle)
-        tests = []
-        for run in tree.get("runs", []):
-            test = ParserTest(
-                name=run["tool"]["driver"]["name"],
-                parser_type=run["tool"]["driver"]["name"],
-                version=run["tool"]["driver"].get("version"),
+    def get_finding_title(self, result, rule, location):
+        """Get and clean the title text for Mayhem SARIF reports."""
+        # Get the default title first
+        title = get_title(result, rule)
+
+        if not title:
+            return ""
+
+        # Remove links (and add limit to avoid catastrophic backtracking)
+        link_regex = r"\[[^\]]{1,100}?\]\([^)]{1,200}?\)"
+        title = re.sub(link_regex, "", title)
+
+        # Remove URL encoded characters
+        url_encoding_regex = r"&#x\d+;"
+        title = re.sub(url_encoding_regex, "", title)
+
+        # Remove single or double quotes
+        quotes_regex = r"[\"']"
+        title = re.sub(quotes_regex, "", title)
+
+        # Remove TDID
+        tdid_regex = r"TDID-\d+\s*-\s*|TDID-\d+-"
+        title = re.sub(tdid_regex, "", title)
+
+        return title.strip()
+
+    def get_finding_description(self, result, rule, location):
+        """Custom description formatting for Mayhem SARIF reports with markdown support"""
+        description = ""
+        message = ""
+        if "message" in result:
+            message = self._get_message_from_multiformatMessageString(
+                result["message"], rule,
             )
-            test.findings = self.__get_items_from_run(run)
-            tests.append(test)
-        return tests
-
-    def __get_items_from_run(self, run):
-        items = []
-        # load rules
-        rules = get_rules(run)
-        # Artifacts do not appear to be used anywhere
-        # artifacts = get_artifacts(run)
-        # get the timestamp of the run if possible
-        run_date = self.__get_last_invocation_date(run)
-        for result in run.get("results", []):
-            result_items = get_items_from_result(result, rules, run_date)
-            if result_items:
-                items.extend(result_items)
-        return items
-
-    def __get_last_invocation_date(self, data):
-        invocations = data.get("invocations", [])
-        if len(invocations) == 0:
-            return None
-        # try to get the last 'endTimeUtc'
-        raw_date = invocations[-1].get("endTimeUtc")
-        if raw_date is None:
-            return None
-        # if the data is here we try to convert it to datetime
-        return dateutil.parser.isoparse(raw_date)
-
-
-def get_result_cwes_mcode(result):
-    """Mayhem SARIF reports include CWE property under taxa.toolComponent.name and number under taxa.id"""
-    cwes = []
-    if "taxa" in result:
-        for taxon in result["taxa"]:
-            if taxon.get("toolComponent", {}).get("name") == "CWE":
-                value = taxon.get("id")
-                if value:
-                    cwes.append(int(value))
-    return cwes
-
-
-def clean_mayhem_title_text(text):
-    """Clean the title text for Mayhem SARIF reports."""
-    if not text:
-        return ""
-
-    # Remove links (and add limit to avoid catastrophic backtracking)
-    link_regex = r"\[[^\]]{1,100}?\]\([^)]{1,200}?\)"
-    text = re.sub(link_regex, "", text)
-
-    # Remove URL encoded characters
-    url_encoding_regex = r"&#x\d+;"
-    text = re.sub(url_encoding_regex, "", text)
-
-    # Remove single or double quotes
-    quotes_regex = r"[\"']"
-    text = re.sub(quotes_regex, "", text)
-
-    # Remove TDID
-    tdid_regex = r"TDID-\d+\s*-\s*|TDID-\d+-"
-    text = re.sub(tdid_regex, "", text)
-
-    return text.strip()
-
-
-def get_message_from_multiformatMessageString(data, rule, content_type="text"):
-    """
-    Get a message from multimessage struct
-
-    Differs from Sarif implementation in that it handles markdown, specifies content_type
-    """
-    if content_type == "markdown" and "markdown" in data:
-        # handle markdown content
-        markdown = data.get("markdown")
-        # strip "headings" or anything that changes text size
-        heading_regex = r"^#+\s*"
-        markdown = re.sub(heading_regex, "", markdown, flags=re.MULTILINE)
-        # replace non-unicode characters with "?"
-        non_unicode_regex = r"[^\x09\x0A\x0D\x20-\x7E]"
-        markdown = re.sub(non_unicode_regex, "?", markdown)
-        return markdown.strip()
-    if content_type == "text" and "text" in data:
-        # handle text content
-        text = data.get("text")
-        if rule is not None and "id" in data:
-            text = rule["messageStrings"][data["id"]].get("text")
-            arguments = data.get("arguments", [])
-            # argument substitution
-            for i in range(6):  # the specification limit to 6
-                substitution_str = "{" + str(i) + "}"
-                if substitution_str in text and i < len(arguments):
-                    text = text.replace(substitution_str, arguments[i])
-        return text
-    return ""
-
-
-def get_description(result, rule, location):
-    """Overwrite the SarifParser get_description to handle markdown"""
-    description = ""
-    message = ""
-    if "message" in result:
-        message = get_message_from_multiformatMessageString(
-            result["message"], rule,
-        )
-        description += f"**Result message:** {message}\n"
-    if get_snippet(location) is not None:
-        description += f"**Snippet:**\n```\n{get_snippet(location)}\n```\n"
-    if rule is not None:
-        if "name" in rule:
-            description += f"**{_('Rule name')}:** {rule.get('name')}\n"
-        shortDescription = ""
-        if "shortDescription" in rule:
-            shortDescription = get_message_from_multiformatMessageString(
-                rule["shortDescription"], rule,
-            )
-            if shortDescription != message:
-                description += f"**{_('Rule short description')}:** {shortDescription}\n"
-        if "fullDescription" in rule:
-            fullDescription = get_message_from_multiformatMessageString(
-                rule["fullDescription"], rule,
-            )
-            if (fullDescription != message) and (fullDescription != shortDescription):
-                description += f"**{_('Rule full description')}:** {fullDescription}\n"
-    if "markdown" in result["message"]:
-        markdown = get_message_from_multiformatMessageString(
-            result["message"], rule, content_type="markdown",
-        )
-        # Replace "Details" with "Link" in the markdown
-        markdown = markdown.replace("Details", "Link")
-        description += f"**{_('Additional Details')}:**\n{markdown}\n"
-        description += "_(Unprintable characters are replaced with '?'; please see Mayhem for full reproducer.)_"
-    if len(result.get("codeFlows", [])) > 0:
-        description += get_codeFlowsDescription(result["codeFlows"])
-
-    return description.removesuffix("\n")
-
-
-def get_items_from_result(result, rules, run_date):
-    # see
-    # https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html
-    # / 3.27.9
-    kind = result.get("kind", "fail")
-    if kind != "fail":
-        return None
-
-    # if finding is suppressed, mark it as False Positive
-    # Note: see
-    # https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html#_Toc10127852
-    suppressed = False
-    if result.get("suppressions"):
-        suppressed = True
-
-    # if there is a location get all files into files list
-
-    files = []
-
-    if "locations" in result:
-        for location in result["locations"]:
-
-            file_path = None
-            line = None
-
-            if "physicalLocation" in location:
-                file_path = location["physicalLocation"]["artifactLocation"]["uri"]
-
-                # 'region' attribute is optionnal
-                if "region" in location["physicalLocation"]:
-                    # https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html / 3.30.1
-                    # need to check whether it is byteOffset
-                    if "byteOffset" in location["physicalLocation"]["region"]:
-                        pass
-                    else:
-                        line = location["physicalLocation"]["region"]["startLine"]
-
-            files.append((file_path, line, location))
-
-    if not files:
-        files.append((None, None, None))
-
-    result_items = []
-
-    for file_path, line, location in files:
-
-        # test rule link
-        rule = rules.get(result.get("ruleId"))
-
-        finding = Finding(
-            title=clean_mayhem_title_text(get_title(result, rule)),
-            severity=get_severity(result, rule),
-            description=get_description(result, rule, location),
-            static_finding=False,
-            dynamic_finding=True,
-            false_p=suppressed,
-            active=not suppressed,
-            file_path=file_path,
-            line=line,
-            references=get_references(rule),
-        )
-
-        if "ruleId" in result:
-            finding.vuln_id_from_tool = result["ruleId"]
-            # for now we only support when the id of the rule is a CVE
-            if cve_try(result["ruleId"]):
-                finding.unsaved_vulnerability_ids = [cve_try(result["ruleId"])]
-        # some time the rule id is here but the tool doesn't define it
+            description += f"**Result message:** {message}\n"
+        if get_snippet(location) is not None:
+            description += f"**Snippet:**\n```\n{get_snippet(location)}\n```\n"
         if rule is not None:
-            cwes_extracted = get_rule_cwes(rule)
-            # Find CWEs in Mayhem SARIF reports
-            cwes_extracted.extend(get_result_cwes_mcode(result))
-            if len(cwes_extracted) > 0:
-                finding.cwe = cwes_extracted[-1]
-
-            # Some tools such as GitHub or Grype return the severity in properties
-            # instead
-            if "properties" in rule and "security-severity" in rule["properties"]:
-                try:
-                    cvss = float(rule["properties"]["security-severity"])
-                    severity = cvss_to_severity(cvss)
-                    finding.cvssv3_score = cvss
-                    finding.severity = severity
-                except ValueError:
-                    if rule["properties"]["security-severity"].lower().capitalize() in {"Info", "Low", "Medium", "High", "Critical"}:
-                        finding.severity = rule["properties"]["security-severity"].lower().capitalize()
-                    else:
-                        finding.severity = "Info"
-
-        # manage the case that some tools produce CWE as properties of the result
-        cwes_properties_extracted = get_result_cwes_properties(result)
-        if len(cwes_properties_extracted) > 0:
-            finding.cwe = cwes_properties_extracted[-1]
-
-        # manage fixes provided in the report
-        if "fixes" in result:
-            finding.mitigation = "\n".join(
-                [fix.get("description", {}).get("text") for fix in result["fixes"]],
+            if "name" in rule:
+                description += f"**{_('Rule name')}:** {rule.get('name')}\n"
+            shortDescription = ""
+            if "shortDescription" in rule:
+                shortDescription = self._get_message_from_multiformatMessageString(
+                    rule["shortDescription"], rule,
+                )
+                if shortDescription != message:
+                    description += f"**{_('Rule short description')}:** {shortDescription}\n"
+            if "fullDescription" in rule:
+                fullDescription = self._get_message_from_multiformatMessageString(
+                    rule["fullDescription"], rule,
+                )
+                if (fullDescription != message) and (fullDescription != shortDescription):
+                    description += f"**{_('Rule full description')}:** {fullDescription}\n"
+        if "markdown" in result["message"]:
+            markdown = self._get_message_from_multiformatMessageString(
+                result["message"], rule, content_type="markdown",
             )
+            # Replace "Details" with "Link" in the markdown
+            markdown = markdown.replace("Details", "Link")
+            description += f"**{_('Additional Details')}:**\n{markdown}\n"
+            description += "_(Unprintable characters are replaced with '?'; please see Mayhem for full reproducer.)_"
+        if len(result.get("codeFlows", [])) > 0:
+            description += get_codeFlowsDescription(result["codeFlows"])
 
-        if run_date:
-            finding.date = run_date
+        return description.removesuffix("\n")
 
-        # manage tags provided in the report and rule and remove duplicated
-        tags = list(set(get_properties_tags(rule) + get_properties_tags(result)))
-        tags = [s.removeprefix("external/cwe/") for s in tags]
-        finding.tags = tags
+    def _get_message_from_multiformatMessageString(self, data, rule, content_type="text"):
+        """
+        Get a message from multimessage struct
 
-        # manage fingerprints
-        # fingerprinting in SARIF is more complete than in current implementation
-        # SARIF standard make it possible to have multiple version in the same report
-        # for now we just take the first one and keep the format to be able to
-        # compare it
-        if result.get("fingerprints"):
-            hashes = get_fingerprints_hashes(result["fingerprints"])
-            first_item = next(iter(hashes.items()))
-            finding.unique_id_from_tool = first_item[1]["value"]
-        elif result.get("partialFingerprints"):
-            # for this one we keep an order to have id that could be compared
-            hashes = get_fingerprints_hashes(result["partialFingerprints"])
-            sorted_hashes = sorted(hashes.keys())
-            finding.unique_id_from_tool = "|".join(
-                [f'{key}:{hashes[key]["value"]}' for key in sorted_hashes],
-            )
-
-        result_items.append(finding)
-
-    return result_items
+        Differs from Sarif implementation in that it handles markdown, specifies content_type
+        """
+        if content_type == "markdown" and "markdown" in data:
+            # handle markdown content
+            markdown = data.get("markdown")
+            # strip "headings" or anything that changes text size
+            heading_regex = r"^#+\s*"
+            markdown = re.sub(heading_regex, "", markdown, flags=re.MULTILINE)
+            # replace non-unicode characters with "?"
+            non_unicode_regex = r"[^\x09\x0A\x0D\x20-\x7E]"
+            markdown = re.sub(non_unicode_regex, "?", markdown)
+            return markdown.strip()
+        if content_type == "text" and "text" in data:
+            # handle text content
+            text = data.get("text")
+            if rule is not None and "id" in data:
+                text = rule["messageStrings"][data["id"]].get("text")
+                arguments = data.get("arguments", [])
+                # argument substitution
+                for i in range(6):  # the specification limit to 6
+                    substitution_str = "{" + str(i) + "}"
+                    if substitution_str in text and i < len(arguments):
+                        text = text.replace(substitution_str, arguments[i])
+            return text
+        return ""

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -3,6 +3,7 @@ import json
 from cvss.cvss3 import CVSS3
 
 from dojo.models import Finding
+from dojo.tools.snyk_code.parser import SnykCodeParser
 
 
 class SnykParser:
@@ -78,7 +79,7 @@ class SnykParser:
         return scan_type  # no custom label for now
 
     def get_description_for_scan_types(self, scan_type):
-        return "Snyk output file (snyk test --json > snyk.json) can be imported in JSON format."
+        return "Snyk output file (snyk test --json > snyk.json) can be imported in JSON format. SARIF format is automatically delegated to the Snyk Code parser."
 
     def get_findings(self, json_output, test):
         reportTree = self.parse_json(json_output)
@@ -107,8 +108,7 @@ class SnykParser:
         return tree
 
     def get_items(self, tree, test):
-        items = {}
-        iterator = 0
+        items = []
         if "vulnerabilities" in tree:
             target_file = tree.get("displayTargetFile", None)
             upgrades = tree.get("remediation", {}).get("upgrade", None)
@@ -117,17 +117,17 @@ class SnykParser:
                 item = self.get_item(
                     node, test, target_file=target_file, upgrades=upgrades,
                 )
-                items[iterator] = item
-                iterator += 1
-        elif "runs" in tree and tree["runs"][0].get("results"):
-            results = tree["runs"][0]["results"]
-            for node in results:
-                item = self.get_code_item(
-                    node, test,
-                )
-                items[iterator] = item
-                iterator += 1
-        return list(items.values())
+                items.append(item)
+            return items
+        if "runs" in tree and tree["runs"][0].get("results"):
+            # Delegate SARIF handling to Snyk Code parser
+            snyk_code_parser = SnykCodeParser()
+            import io
+            json_output = io.StringIO(json.dumps(tree))
+            findings = snyk_code_parser.get_findings(json_output, test)
+            items.extend(findings)
+            return findings
+        return []
 
     def get_item(self, vulnerability, test, target_file=None, upgrades=None):
         # vulnerable and unaffected versions can be in string format for a single vulnerable version,
@@ -280,46 +280,3 @@ class SnykParser:
                     finding.mitigation += f"\nUpgrade from {current_pack_version} to {upgraded_pack} to fix this issue, as well as updating the following:\n - "
                     finding.mitigation += "\n - ".join(tertiary_upgrade_list)
         return finding
-
-    def get_code_item(self, vulnerability, test):
-        ruleId = vulnerability["ruleId"]
-        ruleIndex = vulnerability["ruleIndex"]
-        message = vulnerability["message"]["text"]
-        score = vulnerability["properties"]["priorityScore"]
-        locations_uri = vulnerability["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
-        locations_uriBaseId = vulnerability["locations"][0]["physicalLocation"]["artifactLocation"]["uriBaseId"]
-        locations_startLine = vulnerability["locations"][0]["physicalLocation"]["region"]["startLine"]
-        locations_endLine = vulnerability["locations"][0]["physicalLocation"]["region"]["endLine"]
-        locations_startColumn = vulnerability["locations"][0]["physicalLocation"]["region"]["startColumn"]
-        locations_endColumn = vulnerability["locations"][0]["physicalLocation"]["region"]["endColumn"]
-        isAutofixable = vulnerability["properties"]["isAutofixable"]
-        if score <= 399:
-            severity = "Low"
-        elif score <= 699:
-            severity = "Medium"
-        elif score <= 899:
-            severity = "High"
-        else:
-            severity = "Critical"
-        # create the finding object
-        return Finding(
-            title=ruleId + "_" + locations_uri,
-            test=test,
-            severity=severity,
-            description="**ruleId**: " + str(ruleId) + "\n"
-            + "**ruleIndex**: " + str(ruleIndex) + "\n"
-            + "**message**: " + str(message) + "\n"
-            + "**score**: " + str(score) + "\n"
-            + "**uri**: " + locations_uri + "\n"
-            + "**uriBaseId**: " + locations_uriBaseId + "\n"
-            + "**startLine**: " + str(locations_startLine) + "\n"
-            + "**endLine**: " + str(locations_endLine) + "\n"
-            + "**startColumn**: " + str(locations_startColumn) + "\n"
-            + "**endColumn**: " + str(locations_endColumn) + "\n"
-            + "**isAutofixable**: " + str(isAutofixable) + "\n",
-            false_p=False,
-            duplicate=False,
-            out_of_scope=False,
-            static_finding=True,
-            dynamic_finding=False,
-        )

--- a/dojo/tools/snyk_code/parser.py
+++ b/dojo/tools/snyk_code/parser.py
@@ -1,11 +1,7 @@
-import json
-
-from cvss.cvss3 import CVSS3
-
-from dojo.models import Finding
+from dojo.tools.sarif.parser import SarifParser
 
 
-class SnykCodeParser:
+class SnykCodeParser(SarifParser):
 
     def get_fields(self) -> list[str]:
         """
@@ -70,247 +66,68 @@ class SnykCodeParser:
         return scan_type  # no custom label for now
 
     def get_description_for_scan_types(self, scan_type):
-        return "Snyk output file (snyk test --json > snyk.json) can be imported in JSON format."
+        return "Snyk Code Scan output can be imported in SARIF JSON format. Generate SARIF reports using: snyk code test --sarif"
 
-    def get_findings(self, json_output, test):
-        reportTree = self.parse_json(json_output)
+    def get_finding_title(self, result, rule, location):
+        """Get custom title for Snyk Code with ruleId + file path format"""
+        # For Snyk Code, create custom title format
+        rule_id = result.get("ruleId", "")
+        file_path = ""
+        if location:
+            phys_loc = location.get("physicalLocation", {})
+            artifact_loc = phys_loc.get("artifactLocation", {})
+            file_path = artifact_loc.get("uri", "")
 
-        if isinstance(reportTree, list):
-            temp = []
-            for moduleTree in reportTree:
-                temp += self.process_tree(moduleTree, test)
-            return temp
-        return self.process_tree(reportTree, test)
+        return f"{rule_id}_{file_path}" if rule_id and file_path else rule_id
 
-    def process_tree(self, tree, test):
-        return list(self.get_items(tree, test)) if tree else []
+    def get_finding_description(self, result, rule, location):
+        """Custom description formatting for Snyk Code SARIF reports"""
+        # Extract Snyk Code specific properties
+        props = result.get("properties", {})
+        rule_id = result.get("ruleId", "")
 
-    def parse_json(self, json_output):
-        try:
-            data = json_output.read()
-            try:
-                tree = json.loads(str(data, "utf-8"))
-            except Exception:
-                tree = json.loads(data)
-        except Exception:
-            msg = "Invalid format"
-            raise ValueError(msg)
+        # Build description with Snyk Code specific fields
+        description_parts = [
+            f"**ruleId**: {rule_id}",
+            f"**ruleIndex**: {result.get('ruleIndex', '')}",
+            f"**message**: {result.get('message', {}).get('text', '')}",
+            f"**score**: {props.get('priorityScore', 0)}",
+            f"**isAutofixable**: {props.get('isAutofixable', False)}",
+        ]
 
-        return tree
+        # Add location details if available
+        if location:
+            phys_loc = location.get("physicalLocation", {})
+            artifact_loc = phys_loc.get("artifactLocation", {})
+            region = phys_loc.get("region", {})
 
-    def get_items(self, tree, test):
-        items = {}
-        iterator = 0
-        if "vulnerabilities" in tree:
-            target_file = tree.get("displayTargetFile", None)
-            upgrades = tree.get("remediation", {}).get("upgrade", None)
-            vulnerabilityTree = tree["vulnerabilities"]
-            for node in vulnerabilityTree:
-                item = self.get_item(
-                    node, test, target_file=target_file, upgrades=upgrades,
-                )
-                items[iterator] = item
-                iterator += 1
-        elif "runs" in tree and tree["runs"][0].get("results"):
-            results = tree["runs"][0]["results"]
-            for node in results:
-                item = self.get_code_item(
-                    node, test,
-                )
-                items[iterator] = item
-                iterator += 1
-        return list(items.values())
+            if artifact_loc.get("uri"):
+                description_parts.append(f"**uri**: {artifact_loc.get('uri', '')}")
+            if artifact_loc.get("uriBaseId"):
+                description_parts.append(f"**uriBaseId**: {artifact_loc.get('uriBaseId', '')}")
+            if region.get("startLine"):
+                description_parts.append(f"**startLine**: {region.get('startLine', '')}")
+            if region.get("endLine"):
+                description_parts.append(f"**endLine**: {region.get('endLine', '')}")
+            if region.get("startColumn"):
+                description_parts.append(f"**startColumn**: {region.get('startColumn', '')}")
+            if region.get("endColumn"):
+                description_parts.append(f"**endColumn**: {region.get('endColumn', '')}")
 
-    def get_item(self, vulnerability, test, target_file=None, upgrades=None):
-        # vulnerable and unaffected versions can be in string format for a single vulnerable version,
-        # or an array for multiple versions depending on the language.
-        if isinstance(vulnerability["semver"]["vulnerable"], list):
-            vulnerable_versions = ", ".join(
-                vulnerability["semver"]["vulnerable"],
-            )
-        else:
-            vulnerable_versions = vulnerability["semver"]["vulnerable"]
+        return "\n".join(description_parts)
 
-        # Following the CVSS Scoring per https://nvd.nist.gov/vuln-metrics/cvss
-        if "cvssScore" in vulnerability:
-            if vulnerability["cvssScore"] is None:
-                severity = vulnerability["severity"].title()
-            # If we're dealing with a license finding, there will be no
-            # cvssScore
-            elif vulnerability["cvssScore"] <= 3.9:
-                severity = "Low"
-            elif (
-                vulnerability["cvssScore"] >= 4.0
-                and vulnerability["cvssScore"] <= 6.9
-            ):
-                severity = "Medium"
-            elif (
-                vulnerability["cvssScore"] >= 7.0
-                and vulnerability["cvssScore"] <= 8.9
-            ):
-                severity = "High"
-            else:
-                severity = "Critical"
-        else:
-            # Re-assign 'severity' directly
-            severity = vulnerability["severity"].title()
+    def customize_finding(self, finding, result, rule, location):
+        """Customize SARIF finding for Snyk Code specific formatting"""
+        # Extract Snyk Code specific properties
+        props = result.get("properties", {})
 
-        # Construct "file_path" removing versions
-        vulnPath = ""
-        for index, item in enumerate(vulnerability["from"]):
-            if index == 0:
-                vulnPath += "@".join(item.split("@")[0:-1])
-            else:
-                vulnPath += " > " + "@".join(item.split("@")[0:-1])
-
-        # create the finding object
-        finding = Finding(
-            title=vulnerability["from"][0] + ": " + vulnerability["title"],
-            test=test,
-            severity=severity,
-            severity_justification="Issue severity of: **"
-            + severity
-            + "** from a base "
-            + "CVSS score of: **"
-            + str(vulnerability.get("cvssScore"))
-            + "**",
-            description="## Component Details\n - **Vulnerable Package**: "
-            + vulnerability["packageName"]
-            + "\n- **Current Version**: "
-            + str(vulnerability["version"])
-            + "\n- **Vulnerable Version(s)**: "
-            + vulnerable_versions
-            + "\n- **Vulnerable Path**: "
-            + " > ".join(vulnerability["from"])
-            + "\n"
-            + vulnerability["description"],
-            mitigation="A fix (if available) will be provided in the description.",
-            component_name=vulnerability["packageName"],
-            component_version=vulnerability["version"],
-            false_p=False,
-            duplicate=False,
-            out_of_scope=False,
-            impact=severity,
-            static_finding=True,
-            dynamic_finding=False,
-            file_path=vulnPath,
-            vuln_id_from_tool=vulnerability["id"],
-        )
-        finding.unsaved_tags = []
-
-        # CVSSv3 vector
-        if vulnerability.get("CVSSv3"):
-            finding.cvssv3 = CVSS3(vulnerability["CVSSv3"]).clean_vector()
-
-        # manage CVE and CWE with idnitifiers
-        cwe_references = ""
-        if "identifiers" in vulnerability:
-            if "CVE" in vulnerability["identifiers"]:
-                vulnerability_ids = vulnerability["identifiers"]["CVE"]
-                if vulnerability_ids:
-                    finding.unsaved_vulnerability_ids = vulnerability_ids
-
-            if "CWE" in vulnerability["identifiers"]:
-                cwes = vulnerability["identifiers"]["CWE"]
-                if cwes:
-                    # Per the current json format, if several CWEs, take the
-                    # first one.
-                    finding.cwe = int(cwes[0].split("-")[1])
-                    if len(vulnerability["identifiers"]["CWE"]) > 1:
-                        cwe_references = ", ".join(cwes)
-                else:
-                    finding.cwe = 1035
-
-        references = ""
-        if "id" in vulnerability:
-            references = "**SNYK ID**: https://app.snyk.io/vuln/{}\n\n".format(
-                vulnerability["id"],
-            )
-
-        if cwe_references:
-            references += f"Several CWEs were reported: \n\n{cwe_references}\n"
-
-        # Append vuln references to references section
-        for item in vulnerability.get("references", []):
-            references += "**" + item["title"] + "**: " + item["url"] + "\n"
-
-        finding.references = references
-
-        finding.description = finding.description.strip()
-
-        # Find remediation string limit indexes
-        remediation_index = finding.description.find("## Remediation")
-        references_index = finding.description.find("## References")
-
-        # Add the remediation substring to mitigation section
-        if (remediation_index != -1) and (references_index != -1):
-            finding.mitigation = finding.description[
-                remediation_index:references_index
-            ]
-
-        # Add Target file if supplied
-        if target_file:
-            finding.unsaved_tags.append(f"target_file:{target_file}")
-            finding.mitigation += f"\nUpgrade Location: {target_file}"
-
-        # Add the upgrade libs list to the mitigation section
-        if upgrades:
-            for current_pack_version, meta_dict in upgrades.items():
-                upgraded_pack = meta_dict["upgradeTo"]
-                tertiary_upgrade_list = meta_dict["upgrades"]
-                if any(
-                    lib.split("@")[0] in finding.mitigation
-                    for lib in tertiary_upgrade_list
-                ):
-                    finding.unsaved_tags.append(
-                        f"upgrade_to:{upgraded_pack}",
-                    )
-                    finding.mitigation += f"\nUpgrade from {current_pack_version} to {upgraded_pack} to fix this issue, as well as updating the following:\n - "
-                    finding.mitigation += "\n - ".join(tertiary_upgrade_list)
-        return finding
-
-    def get_code_item(self, vulnerability, test):
-        ruleId = vulnerability["ruleId"]
-        ruleIndex = vulnerability["ruleIndex"]
-        message = vulnerability["message"]["text"]
-        score = vulnerability["properties"]["priorityScore"]
-        locations_uri = vulnerability["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
-        locations_uriBaseId = vulnerability["locations"][0]["physicalLocation"]["artifactLocation"]["uriBaseId"]
-        locations_startLine = vulnerability["locations"][0]["physicalLocation"]["region"]["startLine"]
-        locations_endLine = vulnerability["locations"][0]["physicalLocation"]["region"]["endLine"]
-        locations_startColumn = vulnerability["locations"][0]["physicalLocation"]["region"]["startColumn"]
-        locations_endColumn = vulnerability["locations"][0]["physicalLocation"]["region"]["endColumn"]
-        isAutofixable = vulnerability["properties"]["isAutofixable"]
-
+        # Use priorityScore for severity calculation
+        score = props.get("priorityScore", 0)
         if score <= 399:
-            severity = "Low"
+            finding.severity = "Low"
         elif score <= 699:
-            severity = "Medium"
+            finding.severity = "Medium"
         elif score <= 899:
-            severity = "High"
+            finding.severity = "High"
         else:
-            severity = "Critical"
-        # create the finding object
-        return Finding(
-            vuln_id_from_tool=ruleId,
-            file_path=locations_uri,
-            title=ruleId + "_" + locations_uri,
-            test=test,
-            severity=severity,
-            description="**ruleId**: " + str(ruleId) + "\n"
-            + "**ruleIndex**: " + str(ruleIndex) + "\n"
-            + "**message**: " + str(message) + "\n"
-            + "**score**: " + str(score) + "\n"
-            + "**uri**: " + locations_uri + "\n"
-            + "**uriBaseId**: " + locations_uriBaseId + "\n"
-            + "**startLine**: " + str(locations_startLine) + "\n"
-            + "**endLine**: " + str(locations_endLine) + "\n"
-            + "**startColumn**: " + str(locations_startColumn) + "\n"
-            + "**endColumn**: " + str(locations_endColumn) + "\n"
-            + "**isAutofixable**: " + str(isAutofixable) + "\n",
-            false_p=False,
-            duplicate=False,
-            out_of_scope=False,
-            static_finding=True,
-            dynamic_finding=False,
-        )
+            finding.severity = "Critical"

--- a/unittests/tools/test_snyk_code_parser.py
+++ b/unittests/tools/test_snyk_code_parser.py
@@ -12,8 +12,131 @@ class TestSnykCodeParser(DojoTestCase):
         testfile.close()
         self.assertEqual(206, len(findings))
 
+        # Test specific finding properties for the first finding
+        first_finding = findings[0]
+        self.assertIsNotNone(first_finding.title)
+        self.assertIn("_", first_finding.title)  # Should contain ruleId_filepath format
+        self.assertIn("**ruleId**:", first_finding.description)
+        self.assertIn("**message**:", first_finding.description)
+        self.assertIn("**score**:", first_finding.description)
+        self.assertIn("**isAutofixable**:", first_finding.description)
+        self.assertIn(first_finding.severity, ["Low", "Medium", "High", "Critical"])
+        self.assertTrue(first_finding.static_finding)
+        self.assertFalse(first_finding.dynamic_finding)
+
     def test_snykcode_issue_9270(self):
         with (get_unit_tests_scans_path("snyk_code") / "snykcode_issue_9270.json").open(encoding="utf-8") as testfile:
             parser = SnykCodeParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(39, len(findings))
+
+            # Test specific properties of the first finding
+            first_finding = findings[0]
+            self.assertEqual("javascript/XSS_frontend/src/app/score-board/score-board.component.ts", first_finding.title)
+            self.assertEqual("Medium", first_finding.severity)  # priorityScore: 504 -> Medium
+            self.assertTrue(first_finding.static_finding)
+            self.assertFalse(first_finding.dynamic_finding)
+
+            # Test CWE value is correctly parsed
+            self.assertEqual(79, first_finding.cwe)  # CWE-79 from rule properties
+
+            # Test description contains expected fields
+            self.assertIn("**ruleId**: javascript/XSS", first_finding.description)
+            self.assertIn("**ruleIndex**: 0", first_finding.description)
+            self.assertIn("**score**: 504", first_finding.description)
+            self.assertIn("**isAutofixable**: False", first_finding.description)
+            self.assertIn("**uri**: frontend/src/app/score-board/score-board.component.ts", first_finding.description)
+            self.assertIn("**startLine**: 216", first_finding.description)
+            self.assertIn("**endLine**: 216", first_finding.description)
+            self.assertIn("**startColumn**: 44", first_finding.description)
+            self.assertIn("**endColumn**: 67", first_finding.description)
+
+            # Test file path is correctly set
+            self.assertEqual("frontend/src/app/score-board/score-board.component.ts", first_finding.file_path)
+
+            # Test that different priority scores map to different severities
+            severity_counts = {}
+            for finding in findings:
+                severity_counts[finding.severity] = severity_counts.get(finding.severity, 0) + 1
+
+            # Should have findings with different severities based on priority scores
+            self.assertGreater(len(severity_counts), 1, "Should have multiple severity levels")
+
+            # Test that all findings have the expected custom format
+            for finding in findings:
+                self.assertIn("_", finding.title, "Title should contain ruleId_filepath format")
+                self.assertIn("**ruleId**:", finding.description, "Description should contain ruleId field")
+                self.assertIn("**score**:", finding.description, "Description should contain score field")
+                self.assertTrue(finding.static_finding, "All findings should be static")
+                self.assertFalse(finding.dynamic_finding, "All findings should not be dynamic")
+                self.assertIn(finding.severity, ["Low", "Medium", "High", "Critical"], "Severity should be valid")
+
+            # Test CWE values are parsed correctly
+            cwe_values = [finding.cwe for finding in findings if finding.cwe]
+            self.assertGreater(len(cwe_values), 0, "Should have findings with CWE values")
+
+            # Test that specific CWE values are found (based on the test data)
+            self.assertIn(79, cwe_values, "Should find CWE-79 (XSS)")
+            self.assertTrue(all(isinstance(cwe, int) for cwe in cwe_values), "All CWE values should be integers")
+
+    def test_snykcode_severity_mapping(self):
+        """Test that priority scores are correctly mapped to severities"""
+        with (get_unit_tests_scans_path("snyk_code") / "snykcode_issue_9270.json").open(encoding="utf-8") as testfile:
+            parser = SnykCodeParser()
+            findings = parser.get_findings(testfile, Test())
+
+            # Test specific severity mappings based on priority scores
+            severity_score_mapping = {}
+            for finding in findings:
+                # Extract score from description
+                desc_lines = finding.description.split("\n")
+                score_line = [line for line in desc_lines if line.startswith("**score**:")]
+                if score_line:
+                    score = int(score_line[0].split(": ")[1])
+                    severity_score_mapping[finding.severity] = severity_score_mapping.get(finding.severity, [])
+                    severity_score_mapping[finding.severity].append(score)
+
+            # Test that score ranges map to correct severities
+            for severity, scores in severity_score_mapping.items():
+                if severity == "Low":
+                    self.assertTrue(all(score <= 399 for score in scores), f"Low severity should have scores <= 399, got {scores}")
+                elif severity == "Medium":
+                    self.assertTrue(all(400 <= score <= 699 for score in scores), f"Medium severity should have scores 400-699, got {scores}")
+                elif severity == "High":
+                    self.assertTrue(all(700 <= score <= 899 for score in scores), f"High severity should have scores 700-899, got {scores}")
+                elif severity == "Critical":
+                    self.assertTrue(all(score >= 900 for score in scores), f"Critical severity should have scores >= 900, got {scores}")
+
+    def test_snykcode_cwe_parsing(self):
+        """Test that CWE values are correctly parsed from Snyk Code SARIF rule properties"""
+        with (get_unit_tests_scans_path("snyk_code") / "snykcode_issue_9270.json").open(encoding="utf-8") as testfile:
+            parser = SnykCodeParser()
+            findings = parser.get_findings(testfile, Test())
+
+            # Test that CWE values are parsed correctly
+            cwe_values = [finding.cwe for finding in findings if finding.cwe]
+            self.assertGreater(len(cwe_values), 0, "Should have findings with CWE values")
+
+            # Test that specific CWE values are found (based on the test data)
+            self.assertIn(79, cwe_values, "Should find CWE-79 (XSS)")
+            self.assertTrue(all(isinstance(cwe, int) for cwe in cwe_values), "All CWE values should be integers")
+
+            # Test the first finding has the expected CWE
+            first_finding = findings[0]
+            self.assertEqual(79, first_finding.cwe, "First finding should have CWE-79")
+
+            # Test that findings without CWE values are handled properly
+            [finding for finding in findings if not finding.cwe]
+            findings_with_cwe = [finding for finding in findings if finding.cwe]
+
+            # Should have some findings with CWE values
+            self.assertGreater(len(findings_with_cwe), 0, "Should have findings with CWE values")
+
+            # Test that CWE values are properly extracted from rule properties
+            unique_cwes = set(cwe_values)
+            self.assertGreater(len(unique_cwes), 0, "Should have unique CWE values")
+
+            # All CWE values should be valid integers
+            for cwe in unique_cwes:
+                self.assertIsInstance(cwe, int, f"CWE value {cwe} should be an integer")
+                self.assertGreater(cwe, 0, f"CWE value {cwe} should be positive")


### PR DESCRIPTION
Over time two Sarif based parsers were added because they needed some custom parser logic to fully parse their scan reports:

- Mayhem
- Snyk Code

This resulted in some code duplication. This PR changes the Sarif base parser to be extensible and uses this to simplify the Snyk Code and Mayhem parsers. I didn't go as far as to create extension hooks for each an every field. This PR now has some examples that can be used in future PRs if more fields need to be extendible.

Initially I had the CWE parsing logic for the Mayhem `taxa` based CWEs also in an extenstion hook. But then I found out that the "taxa" format is actually somewhat official Sarif formatting. Also there was already code in the base Sarif parser looking for CWEs in various places. So the PR adds the "taxa way" to the base Sarif parser. This way it's also beneficial for any other non-Mayem report that might use this format.

Additional things in this PR:
- Reduce code duplication between the `snyk` parser and `snyk_code` parser.
- Enhance test cases for the `snyk_code` parser

[sc-11544]