### PR TITLE
Support for whitelisted file extensions

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.validators import FileExtensionValidator
 from django.db.utils import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
@@ -2090,7 +2091,27 @@ class CommonImportScanSerializer(serializers.Serializer):
         default=None,
         help_text="Enter the ID of an Endpoint that is associated with the target Product. New Findings will be added to that Endpoint.",
     )
-    file = serializers.FileField(allow_empty_file=True, required=False)
+    file = serializers.FileField(
+        allow_empty_file=True,
+        required=False,
+        validators=[
+            FileExtensionValidator(
+                allowed_extensions=[
+                    "xml",
+                    "csv",
+                    "nessus",
+                    "json",
+                    "jsonl",
+                    "html",
+                    "js",
+                    "zip",
+                    "xlsx",
+                    "txt",
+                    "sarif",
+                ],
+            ),
+        ],
+    )
     product_type_name = serializers.CharField(required=False)
     product_name = serializers.CharField(required=False)
     engagement_name = serializers.CharField(required=False)

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -12,7 +12,6 @@ from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import PermissionDenied, ValidationError
-from django.core.validators import FileExtensionValidator
 from django.db.utils import IntegrityError
 from django.urls import reverse
 from django.utils import timezone
@@ -125,7 +124,7 @@ from dojo.tools.factory import (
 )
 from dojo.user.utils import get_configuration_permissions_codenames
 from dojo.utils import is_scan_file_too_large
-from dojo.validators import tag_validator
+from dojo.validators import ImporterFileExtensionValidator, tag_validator
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
@@ -2094,23 +2093,7 @@ class CommonImportScanSerializer(serializers.Serializer):
     file = serializers.FileField(
         allow_empty_file=True,
         required=False,
-        validators=[
-            FileExtensionValidator(
-                allowed_extensions=[
-                    "xml",
-                    "csv",
-                    "nessus",
-                    "json",
-                    "jsonl",
-                    "html",
-                    "js",
-                    "zip",
-                    "xlsx",
-                    "txt",
-                    "sarif",
-                ],
-            ),
-        ],
+        validators=[ImporterFileExtensionValidator()],
     )
     product_type_name = serializers.CharField(required=False)
     product_name = serializers.CharField(required=False)

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -18,6 +18,7 @@ from django.contrib.auth.models import Permission
 from django.contrib.auth.password_validation import validate_password
 from django.core import validators
 from django.core.exceptions import ValidationError
+from django.core.validators import FileExtensionValidator
 from django.db.models import Count, Q
 from django.forms import modelformset_factory
 from django.forms.widgets import Select, Widget
@@ -525,11 +526,31 @@ class ImportScanForm(forms.Form):
     source_code_management_uri = forms.URLField(max_length=600, required=False, help_text="Resource link to source code")
     tags = TagField(required=False, help_text="Add tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
-    file = forms.FileField(widget=forms.widgets.FileInput(
-        attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif"}),
+    file = forms.FileField(
+        widget=forms.widgets.FileInput(
+            attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif"},
+        ),
         label="Choose report file",
         allow_empty_file=True,
-        required=False)
+        required=False,
+        validators=[
+            FileExtensionValidator(
+                allowed_extensions=[
+                    "xml",
+                    "csv",
+                    "nessus",
+                    "json",
+                    "jsonl",
+                    "html",
+                    "js",
+                    "zip",
+                    "xlsx",
+                    "txt",
+                    "sarif",
+                ],
+            ),
+        ],
+    )
 
     # Close Old Findings has changed. The default is engagement only, and it requires a second flag to expand to the product scope.
     # Exposing the choice as two different check boxes.
@@ -646,11 +667,31 @@ class ReImportScanForm(forms.Form):
     endpoints = forms.ModelMultipleChoiceField(Endpoint.objects, required=False, label="Systems / Endpoints")
     tags = TagField(required=False, help_text="Modify existing tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
-    file = forms.FileField(widget=forms.widgets.FileInput(
-        attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif"}),
+    file = forms.FileField(
+        widget=forms.widgets.FileInput(
+            attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif"},
+        ),
         label="Choose report file",
         allow_empty_file=True,
-        required=False)
+        required=False,
+        validators=[
+            FileExtensionValidator(
+                allowed_extensions=[
+                    "xml",
+                    "csv",
+                    "nessus",
+                    "json",
+                    "jsonl",
+                    "html",
+                    "js",
+                    "zip",
+                    "xlsx",
+                    "txt",
+                    "sarif",
+                ],
+            ),
+        ],
+    )
     close_old_findings = forms.BooleanField(help_text="Select if old findings in the same test that are no longer present in the report get closed as mitigated when importing.",
                                             required=False, initial=True)
     version = forms.CharField(max_length=100, required=False, help_text="Version that will be set on existing Test object. Leave empty to leave existing value in place.")

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -18,7 +18,6 @@ from django.contrib.auth.models import Permission
 from django.contrib.auth.password_validation import validate_password
 from django.core import validators
 from django.core.exceptions import ValidationError
-from django.core.validators import FileExtensionValidator
 from django.db.models import Count, Q
 from django.forms import modelformset_factory
 from django.forms.widgets import Select, Widget
@@ -113,7 +112,7 @@ from dojo.utils import (
     is_finding_groups_enabled,
     is_scan_file_too_large,
 )
-from dojo.validators import tag_validator
+from dojo.validators import ImporterFileExtensionValidator, tag_validator
 from dojo.widgets import TableCheckboxWidget
 
 logger = logging.getLogger(__name__)
@@ -533,23 +532,7 @@ class ImportScanForm(forms.Form):
         label="Choose report file",
         allow_empty_file=True,
         required=False,
-        validators=[
-            FileExtensionValidator(
-                allowed_extensions=[
-                    "xml",
-                    "csv",
-                    "nessus",
-                    "json",
-                    "jsonl",
-                    "html",
-                    "js",
-                    "zip",
-                    "xlsx",
-                    "txt",
-                    "sarif",
-                ],
-            ),
-        ],
+        validators=[ImporterFileExtensionValidator()],
     )
 
     # Close Old Findings has changed. The default is engagement only, and it requires a second flag to expand to the product scope.
@@ -674,23 +657,7 @@ class ReImportScanForm(forms.Form):
         label="Choose report file",
         allow_empty_file=True,
         required=False,
-        validators=[
-            FileExtensionValidator(
-                allowed_extensions=[
-                    "xml",
-                    "csv",
-                    "nessus",
-                    "json",
-                    "jsonl",
-                    "html",
-                    "js",
-                    "zip",
-                    "xlsx",
-                    "txt",
-                    "sarif",
-                ],
-            ),
-        ],
+        validators=[ImporterFileExtensionValidator()],
     )
     close_old_findings = forms.BooleanField(help_text="Select if old findings in the same test that are no longer present in the report get closed as mitigated when importing.",
                                             required=False, initial=True)

--- a/dojo/validators.py
+++ b/dojo/validators.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import cvss.parser
 from cvss import CVSS2, CVSS3, CVSS4
 from django.core.exceptions import ValidationError
+from django.core.validators import FileExtensionValidator
 
 logger = logging.getLogger(__name__)
 
@@ -72,3 +73,12 @@ def cvss3_validator(value: str | list[str], exception_class: Callable = Validati
     # to avoid 'NoneType' errors during severity processing later.
     msg = "No valid CVSS vectors found by cvss.parse_cvss_from_text()"
     raise exception_class(msg)
+
+
+class ImporterFileExtensionValidator(FileExtensionValidator):
+    default_allowed_extensions = ["xml", "csv", "nessus", "json", "jsonl", "html", "js", "zip", "xlsx", "txt", "sarif"]
+
+    def __init__(self, *args: list, **kwargs: dict):
+        if "allowed_extensions" not in kwargs:
+            kwargs["allowed_extensions"] = self.default_allowed_extensions
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
It is possible to import/reimport any file extension. The UI already enforces a handful of extensions that are allowed, but the API does not validate in the same way 

https://github.com/DefectDojo/django-DefectDojo/blob/2748b8d05450800a36b9282f5bd917bf6e673046/dojo/forms.py#L649-L653

A validation error will look like this:
```json
"file": [
    "File extension “exe” is not allowed. Allowed extensions are: xml, csv, nessus, json, jsonl, html, js, zip, xlsx, txt, sarif."
  ],
```