### PR TITLE
enhance/normalize EDITABLE_MITIGATED_DATA handling

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1676,6 +1676,8 @@ class VulnerabilityIdSerializer(serializers.ModelSerializer):
 
 
 class FindingSerializer(serializers.ModelSerializer):
+    mitigated = serializers.DateTimeField(required=False)
+    mitigated_by = serializers.PrimaryKeyRelatedField(required=False, allow_null=True, queryset=User.objects.all())
     tags = TagListSerializerField(required=False)
     request_response = serializers.SerializerMethodField()
     accepted_risks = RiskAcceptanceSerializer(
@@ -1853,6 +1855,8 @@ class FindingSerializer(serializers.ModelSerializer):
 
 
 class FindingCreateSerializer(serializers.ModelSerializer):
+    mitigated = serializers.DateTimeField(required=False)
+    mitigated_by = serializers.PrimaryKeyRelatedField(required=False, allow_null=True, queryset=User.objects.all())
     notes = serializers.PrimaryKeyRelatedField(
         read_only=True, allow_null=True, required=False, many=True,
     )

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1676,7 +1676,7 @@ class VulnerabilityIdSerializer(serializers.ModelSerializer):
 
 
 class FindingSerializer(serializers.ModelSerializer):
-    mitigated = serializers.DateTimeField(required=False)
+    mitigated = serializers.DateTimeField(required=False, allow_null=True)
     mitigated_by = serializers.PrimaryKeyRelatedField(required=False, allow_null=True, queryset=User.objects.all())
     tags = TagListSerializerField(required=False)
     request_response = serializers.SerializerMethodField()
@@ -1774,14 +1774,17 @@ class FindingSerializer(serializers.ModelSerializer):
         return instance
 
     def validate(self, data):
-        # Enforce mitigated metadata editability (single validate method)
-        attempting_to_set_mitigated = any(field in data for field in ["mitigated", "mitigated_by"])
+        # Enforce mitigated metadata editability (only when non-null values are provided)
+        attempting_to_set_mitigated = any(
+            (field in data) and (data.get(field) is not None)
+            for field in ["mitigated", "mitigated_by"]
+        )
         user = getattr(self.context.get("request", None), "user", None)
         if attempting_to_set_mitigated and not finding_helper.can_edit_mitigated_data(user):
             errors = {}
-            if "mitigated" in data:
+            if ("mitigated" in data) and (data.get("mitigated") is not None):
                 errors["mitigated"] = ["Editing mitigated timestamp is disabled (EDITABLE_MITIGATED_DATA=false)"]
-            if "mitigated_by" in data:
+            if ("mitigated_by" in data) and (data.get("mitigated_by") is not None):
                 errors["mitigated_by"] = ["Editing mitigated_by is disabled (EDITABLE_MITIGATED_DATA=false)"]
             if errors:
                 raise serializers.ValidationError(errors)
@@ -1855,7 +1858,7 @@ class FindingSerializer(serializers.ModelSerializer):
 
 
 class FindingCreateSerializer(serializers.ModelSerializer):
-    mitigated = serializers.DateTimeField(required=False)
+    mitigated = serializers.DateTimeField(required=False, allow_null=True)
     mitigated_by = serializers.PrimaryKeyRelatedField(required=False, allow_null=True, queryset=User.objects.all())
     notes = serializers.PrimaryKeyRelatedField(
         read_only=True, allow_null=True, required=False, many=True,
@@ -1925,14 +1928,17 @@ class FindingCreateSerializer(serializers.ModelSerializer):
         return new_finding
 
     def validate(self, data):
-        # Ensure mitigated fields are only set when editable is enabled
-        attempting_to_set_mitigated = any(field in data for field in ["mitigated", "mitigated_by"])
+        # Ensure mitigated fields are only set when editable is enabled (ignore nulls)
+        attempting_to_set_mitigated = any(
+            (field in data) and (data.get(field) is not None)
+            for field in ["mitigated", "mitigated_by"]
+        )
         user = getattr(getattr(self.context, "request", None), "user", None)
         if attempting_to_set_mitigated and not finding_helper.can_edit_mitigated_data(user):
             errors = {}
-            if "mitigated" in data:
+            if ("mitigated" in data) and (data.get("mitigated") is not None):
                 errors["mitigated"] = ["Editing mitigated timestamp is disabled (EDITABLE_MITIGATED_DATA=false)"]
-            if "mitigated_by" in data:
+            if ("mitigated_by" in data) and (data.get("mitigated_by") is not None):
                 errors["mitigated_by"] = ["Editing mitigated_by is disabled (EDITABLE_MITIGATED_DATA=false)"]
             if errors:
                 raise serializers.ValidationError(errors)

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -933,7 +933,7 @@ class FindingViewSet(
                     finding=finding,
                     user=request.user,
                     is_mitigated=finding_close.validated_data["is_mitigated"],
-                    mitigated=(finding_close.validated_data.get("mitigated") if settings.EDITABLE_MITIGATED_DATA else timezone.now()),
+                    mitigated=(finding_close.validated_data.get("mitigated") if finding_helper.can_edit_mitigated_data(request.user) else timezone.now()),
                     mitigated_by=finding_close.validated_data.get("mitigated_by") or (request.user if not finding_helper.can_edit_mitigated_data(request.user) else None),
                     false_p=finding_close.validated_data.get("false_p", False),
                     out_of_scope=finding_close.validated_data.get("out_of_scope", False),

--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -131,8 +131,10 @@ def update_finding_status(new_state_finding, user, changed_fields=None):
 
     # people may try to remove mitigated/mitigated_by by accident
     if new_state_finding.is_mitigated:
-        new_state_finding.mitigated = new_state_finding.mitigated or now
-        new_state_finding.mitigated_by = new_state_finding.mitigated_by or user
+        # If fields are editable and provided, keep them; otherwise ensure they're set
+        if not can_edit_mitigated_data(user):
+            new_state_finding.mitigated = new_state_finding.mitigated or now
+            new_state_finding.mitigated_by = new_state_finding.mitigated_by or user
 
     if is_new_finding or "active" in changed_fields:
         # finding is being (re)activated
@@ -185,7 +187,7 @@ def filter_findings_by_existence(findings):
 
 
 def can_edit_mitigated_data(user):
-    return settings.EDITABLE_MITIGATED_DATA and user.is_superuser
+    return settings.EDITABLE_MITIGATED_DATA and user and getattr(user, "is_superuser", False)
 
 
 def create_finding_group(finds, finding_group_name):

--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -129,12 +129,13 @@ def update_finding_status(new_state_finding, user, changed_fields=None):
             new_state_finding.mitigated = None
             new_state_finding.mitigated_by = None
 
-    # people may try to remove mitigated/mitigated_by by accident
+    # Ensure mitigated metadata is present for mitigated findings
+    # If values are provided (including custom ones), keep them; if missing, set defaults
     if new_state_finding.is_mitigated:
-        # If fields are editable and provided, keep them; otherwise ensure they're set
-        if not can_edit_mitigated_data(user):
-            new_state_finding.mitigated = new_state_finding.mitigated or now
-            new_state_finding.mitigated_by = new_state_finding.mitigated_by or user
+        if not new_state_finding.mitigated:
+            new_state_finding.mitigated = now
+        if not new_state_finding.mitigated_by:
+            new_state_finding.mitigated_by = user
 
     if is_new_finding or "active" in changed_fields:
         # finding is being (re)activated

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1135,9 +1135,16 @@ def close_finding(request, fid):
     # we can do this with a Note
     note_type_activation = Note_Type.objects.filter(is_active=True)
     missing_note_types = get_missing_mandatory_notetypes(finding) if len(note_type_activation) else note_type_activation
-    form = CloseFindingForm(missing_note_types=missing_note_types)
+    form = CloseFindingForm(
+        missing_note_types=missing_note_types,
+        can_edit_mitigated_data=finding_helper.can_edit_mitigated_data(request.user),
+    )
     if request.method == "POST":
-        form = CloseFindingForm(request.POST, missing_note_types=missing_note_types)
+        form = CloseFindingForm(
+            request.POST,
+            missing_note_types=missing_note_types,
+            can_edit_mitigated_data=finding_helper.can_edit_mitigated_data(request.user),
+        )
 
         if form.is_valid():
             messages.add_message(request, messages.SUCCESS, "Note Saved.", extra_tags="alert-success")

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1898,14 +1898,14 @@ class CloseFindingForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         queryset = kwargs.pop("missing_note_types")
+        # must pop custom kwargs before calling parent __init__ to avoid unexpected kwarg errors
+        self.can_edit_mitigated_data = kwargs.pop("can_edit_mitigated_data") if "can_edit_mitigated_data" in kwargs \
+            else False
         super().__init__(*args, **kwargs)
         if len(queryset) == 0:
             self.fields["note_type"].widget = forms.HiddenInput()
         else:
             self.fields["note_type"] = forms.ModelChoiceField(queryset=queryset, label="Note Type", required=True)
-
-        self.can_edit_mitigated_data = kwargs.pop("can_edit_mitigated_data") if "can_edit_mitigated_data" in kwargs \
-            else False
 
         if self.can_edit_mitigated_data:
             self.fields["mitigated_by"].queryset = get_authorized_users(Permissions.Finding_Edit)


### PR DESCRIPTION
Fixes #6078

I thought it would be nice to allow the Finding API to accept `mitigated` and `mitigated_by` values for super users and when `settings.EDITABLE_MITIGATED_DATA` was `True`.

This PR adds that. It also normalizes the check in all place.

Two notes:
- The Close Finding UI form did not allow setting these fields at all. Now it does if the setting is enabled and the user is a superuser.
- The Close Finding API allowed non-superusers to modify the `mitigated` timestamp field if the `EDITABLE_MITIGATED_DATA`  was enabled. Not sure if this was intentional, but this PR now guards that field by the same central helper method. So only superusers can set if and `EDITABLE_MITIGATED_DATA` must be enabled. Is this oké?
- The Close Finding UI and API have this missing note types functionality. I don't fully understand it, but this PR now allows superusers to create findings that are mitigated and do not have any notes. Is this oké?

It looked like a simple change at first, but these inconsistencies made it hard to find out what is/was the intended behaviour. Do we want to allow creation and updating of findings as mitigated without doing the close finding api call?

Users can do this in the Edit Finding feature of the UI, so I think it should be supported in the API as well.