### PR TITLE
docker: remove dev dependencies from release images

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -31,7 +31,7 @@ COPY requirements.txt ./
 # https://github.com/unbit/uwsgi/issues/1318#issuecomment-542238096
 RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
-FROM base AS django
+FROM base AS release
 WORKDIR /app
 ARG uid=1001
 ARG gid=1337
@@ -136,5 +136,11 @@ ENV \
   DD_UWSGI_NUM_OF_THREADS="2"
 ENTRYPOINT ["/entrypoint-uwsgi.sh"]
 
-FROM django AS django-unittests
+FROM release AS development
+USER root
+COPY requirements-dev.txt ./
+RUN pip3 install --no-cache-dir -r requirements-dev.txt
+USER ${uid}
+
+FROM development AS django-unittests
 COPY unittests/ ./unittests/

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -30,7 +30,7 @@ COPY requirements.txt ./
 # https://github.com/unbit/uwsgi/issues/1318#issuecomment-542238096
 RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
-FROM base AS django
+FROM base AS release
 WORKDIR /app
 ARG uid=1001
 ARG gid=1337
@@ -139,5 +139,11 @@ ENV \
   DD_UWSGI_NUM_OF_THREADS="2"
 ENTRYPOINT ["/entrypoint-uwsgi.sh"]
 
-FROM django AS django-unittests
+FROM release AS development
+USER root
+COPY requirements-dev.txt ./
+RUN pip3 install --no-cache-dir -r requirements-dev.txt
+USER ${uid}
+
+FROM development AS django-unittests
 COPY unittests/ ./unittests/

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -1,6 +1,10 @@
 ---
 services:
   uwsgi:
+    build:
+      context: .
+      dockerfile: Dockerfile.django-debian
+      target: development
     entrypoint: ['/wait-for-it.sh', '${DD_DATABASE_HOST:-postgres}:${DD_DATABASE_PORT:-5432}', '-t', '30', '--', '/entrypoint-uwsgi-dev.sh']
     volumes:
       - '.:/app:z'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     build:
       context: ./
       dockerfile: "Dockerfile.django-${DEFECT_DOJO_OS:-debian}"
-      target: django
+      target: release
     image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
     depends_on:
       initializer:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,15 @@
+# Development-only dependencies for DefectDojo
+# These are only needed during development and testing
+
+# Debug toolbar for development
+django-debug-toolbar==6.0.0
+django-debug-toolbar-request-history==0.1.4
+
+# Testing dependencies
+vcrpy==7.0.0
+vcrpy-unittest==0.1.7
+django-test-migrations==1.4.0
+parameterized==0.9.0
+
+# Development file watching (hot reload)
+watchdog==6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,16 +51,11 @@ packageurl-python==0.17.5
 django-crum==0.7.9
 JSON-log-formatter==1.1.1
 django-split-settings==1.3.2
-django-debug-toolbar==5.2.0
-django-debug-toolbar-request-history==0.1.4
-vcrpy==7.0.0
-vcrpy-unittest==0.1.7
 django-tagulous==2.1.1
 PyJWT==2.10.1
 cvss==3.6
 django-fieldsignals==0.7.0
 hyperlink==21.0.0
-django-test-migrations==1.4.0
 djangosaml2==1.11.1
 drf-spectacular==0.28.0
 drf-spectacular-sidecar==2025.8.1
@@ -75,4 +70,3 @@ fontawesomefree==6.6.0
 PyYAML==6.0.2
 pyopenssl==25.1.0
 parameterized==0.9.0
-watchdog==6.0.0 # only needed for development, but would require some docker refactoring if we want to exclude it for production images


### PR DESCRIPTION
I wasn't going to spend time on this, but then Cursor AI got it right almost on the first go.

Some dependencies are only needed for development, we shouldn't install those in the release ("production")  images.

