### PR TITLE
fix(helm): Empty string values propagated as strings (not as null)

### DIFF
--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -516,13 +516,13 @@ A Helm chart for Kubernetes to install DefectDojo
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| admin.credentialAes256Key | string | `nil` |  |
+| admin.credentialAes256Key | string | `""` |  |
 | admin.firstName | string | `"Administrator"` |  |
 | admin.lastName | string | `"User"` |  |
 | admin.mail | string | `"admin@defectdojo.local"` |  |
-| admin.metricsHttpAuthPassword | string | `nil` |  |
-| admin.password | string | `nil` |  |
-| admin.secretKey | string | `nil` |  |
+| admin.metricsHttpAuthPassword | string | `""` |  |
+| admin.password | string | `""` |  |
+| admin.secretKey | string | `""` |  |
 | admin.user | string | `"admin"` |  |
 | annotations | object | `{}` |  |
 | celery.annotations | object | `{}` |  |
@@ -594,9 +594,9 @@ A Helm chart for Kubernetes to install DefectDojo
 | django.mediaPersistentVolume.name | string | `"media"` |  |
 | django.mediaPersistentVolume.persistentVolumeClaim.accessModes[0] | string | `"ReadWriteMany"` |  |
 | django.mediaPersistentVolume.persistentVolumeClaim.create | bool | `false` |  |
-| django.mediaPersistentVolume.persistentVolumeClaim.name | string | `nil` |  |
+| django.mediaPersistentVolume.persistentVolumeClaim.name | string | `""` |  |
 | django.mediaPersistentVolume.persistentVolumeClaim.size | string | `"5Gi"` |  |
-| django.mediaPersistentVolume.persistentVolumeClaim.storageClassName | string | `nil` |  |
+| django.mediaPersistentVolume.persistentVolumeClaim.storageClassName | string | `""` |  |
 | django.mediaPersistentVolume.type | string | `"emptyDir"` |  |
 | django.nginx.extraEnv | list | `[]` |  |
 | django.nginx.extraVolumeMounts | list | `[]` |  |

--- a/helm/defectdojo/values.schema.json
+++ b/helm/defectdojo/values.schema.json
@@ -6,7 +6,7 @@
             "type": "object",
             "properties": {
                 "credentialAes256Key": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "firstName": {
                     "type": "string"
@@ -18,13 +18,13 @@
                     "type": "string"
                 },
                 "metricsHttpAuthPassword": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "password": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "secretKey": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "user": {
                     "type": "string"
@@ -339,13 +339,13 @@
                                     "type": "boolean"
                                 },
                                 "name": {
-                                    "type": "null"
+                                    "type": "string"
                                 },
                                 "size": {
                                     "type": "string"
                                 },
                                 "storageClassName": {
-                                    "type": "null"
+                                    "type": "string"
                                 }
                             }
                         },

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -124,13 +124,13 @@ tests:
 
 admin:
   user: admin
-  password:
+  password: ""
   firstName: Administrator
   lastName: User
   mail: admin@defectdojo.local
-  secretKey:
-  credentialAes256Key:
-  metricsHttpAuthPassword:
+  secretKey: ""
+  credentialAes256Key: ""
+  metricsHttpAuthPassword: ""
 
 monitoring:
   enabled: false
@@ -356,11 +356,11 @@ django:
     persistentVolumeClaim:
       # set to true to create a new pvc and if django.mediaPersistentVolume.type is set to pvc
       create: false
-      name:
+      name: ""
       size: 5Gi
       accessModes:
       - ReadWriteMany  # check KUBERNETES.md doc first for option to choose
-      storageClassName:
+      storageClassName: ""
 
 initializer:
   run: true


### PR DESCRIPTION
During more testing of the HELM chart with schema, I noticed a collision like
```
- at '/django/mediaPersistentVolume/persistentVolumeClaim/storageClassName': got string, want null
```