### PR TITLE
allow .fpr extension when importing scan

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -675,7 +675,7 @@ class ReImportScanForm(forms.Form):
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(
         widget=forms.widgets.FileInput(
-            attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif"},
+            attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif, .fpr"},
         ),
         label="Choose report file",
         allow_empty_file=True,

--- a/dojo/validators.py
+++ b/dojo/validators.py
@@ -102,7 +102,7 @@ def cvss4_validator(value: str | list[str], exception_class: Callable = Validati
 
 
 class ImporterFileExtensionValidator(FileExtensionValidator):
-    default_allowed_extensions = ["xml", "csv", "nessus", "json", "jsonl", "html", "js", "zip", "xlsx", "txt", "sarif"]
+    default_allowed_extensions = ["xml", "csv", "nessus", "json", "jsonl", "html", "js", "zip", "xlsx", "txt", "sarif", "fpr"]
 
     def __init__(self, *args: list, **kwargs: dict):
         if "allowed_extensions" not in kwargs:


### PR DESCRIPTION
**Description**

[dojo/tools/fortify/parser.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/tools/fortify/parser.py) expects FPR reports to have the .fpr extension, yet .fpr is not part of the allowed import extensions.

Via the UI, it is not listed as _supported type_ but it can still be uploaded (by choosing _any type_). But via API it is simply not possible.

**Test results**

* .fpr shows up as supported type in the report file browse dialog of import scan UI
* .fpr files can be imported via import-scan/reimport-scan API endpoints

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.