### PR TITLE
Endpoint: Make `post_delete` signal more reliable

### DIFF
--- a/dojo/endpoint/signals.py
+++ b/dojo/endpoint/signals.py
@@ -1,3 +1,5 @@
+import contextlib
+
 from auditlog.models import LogEntry
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -12,18 +14,20 @@ from dojo.notifications.helper import create_notification
 
 @receiver(post_delete, sender=Endpoint)
 def endpoint_post_delete(sender, instance, using, origin, **kwargs):
-    if instance == origin:
-        description = _('The endpoint "%(name)s" was deleted') % {"name": str(instance)}
-        if settings.ENABLE_AUDITLOG:
-            if le := LogEntry.objects.filter(
-                action=LogEntry.Action.DELETE,
-                content_type=ContentType.objects.get(app_label="dojo", model="endpoint"),
-                object_id=instance.id,
-            ).order_by("-id").first():
-                description = _('The endpoint "%(name)s" was deleted by %(user)s') % {
-                                "name": str(instance), "user": le.actor}
-        create_notification(event="endpoint_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
-                            title=_("Deletion of %(name)s") % {"name": str(instance)},
-                            description=description,
-                            url=reverse("endpoint"),
-                            icon="exclamation-triangle")
+    # Catch instances in async delete where a single object is deleted more than once
+    with contextlib.suppress(sender.DoesNotExist):
+        if instance == origin:
+            description = _('The endpoint "%(name)s" was deleted') % {"name": str(instance)}
+            if settings.ENABLE_AUDITLOG:
+                if le := LogEntry.objects.filter(
+                    action=LogEntry.Action.DELETE,
+                    content_type=ContentType.objects.get(app_label="dojo", model="endpoint"),
+                    object_id=instance.id,
+                ).order_by("-id").first():
+                    description = _('The endpoint "%(name)s" was deleted by %(user)s') % {
+                                    "name": str(instance), "user": le.actor}
+            create_notification(event="endpoint_deleted",  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
+                                title=_("Deletion of %(name)s") % {"name": str(instance)},
+                                description=description,
+                                url=reverse("endpoint"),
+                                icon="exclamation-triangle")


### PR DESCRIPTION
Continuation of #12867
