### PR TITLE
Chartsynced charts and images for vendoring

### DIFF
--- a/helm/defectdojo/Chart.lock
+++ b/helm/defectdojo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 16.7.0
+  repository: oci://us-docker.pkg.dev/os-public-container-registry/defectdojo
+  version: 16.7.27
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
-  version: 19.6.4
-digest: sha256:20147b5ef71e728a24b1ce410bfbc64885bb824bac17d75dc3ad49e9af5f1b01
-generated: "2025-05-08T15:21:14.221601771Z"
+  repository: oci://us-docker.pkg.dev/os-public-container-registry/defectdojo
+  version: 22.0.6
+digest: sha256:3a18ca95f09d93b0a1a79c06c612d74d9d5450f39ac6da5cd63a992f14efa215
+generated: "2025-08-26T12:26:49.084678-05:00"

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -11,9 +11,9 @@ maintainers:
 dependencies:
   - name: postgresql
     version: ~16.7.0
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "oci://us-docker.pkg.dev/os-public-container-registry/defectdojo"
     condition: postgresql.enabled
   - name: redis
-    version: ~19.6.0
-    repository: "https://charts.bitnami.com/bitnami"
+    version: ~22.0.0
+    repository: "oci://us-docker.pkg.dev/os-public-container-registry/defectdojo"
     condition: redis.enabled


### PR DESCRIPTION
**Description**

Vendoring dependent bitnami charts and images. Chart-syncer was used to translate and push the charts into defectdojo's public repo.


