### PR TITLE
do not build/start unused services in unit test docker compose files

### DIFF
--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -1,10 +1,6 @@
 ---
 services:
-  nginx:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'nginx']
-    volumes:
-      - defectdojo_media_unit_tests:/usr/share/nginx/html/media
+  nginx: !reset
   uwsgi:
     build:
       target: django-unittests
@@ -12,6 +8,9 @@ services:
     volumes:
       - '.:/app:z'
       - "defectdojo_media_unit_tests:${DD_MEDIA_ROOT:-/app/media}"
+    depends_on: !override
+      postgres:
+        condition: service_started
     environment:
       PYTHONWARNINGS: error  # We are strict about Warnings during testing
       DD_DEBUG: 'True'
@@ -30,15 +29,9 @@ services:
       DD_CELERY_BROKER_PATH: '/dojo.celerydb.sqlite'
       DD_CELERY_BROKER_PARAMS: ''
       DD_JIRA_EXTRA_ISSUE_TYPES: 'Vulnerability' # Shouldn't trigger a migration error
-  celerybeat:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'celery beat']
-  celeryworker:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'celery worker']
-  initializer:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'initializer']
+  celerybeat: !reset
+  celeryworker: !reset
+  initializer: !reset
   postgres:
     ports:
       - target: ${DD_DATABASE_PORT:-5432}
@@ -49,9 +42,7 @@ services:
       POSTGRES_DB: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
     volumes:
       - defectdojo_postgres_unit_tests:/var/lib/postgresql/data
-  redis:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'redis']
+  redis: !reset
   "webhook.endpoint":
     image: mccutchen/go-httpbin:2.18.3@sha256:3992f3763e9ce5a4307eae0a869a78b4df3931dc8feba74ab823dd2444af6a6b
 volumes:

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -1,10 +1,6 @@
 ---
 services:
-  nginx:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'nginx']
-    volumes:
-      - defectdojo_media_unit_tests:/usr/share/nginx/html/media
+  nginx: !reset
   uwsgi:
     build:
       target: django-unittests
@@ -12,6 +8,9 @@ services:
     volumes:
       - '.:/app:z'
       - "defectdojo_media_unit_tests:${DD_MEDIA_ROOT:-/app/media}"
+    depends_on: !override
+      postgres:
+        condition: service_started
     environment:
       PYTHONWARNINGS: error  # We are strict about Warnings during testing
       DD_DEBUG: 'True'
@@ -29,15 +28,9 @@ services:
       DD_CELERY_BROKER_PATH: '/dojo.celerydb.sqlite'
       DD_CELERY_BROKER_PARAMS: ''
       DD_JIRA_EXTRA_ISSUE_TYPES: 'Vulnerability' # Shouldn't trigger a migration error
-  celerybeat:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'celery beat']
-  celeryworker:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'celery worker']
-  initializer:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'initializer']
+  celerybeat: !reset
+  celeryworker: !reset
+  initializer: !reset
   postgres:
     ports:
       - target: ${DD_DATABASE_PORT:-5432}
@@ -48,9 +41,7 @@ services:
       POSTGRES_DB: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
     volumes:
       - defectdojo_postgres_unit_tests:/var/lib/postgresql/data
-  redis:
-    image: busybox:1.37.0-musl@sha256:254e6134b1bf813b34e920bc4235864a54079057d51ae6db9a4f2328f261c2ad
-    entrypoint: ['echo', 'skipping', 'redis']
+  redis: !reset
   "webhook.endpoint":
     image: mccutchen/go-httpbin:2.18.3@sha256:3992f3763e9ce5a4307eae0a869a78b4df3931dc8feba74ab823dd2444af6a6b
 volumes:


### PR DESCRIPTION
**Description**

I've often used `deploy.replicas: 0` in compose override files to "disable" some of the services. Yet, that just prevents them from starting, they're still built.

Recently, I've seen "unused profile" being used for the same purpose, with the added benefit that this way services images are not built either.

This PR applies that to the unit test compose overrides.

**Test results**

`docker compose build --no-cache` (with unit_test override set) takes around 120/140 seconds in current file. In this branch, it takes 100/110 seconds (and doesn't start unused services either).

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

