### PR TITLE
GitHub chores: Automatically close issues labelled as `pending-closure`

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -15,6 +15,17 @@ jobs:
   close-stale:
     runs-on: ubuntu-latest
     steps:
+      - name: Close issues and PRs that are pending closure
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          # Disable automatic stale marking - only close manually labeled items
+          days-before-stale: -1
+          days-before-close: 7
+          stale-issue-label: 'pending-closure'
+          stale-pr-label: 'pending-closure'
+          close-issue-message: 'This issue has been automatically closed because it was manually labeled as stale. If you believe this was closed in error, please reopen it and remove the stale label.'
+          close-pr-message: 'This PR has been automatically closed because it was manually labeled as stale. If you believe this was closed in error, please reopen it and remove the stale label.'
+
       - name: Close stale issues and PRs
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
@@ -23,5 +34,5 @@ jobs:
           days-before-close: 7
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          close-issue-message: 'This issue has been automatically closed because it was manually labeled as stale. If you believe this was closed in error, please reopen it and remove the stale label.'
-          close-pr-message: 'This PR has been automatically closed because it was manually labeled as stale. If you believe this was closed in error, please reopen it and remove the stale label.'
+          close-issue-message: 'This issue has been automatically closed because it was labeled as stale. If you believe this was closed in error, please reopen it and remove the stale label.'
+          close-pr-message: 'This PR has been automatically closed because it was labeled as stale. If you believe this was closed in error, please reopen it and remove the stale label.'


### PR DESCRIPTION
I am labelling issues that are done or waiting for feedback as `pending-closure`. These should be closed automatically after 7 days. This PR enabled the GitHub action to do that.

The other existing label `stale` can also still be used, but it feels a bit weird to manually label an issue as stale when in reality  it's an issue that has been fixed or answered and is just waiting for the reporter to confirm. The stale label can be used in the future when we have cleared our backlog and we feel confident that we can automatically label issues as stale after some time.