### PR TITLE
product grade: only update product if grade has changed

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1598,8 +1598,13 @@ def calculate_grade(product, *args, **kwargs):
         aeval = Interpreter()
         aeval(system_settings.product_grade)
         grade_product = f"grade_product({critical}, {high}, {medium}, {low})"
-        product.prod_numeric_grade = aeval(grade_product)
-        super(Product, product).save()
+        prod_numeric_grade = aeval(grade_product)
+        if prod_numeric_grade != product.prod_numeric_grade:
+            logger.debug("Updating product %s grade from %s to %s", product.id, product.prod_numeric_grade, prod_numeric_grade)
+            product.prod_numeric_grade = prod_numeric_grade
+            super(Product, product).save()
+        else:
+            logger.debug("Product %s grade %i is up to date", product.id, prod_numeric_grade)
 
 
 def get_celery_worker_status():

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -201,10 +201,10 @@ class TestDojoImporterPerformance(DojoTestCase):
         DojoSytemSettingsMiddleware.load()
 
         self.import_reimport_performance(
-            expected_num_queries1=732,
+            expected_num_queries1=717,
             expected_num_async_tasks1=15,
-            expected_num_queries2=686,
+            expected_num_queries2=662,
             expected_num_async_tasks2=28,
-            expected_num_queries3=357,
+            expected_num_queries3=337,
             expected_num_async_tasks3=25,
         )


### PR DESCRIPTION
The grades of products are calculated quite often:
- every hour
- every finding.save()
- bulk edit
- ...

This PR ensures the product gets updated only if the grade has changed. This prevents unnecessary database writes.