### PR TITLE
BlackDuck: Support import in plaintext or bytes

### DIFF
--- a/dojo/tools/blackduck_component_risk/importer.py
+++ b/dojo/tools/blackduck_component_risk/importer.py
@@ -26,9 +26,8 @@ class BlackduckCRImporter:
         :param report: Path to zip file
         :return: ( {component_id:details} , {component_id:[vulns]}, {component_id:[source]} )
         """
-        if not issubclass(type(report), Path):
-            report = Path(report.temporary_file_path())
-        if zipfile.is_zipfile(str(report)):
+        if zipfile.is_zipfile(report):
+            report.seek(0)  # rewind after the check
             return self._process_zipfile(report)
         msg = f"File {report} not a zip!"
         raise ValueError(msg)
@@ -43,7 +42,7 @@ class BlackduckCRImporter:
         components = {}
         source = {}
         try:
-            with zipfile.ZipFile(str(report)) as zipf:
+            with zipfile.ZipFile(report) as zipf:
                 c_file = False
                 s_file = False
                 for full_file_name in zipf.namelist():

--- a/unittests/tools/test_blackduck_binary_analysis_parser.py
+++ b/unittests/tools/test_blackduck_binary_analysis_parser.py
@@ -6,55 +6,55 @@ from unittests.dojo_test_case import DojoTestCase, get_unit_tests_scans_path
 
 class TestBlackduckBinaryAnalysisParser(DojoTestCase):
     def test_parse_no_vulns(self):
-        testfile = get_unit_tests_scans_path("blackduck_binary_analysis") / "no_vuln.csv"
-        parser = BlackduckBinaryAnalysisParser()
-        findings = parser.get_findings(testfile, Test())
-        self.assertEqual(0, len(findings))
+        with (get_unit_tests_scans_path("blackduck_binary_analysis") / "no_vuln.csv").open(encoding="utf-8") as testfile:
+            parser = BlackduckBinaryAnalysisParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(0, len(findings))
 
     def test_parse_one_vuln(self):
-        testfile = get_unit_tests_scans_path("blackduck_binary_analysis") / "one_vuln.csv"
-        parser = BlackduckBinaryAnalysisParser()
-        findings = parser.get_findings(testfile, Test())
-        self.assertEqual(1, len(findings))
-        for finding in findings:
-            self.assertIsNotNone(finding.title)
-            self.assertEqual(
-                "instrument.dll: zlib 1.2.13 Vulnerable to CVE-2023-45853",
-                finding.title,
-            )
+        with (get_unit_tests_scans_path("blackduck_binary_analysis") / "one_vuln.csv").open(encoding="utf-8") as testfile:
+            parser = BlackduckBinaryAnalysisParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(1, len(findings))
+            for finding in findings:
+                self.assertIsNotNone(finding.title)
+                self.assertEqual(
+                    "instrument.dll: zlib 1.2.13 Vulnerable to CVE-2023-45853",
+                    finding.title,
+                )
 
-            self.assertIsNotNone(finding.description)
-            self.assertIsNotNone(finding.severity)
-            self.assertEqual("Critical", finding.severity)
+                self.assertIsNotNone(finding.description)
+                self.assertIsNotNone(finding.severity)
+                self.assertEqual("Critical", finding.severity)
 
-            self.assertIsNotNone(finding.component_name)
-            self.assertEqual("zlib", finding.component_name)
+                self.assertIsNotNone(finding.component_name)
+                self.assertEqual("zlib", finding.component_name)
 
-            self.assertIsNotNone(finding.component_version)
-            self.assertEqual("1.2.13", finding.component_version)
+                self.assertIsNotNone(finding.component_version)
+                self.assertEqual("1.2.13", finding.component_version)
 
-            self.assertIsNotNone(finding.file_path)
-            self.assertEqual(
-                "JRE.msi:JRE.msi-30276-90876123.cab:instrument.dll",
-                finding.file_path,
-            )
+                self.assertIsNotNone(finding.file_path)
+                self.assertEqual(
+                    "JRE.msi:JRE.msi-30276-90876123.cab:instrument.dll",
+                    finding.file_path,
+                )
 
-            self.assertIsNotNone(finding.vuln_id_from_tool)
-            self.assertEqual("CVE-2023-45853", finding.vuln_id_from_tool)
+                self.assertIsNotNone(finding.vuln_id_from_tool)
+                self.assertEqual("CVE-2023-45853", finding.vuln_id_from_tool)
 
-            self.assertIsNotNone(finding.unique_id_from_tool)
+                self.assertIsNotNone(finding.unique_id_from_tool)
 
     def test_parse_many_vulns(self):
-        testfile = get_unit_tests_scans_path("blackduck_binary_analysis") / "many_vulns.csv"
-        parser = BlackduckBinaryAnalysisParser()
-        findings = parser.get_findings(testfile, Test())
-        self.assertEqual(5, len(findings))
-        for finding in findings:
-            self.assertIsNotNone(finding.title)
-            self.assertIsNotNone(finding.description)
-            self.assertIsNotNone(finding.severity)
-            self.assertIsNotNone(finding.component_name)
-            self.assertIsNotNone(finding.component_version)
-            self.assertIsNotNone(finding.file_path)
-            self.assertIsNotNone(finding.vuln_id_from_tool)
-            self.assertIsNotNone(finding.unique_id_from_tool)
+        with (get_unit_tests_scans_path("blackduck_binary_analysis") / "many_vulns.csv").open(encoding="utf-8") as testfile:
+            parser = BlackduckBinaryAnalysisParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(5, len(findings))
+            for finding in findings:
+                self.assertIsNotNone(finding.title)
+                self.assertIsNotNone(finding.description)
+                self.assertIsNotNone(finding.severity)
+                self.assertIsNotNone(finding.component_name)
+                self.assertIsNotNone(finding.component_version)
+                self.assertIsNotNone(finding.file_path)
+                self.assertIsNotNone(finding.vuln_id_from_tool)
+                self.assertIsNotNone(finding.unique_id_from_tool)

--- a/unittests/tools/test_blackduck_component_risk_parser.py
+++ b/unittests/tools/test_blackduck_component_risk_parser.py
@@ -6,7 +6,7 @@ from unittests.dojo_test_case import DojoTestCase, get_unit_tests_scans_path
 
 class TestBlackduckComponentRiskParser(DojoTestCase):
     def test_blackduck_enhanced_zip_upload(self):
-        testfile = get_unit_tests_scans_path("blackduck_component_risk") / "blackduck_hub_component_risk.zip"
-        parser = BlackduckComponentRiskParser()
-        findings = parser.get_findings(testfile, Test())
-        self.assertEqual(12, len(findings))
+        with (get_unit_tests_scans_path("blackduck_component_risk") / "blackduck_hub_component_risk.zip").open(mode="rb") as testfile:
+            parser = BlackduckComponentRiskParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(12, len(findings))

--- a/unittests/tools/test_blackduck_parser.py
+++ b/unittests/tools/test_blackduck_parser.py
@@ -6,49 +6,49 @@ from unittests.dojo_test_case import DojoTestCase, get_unit_tests_scans_path
 
 class TestBlackduckHubParser(DojoTestCase):
     def test_blackduck_csv_parser_has_no_finding(self):
-        testfile = get_unit_tests_scans_path("blackduck") / "no_vuln.csv"
-        parser = BlackduckParser()
-        findings = parser.get_findings(testfile, Test())
-        self.assertEqual(0, len(findings))
+        with (get_unit_tests_scans_path("blackduck") / "no_vuln.csv").open(encoding="utf-8") as testfile:
+            parser = BlackduckParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(0, len(findings))
 
     def test_blackduck_csv_parser_has_one_finding(self):
-        testfile = get_unit_tests_scans_path("blackduck") / "one_vuln.csv"
-        parser = BlackduckParser()
-        findings = parser.get_findings(testfile, Test())
-        self.assertEqual(1, len(findings))
+        with (get_unit_tests_scans_path("blackduck") / "one_vuln.csv").open(encoding="utf-8") as testfile:
+            parser = BlackduckParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(1, len(findings))
 
     def test_blackduck_csv_parser_has_many_findings(self):
-        testfile = get_unit_tests_scans_path("blackduck") / "many_vulns.csv"
-        parser = BlackduckParser()
-        findings = parser.get_findings(testfile, Test())
-        self.assertEqual(24, len(findings))
-        findings = list(findings)
-        self.assertEqual(1, len(findings[10].unsaved_vulnerability_ids))
-        self.assertEqual("CVE-2007-3386", findings[10].unsaved_vulnerability_ids[0])
-        self.assertEqual(findings[4].component_name, "Apache Tomcat")
-        self.assertEqual(findings[2].component_name, "Apache HttpComponents Client")
-        self.assertEqual(findings[4].component_version, "5.5.23")
-        self.assertEqual(findings[2].component_version, "4.5.2")
+        with (get_unit_tests_scans_path("blackduck") / "many_vulns.csv").open(encoding="utf-8") as testfile:
+            parser = BlackduckParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(24, len(findings))
+            findings = list(findings)
+            self.assertEqual(1, len(findings[10].unsaved_vulnerability_ids))
+            self.assertEqual("CVE-2007-3386", findings[10].unsaved_vulnerability_ids[0])
+            self.assertEqual(findings[4].component_name, "Apache Tomcat")
+            self.assertEqual(findings[2].component_name, "Apache HttpComponents Client")
+            self.assertEqual(findings[4].component_version, "5.5.23")
+            self.assertEqual(findings[2].component_version, "4.5.2")
 
     def test_blackduck_csv_parser_new_format_has_many_findings(self):
-        testfile = get_unit_tests_scans_path("blackduck") / "many_vulns_new_format.csv"
-        parser = BlackduckParser()
-        findings = parser.get_findings(testfile, Test())
-        findings = list(findings)
-        self.assertEqual(9, len(findings))
-        self.assertEqual(findings[0].component_name, "kryo")
-        self.assertEqual(findings[2].component_name, "jackson-databind")
-        self.assertEqual(findings[0].component_version, "3.0.3")
-        self.assertEqual(findings[2].component_version, "2.9.9.3")
+        with (get_unit_tests_scans_path("blackduck") / "many_vulns_new_format.csv").open(encoding="utf-8") as testfile:
+            parser = BlackduckParser()
+            findings = parser.get_findings(testfile, Test())
+            findings = list(findings)
+            self.assertEqual(9, len(findings))
+            self.assertEqual(findings[0].component_name, "kryo")
+            self.assertEqual(findings[2].component_name, "jackson-databind")
+            self.assertEqual(findings[0].component_version, "3.0.3")
+            self.assertEqual(findings[2].component_version, "2.9.9.3")
 
     def test_blackduck_enhanced_has_many_findings(self):
-        testfile = get_unit_tests_scans_path("blackduck") / "blackduck_enhanced_py3_unittest.zip"
-        parser = BlackduckParser()
-        findings = parser.get_findings(testfile, Test())
-        self.assertEqual(11, len(findings))
+        with (get_unit_tests_scans_path("blackduck") / "blackduck_enhanced_py3_unittest.zip").open(mode="rb") as testfile:
+            parser = BlackduckParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(11, len(findings))
 
     def test_blackduck_enhanced_zip_upload(self):
-        testfile = get_unit_tests_scans_path("blackduck") / "blackduck_enhanced_py3_unittest_v2.zip"
-        parser = BlackduckParser()
-        findings = parser.get_findings(testfile, Test())
-        self.assertEqual(11, len(findings))
+        with (get_unit_tests_scans_path("blackduck") / "blackduck_enhanced_py3_unittest_v2.zip").open(mode="rb") as testfile:
+            parser = BlackduckParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(11, len(findings))


### PR DESCRIPTION
I found that while doing some importing using python request, black duck zip files had to be imported with `rb` mode in the files parameter:
```python
[("file", open(file_path, "rb"))]
```
However, when attempting to process CSV files in this way, I would constantly get an exception for two reasons:
 - The `temporary_file` function does not work well with bytes
 - Following the check if a file is zipped, the file pointer is not reset, so there are no bytes to read, which lead to a None type exception

To mitigate this, we need to support byte imports are a first class citizen. I checked the other black duck parsers as well to get them up to speed