### PR TITLE
Display Tags: Do not rely on the request object being present

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -343,6 +343,9 @@ def action_log_entry(value, autoescape=None):
 
 @register.simple_tag(takes_context=True)
 def dojo_body_class(context):
+    if "request" not in context:
+        return ""
+
     request = context["request"]
     return request.COOKIES.get("dojo-sidebar", "min")
 

--- a/dojo/templatetags/navigation_tags.py
+++ b/dojo/templatetags/navigation_tags.py
@@ -11,6 +11,9 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def query_string_as_hidden(context):
+    if "request" not in context:
+        return ""
+
     request = context["request"]
     query_string = request.META["QUERY_STRING"]
     inputs = ""


### PR DESCRIPTION
In cases of an exception, I was receiving an error page from nginx rather than getting the 5xx response hosted by django. This was caused from a key error of the `request` object in the context of a given view