### PR TITLE
feat(tests): Perform tests on latest supported k8s (1.33.4)

### DIFF
--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -27,7 +27,7 @@ jobs:
           # are tested (https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#available-versions)
           - databases: pgsql
             brokers: redis
-            k8s: 'v1.30.3'
+            k8s: 'v1.33.4'
             os: debian
     steps:
       - name: Checkout


### PR DESCRIPTION
Currently, there is no renovate rule that would detect the latest available Kubernetes. So let's update it by ✋ for now.