### PR TITLE
fix(helm): Drop bitnami repo reference

### DIFF
--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -66,7 +66,6 @@ jobs:
 
       - name: Configure HELM repos
         run: |-
-             helm repo add bitnami https://charts.bitnami.com/bitnami
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
 

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Configure Helm repos
         run: |-
-             helm repo add bitnami https://charts.bitnami.com/bitnami
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
 

--- a/readme-docs/KUBERNETES.md
+++ b/readme-docs/KUBERNETES.md
@@ -51,11 +51,6 @@ minikube addons enable ingress
 
 Helm >= v3
 
-```zsh
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm repo update
-```
-
 Then pull the dependent charts:
 
 ```zsh


### PR DESCRIPTION
As we are not using bitnami anymore, adding it as Helm repo is not needed.
