### PR TITLE
Finding Filters: Add Product Life Cycle filter to be supported in both finding filters

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1702,6 +1702,9 @@ class FindingFilterHelper(FilterSet):
     test_import_finding_action__test_import = NumberFilter(widget=HiddenInput())
     endpoints = NumberFilter(widget=HiddenInput())
     status = FindingStatusFilter(label="Status")
+    test__engagement__product__lifecycle = MultipleChoiceFilter(
+        choices=Product.LIFECYCLE_CHOICES,
+        label="Product lifecycle")
 
     has_component = BooleanFilter(
         field_name="component_name",
@@ -1947,9 +1950,6 @@ class FindingFilter(FindingFilterHelper, FindingTagFilter):
     test__engagement__product__prod_type = ModelMultipleChoiceFilter(
         queryset=Product_Type.objects.none(),
         label="Product Type")
-    test__engagement__product__lifecycle = MultipleChoiceFilter(
-        choices=Product.LIFECYCLE_CHOICES,
-        label="Product lifecycle")
     test__engagement__product = ModelMultipleChoiceFilter(
         queryset=Product.objects.none(),
         label="Product")


### PR DESCRIPTION
When string based filtering is enabled, the product lifecycle filter was totally missing. This is due to a mistake in how the. object vs non object finding filters were constructed

[sc-11750]