### PR TITLE
feat(form-import): DRY File Extension

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -549,9 +549,7 @@ class ImportScanForm(forms.Form):
     tags = TagField(required=False, help_text="Add tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(
-        widget=forms.widgets.FileInput(
-            attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif"},
-        ),
+        widget=forms.widgets.FileInput(attrs={"accept": ", ".join(settings.FILE_IMPORT_TYPES)}),
         label="Choose report file",
         allow_empty_file=True,
         required=False,
@@ -674,9 +672,7 @@ class ReImportScanForm(forms.Form):
     tags = TagField(required=False, help_text="Modify existing tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(
-        widget=forms.widgets.FileInput(
-            attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif, .fpr, .md, .log, .fvdl"},
-        ),
+        widget=forms.widgets.FileInput(attrs={"accept": ", ".join(settings.FILE_IMPORT_TYPES)}),
         label="Choose report file",
         allow_empty_file=True,
         required=False,

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -286,6 +286,9 @@ env = environ.FileAwareEnv(
     # List of acceptable file types that can be uploaded to a given object via arbitrary file upload
     DD_FILE_UPLOAD_TYPES=(list, [".txt", ".pdf", ".json", ".xml", ".csv", ".yml", ".png", ".jpeg",
                                  ".sarif", ".xlsx", ".doc", ".html", ".js", ".nessus", ".zip", ".fpr"]),
+    # List of acceptable file types that can be (re)imported
+    DD_FILE_IMPORT_TYPES=(list, [".xml", ".csv", ".nessus", ".json", ".jsonl", ".html", ".js", ".zip",
+                                 ".xlsx", ".txt", ".sarif", ".fpr", ".md", ".log", ".fvdl"]),
     # Max file size for scan added via API in MB
     DD_SCAN_FILE_MAX_SIZE=(int, 100),
     # When disabled, existing user tokens will not be removed but it will not be
@@ -1876,6 +1879,8 @@ VULNERABILITY_URLS = {
 }
 # List of acceptable file types that can be uploaded to a given object via arbitrary file upload
 FILE_UPLOAD_TYPES = env("DD_FILE_UPLOAD_TYPES")
+# List of acceptable file types that can be (re)imported
+FILE_IMPORT_TYPES = env("DD_FILE_IMPORT_TYPES")
 # Fixes error
 # AttributeError: Problem installing fixture '/app/dojo/fixtures/defect_dojo_sample_data.json': 'Settings' object has no attribute 'AUDITLOG_DISABLE_ON_RAW_SAVE'
 AUDITLOG_DISABLE_ON_RAW_SAVE = False

--- a/dojo/validators.py
+++ b/dojo/validators.py
@@ -3,6 +3,7 @@ import re
 from collections.abc import Callable
 
 from cvss import CVSS2, CVSS3, CVSS4
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
 
@@ -102,7 +103,7 @@ def cvss4_validator(value: str | list[str], exception_class: Callable = Validati
 
 
 class ImporterFileExtensionValidator(FileExtensionValidator):
-    default_allowed_extensions = ["xml", "csv", "nessus", "json", "jsonl", "html", "js", "zip", "xlsx", "txt", "sarif", "fpr", "md", "log", "fvdl"]
+    default_allowed_extensions = [ext[1:] for ext in settings.FILE_IMPORT_TYPES]
 
     def __init__(self, *args: list, **kwargs: dict):
         if "allowed_extensions" not in kwargs:


### PR DESCRIPTION
Apply **DRY** ([Don't repeat yourself](https://en.wikipedia.org/wiki/Don't_repeat_yourself)) principle on the use of File Extension.

Because it is quite easy to forget to add it to other places.