### PR TITLE
new snyk_issue_api parser for `code` issues

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/file/snyk_issue_api.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/snyk_issue_api.md
@@ -35,7 +35,7 @@ The parser maps fields from the Snyk Issue API response to DefectDojo's Finding 
 | static_finding | true | Always set to true |
 | dynamic_finding | false | Always set to false |
 | out_of_scope | attributes.ignored | Set to true if issue is ignored |
-| fix_available | coordinates[].is_fixable_* | True if any fixability flag is true |
+| fix_available* | coordinates[].is_fixable_* | True if any fixability flag is true.  |
 
 #### Impact Field
 The impact field combines multiple pieces of information:

--- a/docs/content/en/connecting_your_tools/parsers/file/snyk_issue_api.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/snyk_issue_api.md
@@ -1,0 +1,63 @@
+---
+title: "Snyk Issue API"
+toc_hide: true
+---
+The Snyk Issue API parser supports importing vulnerability data from the Snyk Issue API in JSON format. Currently only parsing issues of type `code` is supported. Samples of ther issue types are welcome.
+
+For more information about the Snyk Issue API, refer to the [official Snyk API documentation](https://docs.snyk.io/snyk-api/reference/issues#get-orgs-org_id-issues).
+
+### API request
+Example API request to get only code issues:
+```
+GET https://api.snyk.io/rest/orgs/{org_id}/issues?version=2025-08-02&type=code
+```
+
+For more details see: https://docs.snyk.io/snyk-api/reference/issues#get-orgs-org_id-issues
+
+### Sample Scan Data
+Sample Snyk Issue API scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/snyk_issue_api).
+
+### Field Mapping
+The parser maps fields from the Snyk Issue API response to DefectDojo's Finding model as follows:
+
+| Finding Field | Snyk Issue API Field | Notes |
+|--------------|---------------------|-------|
+| title | attributes.title | |
+| severity | attributes.effective_severity_level | Mapped to Critical/High/Medium/Low/Info |
+| description | attributes.description | |
+| unique_id_from_tool | id | Top-level issue ID |
+| file_path | coordinates[].representations[].sourceLocation.file | First occurrence |
+| line | coordinates[].representations[].sourceLocation.region.start.line | Line where the issue starts |
+| date | attributes.created_at | ISO format date |
+| cwe | classes[].id | First CWE class found |
+| active | attributes.status == "open" AND NOT attributes.ignored | Inactive if ignored or not open |
+| verified | true | Always set to true |
+| static_finding | true | Always set to true |
+| dynamic_finding | false | Always set to false |
+| out_of_scope | attributes.ignored | Set to true if issue is ignored |
+| fix_available | coordinates[].is_fixable_* | True if any fixability flag is true |
+
+#### Impact Field
+The impact field combines multiple pieces of information:
+1. Problem details:
+   - Source (e.g., "SNYK")
+   - Type (e.g., "vulnerability")
+   - Last update timestamp
+   - Severity level
+2. All source locations, each containing:
+   - File path
+   - Commit ID
+   - Line range (start-end)
+   - Column range (start-end)
+
+#### Additional Processing
+- Multiple CWEs are handled by using the first one as the primary CWE and listing additional ones in the references field
+- Risk scores are included in the severity_justification field when available
+- Only issues with type="code" are processed
+- Line numbers: Only the starting line is stored in the Finding model, but both start and end lines are included in the impact field for reference
+
+### Default Deduplication Hashcode Fields
+By default, DefectDojo identifies duplicate Findings using these [hashcode fields](https://docs.defectdojo.com/en/working_with_findings/finding_deduplication/about_deduplication/):
+
+- unique id from tool
+- file path

--- a/dojo/tools/snyk_issue_api/parser.py
+++ b/dojo/tools/snyk_issue_api/parser.py
@@ -134,9 +134,12 @@ class SnykIssueApiParser:
             active=attributes.get("status") == "open" and not attributes.get("ignored", False),
             verified=True,
             cwe=cwes[0] if cwes else None,
-            fix_available=fix_available,
             date=created,
         )
+
+        # Set fix_available if the field exists in the model
+        if hasattr(finding, "fix_available"):
+            finding.fix_available = fix_available
 
         # Add risk score if available
         risk = attributes.get("risk", {})

--- a/dojo/tools/snyk_issue_api/parser.py
+++ b/dojo/tools/snyk_issue_api/parser.py
@@ -1,0 +1,177 @@
+import json
+from contextlib import suppress
+from datetime import datetime
+
+from dojo.models import Finding
+
+
+class SnykIssueApiParser:
+    def get_scan_types(self):
+        return ["Snyk Issue API Scan"]
+
+    def get_label_for_scan_types(self, scan_type):
+        return scan_type
+
+    def get_description_for_scan_types(self, scan_type):
+        return "Snyk Issue API output file can be imported in JSON format."
+
+    def get_findings(self, json_output, test):
+        tree = self.parse_json(json_output)
+        return self.process_tree(tree, test)
+
+    def parse_json(self, json_output):
+        try:
+            data = json_output.read()
+            try:
+                tree = json.loads(str(data, "utf-8"))
+            except Exception:
+                tree = json.loads(data)
+        except Exception:
+            msg = "Invalid format"
+            raise ValueError(msg)
+
+        return tree
+
+    def process_tree(self, tree, test):
+        if not tree or "data" not in tree:
+            return []
+
+        findings = []
+        for issue in tree.get("data", []):
+            finding = self.get_finding(issue, test)
+            if finding:
+                findings.append(finding)
+        return findings
+
+    def get_finding(self, issue, test):
+        # Check top-level type must be "issue" as "packages" have their own API it seems.
+        if not issue or issue.get("type") != "issue":
+            return None
+
+        attributes = issue.get("attributes", {})
+
+        # Check attributes-level type must be "code"
+        # Other items are not supported yet due to a lack of samples and lack of documentation
+        # package_vulnerability,license,cloud,code,customconfig
+        if attributes.get("type") != "code":
+            return None
+
+        # Extract CWE classes
+        cwes = []
+        for class_info in attributes.get("classes", []):
+            if class_info.get("source") == "CWE":
+                cwe_id = class_info.get("id", "").replace("CWE-", "")
+                if cwe_id.isdigit():
+                    cwes.append(int(cwe_id))
+
+        # Extract location information, fixability and collect all source locations for impact
+        file_path = None
+        line = None
+        fix_available = False
+        impact_locations = []
+
+        for coordinate in attributes.get("coordinates", []):
+            # Check if any fix is available
+            if coordinate.get("is_fixable_snyk") or \
+               coordinate.get("is_fixable_upstream") or \
+               coordinate.get("is_fixable_manually"):
+                fix_available = True
+
+            for representation in coordinate.get("representations", []):
+                if "sourceLocation" in representation:
+                    location = representation["sourceLocation"]
+                    region = location.get("region", {})
+                    start = region.get("start", {})
+                    end = region.get("end", {})
+
+                    # Store location details for impact field
+                    impact_locations.append([
+                        "Source Location:",
+                        f"File: {location.get('file', 'Unknown')}",
+                        f"Commit: {location.get('commit_id', 'Unknown')}",
+                        f"Lines: {start.get('line', '?')}-{end.get('line', '?')}",
+                        f"Columns: {start.get('column', '?')}-{end.get('column', '?')}",
+                        "",  # Empty line between locations
+                    ])
+
+                    # Store first location for finding fields
+                    if not file_path:
+                        file_path = location.get("file")
+                        if region:
+                            line = start.get("line")
+
+        # Map severity levels
+        severity_map = {
+            "critical": "Critical",
+            "high": "High",
+            "medium": "Medium",
+            "low": "Low",
+            "info": "Info",
+        }
+        severity = severity_map.get(attributes.get("effective_severity_level", "").lower(), "Info")
+
+        # Parse created_at date
+        created = None
+        if attributes.get("created_at"):
+            with suppress(ValueError):
+                created = datetime.strptime(attributes["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ")
+            if not created:
+                with suppress(ValueError):
+                    created = datetime.strptime(attributes["created_at"], "%Y-%m-%dT%H:%M:%SZ")
+
+        # Create finding
+        finding = Finding(
+            title=attributes.get("title", ""),
+            test=test,
+            severity=severity,
+            description=attributes.get("description", ""),
+            static_finding=True,
+            dynamic_finding=False,
+            unique_id_from_tool=issue.get("id"),
+            file_path=file_path,
+            line=line,
+            out_of_scope=attributes.get("ignored", False),
+            active=attributes.get("status") == "open" and not attributes.get("ignored", False),
+            verified=True,
+            cwe=cwes[0] if cwes else None,
+            fix_available=fix_available,
+            date=created,
+        )
+
+        # Add risk score if available
+        risk = attributes.get("risk", {})
+        if risk and "score" in risk:
+            score = risk["score"]
+            if isinstance(score, dict):
+                finding.severity_justification = (
+                    f"Risk Score: {score.get('value', 'N/A')} "
+                    f"(Model: {score.get('model', 'N/A')})"
+                )
+
+        # Add additional CWEs as references
+        if len(cwes) > 1:
+            finding.references = "Additional CWEs: " + ", ".join(f"CWE-{cwe}" for cwe in cwes[1:])
+
+        # Add problem details and all source locations to impact
+        impact_details = []
+
+        # Add problem information
+        problems = attributes.get("problems", [])
+        if problems:
+            problem = problems[0]  # Take the first problem
+            impact_details.extend([
+                f"Source: {problem.get('source', 'Unknown')}",
+                f"Type: {problem.get('type', 'Unknown')}",
+                f"Last Updated: {problem.get('updated_at', 'Unknown')}",
+                f"Severity: {severity}",
+                "",  # Empty line before locations
+            ])
+
+        # Add all source locations
+        for location in impact_locations:
+            impact_details.extend(location)
+
+        if impact_details:
+            finding.impact = "\n".join(impact_details).rstrip()
+
+        return finding

--- a/unittests/scans/snyk_issue_api/empty.json
+++ b/unittests/scans/snyk_issue_api/empty.json
@@ -1,0 +1,6 @@
+{
+    "jsonapi": {
+        "version": "1.0"
+    },
+    "data": []
+}

--- a/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json
+++ b/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json
@@ -1,0 +1,266 @@
+{
+    "jsonapi": {
+        "version": "1.0"
+    },
+    "links": {
+        "self": "/rest/orgs/str123/issues?limit=10&scan_item.id=25502d3a-2799-4e20-97d6-2cb552058894&scan_item.type=project&version=2024-10-15",
+        "first": "/rest/orgs/str123/issues?limit=10&scan_item.id=25502d3a-2799-4e20-97d6-2cb552058894&scan_item.type=project&version=2024-10-15",
+        "last": "/rest/orgs/str123/issues?ending_before=end&limit=10&scan_item.id=25502d3a-2799-4e20-97d6-2cb552058894&scan_item.type=project&version=2024-10-15"
+    },
+    "data": [
+        {
+            "id": "3916a413-2fca-45c9-a1bf-a1373258fe69",
+            "type": "issue",
+            "attributes": {
+                "classes": [
+                    {
+                        "id": "CWE-352",
+                        "source": "CWE",
+                        "type": "weakness"
+                    }
+                ],
+                "coordinates": [
+                    {
+                        "is_fixable_manually": false,
+                        "is_fixable_snyk": false,
+                        "is_fixable_upstream": false,
+                        "representations": [
+                            {
+                                "sourceLocation": {
+                                    "commit_id": "5ab48c7da75182753420725182db92b679c1e4f0",
+                                    "file": "path/path/file.abc",
+                                    "region": {
+                                        "end": {
+                                            "column": 22,
+                                            "line": 71
+                                        },
+                                        "start": {
+                                            "column": 9,
+                                            "line": 65
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "created_at": "2024-12-13T12:29:59.035Z",
+                "description": "Cross-Site Request Forgery (CSRF)",
+                "effective_severity_level": "high",
+                "ignored": false,
+                "key": "9a29d87f-aa94-47eb-b46f-375b293a8631",
+                "key_asset": "4312279e-39d9-463d-b684-3a10059058f6",
+                "problems": [
+                    {
+                        "id": "9a29d87f-aa94-47eb-b46f-375b293a8631",
+                        "source": "SNYK",
+                        "type": "vulnerability",
+                        "updated_at": "2025-04-13T04:13:03.151452Z"
+                    }
+                ],
+                "risk": {
+                    "factors": [],
+                    "score": {
+                        "model": "v1",
+                        "value": 829
+                    }
+                },
+                "status": "open",
+                "title": "Cross-Site Request Forgery (CSRF)",
+                "type": "code",
+                "updated_at": "2025-03-08T01:31:31.667Z"
+            },
+            "relationships": {
+                "organization": {
+                    "data": {
+                        "id": "str123",
+                        "type": "organization"
+                    },
+                    "links": {
+                        "related": "/orgs/str123"
+                    }
+                },
+                "scan_item": {
+                    "data": {
+                        "id": "25502d3a-2799-4e20-97d6-2cb552058894",
+                        "type": "project"
+                    },
+                    "links": {
+                        "related": "/orgs/str123/projects/25502d3a-2799-4e20-97d6-2cb552058894"
+                    }
+                }
+            }
+        },
+        {
+            "id": "605a2477-69d4-4317-8649-1f7b92fa7c27",
+            "type": "issue",
+            "attributes": {
+                "classes": [
+                    {
+                        "id": "CWE-79",
+                        "source": "CWE",
+                        "type": "weakness"
+                    }
+                ],
+                "coordinates": [
+                    {
+                        "is_fixable_manually": false,
+                        "is_fixable_snyk": false,
+                        "is_fixable_upstream": false,
+                        "representations": [
+                            {
+                                "sourceLocation": {
+                                    "commit_id": "pab48c7da7t682753420725182db92b6k9c1e4f0",
+                                    "file": "path/path/file.abc",
+                                    "region": {
+                                        "end": {
+                                            "column": 90,
+                                            "line": 27
+                                        },
+                                        "start": {
+                                            "column": 61,
+                                            "line": 27
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "created_at": "2024-12-13T12:29:59.035Z",
+                "description": "Cross-site Scripting (XSS)",
+                "effective_severity_level": "medium",
+                "ignored": true,
+                "key": "b25fb1d7-c99b-46fb-818b-e94971ee9db0",
+                "key_asset": "081e6cf8-4249-4cbb-ae2f-0e3cdafba0cd",
+                "problems": [
+                    {
+                        "id": "b25fb1d7-c99b-46fb-818b-e94971ee9db0",
+                        "source": "SNYK",
+                        "type": "vulnerability",
+                        "updated_at": "2025-05-10T01:45:25.464473Z"
+                    }
+                ],
+                "risk": {
+                    "factors": [],
+                    "score": {
+                        "model": "v1",
+                        "value": 579
+                    }
+                },
+                "status": "open",
+                "title": "Cross-site Scripting (XSS)",
+                "type": "code",
+                "updated_at": "2025-05-10T01:45:23.452Z"
+            },
+            "relationships": {
+                "organization": {
+                    "data": {
+                        "id": "str123",
+                        "type": "organization"
+                    },
+                    "links": {
+                        "related": "/orgs/str123"
+                    }
+                },
+                "scan_item": {
+                    "data": {
+                        "id": "25502d3a-2799-4e20-97d6-2cb552058894",
+                        "type": "project"
+                    },
+                    "links": {
+                        "related": "/orgs/str123/projects/25502d3a-2799-4e20-97d6-2cb552058894"
+                    }
+                }
+            }
+        },
+        {
+            "id": "922e2d65-d2ce-4a5c-818c-ab196ba834c3",
+            "type": "issue",
+            "attributes": {
+                "classes": [
+                    {
+                        "id": "CWE-259",
+                        "source": "CWE",
+                        "type": "weakness"
+                    },
+                    {
+                        "id": "CWE-798",
+                        "source": "CWE",
+                        "type": "weakness"
+                    }
+                ],
+                "coordinates": [
+                    {
+                        "is_fixable_manually": false,
+                        "is_fixable_snyk": false,
+                        "is_fixable_upstream": false,
+                        "representations": [
+                            {
+                                "sourceLocation": {
+                                    "commit_id": "5ab48c7da75182753420725182db92b679c1e4f0",
+                                    "file": "path/path/file.abc",
+                                    "region": {
+                                        "end": {
+                                            "column": 41,
+                                            "line": 94
+                                        },
+                                        "start": {
+                                            "column": 33,
+                                            "line": 94
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "created_at": "2024-12-13T12:29:59.035Z",
+                "description": "Use of Hardcoded Passwords",
+                "effective_severity_level": "low",
+                "ignored": false,
+                "key": "a8edd3ae-722f-4668-81da-478b46fdf961",
+                "key_asset": "1dc3c841-be59-4889-a88f-a9ad10bbcd98",
+                "problems": [
+                    {
+                        "id": "a8edd3ae-722f-4668-81da-478b46fdf961",
+                        "source": "SNYK",
+                        "type": "vulnerability",
+                        "updated_at": "2025-05-31T01:32:18.84232Z"
+                    }
+                ],
+                "risk": {
+                    "factors": [],
+                    "score": {
+                        "model": "v1",
+                        "value": 379
+                    }
+                },
+                "status": "open",
+                "title": "Use of Hardcoded Passwords",
+                "type": "code",
+                "updated_at": "2025-05-31T01:32:17.121Z"
+            },
+            "relationships": {
+                "organization": {
+                    "data": {
+                        "id": "str123",
+                        "type": "organization"
+                    },
+                    "links": {
+                        "related": "/orgs/str123"
+                    }
+                },
+                "scan_item": {
+                    "data": {
+                        "id": "25502d3a-2799-4e20-97d6-2cb552058894",
+                        "type": "project"
+                    },
+                    "links": {
+                        "related": "/orgs/str123/projects/25502d3a-2799-4e20-97d6-2cb552058894"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/unittests/tools/test_snyk_issue_api_parser.py
+++ b/unittests/tools/test_snyk_issue_api_parser.py
@@ -34,6 +34,9 @@ class TestSnykIssueApiParser(TestCase):
             self.assertEqual(True, finding.static_finding)
             self.assertEqual(False, finding.dynamic_finding)
             self.assertIn("Risk Score: 829", finding.severity_justification)
+            # Check fix_available if the field exists
+            if hasattr(finding, "fix_available"):
+                self.assertEqual(False, finding.fix_available)
 
             # Verify second finding
             finding = findings[1]
@@ -41,6 +44,9 @@ class TestSnykIssueApiParser(TestCase):
             self.assertEqual("Medium", finding.severity)
             self.assertEqual(79, finding.cwe)
             self.assertEqual(True, finding.out_of_scope)  # This one is ignored
+            # Check fix_available if the field exists
+            if hasattr(finding, "fix_available"):
+                self.assertEqual(False, finding.fix_available)
 
             # Verify third finding
             finding = findings[2]
@@ -48,3 +54,6 @@ class TestSnykIssueApiParser(TestCase):
             self.assertEqual("Low", finding.severity)
             self.assertEqual(259, finding.cwe)
             self.assertEqual("Additional CWEs: CWE-798", finding.references)  # Has multiple CWEs
+            # Check fix_available if the field exists
+            if hasattr(finding, "fix_available"):
+                self.assertEqual(False, finding.fix_available)

--- a/unittests/tools/test_snyk_issue_api_parser.py
+++ b/unittests/tools/test_snyk_issue_api_parser.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from django.test import TestCase
+
+from dojo.models import Test
+from dojo.tools.snyk_issue_api.parser import SnykIssueApiParser
+
+
+class TestSnykIssueApiParser(TestCase):
+    def test_parse_no_findings(self):
+        with Path("unittests/scans/snyk_issue_api/empty.json").open(encoding="utf-8") as testfile:
+            parser = SnykIssueApiParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(0, len(findings))
+
+    def test_parse_many_findings(self):
+        with Path("unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json").open(encoding="utf-8") as testfile:
+            parser = SnykIssueApiParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(3, len(findings))
+
+            # Verify first finding
+            finding = findings[0]
+            self.assertEqual("Cross-Site Request Forgery (CSRF)", finding.title)
+            self.assertEqual("High", finding.severity)
+            self.assertEqual("Cross-Site Request Forgery (CSRF)", finding.description)
+            self.assertEqual("path/path/file.abc", finding.file_path)
+            self.assertEqual(65, finding.line)
+            self.assertEqual(352, finding.cwe)
+            self.assertEqual("3916a413-2fca-45c9-a1bf-a1373258fe69", finding.unique_id_from_tool)
+            self.assertEqual(False, finding.false_p)
+            self.assertEqual(True, finding.active)
+            self.assertEqual(True, finding.verified)
+            self.assertEqual(True, finding.static_finding)
+            self.assertEqual(False, finding.dynamic_finding)
+            self.assertIn("Risk Score: 829", finding.severity_justification)
+
+            # Verify second finding
+            finding = findings[1]
+            self.assertEqual("Cross-site Scripting (XSS)", finding.title)
+            self.assertEqual("Medium", finding.severity)
+            self.assertEqual(79, finding.cwe)
+            self.assertEqual(True, finding.out_of_scope)  # This one is ignored
+
+            # Verify third finding
+            finding = findings[2]
+            self.assertEqual("Use of Hardcoded Passwords", finding.title)
+            self.assertEqual("Low", finding.severity)
+            self.assertEqual(259, finding.cwe)
+            self.assertEqual("Additional CWEs: CWE-798", finding.references)  # Has multiple CWEs


### PR DESCRIPTION
Next to the `snyk_code` parser that parses results from the CLI command, this new parser is able to parser results from the Snyk Issue API.

This API returns findings in a completely different format, so this is a new parser.
We only have a sample for issues of type `code`, so that's what supported for now.

The markdown doc has information about the mapping of fields.

Assumptions:
- `id` field is suitable as `unique_finding_from_tool`

[sc-11654]