### PR TITLE
Drop django-tagging as dependency

### DIFF
--- a/docker/sample_data/initial_dojo_data.json
+++ b/docker/sample_data/initial_dojo_data.json
@@ -233,22 +233,6 @@
   },
   {
     "fields": {
-      "model": "tag",
-      "app_label": "tagging"
-    },
-    "model": "contenttypes.contenttype",
-    "pk": 39
-  },
-  {
-    "fields": {
-      "model": "taggeditem",
-      "app_label": "tagging"
-    },
-    "model": "contenttypes.contenttype",
-    "pk": 40
-  },
-  {
-    "fields": {
       "expire_date": "2016-09-10T12:40:25.483Z",
       "session_data": "NjIzODFjMWIxMjVhNzQ1NzNhMTRjMzM1MzQ1MjVkY2VmZGI4YjIzNDp7ImRvam9fYnJlYWRjcnVtYnMiOlt7InVybCI6Ii8iLCJ0aXRsZSI6IkhvbWUifSx7InVybCI6Ii9wcm9maWxlIiwidGl0bGUiOiJFbmdpbmVlciBQcm9maWxlIC0gKGFkbWluKSJ9XSwiX2F1dGhfdXNlcl9oYXNoIjoiYzU0NTg4NGExYTNiOWM3NTA0YjAzM2VhOWMxYTJlMzRiMjQ4Nzk1OSIsIl9hdXRoX3VzZXJfYmFja2VuZCI6ImRqYW5nby5jb250cmliLmF1dGguYmFja2VuZHMuTW9kZWxCYWNrZW5kIiwiX2F1dGhfdXNlcl9pZCI6IjEifQ=="
     },

--- a/docs/content/en/open_source/upgrading/2.0.md
+++ b/docs/content/en/open_source/upgrading/2.0.md
@@ -8,6 +8,7 @@ exclude_search: true
 Follow the usual steps to upgrade as described above.
 
 BEFORE UPGRADING
+- If you are upgrading from a version before 1.11, first do an upgrade to 1.15.1. Then come back to this.
 - If you are using SAML2 checkout the new [documentaion](https://documentation.defectdojo.com/integrations/social-authentication/#saml-20) and update you settings following the migration section. We replaced [django-saml2-auth](https://github.com/fangli/django-saml2-auth) with [djangosaml2](https://github.com/IdentityPython/djangosaml2).
 
 AFTER UPGRADING

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -91,8 +91,6 @@ env = environ.FileAwareEnv(
     DD_WATSON_ASYNC_INDEX_UPDATE_BATCH_SIZE=(int, 1000),
     DD_FOOTER_VERSION=(str, ""),
     # models should be passed to celery by ID, default is False (for now)
-    DD_FORCE_LOWERCASE_TAGS=(bool, True),
-    DD_MAX_TAG_LENGTH=(int, 25),
     DD_DATABASE_ENGINE=(str, "django.db.backends.postgresql"),
     DD_DATABASE_HOST=(str, "postgres"),
     DD_DATABASE_NAME=(str, "defectdojo"),
@@ -781,11 +779,6 @@ TEAM_NAME = env("DD_TEAM_NAME")
 # Used to configure a custom version in the footer of the base.html template.
 FOOTER_VERSION = env("DD_FOOTER_VERSION")
 
-# Django-tagging settings
-FORCE_LOWERCASE_TAGS = env("DD_FORCE_LOWERCASE_TAGS")
-MAX_TAG_LENGTH = env("DD_MAX_TAG_LENGTH")
-
-
 # ------------------------------------------------------------------------------
 # ADMIN
 # ------------------------------------------------------------------------------
@@ -890,7 +883,6 @@ INSTALLED_APPS = (
     "auditlog",
     "dojo",
     "watson",
-    "tagging",  # not used, but still needed for migration 0065_django_tagulous.py (v1.10.0)
     "imagekit",
     "multiselectfield",
     "rest_framework",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,10 +15,6 @@ django-polymorphic==4.1.0
 django-crispy-forms==2.4
 django_extensions==4.1
 django-slack==5.19.0
-# This library is very outdated and not directly. It is used solely for migration
-# purposes to django-tagulous, so it must stay
-# django-tagging==0.5.0
-git+https://github.com/DefectDojo/django-tagging@develop#egg=django-tagging
 django-watson==1.6.3
 django-prometheus==2.4.1
 Django==5.1.12


### PR DESCRIPTION
**Description**

This PR addresses https://github.com/DefectDojo/django-DefectDojo/issues/13161

django-tagging has been replaced with tagulous long time ago, in #3333, including a migration (0066) to copy the tags over. All references later removed in #4419 (migration 0093)
Both of these are merged even before v2.0.0.

I believe this dependency can be safely removed at this point.

This PR removes it from `requirements.txt` and removes the data-migration from 0066:
* New setups do not even run 0066 as there is a squashed 1-90 (post-v2)
* The squashed 1 to 90 does not include data migration
* The fields are removed in 93, which applies whether squashed is used or not

Release notes v2 updated to highlight the new extra step, for those who haven't updated Dojo in over 5 years (if anyone).

**Test results**

Only test assertion done is that unit tests execute properly, including running all migrations on a clean database.
I've also temporarily removed the squashed 1-90 migration to make sure 66 was executed without any issues and it is.

I've tried adding some logic to the migration 0066 as in to check whether tags had been migrated or not (and fail otherwise), but I've been unable to "go back" to a version actively using django-tagging.

I have honestly tried in [this branch](https://github.com/fopina/django-DefectDojo/tree/drop-django-tagging/old-branch) of Dojo v1.11 and fought for quite some time with invalid debian packages and dependency issues (with conflicting requirements due to new versions and lack of transitive dependency pinning).

I ended up realizing that migration 66 (or any other) does not actually delete "tagging" data, so the check I had imagined wouldn't help anyway so I gave up trying this realistic (yet unlikely) scenario

**Documentation**

[release notes for 2.0](docs/content/en/open_source/upgrading/2.0.md) updated

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.