### PR TITLE
Fix: Set pluginID as unique_id_from_tool in Tenable parser

### DIFF
--- a/dojo/tools/tenable/xml_format.py
+++ b/dojo/tools/tenable/xml_format.py
@@ -163,6 +163,9 @@ class TenableXMLParser:
                     nessus_severity_id = int(item.attrib.get("severity", 0))
                     severity = self.get_text_severity(nessus_severity_id)
 
+		    # Determine the pluginID
+		    plugin_id = item.attrib.get("pluginID")
+
                     # Build up the impact
                     impact = ""
                     description_element_text = self.safely_get_element_text(
@@ -289,7 +292,8 @@ class TenableXMLParser:
                             references=references,
                             cwe=cwe,
                             cvssv3=cvssv3,
-                            cvssv3_score=cvssv3_score,
+                 	    cvssv3_score=cvssv3_score,
+                            unique_id_from_tool=plugin_id,
                         )
                         find.unsaved_endpoints = []
                         find.unsaved_vulnerability_ids = []


### PR DESCRIPTION
**Description**

This PR adds support for using the pluginID field from Tenable .nessus scan files as the unique_id_from_tool value in DefectDojo findings.

This enables proper deduplication between scans and reimports when using Tenable Scan, which currently does not populate a unique ID and thus prevents deduplication.

A single line was added to the Tenable parser (dojo/tools/tenable/xml_format.py) to extract the pluginID attribute and pass it into the Finding() constructor as unique_id_from_tool.

**Test results**

Manual testing done using the following steps:
- Uploaded a .nessus scan via the UI and API (import-scan)
- Verified that unique_id_from_tool is set correctly for each finding

`curl -X GET "https://<dojo>/api/v2/findings/?test=<test_id>" \
  -H "Authorization: Token <TOKEN>" \
  --insecure | jq '.results[] | {title, unique_id_from_tool, duplicate}'
`
All findings show the correct unique_id_from_tool values based on Tenable's pluginID.

**Documentation**

No additional documentation needed. The change aligns with existing parser logic and improves deduplication without changing behavior for other tools.
