### PR TITLE
fix datatable search box location with style override

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1439,6 +1439,10 @@ div.dt-buttons {
     margin: 10px!important;
 }
 
+div.dt-search {
+    display: inline-block!important;
+}
+
 table#product_types .btn-success{
 	background-color: #546474;
 	border-color: #546474;


### PR DESCRIPTION
[sc-11702]

This pull requests fixes an issue introduced to the DataTable search functionality that placed the table search `div` on a new line (styled to `display: block;` rather than `display: inline-block;`).

Before:
<img width="998" height="479" alt="Screenshot 2025-08-01 at 12 33 28 AM" src="https://github.com/user-attachments/assets/03cb86bc-6ef5-4adf-aad8-5c2de498d7a5" />


After:
<img width="998" height="479" alt="Screenshot 2025-08-01 at 12 33 13 AM" src="https://github.com/user-attachments/assets/bc0c5e84-c4ca-49f8-86d1-514c0bc583c6" />
