### PR TITLE
product grade logging fix

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1604,7 +1604,8 @@ def calculate_grade(product, *args, **kwargs):
             product.prod_numeric_grade = prod_numeric_grade
             super(Product, product).save()
         else:
-            logger.debug("Product %s grade %i is up to date", product.id, prod_numeric_grade)
+            # Use %s to safely handle None grades without formatter errors
+            logger.debug("Product %s grade %s is up to date", product.id, prod_numeric_grade)
 
 
 def get_celery_worker_status():


### PR DESCRIPTION
For new products without any product grade the first log message would fail due to a None error.

The grading itself was not affected.