### PR TITLE
debug toolbar: downgrade to 5.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ packageurl-python==0.17.3
 django-crum==0.7.9
 JSON-log-formatter==1.1.1
 django-split-settings==1.3.2
-django-debug-toolbar==6.0.0
+django-debug-toolbar==5.2.0
 django-debug-toolbar-request-history==0.1.4
 vcrpy==7.0.0
 vcrpy-unittest==0.1.7


### PR DESCRIPTION
Django Debug Toolbar 6.0.0 no longer working, it crashes the docker build when static files are collected.

Let's wait a bit for 6.0.1 or 6.1.0.