### PR TITLE
perf1: test cases: fix caching of system settings

### DIFF
--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -112,13 +112,6 @@ class DojoSytemSettingsMiddleware:
         cls._thread_local.system_settings = system_settings
         return system_settings
 
-    @classmethod
-    def initialize_for_testing(cls, system_settings):
-        """Initialize system settings for test scenarios where middleware may not be processed normally"""
-        # cleanup any existing settings first to ensure fresh state
-        cls.cleanup()
-        cls._thread_local.system_settings = system_settings
-
 
 class System_Settings_Manager(models.Manager):
 

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -109,6 +109,11 @@ class DojoSytemSettingsMiddleware:
         cls._thread_local.system_settings = system_settings
         return system_settings
 
+    @classmethod
+    def initialize_for_testing(cls, system_settings):
+        """Initialize system settings for test scenarios where middleware may not be processed normally"""
+        cls._thread_local.system_settings = system_settings
+
 
 class System_Settings_Manager(models.Manager):
 

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -83,9 +83,11 @@ class DojoSytemSettingsMiddleware:
 
     def __call__(self, request):
         self.load()
-        response = self.get_response(request)
-        self.cleanup()
-        return response
+        try:
+            return self.get_response(request)
+        finally:
+            # ensure cleanup happens even if an exception occurs
+            self.cleanup()
 
     def process_exception(self, request, exception):
         self.cleanup()
@@ -94,7 +96,6 @@ class DojoSytemSettingsMiddleware:
     def get_system_settings(cls):
         if hasattr(cls._thread_local, "system_settings"):
             return cls._thread_local.system_settings
-
         return None
 
     @classmethod
@@ -104,6 +105,8 @@ class DojoSytemSettingsMiddleware:
 
     @classmethod
     def load(cls):
+        # cleanup any existing settings first to ensure fresh state
+        cls.cleanup()
         from dojo.models import System_Settings
         system_settings = System_Settings.objects.get(no_cache=True)
         cls._thread_local.system_settings = system_settings
@@ -112,6 +115,8 @@ class DojoSytemSettingsMiddleware:
     @classmethod
     def initialize_for_testing(cls, system_settings):
         """Initialize system settings for test scenarios where middleware may not be processed normally"""
+        # cleanup any existing settings first to ensure fresh state
+        cls.cleanup()
         cls._thread_local.system_settings = system_settings
 
 

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -475,9 +475,6 @@ class DojoTestCase(TestCase, DojoTestUtilsMixin):
 
     def setUp(self):
         super().setUp()
-        from dojo.middleware import DojoSytemSettingsMiddleware
-        from dojo.models import System_Settings
-        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
     def common_check_finding(self, finding):
         self.assertIn(finding.severity, SEVERITIES)

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -55,15 +55,15 @@ def toggle_system_setting_boolean(flag_name, value):
         def wrapper(*args, **kwargs):
             # Set the flag to the specified value
             System_Settings.objects.update(**{flag_name: value})
-            # Reinitialize middleware with updated settings
-            DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+            # Reinitialize middleware with updated settings as this doesn't happen automatically during django tests
+            DojoSytemSettingsMiddleware.load()
             try:
                 return test_func(*args, **kwargs)
             finally:
                 # Reset the flag to its original state after the test
                 System_Settings.objects.update(**{flag_name: not value})
-                # Reinitialize middleware with updated settings
-                DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+                # Reinitialize middleware with updated settings as this doesn't happen automatically during django tests
+                DojoSytemSettingsMiddleware.load()
         return wrapper
 
     return decorator
@@ -78,15 +78,15 @@ def with_system_setting(field, value):
             old_value = getattr(System_Settings.objects.get(), field)
             # Set the flag to the specified value
             System_Settings.objects.update(**{field: value})
-            # Reinitialize middleware with updated settings
-            DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+            # Reinitialize middleware with updated settings as this doesn't happen automatically during django tests
+            DojoSytemSettingsMiddleware.load()
             try:
                 return test_func(*args, **kwargs)
             finally:
                 # Reset the flag to its original state after the test
                 System_Settings.objects.update(**{field: old_value})
-                # Reinitialize middleware with updated settings
-                DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+                # Reinitialize middleware with updated settings as this doesn't happen automatically during django tests
+                DojoSytemSettingsMiddleware.load()
 
         return wrapper
 

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from dojo.decorators import dojo_async_task_counter
 from dojo.importers.default_importer import DefaultImporter
 from dojo.importers.default_reimporter import DefaultReImporter
+from dojo.middleware import DojoSytemSettingsMiddleware
 from dojo.models import (
     Development_Environment,
     Dojo_User,
@@ -18,6 +19,7 @@ from dojo.models import (
     Finding,
     Product,
     Product_Type,
+    System_Settings,
     Test,
     User,
 )
@@ -43,6 +45,16 @@ class TestDojoImporterPerformance(DojoTestCase):
         self.system_settings(enable_product_grade=False)
         self.system_settings(enable_github=False)
         # from dojo.models import System_Settings
+
+        # # Configure system settings directly
+        # from dojo.middleware import DojoSytemSettingsMiddleware
+        # from dojo.models import System_Settings
+        # system_settings = System_Settings.objects.get()
+        # system_settings.enable_product_tag_inheritance = True
+        # system_settings.save()
+
+        # Initialize middleware with modified settings
+        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
         # Warm up ContentType cache for relevant models. This is needed if we want to be able to run the test in isolation
         # As part of the test suite the ContentTYpe ids will already be cached and won't affect the query count.

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -9,7 +9,6 @@ from django.utils import timezone
 from dojo.decorators import dojo_async_task_counter
 from dojo.importers.default_importer import DefaultImporter
 from dojo.importers.default_reimporter import DefaultReImporter
-from dojo.middleware import DojoSytemSettingsMiddleware
 from dojo.models import (
     Development_Environment,
     Dojo_User,
@@ -19,7 +18,6 @@ from dojo.models import (
     Finding,
     Product,
     Product_Type,
-    System_Settings,
     Test,
     User,
 )
@@ -54,7 +52,7 @@ class TestDojoImporterPerformance(DojoTestCase):
         # system_settings.save()
 
         # Initialize middleware with modified settings
-        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+        # DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
         # Warm up ContentType cache for relevant models. This is needed if we want to be able to run the test in isolation
         # As part of the test suite the ContentTYpe ids will already be cached and won't affect the query count.
@@ -205,8 +203,6 @@ class TestDojoImporterPerformance(DojoTestCase):
         so we patch the we_want_async decorator to always return False.
         """
         self.system_settings(enable_product_grade=True)
-        # Reinitialize middleware with updated settings
-        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
         self.import_reimport_performance(
             expected_num_queries1=594,

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -119,6 +119,8 @@ class TestDojoImporterPerformance(DojoTestCase):
                 "sync": True,
                 "scan_type": STACK_HAWK_SCAN_TYPE,
                 "engagement": engagement,
+                "tags": ["performance-test", "tag-in-param", "go-faster"],
+                "apply_tags_to_findings": True,
             }
             importer = DefaultImporter(**import_options)
             test, _, _len_new_findings, _len_closed_findings, _, _, _ = importer.process_scan(scan)
@@ -140,6 +142,8 @@ class TestDojoImporterPerformance(DojoTestCase):
                 "verified": True,
                 "sync": True,
                 "scan_type": STACK_HAWK_SCAN_TYPE,
+                "tags": ["performance-test-reimport", "reimport-tag-in-param", "reimport-go-faster"],
+                "apply_tags_to_findings": True,
             }
             reimporter = DefaultReImporter(**reimport_options)
             test, _, _len_new_findings, _len_closed_findings, _, _, _ = reimporter.process_scan(scan)
@@ -167,9 +171,9 @@ class TestDojoImporterPerformance(DojoTestCase):
 
     def test_import_reimport_reimport_performance(self):
         self.import_reimport_performance(
-            expected_num_queries1=554,
+            expected_num_queries1=712,
             expected_num_async_tasks1=15,
-            expected_num_queries2=469,
+            expected_num_queries2=656,
             expected_num_async_tasks2=23,
             expected_num_queries3=332,
             expected_num_async_tasks3=20,
@@ -185,9 +189,9 @@ class TestDojoImporterPerformance(DojoTestCase):
         so we patch the we_want_async decorator to always return False.
         """
         self.import_reimport_performance(
-            expected_num_queries1=554,
+            expected_num_queries1=712,
             expected_num_async_tasks1=15,
-            expected_num_queries2=469,
+            expected_num_queries2=656,
             expected_num_async_tasks2=23,
             expected_num_queries3=332,
             expected_num_async_tasks3=20,
@@ -205,9 +209,9 @@ class TestDojoImporterPerformance(DojoTestCase):
         self.system_settings(enable_product_grade=True)
 
         self.import_reimport_performance(
-            expected_num_queries1=594,
+            expected_num_queries1=752,
             expected_num_async_tasks1=25,
-            expected_num_queries2=503,
+            expected_num_queries2=690,
             expected_num_async_tasks2=30,
             expected_num_queries3=357,
             expected_num_async_tasks3=25,

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -38,9 +38,12 @@ class TestDojoImporterPerformance(DojoTestCase):
 
     def setUp(self):
         super().setUp()
+
         self.system_settings(enable_webhooks_notifications=False)
         self.system_settings(enable_product_grade=False)
         self.system_settings(enable_github=False)
+        # from dojo.models import System_Settings
+
         # Warm up ContentType cache for relevant models. This is needed if we want to be able to run the test in isolation
         # As part of the test suite the ContentTYpe ids will already be cached and won't affect the query count.
         # But if we run the test in isolation, the ContentType ids will not be cached and will result in more queries.
@@ -154,11 +157,11 @@ class TestDojoImporterPerformance(DojoTestCase):
 
     def test_import_reimport_reimport_performance(self):
         self.import_reimport_performance(
-            expected_num_queries1=603,
+            expected_num_queries1=554,
             expected_num_async_tasks1=15,
-            expected_num_queries2=489,
+            expected_num_queries2=469,
             expected_num_async_tasks2=23,
-            expected_num_queries3=347,
+            expected_num_queries3=332,
             expected_num_async_tasks3=20,
         )
 
@@ -172,12 +175,12 @@ class TestDojoImporterPerformance(DojoTestCase):
         so we patch the we_want_async decorator to always return False.
         """
         self.import_reimport_performance(
-            expected_num_queries1=673,
-            expected_num_async_tasks1=25,
-            expected_num_queries2=544,
-            expected_num_async_tasks2=30,
-            expected_num_queries3=387,
-            expected_num_async_tasks3=25,
+            expected_num_queries1=554,
+            expected_num_async_tasks1=15,
+            expected_num_queries2=469,
+            expected_num_async_tasks2=23,
+            expected_num_queries3=332,
+            expected_num_async_tasks3=20,
         )
 
     @patch("dojo.decorators.we_want_async", return_value=False)
@@ -191,10 +194,10 @@ class TestDojoImporterPerformance(DojoTestCase):
         """
         self.system_settings(enable_product_grade=True)
         self.import_reimport_performance(
-            expected_num_queries1=673,
+            expected_num_queries1=594,
             expected_num_async_tasks1=25,
-            expected_num_queries2=544,
+            expected_num_queries2=503,
             expected_num_async_tasks2=30,
-            expected_num_queries3=387,
+            expected_num_queries3=357,
             expected_num_async_tasks3=25,
         )

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -209,7 +209,7 @@ class TestDojoImporterPerformance(DojoTestCase):
         DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
         self.import_reimport_performance(
-            expected_num_queries1=59444,
+            expected_num_queries1=594,
             expected_num_async_tasks1=25,
             expected_num_queries2=503,
             expected_num_async_tasks2=30,

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -205,8 +205,11 @@ class TestDojoImporterPerformance(DojoTestCase):
         so we patch the we_want_async decorator to always return False.
         """
         self.system_settings(enable_product_grade=True)
+        # Reinitialize middleware with updated settings
+        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+
         self.import_reimport_performance(
-            expected_num_queries1=594,
+            expected_num_queries1=59444,
             expected_num_async_tasks1=25,
             expected_num_queries2=503,
             expected_num_async_tasks2=30,

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -292,7 +292,7 @@ class InheritedTagsTests(DojoAPITestCase):
     def setUp(self, *args, **kwargs):
         super().setUp()
         self.login_as_admin()
-        self.system_settings(enable_product_tag_inehritance=True)
+        self.system_settings(enable_product_tag_inheritance=True)
         self.product = self.create_product("Inherited Tags Test", tags=["inherit", "these", "tags"])
         self.scans_path = get_unit_tests_scans_path("zap")
         self.zap_sample5_filename = self.scans_path / "5_zap_sample_one.xml"


### PR DESCRIPTION
There'll be a sequence of import performance related PRs. They are separated into small PRs to simplify review and troubleshooting. As they all use `test_importers_performance`, they'll build on eachother. So they'll have to be merged by natural ordering.

- system settings weren't set in the correct way, resulting in some settings like product grading left enabled resulting in incorrect query counts
- tags weren't provided in the `test_importers_performance.py`
- updated query counts

I also identified that the caching of System_Settings was not working in test cases, which is now fixed.