### PR TITLE
Docs: Restore `package-lock.json`

### DIFF
--- a/docs/config/_default/params.toml
+++ b/docs/config/_default/params.toml
@@ -129,7 +129,7 @@ mainSections = ["docs"]
   [seo.schemas]
     type = "Organization" # Organization (default) or Person
     logo = "favicon-512x512.png" # Logo of Organization — favicon-512x512.png (default)
-    name = "Thulite" # Name of Organization or Person
+    name = "DefectDojo" # Name of Organization or Person
     sameAs = [] # E.g. ["https://github.com/thuliteio/thulite", "https://fosstodon.org/@thulite"]
     images = ["cover.png"] # ["cover.png"] (default)
     article = [] # Article sections

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@docsearch/css": "^3.9.0",
+        "@docsearch/js": "^3.9.0",
         "@tabler/icons": "3.34.1",
         "@thulite/doks-core": "1.8.0",
         "@thulite/images": "3.3.0",


### PR DESCRIPTION
the new `docsearch` dependencies got removed from the `package-lock.json` file during the release due to conflict resolution. When developing locally, the command `npm run dev` is used, which reads from `package.json` and then updates the `package-lock.json` file. However, when docs are deployed for production, the `package-lock.json` file is used to avoid pulling in any upgrades.

The search function is busted because it is trying to reference packages that are not installed