### PR TITLE
dockerfiles: drop wheels from layers

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -29,7 +29,8 @@ RUN \
 COPY requirements.txt ./
 # CPUCOUNT=1 is needed, otherwise the wheel for uwsgi won't always be build succesfully
 # https://github.com/unbit/uwsgi/issues/1318#issuecomment-542238096
-RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
+RUN export PYCURL_SSL_LIBRARY=openssl && \
+    CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
 FROM base AS release
 WORKDIR /app
@@ -55,10 +56,10 @@ RUN \
     && \
     rm -rf /var/cache/apk/* && \
   true
-COPY --from=build /tmp/wheels /tmp/wheels
-COPY requirements.txt ./
-RUN export PYCURL_SSL_LIBRARY=openssl && \
-    pip3 install \
+RUN \
+  --mount=from=build,src=/tmp/wheels,target=/tmp/wheels \
+  --mount=from=build,src=/app/requirements.txt,target=/app/requirements.txt \
+  pip3 install \
 	--no-cache-dir \
 	--no-index \
   --find-links=/tmp/wheels \

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -28,7 +28,8 @@ RUN \
 COPY requirements.txt ./
 # CPUCOUNT=1 is needed, otherwise the wheel for uwsgi won't always be build succesfully
 # https://github.com/unbit/uwsgi/issues/1318#issuecomment-542238096
-RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
+RUN export PYCURL_SSL_LIBRARY=openssl && \
+    CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
 FROM base AS release
 WORKDIR /app
@@ -58,10 +59,10 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists && \
   true
-COPY --from=build /tmp/wheels /tmp/wheels
-COPY requirements.txt ./
-RUN export PYCURL_SSL_LIBRARY=openssl && \
-    pip3 install \
+RUN \
+  --mount=from=build,src=/tmp/wheels,target=/tmp/wheels \
+  --mount=from=build,src=/app/requirements.txt,target=/app/requirements.txt \
+  pip3 install \
 	--no-cache-dir \
 	--no-index \
   --find-links=/tmp/wheels \


### PR DESCRIPTION
**Description**

This is a follow up from the discussion on https://github.com/DefectDojo/django-DefectDojo/pull/13162 related to keeping changes to Dockerfiles at a minimum for now.
I've taken just the wheel dropping piece of that PR and opened this one with it.

Out of that PR, this is the one with most benefit (drop 1/6 of image size) with least changes.
Also, part of that PR was already merged in https://github.com/DefectDojo/django-DefectDojo/pull/13095

No build time improvement, but considerable size reduction which helps in CI with pushing and pulling the images, as not every setup has the docker registry sitting right next to the CI agent 😄 

**Test results**

* `time docker build -t x9x -f Dockerfile.django-??? . --progress plain --no-cache --target release` used for the builds (on an M4 macbook): 
* `--platform linux/amd64` added for benchmarking qemu build

| platform  | Debian Time | Debian Size | Alpine Time | Alpine Size |
| -------- | ------------- | -----------  | ------------ | ----------- |
| arm64 (native) |  1m27 -> 1m23 | 799MB -> 706MB |  1m37 -> 1m32 | 548MB -> 458MB |
| amd64 (qemu) | 8m49 -> 8m57 | 764MB -> 669MB | 8m26 -> 8m34 | 533MB -> 442MB |

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.