### PR TITLE
sonarqube hotspots sync implementation

### DIFF
--- a/dojo/tools/api_sonarqube/api_client.py
+++ b/dojo/tools/api_sonarqube/api_client.py
@@ -334,6 +334,31 @@ class SonarQubeAPI:
             self.rules_cache.update({rule_id: rule})
         return rule
 
+    def get_hotspot(self, rule_id):
+        """
+        Get detailed information about a hotspot
+        :param rule_id:
+        :return:
+        """
+        rule = self.rules_cache.get(rule_id)
+        if not rule:
+            response = self.session.get(
+                url=f"{self.sonar_api_url}/hotspots/search",
+                params={"hotspots": rule_id},
+                headers=self.default_headers,
+                timeout=settings.REQUESTS_TIMEOUT,
+            )
+            if not response.ok:
+                msg = (
+                    f"Unable to get the hotspot rule {rule_id} "
+                    f"due to {response.status_code} - {response.content}"
+                )
+                raise Exception(msg)
+
+            rule = response.json()["hotspots"][0]
+            self.rules_cache.update({rule_id: rule})
+        return rule
+
     def transition_issue(self, issue_key, transition):
         """
         Do workflow transition on an issue. Requires authentication and Browse permission on project.
@@ -371,6 +396,46 @@ class SonarQubeAPI:
         if not response.ok:
             msg = (
                 f"Unable to transition {transition} the issue {issue_key} "
+                f'due to {response.status_code} - {response.content.decode("utf-8")}'
+            )
+            raise Exception(msg)
+
+    def transition_hotspot(self, issue_key, status, resolution=None):
+        """
+        Do workflow transition on an issue. Requires authentication and Browse permission on project.
+        The transitions 'wontfix' and 'falsepositive' require the permission 'Administer Issues'.
+        The transitions involving security hotspots (except 'requestreview') require
+        the permission 'Administer Security Hotspot'.
+
+        Possible resolution values:
+        - FIXED
+        - SAFE
+        - ACKNOWLEDGED
+
+        Possible status values:
+        - TO_REVIEW
+        - REVIEWED
+
+        :param issue_key:
+        :param transition:
+        :return:
+        """
+
+        data = {"hotspot": issue_key, "status": status}
+
+        if resolution:
+            data["resolution"] = resolution
+
+        response = self.session.post(
+            url=f"{self.sonar_api_url}/hotspots/change_status",
+            data=data,
+            headers=self.default_headers,
+            timeout=settings.REQUESTS_TIMEOUT,
+        )
+
+        if not response.ok:
+            msg = (
+                f"Unable to change status {status} / resolution {resolution} the issue {issue_key} "
                 f'due to {response.status_code} - {response.content.decode("utf-8")}'
             )
             raise Exception(msg)

--- a/dojo/tools/api_sonarqube/updater.py
+++ b/dojo/tools/api_sonarqube/updater.py
@@ -52,6 +52,45 @@ class SonarQubeApiUpdater:
         },
     ]
 
+    MAPPING_SONARQUBE_HOTSPOT_STATUS_TRANSITION = [
+        {
+            "from": ["TO_REVIEW"],
+            "to": "RESOLVED / FALSE-POSITIVE",
+            "transition": "REVIEWED",
+            "resolution" : "SAFE"
+        },
+        {
+            "from": ["TO_REVIEW"],
+            "to": "RESOLVED / FIXED",
+            "transition": "REVIEWED",
+            "resolution" : "FIXED"
+        },
+                {
+            "from": ["TO_REVIEW"],
+            "to": "RESOLVED / WONTFIX",
+            "transition": "REVIEWED",
+            "resolution" : "ACKNOWLEDGED"
+        },
+        {
+            "from": ["REVIEWED"],
+            "to": "OPEN",
+            "transition": "TO_REVIEW",
+            "resolution" : None
+        },
+        {
+            "from": ["REVIEWED"],
+            "to": "REOPENED",
+            "transition": "TO_REVIEW",
+            "resolution" : None
+        },
+        {
+            "from": ["REVIEWED"],
+            "to": "CONFIRMED",
+            "transition": "TO_REVIEW",
+            "resolution" : None
+        },
+    ]
+
     @staticmethod
     def get_sonarqube_status_for(finding):
         target_status = None
@@ -66,16 +105,23 @@ class SonarQubeApiUpdater:
         return target_status
 
     def get_sonarqube_required_transitions_for(
-        self, current_status, target_status,
+        self, current_status, target_status, is_hotspot=False
     ):
         # If current and target is the same... do nothing
         if current_status == target_status:
             return None
 
+        # Select the appropriate mapping based on issue type
+        mapping = (
+            self.MAPPING_SONARQUBE_HOTSPOT_STATUS_TRANSITION
+            if is_hotspot
+            else self.MAPPING_SONARQUBE_STATUS_TRANSITION
+        )
+
         # Check if there is at least one transition from current_status...
         if not [
             x
-            for x in self.MAPPING_SONARQUBE_STATUS_TRANSITION
+            for x in mapping
             if current_status in x.get("from")
         ]:
             return None
@@ -84,7 +130,7 @@ class SonarQubeApiUpdater:
         # can transition to target_status
         transitions = [
             x
-            for x in self.MAPPING_SONARQUBE_STATUS_TRANSITION
+            for x in mapping
             if target_status == x.get("to")
         ]
         if transitions:
@@ -92,26 +138,39 @@ class SonarQubeApiUpdater:
                 # There is a direct transition from current status...
                 if current_status in transition.get("from"):
                     t = transition.get("transition")
-                    return [t] if t else None
+                    if is_hotspot:
+                        return [{"status": t, "resolution": transition.get("resolution")}] if t else None
+                    else:
+                        return [t] if t else None
 
-            # We have the last transition to get to our target status but there
-            # is no direct transition
-            transitions_result = deque()
-            transitions_result.appendleft(transitions[0].get("transition"))
+            # Handle complex transitions for regular issues
+            if not is_hotspot:
+                # We have the last transition to get to our target status but there
+                # is no direct transition
+                transitions_result = deque()
+                transitions_result.appendleft(transitions[0].get("transition"))
 
-            # Find out previous transitions that would finish in any FROM of a
-            # previous to use as target
-            for transition in transitions:
-                for t_from in transition.get("from"):
-                    possible_transition = (
-                        self.get_sonarqube_required_transitions_for(
-                            current_status, t_from,
+                # Find out previous transitions that would finish in any FROM of a
+                # previous to use as target
+                for transition in transitions:
+                    for t_from in transition.get("from"):
+                        possible_transition = (
+                            self.get_sonarqube_required_transitions_for(
+                                current_status, t_from, is_hotspot
+                            )
                         )
-                    )
-                    if possible_transition:
-                        transitions_result.extendleft(possible_transition)
-                        return list(transitions_result)
-            return None
+                        if possible_transition:
+                            transitions_result.extendleft(possible_transition)
+                            return list(transitions_result)
+            else:
+                # SQ code is too complicated for ISSUES, there is no such thing for HOTSPOTS,
+                # there are only 2 states: TO_REVIEW and REVIEWED
+                transitions_result = deque()
+                transitions_result.appendleft(
+                    {"status": transitions[0].get("transition"),
+                    "resolution": transitions[0].get("resolution")}
+                )
+                return list(transitions_result)
         return None
 
     def update_sonarqube_finding(self, finding):
@@ -127,45 +186,64 @@ class SonarQubeApiUpdater:
         # we don't care about config, each finding knows which config was used
         # during import
 
+        type = sonarqube_issue.type
         target_status = self.get_sonarqube_status_for(finding)
+        is_hotspot = type == "SECURITY_HOTSPOT"
 
-        issue = client.get_issue(sonarqube_issue.key)
-        if (
-            issue
-        ):  # Issue could have disappeared in SQ because a previous scan has resolved the issue as fixed
+        if is_hotspot:
+            issue = client.get_hotspot(sonarqube_issue.key)
+        else:
+            issue = client.get_issue(sonarqube_issue.key)
+
+        # Issue does not exist (could have disappeared in SQ because a previous scan resolved it)
+        if not issue:
+            return
+
+        if is_hotspot:
+            current_status = issue.get("status")
+        else:
             if issue.get("resolution"):
                 current_status = "{} / {}".format(
                     issue.get("status"), issue.get("resolution"),
-                )
+            )
             else:
                 current_status = issue.get("status")
 
+        # Get required transitions
+        transitions = self.get_sonarqube_required_transitions_for(
+            current_status, target_status, is_hotspot=is_hotspot
+        )
+
+        if not transitions:
             logger.debug(
-                f"--> SQ Current status: {current_status}. Current target status: {target_status}",
+                f"There are no transitions between {current_status} and {target_status} for finding '{finding}' in SonarQube",
+            )
+            return
+
+        logger.debug(
+                f"Updating finding '{finding}' transition {current_status} -> {target_status} in SonarQube",
             )
 
-            transitions = self.get_sonarqube_required_transitions_for(
-                current_status, target_status,
+        # Apply transitions
+        for transition in transitions:
+            if is_hotspot:
+                client.transition_hotspot(sonarqube_issue.key,
+                            status=transition["status"],
+                            resolution=transition["resolution"])
+            else:
+                client.transition_issue(sonarqube_issue.key, transition)
+
+        # Track that Defect Dojo has updated the SonarQube issue
+        Sonarqube_Issue_Transition.objects.create(
+            sonarqube_issue=finding.sonarqube_issue,
+            # not sure if this is needed, but looks like the original author decided to send display status
+            # to sonarqube we changed Accepted into Risk Accepted, but we change it back to be sure we don't
+            # break the integration
+            finding_status=finding.status().replace(
+            "Risk Accepted", "Accepted",
             )
-            if transitions:
-                logger.info(
-                    f"Updating finding '{finding}' in SonarQube",
-                )
-
-                for transition in transitions:
-                    client.transition_issue(sonarqube_issue.key, transition)
-
-                # Track Defect Dojo has updated the SonarQube issue
-                Sonarqube_Issue_Transition.objects.create(
-                    sonarqube_issue=finding.sonarqube_issue,
-                    # not sure if this is needed, but looks like the original author decided to send display status
-                    # to sonarqube we changed Accepted into Risk Accepted, but we change it back to be sure we don't
-                    # break the integration
-                    finding_status=finding.status().replace(
-                        "Risk Accepted", "Accepted",
-                    )
-                    if finding.status()
-                    else finding.status(),
-                    sonarqube_status=current_status,
-                    transitions=",".join(transitions),
-                )
+            if finding.status()
+            else finding.status(),
+            sonarqube_status=current_status,
+            transitions=",".join(transition["status"] if is_hotspot else transition for transition in transitions),
+        )

--- a/unittests/test_api_sonarqube_updater.py
+++ b/unittests/test_api_sonarqube_updater.py
@@ -12,86 +12,147 @@ class TestSonarQubeApiUpdater(DojoTestCase):
 
         self.updater = SonarQubeApiUpdater()
 
-    def test_transitions_for_sonarqube_from_open_1(self):
+    def test_transitions_for_sonarqube_issue_from_open_to_confirmed(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("OPEN", "CONFIRMED"),
+            self.updater.get_sonarqube_required_transitions_for("OPEN", "CONFIRMED", is_hotspot=False),
             ["confirm"],
         )
 
-    def test_transitions_for_sonarqube_from_open_2(self):
+    def test_transitions_for_sonarqube_issue_from_open_to_resolved_fixed(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("OPEN", "RESOLVED / FIXED"),
+            self.updater.get_sonarqube_required_transitions_for("OPEN", "RESOLVED / FIXED", is_hotspot=False),
             ["resolve"],
         )
 
-    def test_transitions_for_sonarqube_from_reopened_1(self):
+    def test_transitions_for_sonarqube_issue_from_reopened_to_resolved_fixed(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("REOPENED", "RESOLVED / FIXED"),
+            self.updater.get_sonarqube_required_transitions_for("REOPENED", "RESOLVED / FIXED", is_hotspot=False),
             ["resolve"],
         )
 
-    def test_transitions_for_sonarqube_from_reopened_2(self):
+    def test_transitions_for_sonarqube_issue_from_reopened_to_confirmed(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("REOPENED", "CONFIRMED"),
+            self.updater.get_sonarqube_required_transitions_for("REOPENED", "CONFIRMED", is_hotspot=False),
             ["confirm"],
         )
 
-    def test_transitions_for_sonarqube_from_resolved_1(self):
+    def test_transitions_for_sonarqube_issue_from_resolved_fixed_to_confirmed(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("RESOLVED / FIXED", "CONFIRMED"),
+            self.updater.get_sonarqube_required_transitions_for("RESOLVED / FIXED", "CONFIRMED", is_hotspot=False),
             ["reopen", "confirm"],
         )
 
-    def test_transitions_for_sonarqube_from_resolved_2(self):
+    def test_transitions_for_sonarqube_issue_from_resolved_fixed_to_resolved_falsepositive(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("RESOLVED / FIXED", "RESOLVED / FALSE-POSITIVE"),
+            self.updater.get_sonarqube_required_transitions_for("RESOLVED / FIXED", "RESOLVED / FALSE-POSITIVE", is_hotspot=False),
             ["reopen", "falsepositive"],
         )
 
-    def test_transitions_for_sonarqube_from_resolved_3(self):
+    def test_transitions_for_sonarqube_issue_from_resolved_fixed_to_resolved_wontfix(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("RESOLVED / FIXED", "RESOLVED / WONTFIX"),
+            self.updater.get_sonarqube_required_transitions_for("RESOLVED / FIXED", "RESOLVED / WONTFIX", is_hotspot=False),
             ["reopen", "wontfix"],
         )
 
-    def test_transitions_for_sonarqube_fake_target_origin(self):
+    def test_transitions_for_sonarqube_issue_from_confirmed_to_reopened(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("FAKE_STATUS", "RESOLVED / FIXED"),
-            None,
-        )
-
-    def test_transitions_for_sonarqube_fake_target_status(self):
-        self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("RESOLVED / FIXED", "FAKE_STATUS"),
-            None,
-        )
-
-    def test_transitions_for_sonarqube_from_confirmed_1(self):
-        self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("CONFIRMED", "REOPENED"),
+            self.updater.get_sonarqube_required_transitions_for("CONFIRMED", "REOPENED", is_hotspot=False),
             ["unconfirm"],
         )
 
-    def test_transitions_for_sonarqube_from_confirmed_2(self):
+    def test_transitions_for_sonarqube_issue_from_confirmed_to_resolved_fixed(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("CONFIRMED", "RESOLVED / FIXED"),
+            self.updater.get_sonarqube_required_transitions_for("CONFIRMED", "RESOLVED / FIXED", is_hotspot=False),
             ["resolve"],
         )
 
-    def test_transitions_for_open_reopen_status_1(self):
+    def test_transitions_for_sonarqube_issue_from_confirmed_to_resolved_wontfix(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("OPEN", "REOPENED"),
+            self.updater.get_sonarqube_required_transitions_for("CONFIRMED", "RESOLVED / WONTFIX", is_hotspot=False),
+            ["wontfix"],
+        )
+
+    def test_transitions_for_sonarqube_issue_from_confirmed_to_resolved_falsepositive(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("CONFIRMED", "RESOLVED / FALSE-POSITIVE", is_hotspot=False),
+            ["falsepositive"],
+        )
+
+    def test_transitions_for_sonarqube_issue_open_reopen_status_same(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("OPEN", "OPEN", is_hotspot=False),
             None,
         )
 
-    def test_transitions_for_open_reopen_status_2(self):
+    def test_transitions_for_sonarqube_issue_open_reopen_status_different(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("REOPENED", "OPEN"),
+            self.updater.get_sonarqube_required_transitions_for("OPEN", "REOPENED", is_hotspot=False),
             None,
         )
 
-    def test_transitions_for_open_reopen_status_3(self):
+    def test_transitions_for_sonarqube_issue_fake_status(self):
         self.assertEqual(
-            self.updater.get_sonarqube_required_transitions_for("REOPENED", "REOPENED"),
+            self.updater.get_sonarqube_required_transitions_for("FAKE_STATUS", "RESOLVED / FIXED", is_hotspot=False),
+            None,
+        )
+
+    def test_transitions_for_sonarqube_issue_fake_target(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("RESOLVED / FIXED", "FAKE_STATUS", is_hotspot=False),
+            None,
+        )
+
+    # Tests for hotspot transitions
+    def test_transitions_for_sonarqube_hotspot_from_to_review_to_resolved_falsepositive(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("TO_REVIEW", "RESOLVED / FALSE-POSITIVE", is_hotspot=True),
+            [{"status": "REVIEWED", "resolution": "SAFE"}],
+        )
+
+    def test_transitions_for_sonarqube_hotspot_from_to_review_to_resolved_fixed(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("TO_REVIEW", "RESOLVED / FIXED", is_hotspot=True),
+            [{"status": "REVIEWED", "resolution": "FIXED"}],
+        )
+
+    def test_transitions_for_sonarqube_hotspot_from_to_review_to_resolved_wontfix(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("TO_REVIEW", "RESOLVED / WONTFIX", is_hotspot=True),
+            [{"status": "REVIEWED", "resolution": "ACKNOWLEDGED"}],
+        )
+
+    def test_transitions_for_sonarqube_hotspot_from_reviewed_to_open(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("REVIEWED", "OPEN", is_hotspot=True),
+            [{"status": "TO_REVIEW", "resolution": None}],
+        )
+
+    def test_transitions_for_sonarqube_hotspot_from_reviewed_to_reopened(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("REVIEWED", "REOPENED", is_hotspot=True),
+            [{"status": "TO_REVIEW", "resolution": None}],
+        )
+
+    def test_transitions_for_sonarqube_hotspot_from_reviewed_to_confirmed(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("REVIEWED", "CONFIRMED", is_hotspot=True),
+            [{"status": "TO_REVIEW", "resolution": None}],
+        )
+
+    def test_transitions_for_sonarqube_hotspot_same_status(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("TO_REVIEW", "TO_REVIEW", is_hotspot=True),
+            None,
+        )
+
+    def test_transitions_for_sonarqube_hotspot_fake_status(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("FAKE_STATUS", "REVIEWED", is_hotspot=True),
+            None,
+        )
+
+    def test_transitions_for_sonarqube_hotspot_fake_target(self):
+        self.assertEqual(
+            self.updater.get_sonarqube_required_transitions_for("TO_REVIEW", "FAKE_STATUS", is_hotspot=True),
             None,
         )


### PR DESCRIPTION
**Description**

Currently master branch just throws exception ( since wrong API method is called ) when trying to update HotSpot entity, 
and no HotSpot data is updated on SQ side.

This PR introduces:
- proper API methods to get / update hotspot status
- transition states for entity type of hotspot
- tests to cover transitions for hotspot entities

**Test results**

Tests were updated to include hotspots and passed.
Manual testing was performed before creating PR.
I've tested transition for Issues and for Hotspots and changes reflected in SQ.

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [X] Bugfixes should be submitted against the `bugfix` branch.
- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [X] Add applicable tests to the unit tests.
- [X] Add the proper label to categorize your PR.