### PR TITLE
Fix 12955 / Set default value of postgresql.postgresServer to 127.0.0.1 in helm chart

### DIFF
--- a/helm/defectdojo/templates/_helpers.tpl
+++ b/helm/defectdojo/templates/_helpers.tpl
@@ -47,13 +47,13 @@ Create the name of the service account to use
 */}}
 {{- define "postgresql.hostname" -}}
 {{- if .Values.postgresql.enabled -}}
-{{- if eq .Values.postgresql.architecture "replication" -}}
-{{- printf "%s-%s-%s" .Release.Name "postgresql" .Values.postgresql.primary.name | trunc 63 | trimSuffix "-" -}}
+{{-  if eq .Values.postgresql.architecture "replication" -}}
+{{-   printf "%s-%s-%s" .Release.Name "postgresql" .Values.postgresql.primary.name | trunc 63 | trimSuffix "-" -}}
+{{-  else -}}
+{{-   printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{-  end -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- else -}}
-{{- printf "%s" .Values.postgresql.postgresServer -}}
+{{-  printf "%s" ( .Values.postgresql.postgresServer | default "127.0.0.1" ) -}}
 {{- end -}}
 {{- end -}}
 {{- define "redis.hostname" -}}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -405,6 +405,9 @@ initializer:
   staticName: false
 
 postgresql:
+  # To use an external PostgreSQL instance (like CloudSQL), set enabled to false, set items in auth part for authentication,
+  # and uncomment the line below:
+  # postgresServer: "127.0.0.1"
   enabled: true
   auth:
     username: defectdojo
@@ -443,10 +446,6 @@ postgresql:
   shmVolume:
     chmod:
       enabled: false
-
-  # To use an external PostgreSQL instance, set enabled to false and uncomment
-  # the line below:
-  # postgresServer: "127.0.0.1"
 
 # Google CloudSQL support in GKE via gce-proxy
 cloudsql:


### PR DESCRIPTION
**Description**

Fix #12955 
Set default value of postgresql.postgresServer to 127.0.0.1 so helm install won't failed if it's not defined.
Move the comment on postgresServer at the beginning of postgresql item, to ease the usage of external instance.

**Test results**

```
helm template . --values myvalues.yaml --show-only templates/configmap.yaml
```

```
---
# Source: defectdojo/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: defectdojo
  labels:
    app.kubernetes.io/name: defectdojo
    app.kubernetes.io/instance: defectdojo
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: defectdojo-1.6.203-dev
data:
.... 
  DD_DATABASE_HOST: 127.0.0.1
.... 
```

**Documentation**

N/A 

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
