### PR TITLE
Bump cvss from 3.4 to 3.6 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ vcrpy==7.0.0
 vcrpy-unittest==0.1.7
 django-tagulous==2.1.1
 PyJWT==2.10.1
-cvss==3.4
+cvss==3.6
 django-fieldsignals==0.7.0
 hyperlink==21.0.0
 django-test-migrations==1.4.0

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1373,24 +1373,24 @@ class FindingsTest(BaseClass.BaseClassTest):
         self.maxDiff = None
         with self.subTest(i=0):
             self.assertEqual(None, Finding.objects.get(id=2).cvssv3)
-            result = self.client.patch(self.url + "2/", data={"cvssv4": "CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/S:P/AU:Y/R:U/V:C/RE:M/U:Green/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/CR:M/IR:M/AR:M/E:A", "cvssv4_score": 3})
+            result = self.client.patch(self.url + "2/", data={"cvssv4": "CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/E:A/CR:M/IR:M/AR:M/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/S:P/AU:Y/R:U/V:C/RE:M/U:Green", "cvssv4_score": 3})
             self.assertEqual(result.status_code, status.HTTP_200_OK)
             finding = Finding.objects.get(id=2)
             # valid so vector must be set and score calculated overrides the provided score
-            self.assertEqual("CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/S:P/AU:Y/R:U/V:C/RE:M/U:Green/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/CR:M/IR:M/AR:M/E:A", finding.cvssv4)
+            self.assertEqual("CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/E:A/CR:M/IR:M/AR:M/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/S:P/AU:Y/R:U/V:C/RE:M/U:Green", finding.cvssv4)
             self.assertEqual(2.3, finding.cvssv4_score)
 
         with self.subTest(i=1):
-            result = self.client.patch(self.url + "5/", data={"cvssv4": "CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/S:P/AU:Y/R:U/V:C/RE:M/U:Green/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/CR:M/IR:M/AR:M/E:A"})
+            result = self.client.patch(self.url + "5/", data={"cvssv4": "CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/E:A/CR:M/IR:M/AR:M/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/S:P/AU:Y/R:U/V:C/RE:M/U:Green"})
             self.assertEqual(result.status_code, status.HTTP_200_OK)
             finding = Finding.objects.get(id=5)
             # valid so vector must be set and score calculated
-            self.assertEqual("CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/S:P/AU:Y/R:U/V:C/RE:M/U:Green/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/CR:M/IR:M/AR:M/E:A", finding.cvssv4)
+            self.assertEqual("CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/E:A/CR:M/IR:M/AR:M/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/S:P/AU:Y/R:U/V:C/RE:M/U:Green", finding.cvssv4)
             self.assertEqual(2.3, finding.cvssv4_score)
 
         with self.subTest(i=2):
             # extra slash makes it invalid
-            result = self.client.patch(self.url + "3/", data={"cvssv4": "CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/S:P/AU:Y/R:U/V:C/RE:M/U:Green/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/CR:M/IR:M/AR:M/E:A/", "cvssv4_score": 3})
+            result = self.client.patch(self.url + "3/", data={"cvssv4": "CVSS:4.0/AV:A/AC:H/AT:N/PR:H/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N/E:A/CR:M/IR:M/AR:M/MAV:A/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:L/MVA:L/MSC:L/MSI:H/MSA:H/S:P/AU:Y/R:U/V:C/RE:M/U:Green/", "cvssv4_score": 3})
             self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
             finding = Finding.objects.get(id=3)
             self.assertEqual(result.json()["cvssv4"], ["No valid CVSS4 vectors found by cvss.parse_cvss_from_text()"])


### PR DESCRIPTION
Supersedes #12917

upgrades cvss to 3.6, as originally proposed by Dependabot, but fixes cvssv4 test to account for them fixing CVSS metric order to comply with spec

