### PR TITLE
Update Docs Link in Settings.py to Match Current Docs Structure

### DIFF
--- a/dojo/settings/settings.py
+++ b/dojo/settings/settings.py
@@ -1,7 +1,7 @@
 
 from split_settings.tools import include, optional
 
-# See https://documentation.defectdojo.com/getting_started/configuration/ for options
+# See https://docs.defectdojo.com/en/open_source/installation/configuration/ for options
 # how to tune the configuration to your needs.
 
 include(


### PR DESCRIPTION
Update the invalid docs link in Settings.py to the current docs page that should be present in the file.

Old:
https://documentation.defectdojo.com/getting_started/configuration/

New:
https://docs.defectdojo.com/en/open_source/installation/configuration/