### PR TITLE
restore entrypoint-unit-tests-devDocker.sh

### DIFF
--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -73,15 +73,15 @@ echo "Unit Tests"
 echo "------------------------------------------------------------"
 
 # Removing parallel and shuffle for now to maintain stability
-# python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag="non-parallel" || {
-#     exit 1;
-# }
-# python3 manage.py test unittests -v 3 --keepdb --no-input --tag="non-parallel" || {
-#     exit 1;
-# }
+python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag="non-parallel" || {
+    exit 1;
+}
+python3 manage.py test unittests -v 3 --keepdb --no-input --tag="non-parallel" || {
+    exit 1;
+}
 
 # you can select a single file to "test" unit tests
-python3 manage.py test unittests.test_importers_performance.TestDojoImporterPerformance --keepdb -v 3 &> /app/dev2.log
+# python3 manage.py test unittests.test_importers_performance.TestDojoImporterPerformance --keepdb -v 3 &> /app/dev2.log
 
 # or even a single method
 # python3 manage.py test unittests.tools.test_npm_audit_scan_parser.TestNpmAuditParser.test_npm_audit_parser_many_vuln_npm7 --keepdb -v 3


### PR DESCRIPTION
applies only to local running of unit tests: this entrypoint had some changes used for testing, but should be reverted to the version that runs all tests.