### PR TITLE
static group view

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1999,6 +1999,41 @@ class FindingFilter(FindingFilterHelper, FindingTagFilter):
         self.form.fields["reviewers"].queryset = self.form.fields["reporter"].queryset
 
 
+class FindingGroupsFilter(FilterSet):
+    name = CharFilter(method="filter_name", label="Name")
+    severity = ChoiceFilter(
+        choices=[
+            ("Low", "Low"),
+            ("Medium", "Medium"),
+            ("High", "High"),
+            ("Critical", "Critical"),
+        ],
+        method="filter_min_severity",
+        label="Min Severity",
+    )
+    engagement = ModelMultipleChoiceFilter(queryset=Engagement.objects.none(), label="Engagement")
+    product = ModelMultipleChoiceFilter(queryset=Product.objects.none(), label="Product")
+
+    class Meta:
+        model = Finding
+        fields = ["name", "severity", "engagement", "product"]
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop("user", None)
+        self.pid = kwargs.pop("pid", None)
+        super().__init__(*args, **kwargs)
+        self.set_related_object_fields()
+
+    def set_related_object_fields(self):
+        if self.pid is not None:
+            self.form.fields["engagement"].queryset = Engagement.objects.filter(product_id=self.pid)
+            if "product" in self.form.fields:
+                del self.form.fields["product"]
+        else:
+            self.form.fields["product"].queryset = get_authorized_products(Permissions.Product_View)
+            self.form.fields["engagement"].queryset = get_authorized_engagements(Permissions.Engagement_View)
+
+
 class AcceptedFindingFilter(FindingFilter):
     risk_acceptance__created__date = DateRangeFilter(label="Acceptance Date")
     risk_acceptance__owner = ModelMultipleChoiceFilter(

--- a/dojo/finding_group/urls.py
+++ b/dojo/finding_group/urls.py
@@ -8,4 +8,9 @@ urlpatterns = [
     re_path(r"^finding_group/(?P<fgid>\d+)/delete$", views.delete_finding_group, name="delete_finding_group"),
     re_path(r"^finding_group/(?P<fgid>\d+)/jira/push$", views.push_to_jira, name="finding_group_push_to_jira"),
     re_path(r"^finding_group/(?P<fgid>\d+)/jira/unlink$", views.unlink_jira, name="finding_group_unlink_jira"),
+
+    # finding group list views
+    re_path(r"^finding_group/all$", views.ListFindingGroups.as_view(), name="all_finding_groups"),
+    re_path(r"^finding_group/open$", views.ListOpenFindingGroups.as_view(), name="open_finding_groups"),
+    re_path(r"^finding_group/closed$", views.ListClosedFindingGroups.as_view(), name="closed_finding_groups"),
 ]

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -2,20 +2,28 @@ import logging
 
 from django.contrib import messages
 from django.contrib.admin.utils import NestedObjects
+from django.core.paginator import Page, Paginator
+from django.db.models import Count, Min, Q, QuerySet, Subquery
 from django.db.utils import DEFAULT_DB_ALIAS
+from django.http import HttpRequest
 from django.http.response import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls.base import reverse
+from django.views import View
 from django.views.decorators.http import require_POST
 
 import dojo.jira_link.helper as jira_helper
 from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.authorization.authorization_decorators import user_is_authorized
 from dojo.authorization.roles_permissions import Permissions
-from dojo.filters import FindingFilter, FindingFilterWithoutObjectLookups
+from dojo.filters import (
+    FindingFilter,
+    FindingFilterWithoutObjectLookups,
+    FindingGroupsFilter,
+)
 from dojo.finding.views import prefetch_for_findings
 from dojo.forms import DeleteFindingGroupForm, EditFindingGroupForm, FindingBulkUpdateForm
-from dojo.models import Engagement, Finding, Finding_Group, GITHUB_PKey, Product
+from dojo.models import Dojo_Group, Engagement, Finding, Finding_Group, GITHUB_PKey, Global_Role, Product
 from dojo.utils import Product_Tab, add_breadcrumb, get_page_items, get_setting, get_system_setting, get_words_for_field
 
 logger = logging.getLogger(__name__)
@@ -204,3 +212,118 @@ def push_to_jira(request, fgid):
             "Error pushing to JIRA",
             extra_tags="alert-danger")
         return HttpResponse(status=500)
+
+
+class ListFindingGroups(View):
+    filter_name: str = "All"
+
+    SEVERITY_ORDER = {
+        "Critical": 4,
+        "High": 3,
+        "Medium": 2,
+        "Low": 1,
+        "Info": 0,
+    }
+
+    def get_template(self) -> str:
+        return "dojo/finding_groups_list.html"
+
+    def order_field(self, request: HttpRequest, group_findings_queryset: QuerySet[Finding_Group]) -> QuerySet[Finding_Group]:
+        order_field_param: str | None = request.GET.get("o")
+        if order_field_param:
+            reverse_order = order_field_param.startswith("-")
+            order_field_param = order_field_param[1:] if reverse_order else order_field_param
+            if order_field_param in {"name", "creator", "findings_count", "sla_deadline"}:
+                prefix = "-" if reverse_order else ""
+                group_findings_queryset = group_findings_queryset.order_by(f"{prefix}{order_field_param}")
+        return group_findings_queryset
+
+    def filters(self, request: HttpRequest) -> tuple[str, str | None, list[str], list[str]]:
+        name_filter: str = request.GET.get("name", "").lower()
+        min_severity_filter: str | None = request.GET.get("severity")
+        engagement_filter: list[str] = request.GET.getlist("engagement")
+        product_filter: list[str] = request.GET.getlist("product")
+        return name_filter, min_severity_filter, engagement_filter, product_filter
+
+    def filter_check(self, request: HttpRequest) -> Q:
+        name_filter, min_severity_filter, engagement_filter, product_filter = self.filters(request)
+        q_objects = Q()
+        if name_filter:
+            q_objects &= Q(name__icontains=name_filter)
+        if product_filter:
+            q_objects &= Q(findings__test__engagement__product__id__in=product_filter)
+        if engagement_filter:
+            q_objects &= Q(findings__test__engagement__id__in=engagement_filter)
+        if min_severity_filter:
+            min_severity_order_value = self.SEVERITY_ORDER.get(min_severity_filter, -1)
+            valid_severities_for_filter = [
+                sev for sev, order in self.SEVERITY_ORDER.items() if order >= min_severity_order_value
+            ]
+            q_objects &= Q(findings__severity__in=valid_severities_for_filter)
+        return q_objects
+
+    def get_findings(self, products: QuerySet[Product] | None) -> tuple[QuerySet[Finding], QuerySet[Finding]]:
+        filters: dict = {}
+        if products:
+            filters["test__engagement__product__in"] = products
+        user_findings_qs = Finding.objects.filter(**filters)
+        return user_findings_qs, user_findings_qs.filter(active=True)
+
+    def get_finding_groups(self, request: HttpRequest, products: QuerySet[Product] | None = None) -> QuerySet[Finding_Group]:
+        finding_groups_queryset = Finding_Group.objects.all()
+        if products is not None:
+            user_findings, _ = self.get_findings(products)
+            finding_groups_queryset = finding_groups_queryset.filter(findings__id__in=Subquery(user_findings.values("id"))).distinct()
+        request_filters_q = self.filter_check(request)
+        finding_groups_queryset = finding_groups_queryset.filter(request_filters_q).distinct()
+        finding_groups_queryset = finding_groups_queryset.annotate(
+            findings_count=Count("findings", distinct=True),
+            sla_deadline=Min("findings__sla_expiration_date"),
+        )
+        return self.order_field(request, finding_groups_queryset)
+
+    def paginate_queryset(self, queryset: QuerySet[Finding_Group], request: HttpRequest) -> Page:
+        page_size = int(request.GET.get("page_size", 25))
+        paginator = Paginator(queryset, page_size)
+        page_number = request.GET.get("page")
+        return paginator.get_page(page_number)
+
+    def get(self, request: HttpRequest) -> HttpResponse:
+        global_role = Global_Role.objects.filter(user=request.user).first()
+        user_groups = Dojo_Group.objects.filter(users=request.user)
+        products = Product.objects.filter(Q(members=request.user) | Q(authorization_groups__in=user_groups)).distinct()
+        if request.user.is_superuser or (global_role and global_role.role):
+            finding_groups = self.get_finding_groups(request)
+        elif products.exists():
+            finding_groups = self.get_finding_groups(request, products)
+        else:
+            finding_groups = Finding_Group.objects.none()
+
+        paginated_finding_groups = self.paginate_queryset(finding_groups, request)
+
+        context = {
+            "filter_name": self.filter_name,
+            "filtered": FindingGroupsFilter(request.GET),
+            "finding_groups": paginated_finding_groups,
+        }
+
+        add_breadcrumb(title="Finding Group", top_level=not request.GET, request=request)
+        return render(request, self.get_template(), context)
+
+
+class ListOpenFindingGroups(ListFindingGroups):
+    filter_name: str = "Open"
+
+    def get_finding_groups(self, request: HttpRequest, products: QuerySet[Product] | None = None) -> QuerySet[Finding_Group]:
+        finding_groups_queryset = super().get_finding_groups(request, products)
+        _, active_findings = self.get_findings(products)
+        return finding_groups_queryset.filter(findings__id__in=Subquery(active_findings.values("id"))).distinct()
+
+
+class ListClosedFindingGroups(ListFindingGroups):
+    filter_name: str = "Closed"
+
+    def get_finding_groups(self, request: HttpRequest, products: QuerySet[Product] | None = None) -> QuerySet[Finding_Group]:
+        finding_groups_queryset = super().get_finding_groups(request, products)
+        _, active_findings = self.get_findings(products)
+        return finding_groups_queryset.exclude(findings__id__in=Subquery(active_findings.values("id"))).distinct()

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -339,6 +339,31 @@
                                             <!-- /.nav-second-level -->
                                         </li>
                                         <li>
+                                            <a href="{% url 'all_finding_groups' %}" aria-expanded="false" aria-label="Problems">
+                                                <i class="fa-solid fa-triangle-exclamation fa-fw"></i>
+                                                <span>{% trans "Dashboard" %}</span>
+                                                <span class="glyphicon arrow"></span>
+                                            </a> 
+                                            <ul class="nav nav-second-level">
+                                                <li>
+                                                    <a href="{% url 'open_finding_groups' %}">
+                                                        {% trans "Open Findings Groups" %}
+                                                    </a>
+                                                </li>
+                                                <li>
+                                                    <a href="{% url 'all_finding_groups' %}">
+                                                        {% trans "All Findings Groups" %}
+                                                    </a>
+                                                </li>
+                                                <li>
+                                                    <a href="{% url 'closed_finding_groups' %}">
+                                                        {% trans "Closed Findings Groups" %}
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                            <!-- /.nav-second-level -->
+                                        </li>
+                                        <li>
                                             <a href="{% url 'components' %}" id="product_component_view" aria-expanded="false"  aria-label="Components">
                                                 <i class="fa-solid fa-table-cells-large fa-fw"></i>
                                                 <span>{% trans "Components" %}</span>

--- a/dojo/templates/dojo/finding_groups_list.html
+++ b/dojo/templates/dojo/finding_groups_list.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% load navigation_tags %}
+{% load display_tags %}
+{% load static %}
+{% block content %}
+    {% comment %} All/Open/Closed Finding Groups {% endcomment %}
+    {% include "dojo/finding_groups_list_snippet.html" %}
+{% endblock %}

--- a/dojo/templates/dojo/finding_groups_list_snippet.html
+++ b/dojo/templates/dojo/finding_groups_list_snippet.html
@@ -1,0 +1,243 @@
+{% load navigation_tags %}
+{% load display_tags %}
+{% load authorization_tags %}
+{% load get_endpoint_status %}
+{% load static %}
+{% load i18n %}
+{% block finding_groups_list %}
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading tight">
+                    <h3 class="has-filters">
+                        {% blocktrans %}{{ filter_name }} Findings Groups{% endblocktrans %}
+                        <div class="dropdown pull-right">
+                            &nbsp;
+                            <button id="show-filters"
+                                    data-toggle="collapse"
+                                    data-target="#the-filters"
+                                    class="btn btn-primary toggle-filters"
+                                    aria-label="show-filters">
+                                <i class="fa-solid fa-filter"></i> <i class="caret"></i>
+                            </button>
+                        </div>
+                    </h3>
+                </div>
+                <div id="the-filters" class="is-filters panel-body collapse">
+                    {% include "dojo/filter_snippet.html" with form=filtered.form %}
+                </div>
+            </div>
+            {% if finding_groups %}
+                <div class="clearfix">{% include "dojo/paging_snippet.html" with page=finding_groups page_size=True %}</div>
+                <div class="panel panel-default table-responsive">
+                    <table id="open_finding_groups" class="tablesorter-bootstrap table table-condensed table-striped table-hover" data-sort-order="asc">
+                        <thead>
+                            <tr>
+                                {% block header %}
+                                    <th>{% dojo_sort request "Name" "name" %}</th>
+                                    <th class="nowrap centered severity-sort">
+                                        {% trans "Severity" %}
+                                    </th>
+                                    <th>{% dojo_sort request "Findings Count" "findings_count" %}</th>
+                                    <th>{% trans "Age" %}</th>
+                                    <th>{% trans "SLA" %}</th>
+                                    <th>{% trans "Status" %}</th>
+                                    <th>{% dojo_sort request "Creator" "creator" %}</th>
+                                    <th>{% dojo_sort request "Deadline" "sla_deadline" %}</th>
+                                {% endblock %}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for finding_group in finding_groups %}
+                            <tr>
+                                <td>
+                                    <a href="{% url 'view_finding_group' finding_group.id %}">
+                                        {{ finding_group.name }}
+                                    </a>
+                                </td>
+                                <td class="centered severity-sort" data-severity="{{ finding_group.severity }}">
+                                    <span class="label severity severity-{{ finding_group.severity }}">
+                                        {{ finding_group.severity }}
+                                    </span>
+                                </td>
+                                <td class="centered">
+                                    {{ finding_group.findings_count }}
+                                </td>
+                                <td class="centered">
+                                    {% if finding_group.age %}
+                                        {{ finding_group.age }}
+                                    {% else %}
+                                        <span class="text-muted">{{ finding_group.age }}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="centered">
+                                    {% if finding_group.sla_days_remaining %}
+                                        {{ finding_group.sla_days_remaining }}
+                                    {% else %}
+                                        <span class="text-muted">{{ finding_group.sla_days_remaining }}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="centered">
+                                    {% if finding_group.status %}
+                                        {{ finding_group.status }}
+                                    {% else %}
+                                        <span class="text-muted">{{ finding_group.status }}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="centered">
+                                    {{ finding_group.creator }}
+                                </td>
+                                <td class="centered" data-order="{{ finding_group.sla_deadline|date:'Y-m-d' }}">
+                                    {% if finding_group.sla_deadline %}
+                                        {{ finding_group.sla_deadline|date:"F d, Y" }}
+                                    {% else %}
+                                        <span class="text-muted">{{ finding_group.sla_deadline }}</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                <div class="clearfix">
+                    {% include "dojo/paging_snippet.html" with page=finding_groups %}
+                </div>
+            {% else %}
+                <div id="no_finding_groups" class="panel-body">
+                    <p class="text-center">
+                        {% trans "No finding groups found." %}
+                    </p>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}
+{% block postscript %}
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript">
+        {% block datatables_columns %}
+            var percentSort = function(data, type, row, meta) {
+                if (type === 'sort') {
+                    return (data && data.endsWith("%")) ? parseFloat(data.slice(0, -1)) : -1.00;
+                }
+                return data;
+            };
+            var datatables_columns = [
+                { "data": "name", "render": function(data, type, row) {
+                    return type === 'export' ? getDojoExportValueFromTag(data, 'a') : data;
+                }},
+                { "data": "severity" },
+                { "data": "findings_count", "type": "num" },
+                { "data": "age", "type": "num" },
+                { "data": "sla", "type": "num", render: function (data, type, row, meta) {
+                    if(type === 'sort') {
+                        var api = new $.fn.dataTable.Api(meta.settings);
+                        var td = api.cell({row: meta.row, column: meta.col}).node();
+                        var data = $(td).find("a").text();
+                    }
+                    return data;
+                }},
+                { "data": "status" },
+                { "data": "creator" },
+                { "data": "sla_deadline", render: function (data, type, row, meta) {
+                    if(type === 'sort') {
+                        var api = new $.fn.dataTable.Api(meta.settings);
+                        var td = api.cell({row: meta.row, column: meta.col}).node();
+                        var data = $(td).attr("data-order");
+                    }
+                    return data;
+                }},
+            ];
+        {% endblock %}
+    </script>
+    <script type="application/javascript">
+        $.fn.dataTable.ext.order['severity-asc'] = function (settings, col) {
+            return this.api().column(col, { order: 'index' }).nodes().map(function (td, i) {
+                var severity = $(td).data('severity');
+                switch (severity) {
+                    case 'Info':
+                        return 1;
+                    case 'Low':
+                        return 2;
+                    case 'Medium':
+                        return 3;
+                    case 'High':
+                        return 4;
+                    case 'Critical':
+                        return 5;
+                    default:
+                        return 1;
+                }
+            });
+        };
+
+        $(document).ready(function() {
+            $('#open_finding_groups').DataTable({
+                drawCallback: function(){
+                    $('#open_finding_groups .has-popover').hover(
+                        function() { $(this).popover('show'); },
+                        function() { $(this).popover('hide'); } 
+                    );
+                },
+                colReorder: true,
+                columns: datatables_columns,
+                order: [],
+                columnDefs: [
+                    {
+                        targets: 'severity-sort',
+                        orderDataType: 'severity-asc'
+                    },
+                ],
+                dom: 'Bfrtip',
+                paging: false,
+                info: false,
+                buttons: [
+                    {
+                        extend: 'colvis',
+                        columns: ':not(.noVis)'
+                    },
+                    {
+                        extend: 'copy',
+                        exportOptions: {
+                            columns: [0, 1, 2, 3, 4, 5, 6, 7],
+                            stripHtml: true,
+                            stripNewlines: true,
+                            trim: true,
+                            orthogonal: 'export'
+                        },
+                        filename: 'Finding_Group_List',
+                        title: 'Finding Group List'
+                    },
+                    {
+                        extend: 'pdf',
+                        orientation: 'landscape',
+                        pageSize: 'LETTER',
+                        exportOptions: {
+                            columns: [0, 1, 2, 3, 4, 5, 6, 7],
+                            stripHtml: true,
+                            stripNewlines: true,
+                            trim: true,
+                            orthogonal: 'export'
+                        },
+                        filename: 'Finding_Group_List',
+                        title: 'Finding Group List'
+                    },
+                    {
+                        extend: 'print',
+                        exportOptions: {
+                            columns: [0, 1, 2, 3, 4, 5, 6, 7],
+                            stripHtml: true,
+                            stripNewlines: true,
+                            trim: true,
+                            orthogonal: 'export'
+                        },
+                        filename: 'Finding_Group_List',
+                        title: 'Finding Group List'
+                    }
+                ]
+            });
+        });
+    </script>
+    {% include "dojo/filter_js_snippet.html" %}
+    {% include "dojo/snippets/selectpicker_in_dropdown.html" %}
+{% endblock %}


### PR DESCRIPTION
I developed a new tab so that people can better see the information of the Finding_Group that is created during the scan import. This is acording to #12684.
As a next step we plan to allow include an option to dynamically create and visualize groups by properties of Findings.

Bellow the image of Findings tab:
<img width="1814" height="616" alt="Screenshot from 2025-07-18 12-40-52" src="https://github.com/user-attachments/assets/5a2b3ffe-5d9b-4fc6-ac46-7836de1319ca" />
And the image of the reduced result with Finding_Group tab:
<img width="1809" height="610" alt="Screenshot from 2025-07-18 12-37-30" src="https://github.com/user-attachments/assets/fbceaefd-d3f6-4fe8-986d-7887243eb027" />

