### PR TITLE
Added Line Field for SonarQube Scan and SonarQube Scan Detailed Scan Types

### DIFF
--- a/dojo/tools/sonarqube/sonarqube_restapi_json.py
+++ b/dojo/tools/sonarqube/sonarqube_restapi_json.py
@@ -13,7 +13,7 @@ class SonarQubeRESTAPIJSON:
                     rule = issue.get("rule")
                     component = issue.get("component")
                     project = issue.get("project")
-                    line = str(issue.get("line"))
+                    line = issue.get("line")
                     textRange = issue.get("textRange", {})
                     flows = issue.get("flows", [])
                     status = issue.get("status")
@@ -28,7 +28,7 @@ class SonarQubeRESTAPIJSON:
                     description += "**rule:** " + rule + "\n"
                     description += "**component:** " + component + "\n"
                     description += "**project:** " + project + "\n"
-                    description += "**line:** " + line + "\n"
+                    description += "**line:** " + str(line) + "\n"
                     if bool(textRange):
                         res = [item + ": " + str(textRange[item]) for item in textRange]
                         description += "**textRange:** " + ", ".join(res) + "\n"
@@ -59,7 +59,7 @@ class SonarQubeRESTAPIJSON:
                     flows = issue.get("flows", [])
                     status = issue.get("status")
                     message = issue.get("message")
-                    line = str(issue.get("line"))
+                    line = issue.get("line")
                     cwe = None
                     if "Category: CWE-" in message:
                         cwe_pattern = r"Category: CWE-\d{1,5}"
@@ -93,7 +93,7 @@ class SonarQubeRESTAPIJSON:
                     description += "**rule:** " + rule + "\n"
                     description += "**component:** " + component + "\n"
                     description += "**project:** " + project + "\n"
-                    description += "**line:** " + line + "\n"
+                    description += "**line:** " + str(line) + "\n"
                     if flows != []:
                         description += "**flows:** " + str(flows) + "\n"
                     description += "**status:** " + status + "\n"
@@ -145,7 +145,7 @@ class SonarQubeRESTAPIJSON:
                     rule = issue.get("rule")
                     component = issue.get("component")
                     project = issue.get("project")
-                    line = str(issue.get("line"))
+                    line = issue.get("line")
                     textRange = issue.get("textRange", {})
                     flows = issue.get("flows", [])
                     status = issue.get("status")
@@ -158,7 +158,7 @@ class SonarQubeRESTAPIJSON:
                     description += "**rule:** " + rule + "\n"
                     description += "**component:** " + component + "\n"
                     description += "**project:** " + project + "\n"
-                    description += "**line:** " + line + "\n"
+                    description += "**line:** " + str(line) + "\n"
                     if bool(textRange):
                         res = []
                         for item in textRange:
@@ -194,7 +194,7 @@ class SonarQubeRESTAPIJSON:
                 project = hotspot.get("project")
                 securityCategory = hotspot.get("securityCategory")
                 status = hotspot.get("status")
-                line = str(hotspot.get("line"))
+                line = hotspot.get("line")
                 message = hotspot.get("message")
                 textRange = hotspot.get("textRange", {})
                 flows = hotspot.get("flows", [])
@@ -206,7 +206,7 @@ class SonarQubeRESTAPIJSON:
                 description += "**project:** " + project + "\n"
                 description += "**securityCategory:** " + securityCategory + "\n"
                 description += "**status:** " + status + "\n"
-                description += "**line:** " + line + "\n"
+                description += "**line:** " + str(line) + "\n"
                 description += "**message:** " + message + "\n"
                 if bool(textRange):
                     res = []

--- a/dojo/tools/sonarqube/sonarqube_restapi_json.py
+++ b/dojo/tools/sonarqube/sonarqube_restapi_json.py
@@ -49,6 +49,7 @@ class SonarQubeRESTAPIJSON:
                         static_finding=True,
                         dynamic_finding=False,
                         tags=["bug"],
+                        line=line,
                     )
                 elif issue.get("type") == "VULNERABILITY":
                     key = issue.get("key")
@@ -58,6 +59,7 @@ class SonarQubeRESTAPIJSON:
                     flows = issue.get("flows", [])
                     status = issue.get("status")
                     message = issue.get("message")
+                    line = str(issue.get("line"))
                     cwe = None
                     if "Category: CWE-" in message:
                         cwe_pattern = r"Category: CWE-\d{1,5}"
@@ -91,6 +93,7 @@ class SonarQubeRESTAPIJSON:
                     description += "**rule:** " + rule + "\n"
                     description += "**component:** " + component + "\n"
                     description += "**project:** " + project + "\n"
+                    description += "**line:** " + line + "\n"
                     if flows != []:
                         description += "**flows:** " + str(flows) + "\n"
                     description += "**status:** " + status + "\n"
@@ -115,6 +118,7 @@ class SonarQubeRESTAPIJSON:
                         cvssv3_score=cvss,
                         file_path=component,
                         tags=["vulnerability"],
+                        line=line,
                     )
                     vulnids = []
                     if "Reference: CVE" in message:
@@ -180,6 +184,7 @@ class SonarQubeRESTAPIJSON:
                         dynamic_finding=False,
                         file_path=component,
                         tags=["code_smell"],
+                        line=line,
                     )
                 items.append(item)
         if json_content.get("hotspots"):
@@ -223,6 +228,7 @@ class SonarQubeRESTAPIJSON:
                     dynamic_finding=False,
                     file_path=component,
                     tags=["hotspot"],
+                    line=line,
                 )
                 items.append(item)
         return items


### PR DESCRIPTION
[sc-11829]

I added the line field everywhere relevant except for [this location](https://github.com/Jino-T/django-DefectDojo/blob/7c0f3f0252c7a76d5c5863ca186360c7c3856d2d/dojo/tools/sonarqube/soprasteria_helper.py#L77). I trusted the comment left here. Let me know if I should overrule this.