### PR TITLE
fix(product): Drop import_scan_results_prod

### DIFF
--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -888,12 +888,6 @@ def prefetch_for_view_engagements(engagements, recent_test_day_count):
     return engagements
 
 
-# Authorization is within the import_scan_results method
-def import_scan_results_prod(request, pid=None):
-    from dojo.engagement.views import import_scan_results
-    return import_scan_results(request, pid=pid)
-
-
 def new_product(request, ptid=None):
     if get_authorized_product_types(Permissions.Product_Type_Add_Product).count() == 0:
         raise PermissionDenied


### PR DESCRIPTION
During troubleshooting another issue (#13042), I noticed that this function is not used anywhere. And if it is called, it is pointing to an obsolete import that no longer exists.