### PR TITLE
fix: uncontrolled data used in path expression

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import re
 from calendar import monthrange
+from werkzeug.utils import secure_filename
 from collections.abc import Callable
 from datetime import date, datetime, timedelta
 from math import pi, sqrt
@@ -1363,8 +1364,14 @@ def get_page_items_and_count(request, items, page_size, prefix="", *, do_count=T
 
 
 def handle_uploaded_threat(f, eng):
-    path = Path(f.name)
+    # Sanitize the file extension
+    original_name = secure_filename(f.name)
+    path = Path(original_name)
     extension = path.suffix
+    # Optional: limit to a whitelist of allowed extensions
+    allowed_extensions = {'.zip', '.pdf', '.docx', '.xlsx', '.png', '.jpg', '.jpeg', '.svg', '.txt'}
+    if extension.lower() not in allowed_extensions:
+        extension = '.bin'
     # Check if threat folder exist.
     threat_dir = Path(settings.MEDIA_ROOT) / "threat"
     if not threat_dir.is_dir():


### PR DESCRIPTION

fix this issue, we need to prevent the user from being able to specify arbitrary or dangerous file extensions via the upload. The best way to address this without breaking existing functionality is to extract the extension, sanitize it (e.g., restrict it to a defined set such as `.zip`, `.pdf`, etc., or otherwise ensure only alphanumeric/expected extensions are used), and ensure it does not contain any path separators or special characters. An alternative is to discard the user-supplied extension and use a fixed, safe one, or check that it matches a whitelist.

Implement this by:  
- Importing `werkzeug.utils.secure_filename` (or, if not allowed, do minimal extension sanitization inline).
- Validating the extracted extension, e.g., by matching against a regular expression that allows only safe characters (e.g., `^[a-zA-Z0-9.]+$` and not starting with a dot-dot or containing slashes).
- Optionally filtering extensions to a whitelist (e.g., `.zip`, `.pdf`).
- If the extension is not valid, either reject the upload or set a safe default (such as `.bin`).

Modify only the relevant lines in `handle_uploaded_threat` in `dojo/utils.py`, adding any necessary imports above.


**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [ ] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

