### PR TITLE
fix(eng/failure_redirect): Fix rendering when coming from product site

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -1055,9 +1055,14 @@ class ImportScanResultsView(View):
     ) -> HttpResponseRedirect:
         """Redirect the user to a place that indicates a failed import"""
         ErrorPageProductAnnouncement(request=request)
+        if obj := context.get("engagement"):
+            url = "import_scan_results"
+        else:
+            obj = context.get("product")
+            url = "import_scan_results_prod"
         return HttpResponseRedirect(reverse(
-            "import_scan_results",
-            args=(context.get("engagement", context.get("product")).id, ),
+            url,
+            args=(obj.id, ),
         ))
 
     def get(


### PR DESCRIPTION
Django raised `AttributeError: 'NoneType' object has no attribute 'id'` when a user visited `DD/product/<id>/import_scan_results` and triggered `failure_redirect`.