### PR TITLE
Tags: Remove duplicates in edit forms

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -342,6 +342,10 @@ class ProductForm(forms.ModelForm):
     product_manager = forms.ModelChoiceField(queryset=Dojo_User.objects.exclude(is_active=False).order_by("first_name", "last_name"), required=False)
     technical_contact = forms.ModelChoiceField(queryset=Dojo_User.objects.exclude(is_active=False).order_by("first_name", "last_name"), required=False)
     team_manager = forms.ModelChoiceField(queryset=Dojo_User.objects.exclude(is_active=False).order_by("first_name", "last_name"), required=False)
+    tags = TagField(
+        required=False,
+        help_text="Add tags that help describe this product. Choose from the list or add new tags. Press Enter key to add.",
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1013,6 +1017,10 @@ class EngForm(forms.ModelForm):
         queryset=None,
         required=True, label="Testing Lead")
     test_strategy = forms.URLField(required=False, label="Test Strategy URL")
+    tags = TagField(
+        required=False,
+        help_text="Add tags that help describe this engagement. Choose from the list or add new tags. Press Enter key to add.",
+    )
 
     def __init__(self, *args, **kwargs):
         cicd = False
@@ -1092,10 +1100,13 @@ class TestForm(forms.ModelForm):
         attrs={"class": "datepicker", "autocomplete": "off"}))
     target_end = forms.DateTimeField(widget=forms.TextInput(
         attrs={"class": "datepicker", "autocomplete": "off"}))
-
     lead = forms.ModelChoiceField(
         queryset=None,
         required=False, label="Testing Lead")
+    tags = TagField(
+        required=False,
+        help_text="Add tags that help describe this test. Choose from the list or add new tags. Press Enter key to add.",
+    ) 
 
     def __init__(self, *args, **kwargs):
         obj = None
@@ -1452,6 +1463,10 @@ class FindingForm(forms.ModelForm):
         choices=EFFORT_FOR_FIXING_CHOICES,
         error_messages={
             "invalid_choice": EFFORT_FOR_FIXING_INVALID_CHOICE})
+    tags = TagField(
+        required=False,
+        help_text="Add tags that help describe this finding. Choose from the list or add new tags. Press Enter key to add.",
+    )
 
     # the only reliable way without hacking internal fields to get predicatble ordering is to make it explicit
     field_order = ("title", "group", "date", "sla_start_date", "sla_expiration_date", "cwe", "vulnerability_ids", "severity", "cvss_info", "cvssv3",
@@ -1723,6 +1738,11 @@ class FindingBulkUpdateForm(forms.ModelForm):
 
 
 class EditEndpointForm(forms.ModelForm):
+    tags = TagField(
+        required=False,
+        help_text="Add tags that help describe this endpoint. Choose from the list or add new tags. Press Enter key to add.",
+    )
+
     class Meta:
         model = Endpoint
         exclude = ["product", "inherited_tags"]


### PR DESCRIPTION
When editing objects with tags, each entry was being duplicated:

<img width="444" height="204" alt="image" src="https://github.com/user-attachments/assets/475b6536-a7b8-470c-966b-ff616acc3eed" />

Adding a specific definition of the `TagField` in the form classes for each object has something to do with the way the form is rendered automatically by django