### PR TITLE
Rename duplicate 'Dashboard' to 'Finding Groups'

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -341,7 +341,7 @@
                                         <li>
                                             <a href="{% url 'all_finding_groups' %}" aria-expanded="false" aria-label="Problems">
                                                 <i class="fa-solid fa-triangle-exclamation fa-fw"></i>
-                                                <span>{% trans "Dashboard" %}</span>
+                                                <span>{% trans "Finding Groups" %}</span>
                                                 <span class="glyphicon arrow"></span>
                                             </a> 
                                             <ul class="nav nav-second-level">


### PR DESCRIPTION
Rename duplicate 'Dashboard' to 'Finding Groups'

**Description**

In 2.50.0 https://github.com/DefectDojo/django-DefectDojo/pull/12814 has a second 'Dashboard' named tile in the navigation bar.  This PR aims to rename it to something more appropriate like 'Finding Groups'.
