### PR TITLE
Docs: Update outdated URLs

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/file/aws_prowler_v3plus.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/aws_prowler_v3plus.md
@@ -5,7 +5,7 @@ toc_hide: true
 
 ### File Types
 DefectDojo parser accepts a native `json` file produced by prowler v3 with file extension `.json` or a `ocsf-json` file produced by prowler v4 with file extension `.ocsf.json`. 
-Please note: earlier versions of AWS Prowler create output data in a different format. See our other [prowler parser documentation](https://documentation.defectdojo.com/integrations/parsers/file/aws_prowler/) if you are using an earlier version of AWS Prowler. 
+Please note: earlier versions of AWS Prowler create output data in a different format. See our other [prowler parser documentation](https://docs.defectdojo.com/en/connecting_your_tools/parsers/file/aws_prowler/) if you are using an earlier version of AWS Prowler. 
 
 JSON reports can be created from the [AWS Prowler v3 CLI](https://docs.prowler.com/projects/prowler-open-source/en/v3/tutorials/reporting/#json) using the following command: `prowler <provider> -M json`
 

--- a/docs/content/en/connecting_your_tools/parsers/file/burp.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/burp.md
@@ -4,7 +4,7 @@ toc_hide: true
 ---
 ### File Types
 DefectDojo parser accepts Burp Issue data as an .xml file.
-To parse an HTML file instead, use this method: https://documentation.defectdojo.com/integrations/parsers/file/burp_suite_dast/
+To parse an HTML file instead, use this method: https://docs.defectdojo.com/en/connecting_your_tools/parsers/file/burp_suite_dast/
 
 When the Burp report is generated, **the recommended option is Base64
 encoding both the request and response fields** - e.g. check the box

--- a/docs/content/en/open_source/contributing/branching-model.md
+++ b/docs/content/en/open_source/contributing/branching-model.md
@@ -28,8 +28,6 @@ PRs that relate to security issues are done through [security advisories](https:
 
 Diagrams created with [plantUML](https://plantuml.com). Find a web-based editor for PlantUML at https://www.planttext.com.
 
-## Documentation
-A `dev` version of the documentation built from the `dev` branch is available at [DefectDojo Documentation - dev branch](https://documentation.defectdojo.com/dev/).
 
 
 <!-- PlantUML Schema -->

--- a/docs/content/en/open_source/contributing/how-to-write-a-parser.md
+++ b/docs/content/en/open_source/contributing/how-to-write-a-parser.md
@@ -241,7 +241,7 @@ Do not do something like this:
 
 ## Deduplication algorithm
 
-By default a new parser uses the 'legacy' deduplication algorithm documented at https://documentation.defectdojo.com/usage/features/#deduplication-algorithms
+By default a new parser uses the 'legacy' deduplication algorithm documented at https://docs.defectdojo.com/en/open_source/archived_docs/usage/features/#deduplication
 
 Please use a pre-defined deduplication algorithm where applicable. When using the `unique_id_from_tool` or `vuln_id_from_tool` fields in the hash code configuration, it's important that these are uqniue for the finding and constant over time across subsequent scans. If this is not the case, the values can still be useful to set on the finding model without using them for deduplication.
 The values must be coming from the report directly and must not be something that is calculated by the parser internally.


### PR DESCRIPTION
This PR updates outdated URLs found in the documentation to point to their current and correct locations.
Let me know if any additional references should be updated or verified.