### PR TITLE
bulk edit: add None check on JIRA sync check

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -148,7 +148,9 @@ def is_keep_in_sync_with_jira(finding):
     jira_issue_exists = finding.has_jira_issue or (finding.finding_group and finding.finding_group.has_jira_issue)
     if jira_issue_exists:
         # Determine if any automatic sync should occur
-        keep_in_sync_enabled = get_jira_instance(finding).finding_jira_sync
+        jira_instance = get_jira_instance(finding)
+        if jira_instance:
+            keep_in_sync_enabled = jira_instance.finding_jira_sync
 
     return keep_in_sync_enabled
 


### PR DESCRIPTION
It's not clear how this can happen, but on the demo instance we're seeing errors on bulk edit on this exact line.

The PR adds a check to make this code "None-safe".
