### PR TITLE
Unit Tests: Ignore deprecation Warning from BlackDuck pypi package

### DIFF
--- a/dojo/tools/api_blackduck/api_client.py
+++ b/dojo/tools/api_blackduck/api_client.py
@@ -1,3 +1,8 @@
+import warnings
+
+# Ignore DeprecationWarning from the blackduck library because we cannot do anything about it
+# until they fix it in their library
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 from blackduck import Client
 
 

--- a/dojo/tools/api_blackduck/api_client.py
+++ b/dojo/tools/api_blackduck/api_client.py
@@ -3,7 +3,7 @@ import warnings
 # Ignore DeprecationWarning from the blackduck library because we cannot do anything about it
 # until they fix it in their library
 warnings.filterwarnings("ignore", category=DeprecationWarning)
-from blackduck import Client
+from blackduck import Client  # noqa: E402
 
 
 class BlackduckAPI:


### PR DESCRIPTION
Unit tests are failing due to a deprecation warning in the black duck pypi package. The library does not appear to be very active these days, so ignoring the warning feels like the quickest path to getting our tests back on track