### PR TITLE
Fix: Add pluginID as unique_id_from_tool for Tenable XML parser

### DIFF
--- a/dojo/tools/tenable/xml_format.py
+++ b/dojo/tools/tenable/xml_format.py
@@ -275,6 +275,9 @@ class TenableXMLParser:
                     if cvss is not None:
                         severity = self.get_cvss_severity(cvss)
 
+		    # set the pluginID
+		    plugin_id = item.attrib.get("pluginID")
+
                     # Determine the current entry has already been parsed in
                     # this report
                     dupe_key = severity + title
@@ -290,6 +293,7 @@ class TenableXMLParser:
                             cwe=cwe,
                             cvssv3=cvssv3,
                             cvssv3_score=cvssv3_score,
+			    unique_id_from_tool=plugin_id,
                         )
                         find.unsaved_endpoints = []
                         find.unsaved_vulnerability_ids = []


### PR DESCRIPTION
## Description

This PR adds support for using the pluginID field from Tenable .nessus scan files as the unique_id_from_tool value in DefectDojo findings.

This enables proper deduplication between scans and reimports when using Tenable Scan, which currently does not populate a unique ID and thus prevents deduplication.

A single line was added to the Tenable parser (dojo/tools/tenable/xml_format.py) to extract the pluginID attribute and pass it into the Finding() constructor as unique_id_from_tool.

### Test results

Manual testing done using the following steps:

Uploaded a .nessus scan via the UI and API (import-scan)
Verified that unique_id_from_tool is set correctly for each finding

`curl -X GET "https://<dojo>/api/v2/findings/?test=<test_id>" -H "Authorization: Token <TOKEN>" | jq '.results[] | {title, unique_id_from_tool, duplicate}' `

All findings show the correct unique_id_from_tool values based on Tenable's pluginID.

### Documentation

No additional documentation needed. The change aligns with existing parser logic and improves deduplication without changing behavior for other tools.

Suggested labels: bugfix, Import Scans.