### PR TITLE
System settings: correct page title/breadcrumbs

### DIFF
--- a/dojo/system_settings/views.py
+++ b/dojo/system_settings/views.py
@@ -129,7 +129,7 @@ class SystemSettingsView(View):
         # Set up the initial context
         context = self.get_context(request)
         # Add some breadcrumbs
-        add_breadcrumb(title="Application settings", top_level=False, request=request)
+        add_breadcrumb(title="System settings", top_level=False, request=request)
         # Render the page
         return render(request, self.get_template(), context)
 
@@ -144,6 +144,6 @@ class SystemSettingsView(View):
         # Check the status of celery
         request, _ = self.validate_form(request, context)
         # Add some breadcrumbs
-        add_breadcrumb(title="Application settings", top_level=False, request=request)
+        add_breadcrumb(title="System settings", top_level=False, request=request)
         # Render the page
         return render(request, self.get_template(), context)


### PR DESCRIPTION
Small textual change to help people find the right browser tab and not confuse Application Settings (which don't exist in OS) and System Settings (which are great).

The page title had "Application Settings" when viewing the "System settings", this PR corrects that. 
