### PR TITLE
product api: optimize list of finding ids

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2062,7 +2062,7 @@ class ProductSerializer(serializers.ModelSerializer):
 
     # TODO: maybe extend_schema_field is needed here?
     def get_findings_list(self, obj) -> list[int]:
-        return obj.open_findings_list
+        return obj.open_findings_list()
 
 
 class CommonImportScanSerializer(serializers.Serializer):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1322,12 +1322,10 @@ class Product(models.Model):
     def get_product_type(self):
         return self.prod_type if self.prod_type is not None else "unknown"
 
-    # only used in APIv2 serializers.py, query should be aligned with findings_count
-    @cached_property
+    # only used in APIv2 serializers.py, should be deprecated or at least prefetched
     def open_findings_list(self):
-        findings = Finding.objects.filter(test__engagement__product=self,
-                                          active=True)
-        return [i.id for i in findings]
+        findings = Finding.objects.filter(test__engagement__product=self, active=True).values_list("id", flat=True)
+        return list(findings)
 
     @property
     def has_jira_configured(self):


### PR DESCRIPTION
The `products` API endpoint returns the list of ids of all active findings for each product.

This is slow in larger instances or large page sizes.

This PR optimizes the query a little bit. For a 100K finding instance the response time went from ~6s to ~0.9s. Of course the mileage may vary depending on available resources and dataset specifics.

I tried fursther optimizing is using prefetching. But prefetching across multiple relationship levels in Django ORM isn't possible in one ago and requires some aggregation/counting in python making it slower again.

[sc-11611]