### PR TITLE
feat(helm): Drop support for annotation "kubernetes.io/ingress.class" in GKE

### DIFF
--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -23,7 +23,6 @@ metadata:
   {{- toYaml . | nindent 4 }}
 {{- end }}
   {{- if .Values.gke.useGKEIngress }}
-    kubernetes.io/ingress.class: gce
     {{- if .Values.gke.useManagedCertificate }}
     kubernetes.io/ingress.allow-http: "false"
     networking.gke.io/managed-certificates: {{ $fullName }}-django


### PR DESCRIPTION
Fix #9807