### PR TITLE
fix dojo_testdata fixture

### DIFF
--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -1,5 +1,78 @@
 [
   {
+    "model": "dojo.role",
+    "pk": 1,
+    "fields": {
+      "name": "API_Importer",
+      "is_owner": false
+    }
+  },
+  {
+    "model": "dojo.role",
+    "pk": 2,
+    "fields": {
+      "name": "Writer",
+      "is_owner": false
+    }
+  },
+  {
+    "model": "dojo.role",
+    "pk": 3,
+    "fields": {
+      "name": "Maintainer",
+      "is_owner": false
+    }
+  },
+  {
+    "model": "dojo.role",
+    "pk": 4,
+    "fields": {
+      "name": "Owner",
+      "is_owner": true
+    }
+  },
+  {
+    "model": "dojo.role",
+    "pk": 5,
+    "fields": {
+      "name": "Reader",
+      "is_owner": false
+    }
+  },
+  {
+    "model": "dojo.sla_configuration",
+    "pk": 1,
+    "fields": {
+      "name": "Default",
+      "description": "The Default SLA Configuration. Products not using an explicit SLA Configuration will use this one.",
+      "critical": 7,
+      "enforce_critical": true,
+      "high": 30,
+      "enforce_high": true,
+      "medium": 90,
+      "enforce_medium": true,
+      "low": 120,
+      "enforce_low": true,
+      "async_updating": false
+    }
+  },
+  {
+    "model": "dojo.sla_configuration",
+    "fields": {
+      "name": "No SLA Enforced",
+      "description": "No SLA is enforced for a product which uses this SLA configuration.",
+      "critical": 7,
+      "enforce_critical": false,
+      "high": 30,
+      "enforce_high": false,
+      "medium": 90,
+      "enforce_medium": false,
+      "low": 120,
+      "enforce_low": false,
+      "async_updating": false
+    }
+  },
+  {
     "pk": 1,
     "model": "auth.user",
     "fields": {
@@ -102,10 +175,26 @@
       "last_login": null,
       "groups": [],
       "user_permissions": [
-        218,
-        220,
-        26,
-        28
+        [
+          "change_finding_template",
+          "dojo",
+          "finding_template"
+        ],
+        [
+          "view_finding_template",
+          "dojo",
+          "finding_template"
+        ],
+        [
+          "change_logentry",
+          "admin",
+          "logentry"
+        ],
+        [
+          "view_logentry",
+          "admin",
+          "logentry"
+        ]
       ],
       "password": "pbkdf2_sha256$36000$pe8Ff8HrBPac$Lb3ee6/R9z/aL9nM+D2AXWTpIt9Pa9kcLueXxYNy1ZY=",
       "email": "user5@email.com",
@@ -145,36 +234,13 @@
     }
   },
   {
-    "pk": 1,
-    "model": "admin.logentry",
-    "fields": {
-      "action_flag": 1,
-      "action_time": "2018-04-13T07:59:51.689Z",
-      "object_repr": "user1",
-      "object_id": "2",
-      "change_message": "[{\"added\": {}}]",
-      "user": 1,
-      "content_type": 3
-    }
-  },
-  {
-    "pk": 2,
-    "model": "admin.logentry",
-    "fields": {
-      "action_flag": 1,
-      "action_time": "2018-04-13T08:00:00.153Z",
-      "object_repr": "user2",
-      "object_id": "3",
-      "change_message": "[{\"added\": {}}]",
-      "user": 1,
-      "content_type": 3
-    }
-  },
-  {
     "model": "auditlog.logentry",
     "pk": 803,
     "fields": {
-      "content_type": 28,
+      "content_type": [
+        "dojo",
+        "product"
+      ],
       "object_pk": "1",
       "object_id": 1,
       "object_repr": "BodgeIt",
@@ -184,40 +250,46 @@
       "remote_addr": null,
       "timestamp": "2021-10-22T01:24:54.921Z",
       "additional_data": null
-      }
-    },
-    {
-      "model": "auditlog.logentry",
-      "pk": 804,
-      "fields": {
-        "content_type": 28,
-        "object_pk": "2",
-        "object_id": 2,
-        "object_repr": "Internal CRM App",
-        "action": 0,
-        "changes": "{\"product\": [\"None\", \"dojo.Cred_Mapping.None\"], \"product_meta\": [\"None\", \"dojo.DojoMeta.None\"], \"name\": [\"None\", \"Internal CRM App\"], \"description\": [\"None\", \"* New product in development that attempts to follow all best practices\"], \"product_manager\": [\"None\", \"(product_manager)\"], \"technical_contact\": [\"None\", \"(product_manager)\"], \"team_manager\": [\"None\", \"(user2)\"], \"prod_type\": [\"None\", \"Commerce\"], \"id\": [\"None\", \"2\"], \"tid\": [\"None\", \"0\"], \"business_criticality\": [\"None\", \"medium\"], \"platform\": [\"None\", \"web\"], \"lifecycle\": [\"None\", \"construction\"], \"origin\": [\"None\", \"internal\"], \"external_audience\": [\"None\", \"False\"], \"internet_accessible\": [\"None\", \"False\"], \"enable_simple_risk_acceptance\": [\"None\", \"False\"], \"enable_full_risk_acceptance\": [\"None\", \"True\"]}",
-        "actor": null,
-        "remote_addr": null,
-        "timestamp": "2021-10-22T01:24:55.044Z",
-        "additional_data": null
-      }
-    },
-    {
-      "model": "auditlog.logentry",
-      "pk": 805,
-      "fields": {
-        "content_type": 28,
-        "object_pk": "3",
-        "object_id": 3,
-        "object_repr": "Apple Accounting Software",
-        "action": 0,
-        "changes": "{\"product\": [\"None\", \"dojo.Cred_Mapping.None\"], \"product_meta\": [\"None\", \"dojo.DojoMeta.None\"], \"name\": [\"None\", \"Apple Accounting Software\"], \"description\": [\"None\", \"Accounting software is typically composed of various modules, different sections dealing with particular areas of accounting. Among the most common are:\\r\\n\\r\\n**Core modules**\\r\\n\\r\\n* Accounts receivable\\u2014where the company enters money received\\r\\n* Accounts payable\\u2014where the company enters its bills and pays money it owes\\r\\n* General ledger\\u2014the company's \\\"books\\\"\\r\\n* Billing\\u2014where the company produces invoices to clients/customers\"], \"product_manager\": [\"None\", \"(admin)\"], \"technical_contact\": [\"None\", \"(user2)\"], \"team_manager\": [\"None\", \"(user2)\"], \"prod_type\": [\"None\", \"Billing\"], \"id\": [\"None\", \"3\"], \"tid\": [\"None\", \"0\"], \"business_criticality\": [\"None\", \"high\"], \"platform\": [\"None\", \"web\"], \"lifecycle\": [\"None\", \"production\"], \"origin\": [\"None\", \"purchased\"], \"user_records\": [\"None\", \"5000\"], \"external_audience\": [\"None\", \"True\"], \"internet_accessible\": [\"None\", \"False\"], \"enable_simple_risk_acceptance\": [\"None\", \"False\"], \"enable_full_risk_acceptance\": [\"None\", \"True\"]}",
-        "actor": null,
-        "remote_addr": null,
-        "timestamp": "2021-10-22T01:24:55.071Z",
-        "additional_data": null
-      }
-    },
+    }
+  },
+  {
+    "model": "auditlog.logentry",
+    "pk": 804,
+    "fields": {
+      "content_type": [
+        "dojo",
+        "product"
+      ],
+      "object_pk": "2",
+      "object_id": 2,
+      "object_repr": "Internal CRM App",
+      "action": 0,
+      "changes": "{\"product\": [\"None\", \"dojo.Cred_Mapping.None\"], \"product_meta\": [\"None\", \"dojo.DojoMeta.None\"], \"name\": [\"None\", \"Internal CRM App\"], \"description\": [\"None\", \"* New product in development that attempts to follow all best practices\"], \"product_manager\": [\"None\", \"(product_manager)\"], \"technical_contact\": [\"None\", \"(product_manager)\"], \"team_manager\": [\"None\", \"(user2)\"], \"prod_type\": [\"None\", \"Commerce\"], \"id\": [\"None\", \"2\"], \"tid\": [\"None\", \"0\"], \"business_criticality\": [\"None\", \"medium\"], \"platform\": [\"None\", \"web\"], \"lifecycle\": [\"None\", \"construction\"], \"origin\": [\"None\", \"internal\"], \"external_audience\": [\"None\", \"False\"], \"internet_accessible\": [\"None\", \"False\"], \"enable_simple_risk_acceptance\": [\"None\", \"False\"], \"enable_full_risk_acceptance\": [\"None\", \"True\"]}",
+      "actor": null,
+      "remote_addr": null,
+      "timestamp": "2021-10-22T01:24:55.044Z",
+      "additional_data": null
+    }
+  },
+  {
+    "model": "auditlog.logentry",
+    "pk": 805,
+    "fields": {
+      "content_type": [
+        "dojo",
+        "product"
+      ],
+      "object_pk": "3",
+      "object_id": 3,
+      "object_repr": "Apple Accounting Software",
+      "action": 0,
+      "changes": "{\"product\": [\"None\", \"dojo.Cred_Mapping.None\"], \"product_meta\": [\"None\", \"dojo.DojoMeta.None\"], \"name\": [\"None\", \"Apple Accounting Software\"], \"description\": [\"None\", \"Accounting software is typically composed of various modules, different sections dealing with particular areas of accounting. Among the most common are:\\r\\n\\r\\n**Core modules**\\r\\n\\r\\n* Accounts receivable\\u2014where the company enters money received\\r\\n* Accounts payable\\u2014where the company enters its bills and pays money it owes\\r\\n* General ledger\\u2014the company's \\\"books\\\"\\r\\n* Billing\\u2014where the company produces invoices to clients/customers\"], \"product_manager\": [\"None\", \"(admin)\"], \"technical_contact\": [\"None\", \"(user2)\"], \"team_manager\": [\"None\", \"(user2)\"], \"prod_type\": [\"None\", \"Billing\"], \"id\": [\"None\", \"3\"], \"tid\": [\"None\", \"0\"], \"business_criticality\": [\"None\", \"high\"], \"platform\": [\"None\", \"web\"], \"lifecycle\": [\"None\", \"production\"], \"origin\": [\"None\", \"purchased\"], \"user_records\": [\"None\", \"5000\"], \"external_audience\": [\"None\", \"True\"], \"internet_accessible\": [\"None\", \"False\"], \"enable_simple_risk_acceptance\": [\"None\", \"False\"], \"enable_full_risk_acceptance\": [\"None\", \"True\"]}",
+      "actor": null,
+      "remote_addr": null,
+      "timestamp": "2021-10-22T01:24:55.071Z",
+      "additional_data": null
+    }
+  },
   {
     "pk": 1,
     "model": "dojo.system_settings",
@@ -2423,7 +2495,10 @@
       "url": "",
       "object_id": "1",
       "content": "Python How-to test product 0 0 0",
-      "content_type": 21,
+      "content_type": [
+        "dojo",
+        "product"
+      ],
       "object_id_int": 1
     }
   },
@@ -2438,7 +2513,10 @@
       "url": "",
       "object_id": "2",
       "content": "Security How-to test product 0 0 0",
-      "content_type": 21,
+      "content_type": [
+        "dojo",
+        "product"
+      ],
       "object_id_int": 2
     }
   },
@@ -2453,7 +2531,10 @@
       "url": "",
       "object_id": "3",
       "content": "Security Podcast test product 0 0 0",
-      "content_type": 21,
+      "content_type": [
+        "dojo",
+        "product"
+      ],
       "object_id_int": 3
     }
   },
@@ -2468,7 +2549,10 @@
       "url": "",
       "object_id": "3",
       "content": "",
-      "content_type": 31,
+      "content_type": [
+        "dojo",
+        "test"
+      ],
       "object_id_int": 3
     }
   },
@@ -2483,7 +2567,10 @@
       "url": "",
       "object_id": "13",
       "content": "",
-      "content_type": 31,
+      "content_type": [
+        "dojo",
+        "test"
+      ],
       "object_id_int": 13
     }
   },
@@ -2498,7 +2585,10 @@
       "url": "",
       "object_id": "14",
       "content": "",
-      "content_type": 31,
+      "content_type": [
+        "dojo",
+        "test"
+      ],
       "object_id_int": 14
     }
   },
@@ -2513,7 +2603,10 @@
       "url": "",
       "object_id": "2",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 2
     }
   },
@@ -2528,7 +2621,10 @@
       "url": "",
       "object_id": "3",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 3
     }
   },
@@ -2543,7 +2639,10 @@
       "url": "",
       "object_id": "4",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 4
     }
   },
@@ -2558,7 +2657,10 @@
       "url": "",
       "object_id": "5",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 5
     }
   },
@@ -2573,7 +2675,10 @@
       "url": "",
       "object_id": "6",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 6
     }
   },
@@ -2588,7 +2693,10 @@
       "url": "",
       "object_id": "1",
       "content": "Python How-to test product 0 0 0",
-      "content_type": 21,
+      "content_type": [
+        "dojo",
+        "product"
+      ],
       "object_id_int": 1
     }
   },
@@ -2603,7 +2711,10 @@
       "url": "",
       "object_id": "2",
       "content": "Security How-to test product 0 0 0",
-      "content_type": 21,
+      "content_type": [
+        "dojo",
+        "product"
+      ],
       "object_id_int": 2
     }
   },
@@ -2618,7 +2729,10 @@
       "url": "",
       "object_id": "3",
       "content": "Security Podcast test product 0 0 0",
-      "content_type": 21,
+      "content_type": [
+        "dojo",
+        "product"
+      ],
       "object_id_int": 3
     }
   },
@@ -2633,7 +2747,10 @@
       "url": "",
       "object_id": "3",
       "content": "",
-      "content_type": 31,
+      "content_type": [
+        "dojo",
+        "test"
+      ],
       "object_id_int": 3
     }
   },
@@ -2648,7 +2765,10 @@
       "url": "",
       "object_id": "13",
       "content": "",
-      "content_type": 31,
+      "content_type": [
+        "dojo",
+        "test"
+      ],
       "object_id_int": 13
     }
   },
@@ -2663,7 +2783,10 @@
       "url": "",
       "object_id": "14",
       "content": "",
-      "content_type": 31,
+      "content_type": [
+        "dojo",
+        "test"
+      ],
       "object_id_int": 14
     }
   },
@@ -2678,7 +2801,10 @@
       "url": "",
       "object_id": "2",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 2
     }
   },
@@ -2693,7 +2819,10 @@
       "url": "",
       "object_id": "3",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 3
     }
   },
@@ -2708,7 +2837,10 @@
       "url": "",
       "object_id": "4",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 4
     }
   },
@@ -2723,7 +2855,10 @@
       "url": "",
       "object_id": "5",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 5
     }
   },
@@ -2738,7 +2873,10 @@
       "url": "",
       "object_id": "6",
       "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 6
     }
   },
@@ -2753,7 +2891,10 @@
       "url": "",
       "object_id": "7",
       "content": "DUMMY FINDING http://www.example.com High TEST finding MITIGATION High  S0 None None None None None c89d25e445b088ba339908f68e15e3177b78d22f3039d1bfea51c4be251bf4e0 ",
-      "content_type": 33,
+      "content_type": [
+        "dojo",
+        "finding"
+      ],
       "object_id_int": 7
     }
   },
@@ -2927,78 +3068,6 @@
       "sla_breach": "alert",
       "risk_acceptance_expiration": "alert",
       "sla_breach_combined": "alert"
-    }
-  },
-  {
-    "model": "auth.permission",
-    "pk": 217,
-    "fields": {
-      "name": "Can add finding_ template",
-      "content_type": 55,
-      "codename": "add_finding_template"
-    }
-  },
-  {
-    "model": "auth.permission",
-    "pk": 218,
-    "fields": {
-      "name": "Can change finding_ template",
-      "content_type": 55,
-      "codename": "change_finding_template"
-    }
-  },
-  {
-    "model": "auth.permission",
-    "pk": 219,
-    "fields": {
-      "name": "Can delete finding_ template",
-      "content_type": 55,
-      "codename": "delete_finding_template"
-    }
-  },
-  {
-    "model": "auth.permission",
-    "pk": 220,
-    "fields": {
-      "name": "Can view finding_ template",
-      "content_type": 55,
-      "codename": "view_finding_template"
-    }
-  },
-  {
-    "model": "auth.permission",
-    "pk": 25,
-    "fields": {
-      "name": "Can add log entry",
-      "content_type": 7,
-      "codename": "add_logentry"
-    }
-  },
-  {
-    "model": "auth.permission",
-    "pk": 26,
-    "fields": {
-      "name": "Can change log entry",
-      "content_type": 7,
-      "codename": "change_logentry"
-    }
-  },
-  {
-    "model": "auth.permission",
-    "pk": 27,
-    "fields": {
-      "name": "Can delete log entry",
-      "content_type": 7,
-      "codename": "delete_logentry"
-    }
-  },
-  {
-    "model": "auth.permission",
-    "pk": 28,
-    "fields": {
-      "name": "Can view log entry",
-      "content_type": 7,
-      "codename": "view_logentry"
     }
   },
   {


### PR DESCRIPTION
During #13182 I ran into some obscure fixture data loading errors. Turns out that by using a Django TransactionTestCase, it can leave data behind or put the (test) database into a mode where it won't accept any invalid fixtures.
Turns out that the `dojo_testdata.json` fixture we're using is missing some data and has some out-of-sync contenttypes.
With the changes in this PR the fixture loads fine again. I decided to submit it as a PR on its own.