### PR TITLE
Fix: Apply unsaved tags to endpoints during import

### DIFF
--- a/dojo/importers/endpoint_manager.py
+++ b/dojo/importers/endpoint_manager.py
@@ -41,6 +41,9 @@ class EndpointManager:
                     query=endpoint.query,
                     fragment=endpoint.fragment,
                     product=finding.test.engagement.product)
+                if hasattr(endpoint, 'unsaved_tags') and endpoint.unsaved_tags:
+                    logger.debug(f"Applying tags to endpoint {ep.host}: {endpoint.unsaved_tags}")
+                    ep.tags.add(*[tag.lower() for tag in endpoint.unsaved_tags])
             except (MultipleObjectsReturned):
                 msg = (
                     f"Endpoints in your database are broken. "

--- a/dojo/importers/endpoint_manager.py
+++ b/dojo/importers/endpoint_manager.py
@@ -43,7 +43,7 @@ class EndpointManager:
                     product=finding.test.engagement.product)
                 if hasattr(endpoint, 'unsaved_tags') and endpoint.unsaved_tags:
                     logger.debug(f"Applying tags to endpoint {ep.host}: {endpoint.unsaved_tags}")
-                    ep.tags.add(*[tag.lower() for tag in endpoint.unsaved_tags])
+                    ep.tags.add(*[tag.lower() for tag in endpoint.unsaved_tags]) 
             except (MultipleObjectsReturned):
                 msg = (
                     f"Endpoints in your database are broken. "


### PR DESCRIPTION
Tags were not being applied to endpoints when importing in "add_endpoints_to_unsaved_finding" (endpoint_manager.py) due to missing code.