### PR TITLE
perf3: importers should not save findings again

### DIFF
--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -198,7 +198,9 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
 
             # Force parsers to use unsaved_tags (stored in below after saving)
             unsaved_finding.tags = None
-            unsaved_finding.save(dedupe_option=False)
+            # unsaved_finding.save(dedupe_option=False)
+            # postprocessing will be done on next save.
+            unsaved_finding.save_no_options()
             finding = unsaved_finding
             # Determine how the finding should be grouped
             self.process_finding_groups(

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -198,7 +198,6 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
 
             # Force parsers to use unsaved_tags (stored in below after saving)
             unsaved_finding.tags = None
-            # unsaved_finding.save(dedupe_option=False)
             # postprocessing will be done on next save.
             unsaved_finding.save_no_options()
             finding = unsaved_finding

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -236,12 +236,14 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                     finding,
                     unsaved_finding,
                 )
-                # finding = new finding or existing finding still in the upload report
+                # by this time the finding has been processed and saved to the database.
+                # since the save above no changes have been made to the finding, only to related objects such as endpoints.
+                # we don't have to save the finding again and can trigger postprocessing directly
+                # this saves a database UDPATE which is costly (and may trigger extra processing via signals such as audit logging)
+
                 # to avoid pushing a finding group multiple times, we push those outside of the loop
-                if self.findings_groups_enabled and self.group_by:
-                    finding.save()
-                else:
-                    finding.save(push_to_jira=self.push_to_jira)
+                push_to_jira = self.push_to_jira and (not self.findings_groups_enabled or not self.group_by)
+                finding_helper.post_process_finding_save(finding, dedupe_option=True, rules_option=True, product_grading_option=True, issue_updater_option=True, push_to_jira=push_to_jira)
 
         self.to_mitigate = (set(self.original_items) - set(self.reactivated_items) - set(self.unchanged_items))
         # due to #3958 we can have duplicates inside the same report
@@ -547,6 +549,8 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                 existing_finding.active = False
                 if self.verified is not None:
                     existing_finding.verified = self.verified
+                existing_finding.save_no_options()
+
             elif unsaved_finding.risk_accepted or unsaved_finding.false_p or unsaved_finding.out_of_scope:
                 logger.debug("Reimported mitigated item matches a finding that is currently open, closing.")
                 logger.debug(
@@ -559,6 +563,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                 existing_finding.active = False
                 if self.verified is not None:
                     existing_finding.verified = self.verified
+                existing_finding.save_no_options()
             else:
                 # if finding is the same but list of affected was changed, finding is marked as unchanged. This is a known issue
                 self.unchanged_items.append(existing_finding)

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -480,7 +480,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                 )
                 note.save()
                 existing_finding.notes.add(note)
-                existing_finding.save(dedupe_option=False)
+                existing_finding.save_no_options()
             # Return True here to force the loop to continue
             return existing_finding, True
         logger.debug(
@@ -571,7 +571,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         ):
             existing_finding.component_name = existing_finding.component_name or component_name
             existing_finding.component_version = existing_finding.component_version or component_version
-            existing_finding.save(dedupe_option=False)
+            existing_finding.save_no_options()
         # Return False here to make sure further processing happens
         return existing_finding, False
 
@@ -594,7 +594,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         if self.scan_date_override:
             unsaved_finding.date = self.scan_date.date()
         # Save it. Don't dedupe before endpoints are added.
-        unsaved_finding.save(dedupe_option=False)
+        unsaved_finding.save_no_options()
         finding = unsaved_finding
         # Force parsers to use unsaved_tags (stored in finding_post_processing function below)
         finding.tags = None

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -498,9 +498,8 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         component_version = getattr(unsaved_finding, "component_version", None)
         existing_finding.component_name = existing_finding.component_name or component_name
         existing_finding.component_version = existing_finding.component_version or component_version
-        existing_finding.save(dedupe_option=False)
-        # don't dedupe before endpoints are added
-        existing_finding.save(dedupe_option=False)
+        # don't dedupe before endpoints are added, postprocessing will be done on next save (in calling method)
+        existing_finding.save_no_options()
         note = Notes(entry=f"Re-activated by {self.scan_type} re-upload.", author=self.user)
         note.save()
         endpoint_statuses = existing_finding.status_finding.exclude(

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -112,13 +112,6 @@ class DojoSytemSettingsMiddleware:
         cls._thread_local.system_settings = system_settings
         return system_settings
 
-    @classmethod
-    def initialize_for_testing(cls, system_settings):
-        """Initialize system settings for test scenarios where middleware may not be processed normally"""
-        # cleanup any existing settings first to ensure fresh state
-        cls.cleanup()
-        cls._thread_local.system_settings = system_settings
-
 
 class System_Settings_Manager(models.Manager):
 

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -109,6 +109,11 @@ class DojoSytemSettingsMiddleware:
         cls._thread_local.system_settings = system_settings
         return system_settings
 
+    @classmethod
+    def initialize_for_testing(cls, system_settings):
+        """Initialize system settings for test scenarios where middleware may not be processed normally"""
+        cls._thread_local.system_settings = system_settings
+
 
 class System_Settings_Manager(models.Manager):
 

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -83,9 +83,11 @@ class DojoSytemSettingsMiddleware:
 
     def __call__(self, request):
         self.load()
-        response = self.get_response(request)
-        self.cleanup()
-        return response
+        try:
+            return self.get_response(request)
+        finally:
+            # ensure cleanup happens even if an exception occurs
+            self.cleanup()
 
     def process_exception(self, request, exception):
         self.cleanup()
@@ -94,7 +96,6 @@ class DojoSytemSettingsMiddleware:
     def get_system_settings(cls):
         if hasattr(cls._thread_local, "system_settings"):
             return cls._thread_local.system_settings
-
         return None
 
     @classmethod
@@ -104,6 +105,8 @@ class DojoSytemSettingsMiddleware:
 
     @classmethod
     def load(cls):
+        # cleanup any existing settings first to ensure fresh state
+        cls.cleanup()
         from dojo.models import System_Settings
         system_settings = System_Settings.objects.get(no_cache=True)
         cls._thread_local.system_settings = system_settings
@@ -112,6 +115,8 @@ class DojoSytemSettingsMiddleware:
     @classmethod
     def initialize_for_testing(cls, system_settings):
         """Initialize system settings for test scenarios where middleware may not be processed normally"""
+        # cleanup any existing settings first to ensure fresh state
+        cls.cleanup()
         cls._thread_local.system_settings = system_settings
 
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2773,7 +2773,8 @@ class Finding(models.Model):
         self.found_by.add(self.test.test_type)
 
         # only perform post processing (in celery task) if needed. this check avoids submitting 1000s of tasks to celery that will do nothing
-        if dedupe_option or issue_updater_option or product_grading_option or push_to_jira:
+        system_settings = System_Settings.objects.get()
+        if dedupe_option or issue_updater_option or (product_grading_option and system_settings.enable_product_grade) or push_to_jira:
             finding_helper.post_process_finding_save(self, dedupe_option=dedupe_option, rules_option=rules_option, product_grading_option=product_grading_option,
                 issue_updater_option=issue_updater_option, push_to_jira=push_to_jira, user=user, *args, **kwargs)
         else:

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -475,9 +475,6 @@ class DojoTestCase(TestCase, DojoTestUtilsMixin):
 
     def setUp(self):
         super().setUp()
-        from dojo.middleware import DojoSytemSettingsMiddleware
-        from dojo.models import System_Settings
-        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
     def common_check_finding(self, finding):
         self.assertIn(finding.severity, SEVERITIES)

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -55,15 +55,15 @@ def toggle_system_setting_boolean(flag_name, value):
         def wrapper(*args, **kwargs):
             # Set the flag to the specified value
             System_Settings.objects.update(**{flag_name: value})
-            # Reinitialize middleware with updated settings
-            DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+            # Reinitialize middleware with updated settings as this doesn't happen automatically during django tests
+            DojoSytemSettingsMiddleware.load()
             try:
                 return test_func(*args, **kwargs)
             finally:
                 # Reset the flag to its original state after the test
                 System_Settings.objects.update(**{flag_name: not value})
-                # Reinitialize middleware with updated settings
-                DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+                # Reinitialize middleware with updated settings as this doesn't happen automatically during django tests
+                DojoSytemSettingsMiddleware.load()
         return wrapper
 
     return decorator
@@ -78,15 +78,15 @@ def with_system_setting(field, value):
             old_value = getattr(System_Settings.objects.get(), field)
             # Set the flag to the specified value
             System_Settings.objects.update(**{field: value})
-            # Reinitialize middleware with updated settings
-            DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+            # Reinitialize middleware with updated settings as this doesn't happen automatically during django tests
+            DojoSytemSettingsMiddleware.load()
             try:
                 return test_func(*args, **kwargs)
             finally:
                 # Reset the flag to its original state after the test
                 System_Settings.objects.update(**{field: old_value})
-                # Reinitialize middleware with updated settings
-                DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+                # Reinitialize middleware with updated settings as this doesn't happen automatically during django tests
+                DojoSytemSettingsMiddleware.load()
 
         return wrapper
 

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -203,7 +203,7 @@ class TestDojoImporterPerformance(DojoTestCase):
         self.import_reimport_performance(
             expected_num_queries1=732,
             expected_num_async_tasks1=15,
-            expected_num_queries2=690,
+            expected_num_queries2=686,
             expected_num_async_tasks2=28,
             expected_num_queries3=357,
             expected_num_async_tasks3=25,

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -161,7 +161,7 @@ class TestDojoImporterPerformance(DojoTestCase):
     def test_import_reimport_reimport_performance(self):
         self.import_reimport_performance(
             expected_num_queries1=712,
-            expected_num_async_tasks1=15,
+            expected_num_async_tasks1=10,
             expected_num_queries2=656,
             expected_num_async_tasks2=23,
             expected_num_queries3=332,
@@ -179,7 +179,7 @@ class TestDojoImporterPerformance(DojoTestCase):
         """
         self.import_reimport_performance(
             expected_num_queries1=712,
-            expected_num_async_tasks1=15,
+            expected_num_async_tasks1=10,
             expected_num_queries2=656,
             expected_num_async_tasks2=23,
             expected_num_queries3=332,
@@ -201,8 +201,8 @@ class TestDojoImporterPerformance(DojoTestCase):
         DojoSytemSettingsMiddleware.load()
 
         self.import_reimport_performance(
-            expected_num_queries1=752,
-            expected_num_async_tasks1=25,
+            expected_num_queries1=732,
+            expected_num_async_tasks1=15,
             expected_num_queries2=690,
             expected_num_async_tasks2=30,
             expected_num_queries3=357,

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from dojo.decorators import dojo_async_task_counter
 from dojo.importers.default_importer import DefaultImporter
 from dojo.importers.default_reimporter import DefaultReImporter
+from dojo.middleware import DojoSytemSettingsMiddleware
 from dojo.models import (
     Development_Environment,
     Dojo_User,
@@ -18,6 +19,7 @@ from dojo.models import (
     Finding,
     Product,
     Product_Type,
+    System_Settings,
     Test,
     User,
 )
@@ -43,6 +45,16 @@ class TestDojoImporterPerformance(DojoTestCase):
         self.system_settings(enable_product_grade=False)
         self.system_settings(enable_github=False)
         # from dojo.models import System_Settings
+
+        # # Configure system settings directly
+        # from dojo.middleware import DojoSytemSettingsMiddleware
+        # from dojo.models import System_Settings
+        # system_settings = System_Settings.objects.get()
+        # system_settings.enable_product_tag_inheritance = True
+        # system_settings.save()
+
+        # Initialize middleware with modified settings
+        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
         # Warm up ContentType cache for relevant models. This is needed if we want to be able to run the test in isolation
         # As part of the test suite the ContentTYpe ids will already be cached and won't affect the query count.

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -9,7 +9,6 @@ from django.utils import timezone
 from dojo.decorators import dojo_async_task_counter
 from dojo.importers.default_importer import DefaultImporter
 from dojo.importers.default_reimporter import DefaultReImporter
-from dojo.middleware import DojoSytemSettingsMiddleware
 from dojo.models import (
     Development_Environment,
     Dojo_User,
@@ -19,7 +18,6 @@ from dojo.models import (
     Finding,
     Product,
     Product_Type,
-    System_Settings,
     Test,
     User,
 )
@@ -54,7 +52,7 @@ class TestDojoImporterPerformance(DojoTestCase):
         # system_settings.save()
 
         # Initialize middleware with modified settings
-        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+        # DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
         # Warm up ContentType cache for relevant models. This is needed if we want to be able to run the test in isolation
         # As part of the test suite the ContentTYpe ids will already be cached and won't affect the query count.
@@ -205,8 +203,6 @@ class TestDojoImporterPerformance(DojoTestCase):
         so we patch the we_want_async decorator to always return False.
         """
         self.system_settings(enable_product_grade=True)
-        # Reinitialize middleware with updated settings
-        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
         self.import_reimport_performance(
             expected_num_queries1=594,

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -163,7 +163,7 @@ class TestDojoImporterPerformance(DojoTestCase):
             expected_num_queries1=712,
             expected_num_async_tasks1=10,
             expected_num_queries2=656,
-            expected_num_async_tasks2=23,
+            expected_num_async_tasks2=22,
             expected_num_queries3=332,
             expected_num_async_tasks3=20,
         )
@@ -181,7 +181,7 @@ class TestDojoImporterPerformance(DojoTestCase):
             expected_num_queries1=712,
             expected_num_async_tasks1=10,
             expected_num_queries2=656,
-            expected_num_async_tasks2=23,
+            expected_num_async_tasks2=22,
             expected_num_queries3=332,
             expected_num_async_tasks3=20,
         )
@@ -204,7 +204,7 @@ class TestDojoImporterPerformance(DojoTestCase):
             expected_num_queries1=732,
             expected_num_async_tasks1=15,
             expected_num_queries2=690,
-            expected_num_async_tasks2=30,
+            expected_num_async_tasks2=28,
             expected_num_queries3=357,
             expected_num_async_tasks3=25,
         )

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -38,9 +38,12 @@ class TestDojoImporterPerformance(DojoTestCase):
 
     def setUp(self):
         super().setUp()
+
         self.system_settings(enable_webhooks_notifications=False)
         self.system_settings(enable_product_grade=False)
         self.system_settings(enable_github=False)
+        # from dojo.models import System_Settings
+
         # Warm up ContentType cache for relevant models. This is needed if we want to be able to run the test in isolation
         # As part of the test suite the ContentTYpe ids will already be cached and won't affect the query count.
         # But if we run the test in isolation, the ContentType ids will not be cached and will result in more queries.
@@ -154,11 +157,11 @@ class TestDojoImporterPerformance(DojoTestCase):
 
     def test_import_reimport_reimport_performance(self):
         self.import_reimport_performance(
-            expected_num_queries1=603,
+            expected_num_queries1=554,
             expected_num_async_tasks1=15,
-            expected_num_queries2=489,
+            expected_num_queries2=469,
             expected_num_async_tasks2=23,
-            expected_num_queries3=347,
+            expected_num_queries3=332,
             expected_num_async_tasks3=20,
         )
 
@@ -172,12 +175,12 @@ class TestDojoImporterPerformance(DojoTestCase):
         so we patch the we_want_async decorator to always return False.
         """
         self.import_reimport_performance(
-            expected_num_queries1=673,
-            expected_num_async_tasks1=25,
-            expected_num_queries2=544,
-            expected_num_async_tasks2=30,
-            expected_num_queries3=387,
-            expected_num_async_tasks3=25,
+            expected_num_queries1=554,
+            expected_num_async_tasks1=15,
+            expected_num_queries2=469,
+            expected_num_async_tasks2=23,
+            expected_num_queries3=332,
+            expected_num_async_tasks3=20,
         )
 
     @patch("dojo.decorators.we_want_async", return_value=False)
@@ -191,10 +194,10 @@ class TestDojoImporterPerformance(DojoTestCase):
         """
         self.system_settings(enable_product_grade=True)
         self.import_reimport_performance(
-            expected_num_queries1=673,
+            expected_num_queries1=594,
             expected_num_async_tasks1=25,
-            expected_num_queries2=544,
+            expected_num_queries2=503,
             expected_num_async_tasks2=30,
-            expected_num_queries3=387,
+            expected_num_queries3=357,
             expected_num_async_tasks3=25,
         )

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -42,17 +42,6 @@ class TestDojoImporterPerformance(DojoTestCase):
         self.system_settings(enable_webhooks_notifications=False)
         self.system_settings(enable_product_grade=False)
         self.system_settings(enable_github=False)
-        # from dojo.models import System_Settings
-
-        # # Configure system settings directly
-        # from dojo.middleware import DojoSytemSettingsMiddleware
-        # from dojo.models import System_Settings
-        # system_settings = System_Settings.objects.get()
-        # system_settings.enable_product_tag_inheritance = True
-        # system_settings.save()
-
-        # Initialize middleware with modified settings
-        # DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
         # Warm up ContentType cache for relevant models. This is needed if we want to be able to run the test in isolation
         # As part of the test suite the ContentTYpe ids will already be cached and won't affect the query count.
@@ -168,7 +157,7 @@ class TestDojoImporterPerformance(DojoTestCase):
     def test_import_reimport_reimport_performance(self):
         self.import_reimport_performance(
             expected_num_queries1=554,
-            expected_num_async_tasks1=15,
+            expected_num_async_tasks1=10,
             expected_num_queries2=469,
             expected_num_async_tasks2=23,
             expected_num_queries3=332,
@@ -186,7 +175,7 @@ class TestDojoImporterPerformance(DojoTestCase):
         """
         self.import_reimport_performance(
             expected_num_queries1=554,
-            expected_num_async_tasks1=15,
+            expected_num_async_tasks1=10,
             expected_num_queries2=469,
             expected_num_async_tasks2=23,
             expected_num_queries3=332,
@@ -203,10 +192,13 @@ class TestDojoImporterPerformance(DojoTestCase):
         so we patch the we_want_async decorator to always return False.
         """
         self.system_settings(enable_product_grade=True)
+        # Refresh the cache with the new settings
+        from dojo.middleware import DojoSytemSettingsMiddleware
+        DojoSytemSettingsMiddleware.load()
 
         self.import_reimport_performance(
-            expected_num_queries1=594,
-            expected_num_async_tasks1=25,
+            expected_num_queries1=574,
+            expected_num_async_tasks1=15,
             expected_num_queries2=503,
             expected_num_async_tasks2=30,
             expected_num_queries3=357,

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -209,7 +209,7 @@ class TestDojoImporterPerformance(DojoTestCase):
         DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
 
         self.import_reimport_performance(
-            expected_num_queries1=59444,
+            expected_num_queries1=594,
             expected_num_async_tasks1=25,
             expected_num_queries2=503,
             expected_num_async_tasks2=30,

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -205,8 +205,11 @@ class TestDojoImporterPerformance(DojoTestCase):
         so we patch the we_want_async decorator to always return False.
         """
         self.system_settings(enable_product_grade=True)
+        # Reinitialize middleware with updated settings
+        DojoSytemSettingsMiddleware.initialize_for_testing(System_Settings.objects.get())
+
         self.import_reimport_performance(
-            expected_num_queries1=594,
+            expected_num_queries1=59444,
             expected_num_async_tasks1=25,
             expected_num_queries2=503,
             expected_num_async_tasks2=30,

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -108,6 +108,8 @@ class TestDojoImporterPerformance(DojoTestCase):
                 "sync": True,
                 "scan_type": STACK_HAWK_SCAN_TYPE,
                 "engagement": engagement,
+                "tags": ["performance-test", "tag-in-param", "go-faster"],
+                "apply_tags_to_findings": True,
             }
             importer = DefaultImporter(**import_options)
             test, _, _len_new_findings, _len_closed_findings, _, _, _ = importer.process_scan(scan)
@@ -129,6 +131,8 @@ class TestDojoImporterPerformance(DojoTestCase):
                 "verified": True,
                 "sync": True,
                 "scan_type": STACK_HAWK_SCAN_TYPE,
+                "tags": ["performance-test-reimport", "reimport-tag-in-param", "reimport-go-faster"],
+                "apply_tags_to_findings": True,
             }
             reimporter = DefaultReImporter(**reimport_options)
             test, _, _len_new_findings, _len_closed_findings, _, _, _ = reimporter.process_scan(scan)
@@ -156,9 +160,9 @@ class TestDojoImporterPerformance(DojoTestCase):
 
     def test_import_reimport_reimport_performance(self):
         self.import_reimport_performance(
-            expected_num_queries1=554,
-            expected_num_async_tasks1=10,
-            expected_num_queries2=469,
+            expected_num_queries1=712,
+            expected_num_async_tasks1=15,
+            expected_num_queries2=656,
             expected_num_async_tasks2=23,
             expected_num_queries3=332,
             expected_num_async_tasks3=20,
@@ -174,9 +178,9 @@ class TestDojoImporterPerformance(DojoTestCase):
         so we patch the we_want_async decorator to always return False.
         """
         self.import_reimport_performance(
-            expected_num_queries1=554,
-            expected_num_async_tasks1=10,
-            expected_num_queries2=469,
+            expected_num_queries1=712,
+            expected_num_async_tasks1=15,
+            expected_num_queries2=656,
             expected_num_async_tasks2=23,
             expected_num_queries3=332,
             expected_num_async_tasks3=20,
@@ -197,9 +201,9 @@ class TestDojoImporterPerformance(DojoTestCase):
         DojoSytemSettingsMiddleware.load()
 
         self.import_reimport_performance(
-            expected_num_queries1=574,
-            expected_num_async_tasks1=15,
-            expected_num_queries2=503,
+            expected_num_queries1=752,
+            expected_num_async_tasks1=25,
+            expected_num_queries2=690,
             expected_num_async_tasks2=30,
             expected_num_queries3=357,
             expected_num_async_tasks3=25,

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -292,7 +292,7 @@ class InheritedTagsTests(DojoAPITestCase):
     def setUp(self, *args, **kwargs):
         super().setUp()
         self.login_as_admin()
-        self.system_settings(enable_product_tag_inehritance=True)
+        self.system_settings(enable_product_tag_inheritance=True)
         self.product = self.create_product("Inherited Tags Test", tags=["inherit", "these", "tags"])
         self.scans_path = get_unit_tests_scans_path("zap")
         self.zap_sample5_filename = self.scans_path / "5_zap_sample_one.xml"


### PR DESCRIPTION
At the end of the import or reimport process there was an call to `finding.save()` mainly to trigger post processing such as dedupe, pushing to JIRA and product grading.
But at that point all finding data was already saved in earlier steps of the import process. So instead of doing a save, we call the post processing directly. This saves a database UPDATE statement which is expensive and can trigger further processing/queries such as audit logging. Some may argue the code becomes less clear or harder to understand. Since this is the primary process of Defect Dojo and the main performance concern it is an acceptable downside.