### PR TITLE
Unit Testing: Do no run in debug mode in order to reduce logging

### DIFF
--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -14,7 +14,7 @@ services:
       - "defectdojo_media_unit_tests:${DD_MEDIA_ROOT:-/app/media}"
     environment:
       PYTHONWARNINGS: error  # We are strict about Warnings during testing
-      DD_DEBUG: 'True'
+      DD_DEBUG: 'False'
       DD_LOG_LEVEL: 'ERROR'
       DD_TEST_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
       DD_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}


### PR DESCRIPTION
Viewing a failed test in the GHA logs is not very helpful without rendering the raw view because there are 50k+ lines of debug logs. Reducing the logging verbosity would make the tests quite a bit faster as well as finding failures easier in the GHA UI
