### PR TITLE
Github Vulnerability Parser: Update docs to generate correct schema

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/file/github_vulnerability.md
+++ b/docs/content/en/connecting_your_tools/parsers/file/github_vulnerability.md
@@ -183,8 +183,8 @@ def get_dependabot_alerts_repository(repo, owner):
         )
 
         result = request.json()
-        output_result["data"]["repository"]["name"] = result["data"]["repository"][
-            "name"
+        output_result["data"]["repository"]["nameWithOwner"] = result["data"]["repository"][
+            "nameWithOwner"
         ]
         output_result["data"]["repository"]["url"] = result["data"]["repository"]["url"]
         if result["data"]["repository"]["vulnerabilityAlerts"]["totalCount"] == 0:


### PR DESCRIPTION
The docs became outdated from the parser