### PR TITLE
Fix 12955 / helm chart not rendering when cloudsql is enabled and postgresql is not.

### DIFF
--- a/helm/defectdojo/templates/_helpers.tpl
+++ b/helm/defectdojo/templates/_helpers.tpl
@@ -46,14 +46,16 @@ Create the name of the service account to use
   Determine the hostname to use for PostgreSQL/Redis.
 */}}
 {{- define "postgresql.hostname" -}}
-{{- if .Values.postgresql.enabled -}}
-{{- if eq .Values.postgresql.architecture "replication" -}}
-{{- printf "%s-%s-%s" .Release.Name "postgresql" .Values.postgresql.primary.name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.cloudsql.enabled -}}
+{{-  printf "127.0.0.1" -}}
+{{- else if .Values.postgresql.enabled -}}
+{{-  if eq .Values.postgresql.architecture "replication" -}}
+{{-   printf "%s-%s-%s" .Release.Name "postgresql" .Values.postgresql.primary.name | trunc 63 | trimSuffix "-" -}}
+{{-  else -}}
+{{-   printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{-  end -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- else -}}
-{{- printf "%s" .Values.postgresql.postgresServer -}}
+{{-  printf "%s" .Values.postgresql.postgresServer -}}
 {{- end -}}
 {{- end -}}
 {{- define "redis.hostname" -}}


### PR DESCRIPTION
**Description**

Fix #12955 
Manage database hostname for cloudsql.
I added indentation to easy ifs nesting in the template.

**Test results**

Use procedure from the issue, and generate template.
```
helm template . --values myvalues.yaml --show-only templates/configmap.yaml --debug | grep -n '^' 
```

The result:
```
install.go:225: 2025-08-10 09:14:48.135652129 +0000 UTC m=+0.049080703 [debug] Original chart version: ""
install.go:242: 2025-08-10 09:14:48.135719374 +0000 UTC m=+0.049147878 [debug] CHART PATH: /tmp/defectdojo/lc/django-DefectDojo/helm/defectdojo

walk.go:75: found symbolic link in path: /tmp/defectdojo/lc/django-DefectDojo/helm/defectdojo/README.md resolves to /tmp/defectdojo/lc/django-DefectDojo/readme-docs/KUBERNETES.md. Contents of linked file included and used
1:---
2:# Source: defectdojo/templates/configmap.yaml
3:apiVersion: v1
4:kind: ConfigMap
5:metadata:
6:  name: release-name-defectdojo
7:  labels:
8:    app.kubernetes.io/name: defectdojo
9:    app.kubernetes.io/instance: release-name
10:    app.kubernetes.io/managed-by: Helm
11:    helm.sh/chart: defectdojo-1.6.201
12:data:
13:  DD_ADMIN_USER: admin
14:  DD_ADMIN_MAIL: admin@defectdojo.local
15:  DD_ADMIN_FIRST_NAME: Admin
16:  DD_ADMIN_LAST_NAME: User
17:  DD_ALLOWED_HOSTS: defectdojo.default.minikube.local
18:  DD_SITE_URL: http://localhost:8080
19:  DD_CELERY_BROKER_SCHEME: redis
20:  DD_CELERY_BROKER_USER: ''
21:  DD_CELERY_BROKER_HOST: release-name-redis-master
22:  DD_CELERY_BROKER_PORT: '6379'
23:  DD_CELERY_BROKER_PARAMS: ''
24:  DD_CELERY_BROKER_PATH: '//'
25:  DD_CELERY_LOG_LEVEL: INFO
26:  DD_CELERY_WORKER_POOL_TYPE: solo
27:  DD_CELERY_WORKER_AUTOSCALE_MIN: ''
28:  DD_CELERY_WORKER_AUTOSCALE_MAX: ''
29:  DD_CELERY_WORKER_CONCURRENCY: ''
30:  DD_CELERY_WORKER_PREFETCH_MULTIPLIER: ''
31:  DD_DATABASE_ENGINE: django.db.backends.postgresql
32:  DD_DATABASE_HOST: 127.0.0.1   <=========================== HERE
33:  DD_DATABASE_PORT: '5432'
34:  DD_DATABASE_USER: defectdojo
35:  DD_DATABASE_NAME: defectdojo
36:  DD_INITIALIZE: 'true'
37:  DD_UWSGI_ENDPOINT: /run/defectdojo/uwsgi.sock
38:  DD_UWSGI_HOST: localhost
39:  DD_UWSGI_PASS: unix:///run/defectdojo/uwsgi.sock
40:  DD_UWSGI_NUM_OF_PROCESSES: '2'
41:  DD_UWSGI_NUM_OF_THREADS: '2'
42:  DD_UWSGI_MAX_FD: ''
43:  DD_DJANGO_METRICS_ENABLED: 'false'
44:  NGINX_METRICS_ENABLED: 'false'
45:  METRICS_HTTP_AUTH_USER: monitoring
```
