### PR TITLE
[docs] add new opensource page

### DIFF
--- a/docs/content/en/about_defectdojo/contact_defectdojo_support.md
+++ b/docs/content/en/about_defectdojo/contact_defectdojo_support.md
@@ -16,7 +16,7 @@ For Open-Source users, the quickest way to get help is through the [OWASP Slack 
 
 To report a bug, issues can be raised on our [GitHub](https://github.com/DefectDojo/django-DefectDojo).
 
-See our [Community Site](https://defectdojo.com/community) for more information.
+See our [Community Site](https://defectdojo.com/open-source) for more information.
 
 ## DefectDojo Pro Support
 

--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -44,7 +44,7 @@
       <div class="row justify-content-center text-center">
         <div class="col-lg-5">
           <h2 class="h4">Join the Dojo community</h2>
-          <p>Check out live events, upcoming features and connect with other security professionals on our <a href="https://defectdojo.com/community">Community Page</a>.</p>
+          <p>Check out live events, upcoming features and connect with other security professionals on our <a href="https://defectdojo.com/open-source">Community Page</a>.</p>
         </div>
         <div class="col-lg-5">
           <h2 class="h4">Sign up for a trial</h2>


### PR DESCRIPTION
We have a new /opensource page, this PR updates all the links to reflect that.