### PR TITLE
fix(helm): Update annotations during releasing

### DIFF
--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -80,6 +80,11 @@ jobs:
               sed -ri "0,/version/s/version: \S+/$NEW_CHART_VERSION/" helm/defectdojo/Chart.yaml
           fi
 
+      - name: Update values in HELM chart
+        run: |
+          yq -i '.annotations."artifacthub.io/prerelease" = "false"' helm/defectdojo/Chart.yaml
+          yq -i '.annotations."artifacthub.io/changes" += "- kind: changed\n  description: Bump DefectDojo to ${{ inputs.release_number }}\n"' helm/defectdojo/Chart.yaml
+
       - name: Check version numbers
         run: |
           grep -H version dojo/__init__.py

--- a/.github/workflows/release-3-master-into-dev.yml
+++ b/.github/workflows/release-3-master-into-dev.yml
@@ -74,6 +74,12 @@ jobs:
           git add docs/content/en/open_source/upgrading/$minorv.md
         if: endsWith(inputs.release_number_new, '.0') && endsWith(inputs.release_number_dev, '.0-dev')
 
+      - name: Update values in HELM chart
+        run: |
+          yq -i '.annotations = {}' helm/defectdojo/Chart.yaml
+          yq -i '.annotations."artifacthub.io/prerelease" = "true"' helm/defectdojo/Chart.yaml
+          yq -i '.annotations."artifacthub.io/changes" = ""' helm/defectdojo/Chart.yaml
+
       - name: Run helm-docs
         uses: losisin/helm-docs-github-action@a57fae5676e4c55a228ea654a1bcaec8dd3cf5b5 # v1.6.2
         with:
@@ -143,6 +149,12 @@ jobs:
           grep version dojo/__init__.py
           grep appVersion helm/defectdojo/Chart.yaml
           grep version components/package.json
+
+      - name: Update values in HELM chart
+        run: |
+          yq -i '.annotations = {}' helm/defectdojo/Chart.yaml
+          yq -i '.annotations."artifacthub.io/prerelease" = "true"' helm/defectdojo/Chart.yaml
+          yq -i '.annotations."artifacthub.io/changes" = ""' helm/defectdojo/Chart.yaml
 
       - name: Run helm-docs
         uses: losisin/helm-docs-github-action@a57fae5676e4c55a228ea654a1bcaec8dd3cf5b5 # v1.6.2

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -65,6 +65,26 @@ jobs:
         run: ct lint --config ct.yaml --target-branch ${{ env.ct-branch }} --check-version-increment=false
         if: env.changed == 'true'
 
+      - name: Check update of "artifacthub.io/changes" HELM annotation
+        if: env.changed == 'true'
+        run: |
+          target_branch=${{ env.ct-branch }}
+
+          echo "Checking Chart.yaml annotation changes"
+
+          # Get current branch annotation
+          current_annotation=$(yq e '.annotations."artifacthub.io/changes"' "helm/defectdojo/Chart.yaml")
+
+          # Get target branch version of Chart.yaml annotation
+          target_annotation=$(git show "${{ env.ct-branch }}:helm/defectdojo/Chart.yaml" | yq e '.annotations."artifacthub.io/changes"' -)
+
+          if [[ "$current_annotation" == "$target_annotation" ]]; then
+            echo "::error file=helm/defectdojo/Chart.yaml::The 'artifacthub.io/changes' annotation has not been updated compared to ${{ env.ct-branch }}"
+            exit 1
+          fi
+
+          echo "'artifacthub.io/changes' annotation updated in helm/defectdojo"
+
       # - name: Create kind cluster
       #  uses: helm/kind-action@v1.1.0
       #  if: env.changed == 'true'

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -17,3 +17,6 @@ dependencies:
     version: ~19.6.4
     repository: "oci://us-docker.pkg.dev/os-public-container-registry/defectdojo"
     condition: redis.enabled
+annotations:
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/changes: ""


### PR DESCRIPTION
ArtifactHub.io keeps track of HELM chart: https://artifacthub.io/packages/helm/defectdojo/defectdojo
It would be good to add more useful annotations.