### PR TITLE
fix(timezone/commands): Drop obsolite 'locale' definitions

### DIFF
--- a/dojo/management/commands/csv_findings_export.py
+++ b/dojo/management/commands/csv_findings_export.py
@@ -1,13 +1,9 @@
 import csv
-import zoneinfo
 from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
 from dojo.models import Finding
-from dojo.utils import get_system_setting
-
-locale = zoneinfo.ZoneInfo(get_system_setting("time_zone"))
 
 """
 Author: Aaron Weaver

--- a/dojo/management/commands/dedupe.py
+++ b/dojo/management/commands/dedupe.py
@@ -1,5 +1,4 @@
 import logging
-import zoneinfo
 
 from django.core.management.base import BaseCommand
 
@@ -11,8 +10,6 @@ from dojo.utils import (
     get_system_setting,
     mass_model_updater,
 )
-
-locale = zoneinfo.ZoneInfo(get_system_setting("time_zone"))
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")

--- a/dojo/management/commands/import_surveys.py
+++ b/dojo/management/commands/import_surveys.py
@@ -1,13 +1,9 @@
-import zoneinfo
 from pathlib import Path
 
 from django.core.management.base import BaseCommand
 from django.db import connection
 
 from dojo.models import TextQuestion
-from dojo.utils import get_system_setting
-
-locale = zoneinfo.ZoneInfo(get_system_setting("time_zone"))
 
 """
 Author: Cody Maffucci

--- a/dojo/management/commands/push_to_jira_update.py
+++ b/dojo/management/commands/push_to_jira_update.py
@@ -1,5 +1,4 @@
 import logging
-import zoneinfo
 
 from django.core.management.base import BaseCommand
 
@@ -9,7 +8,6 @@ from dojo.utils import get_system_setting
 
 logger = logging.getLogger(__name__)
 
-locale = zoneinfo.ZoneInfo(get_system_setting("time_zone"))
 
 """
 Author: Aaron Weaver

--- a/dojo/management/commands/rename_mend_findings.py
+++ b/dojo/management/commands/rename_mend_findings.py
@@ -1,16 +1,13 @@
 import logging
 import re
-import zoneinfo
 
 from django.core.management.base import BaseCommand
 
 from dojo.celery import app
 from dojo.models import Finding, Test_Type
-from dojo.utils import get_system_setting
 
 logger = logging.getLogger(__name__)
 
-locale = zoneinfo.ZoneInfo(get_system_setting("time_zone"))
 
 """
 Author: Aaron Weaver

--- a/dojo/management/commands/stamp_finding_last_reviewed.py
+++ b/dojo/management/commands/stamp_finding_last_reviewed.py
@@ -1,13 +1,9 @@
-import zoneinfo
 
 from auditlog.models import LogEntry
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 
 from dojo.models import Finding
-from dojo.utils import get_system_setting
-
-locale = zoneinfo.ZoneInfo(get_system_setting("time_zone"))
 
 """
 Authors: Jay Paz


### PR DESCRIPTION
# TL;DR

During a deeper analysis of #12974 (why there are `locale` definitions in commands), I noticed that they are copy-paste leftovers and were never used. They can be removed.

# Full story

I was trying to identify the reason for `locale` in those many commands which has never been used.

```bash
$ git log -p -S'locale = ' dojo/management/commands | grep 'locale'              
-locale = timezone(get_system_setting('time_zone'))
-locale = timezone(get_system_setting('time_zone'))
-locale = timezone(get_system_setting('time_zone'))
-locale = timezone(get_system_setting('time_zone'))
-                    current_scan.date = locale.localize(datetime.today())
-            msg += " was performed on " + locale.normalize(
-                                       date=locale.localize(datetime.today()))
-locale = timezone(get_system_setting('time_zone'))
-locale = timezone(get_system_setting('time_zone'))
+locale = timezone(get_system_setting('time_zone'))
+locale = timezone(get_system_setting('time_zone'))
+locale = timezone(get_system_setting('time_zone'))
+locale = timezone(get_system_setting('time_zone'))
+locale = timezone(get_system_setting('time_zone'))
+locale = timezone(settings.TIME_ZONE)
+locale = timezone(settings.TIME_ZONE)
+locale = timezone(settings.TIME_ZONE)
+locale = timezone(settings.TIME_ZONE)
-locale = timezone(settings.TIME_ZONE)
+locale = timezone(settings.TIME_ZONE)
+locale = timezone(settings.TIME_ZONE)
+locale = timezone(settings.TIME_ZONE)
+locale = timezone(settings.TIME_ZONE)
+                    current_scan.date = locale.localize(datetime.today())
+            msg += " was performed on " + locale.normalize(
+                                       date=locale.localize(datetime.today()))
```

```bash
git log -p -S'current_scan.date = locale' dojo/management/commands | grep index
index 119a633a21..0000000000
index 0000000000..196e37e26d
```

Unfortunately, I wasn't able to fully find full context

```bash
$ git checkout 196e37e26d                                                        
fatal: unable to read tree (196e37e26de63463986c412b9105feb73e975cbf)
$ git checkout 119a633a21          
fatal: unable to read tree (119a633a218a0ec7b6353c91c255281b23de860d)
```

But I have at least partial results

```bash
git log -p -S'current_scan.date = locale' dojo/management/commands | grep '^diff'
diff --git a/dojo/management/commands/run_scan.py b/dojo/management/commands/run_scan.py
diff --git a/dojo/management/commands/run_scan.py b/dojo/management/commands/run_scan.py
```

```
$ git show 196e37e26de63463986c412b9105feb73e975cbf | grep -C 3 locale
import dojo.settings as settings


locale = timezone(settings.TIME_ZONE)


"""
--
            for host in p_dict:
                current_scan = Scan.objects.get(id=p_dict[host]['scan_id'])
                if not current_scan.date:
                    current_scan.date = locale.localize(datetime.today())

                # For each host, save the IPScan and the date to the scan
                # to the db
--
            # necessary
            product = Product.objects.get(id=prod_id).name
            msg = "Hello, \n\nA port scan of the product " + product
            msg += " was performed on " + locale.normalize(
                current_scan.date).strftime("%A %B %d, %Y at %I:%M:%S %p")
            msg += "\nThe results of the scan show that the following ip "
            msg += "addresses have the following ports open: \n\n"
--
            # Create a Scan for each requested Scan (Scan Setting)
            scan = Scan.objects.create(scan_settings_id=s.id,
                                       protocol=s.protocol,
                                       date=locale.localize(datetime.today()))
            prod_id = str(s.product_id)
            list_addresses = s.addresses.strip().split(",")
            for line in list_addresses:
```

## Summary

It was implemented as part of `dojo/management/commands/run_scan.py` and copy-pasted to many other commands where `locale` was not necessary. `dojo/management/commands/run_scan.py` is not there anymore, and `locale` is not needed in any of commands.