### PR TITLE
feat(helm): Drop support for networking.k8s.io/v1beta1

### DIFF
--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -1,10 +1,6 @@
 {{- if .Values.django.ingress.enabled -}}
 {{- $fullName := include "defectdojo.fullname" . -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
-{{- else -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -31,11 +27,9 @@ metadata:
   {{- end }}
 {{- end }}
 spec:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
   {{- if .Values.django.ingress.ingressClassName }}
   ingressClassName: {{ .Values.django.ingress.ingressClassName }}
   {{- end }}
-{{- end }}
 {{- if .Values.django.ingress.activateTLS }}
   tls:
   - hosts:
@@ -48,7 +42,6 @@ spec:
   - host: {{ .Values.host }}
     http:
       paths:
-        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
         - pathType: Prefix
           {{- if .Values.django.ingress.path }}
           path: {{ .Values.django.ingress.path }}
@@ -60,14 +53,4 @@ spec:
               name: {{ $fullName }}-django
               port:
                 name: http
-        {{- else }}
-        {{- if .Values.django.ingress.path }}
-        - path: {{ .Values.django.ingress.path }}
-        {{- else }}
-        - path: /
-        {{- end }}
-          backend:
-            serviceName: {{ $fullName }}-django
-            servicePort: http
-        {{- end }}
 {{- end }}


### PR DESCRIPTION
Reason: Linter was complaining about
```
[WARNING] templates/django-ingress.yaml: networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```

EOL of 1.19 was 2021-10-28
EOL of 1.22 was 2022-12-08

It is fine to drop this.