### PR TITLE
make close_old_findings tooltip clearer when service is not set

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2314,14 +2314,16 @@ class ImportScanSerializer(CommonImportScanSerializer):
         required=False,
         default=False,
         help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
-                    "If service has been set, only the findings for this service will be closed. "
+                    "If service has been set, only the findings for this service will be closed; "
+                    "if no service is set, only findings without a service will be closed. "
                     "This only affects findings within the same engagement.",
     )
     close_old_findings_product_scope = serializers.BooleanField(
         required=False,
         default=False,
         help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
-                    "If service has been set, only the findings for this service will be closed. "
+                    "If service has been set, only the findings for this service will be closed; "
+                    "if no service is set, only findings without a service will be closed. "
                     "This only affects findings within the same product."
                     "By default, it is false meaning that only old findings of the same type in the engagement are in scope.",
     )
@@ -2396,7 +2398,8 @@ class ReImportScanSerializer(CommonImportScanSerializer):
         required=False,
         default=True,
         help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
-                    "If service has been set, only the findings for this service will be closed. "
+                    "If service has been set, only the findings for this service will be closed; "
+                    "if no service is set, only findings without a service will be closed. "
                     "This only affects findings within the same test.",
     )
     close_old_findings_product_scope = serializers.BooleanField(

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -559,13 +559,15 @@ class ImportScanForm(forms.Form):
     # Exposing the choice as two different check boxes.
     # If 'close_old_findings_product_scope' is selected, the backend will ensure that both flags are set.
     close_old_findings = forms.BooleanField(help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
-                                                        "If service has been set, only the findings for this service will be closed. "
+                                                        "If service has been set, only the findings for this service will be closed; "
+                                                        "if no service is set, only findings without a service will be closed. "
                                                         "This affects findings within the same engagement by default.",
                                             label="Close old findings",
                                             required=False,
                                             initial=False)
     close_old_findings_product_scope = forms.BooleanField(help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
-                                                        "If service has been set, only the findings for this service will be closed. "
+                                                        "If service has been set, only the findings for this service will be closed; "
+                                                        "if no service is set, only findings without a service will be closed. "
                                                         "This affects findings within the same product.",
                                             label="Close old findings within this product",
                                             required=False,


### PR DESCRIPTION
**Description**

This fixes #13163 

> Old findings no longer present in the new report get closed as mitigated when importing. If service has been set, only the findings for this service will be closed. 

The current tooltip misled me into thinking that `when service is NOT set, all findings are considered regardless of service`, yet it is not the behavior: when service is not set, only findings without a service will be closed.

I thought it could be just me and my english but at least [ChatGPT agrees](https://chatgpt.com/share/68cae627-0c30-800c-99ac-e07e6e922176) 😄 

Tried to come up with a smaller change but in the end I think just making it explicit does not make it too big anyway.

<img width="718" height="132" alt="Screenshot 2025-09-17 at 23 00 55" src="https://github.com/user-attachments/assets/28c0e7f4-5a81-4c33-a180-976460c6fc2c" />


**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
