### PR TITLE
Password Reset: Disable for SSO users

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -614,6 +614,13 @@ class UserContactInfoSerializer(serializers.ModelSerializer):
         model = UserContactInfo
         fields = "__all__"
 
+    def validate(self, data):
+        user = data.get("user", None) or self.instance.user
+        if data.get("force_password_reset", False) and not user.has_usable_password():
+            msg = "Password resets are not allowed for users authorized through SSO."
+            raise ValidationError(msg)
+        return super().validate(data)
+
 
 class UserStubSerializer(serializers.ModelSerializer):
     class Meta:

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2392,7 +2392,14 @@ class UserContactInfoForm(forms.ModelForm):
         exclude = ["user", "slack_user_id"]
 
     def __init__(self, *args, **kwargs):
+        user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
+        # Do not expose force password reset if the current user does not have a password to reset
+        if user is not None:
+            if not user.has_usable_password():
+                self.fields["force_password_reset"].disabled = True
+                self.fields["force_password_reset"].help_text = "This user is authorized through SSO, and does not have a password to reset"
+        # Determine some other settings based on the current user
         current_user = get_current_user()
         if not current_user.is_superuser:
             if not user_has_configuration_permission(current_user, "auth.change_user") and \

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -230,7 +230,7 @@ def view_profile(request):
     group_members = get_authorized_group_members_for_user(user)
 
     user_contact = user.usercontactinfo if hasattr(user, "usercontactinfo") else None
-    contact_form = UserContactInfoForm() if user_contact is None else UserContactInfoForm(instance=user_contact)
+    contact_form = UserContactInfoForm(user=user) if user_contact is None else UserContactInfoForm(instance=user_contact, user=user)
 
     global_role = user.global_role if hasattr(user, "global_role") else None
     if global_role is None:
@@ -242,7 +242,7 @@ def view_profile(request):
 
     if request.method == "POST":
         form = DojoUserForm(request.POST, instance=user)
-        contact_form = UserContactInfoForm(request.POST, instance=user_contact)
+        contact_form = UserContactInfoForm(request.POST, instance=user_contact, user=user)
         global_role_form = GlobalRoleForm(request.POST, instance=global_role)
         if form.is_valid() and contact_form.is_valid() and global_role_form.is_valid():
             form.save()
@@ -393,7 +393,7 @@ def edit_user(request, uid):
     form = EditDojoUserForm(instance=user)
 
     user_contact = user.usercontactinfo if hasattr(user, "usercontactinfo") else None
-    contact_form = UserContactInfoForm() if user_contact is None else UserContactInfoForm(instance=user_contact)
+    contact_form = UserContactInfoForm(user=user) if user_contact is None else UserContactInfoForm(instance=user_contact, user=user)
 
     global_role = user.global_role if hasattr(user, "global_role") else None
     global_role_form = GlobalRoleForm() if global_role is None else GlobalRoleForm(instance=global_role)
@@ -401,9 +401,9 @@ def edit_user(request, uid):
     if request.method == "POST":
         form = EditDojoUserForm(request.POST, instance=user)
         if user_contact is None:
-            contact_form = UserContactInfoForm(request.POST)
+            contact_form = UserContactInfoForm(request.POST, user=user)
         else:
-            contact_form = UserContactInfoForm(request.POST, instance=user_contact)
+            contact_form = UserContactInfoForm(request.POST, instance=user_contact, user=user)
 
         if global_role is None:
             global_role_form = GlobalRoleForm(request.POST)


### PR DESCRIPTION
It is possible to set password reset for users that were authorized through SSO mechanisms. This has potential to lock a user into a flow of not being able to reset a password that does not exist 