### PR TITLE
Add CVSS details extraction to AWS Inspector2 parser

### DIFF
--- a/dojo/tools/aws_inspector2/parser.py
+++ b/dojo/tools/aws_inspector2/parser.py
@@ -105,11 +105,8 @@ class AWSInspector2Parser:
         if cvss_vector := cvss_details.get("scoringVector"):
             if cvss_data := parse_cvss_data(cvss_vector):
                 finding.cvssv2 = cvss_data.get("cvssv2")
-                finding.cvssv2_score = cvss_data.get("cvssv2_score")
                 finding.cvssv3 = cvss_data.get("cvssv3")
-                finding.cvssv3_score = cvss_data.get("cvssv3_score")
                 finding.cvssv4 = cvss_data.get("cvssv4")
-                finding.cvssv4_score = cvss_data.get("cvssv4_score")
 
         return finding
 

--- a/dojo/tools/aws_inspector2/parser.py
+++ b/dojo/tools/aws_inspector2/parser.py
@@ -4,7 +4,6 @@ from datetime import UTC, datetime
 from dateutil import parser as date_parser
 
 from dojo.models import Endpoint, Finding
-
 from dojo.utils import parse_cvss_data
 
 

--- a/unittests/tools/test_aws_inspector2_parser.py
+++ b/unittests/tools/test_aws_inspector2_parser.py
@@ -28,6 +28,8 @@ class TestAWSInspector2Parser(TestCase):
             self.assertEqual(1, len(findings))
             self.assertEqual("CVE-2021-3744 - linux", findings[0].title)
             self.assertEqual("Medium", findings[0].severity)
+            self.assertEqual("CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H", findings[0].cvssv3)
+            self.assertEqual(5.5, findings[0].cvssv3_score)
 
     def test_aws_inspector2_parser_with_many_vuln_has_many_findings(self):
         with (get_unit_tests_scans_path("aws_inspector2") / "aws_inspector2_many_vul.json").open(encoding="utf-8") as testfile:
@@ -41,6 +43,8 @@ class TestAWSInspector2Parser(TestCase):
             self.assertEqual(True, findings[0].is_mitigated)
             # 2024-06-14T04:03:53.051000+02:00
             self.assertEqual(datetime(2024, 6, 14, 4, 3, 53, 51000, tzinfo=tzoffset(None, 7200)), findings[0].mitigated)
+            self.assertEqual("CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H", findings[0].cvssv3)
+            self.assertEqual(5.5, findings[0].cvssv3_score)
 
     def test_aws_inspector2_parser_empty_with_error(self):
         with self.assertRaises(TypeError) as context, \

--- a/unittests/tools/test_aws_inspector2_parser.py
+++ b/unittests/tools/test_aws_inspector2_parser.py
@@ -29,7 +29,7 @@ class TestAWSInspector2Parser(TestCase):
             self.assertEqual("CVE-2021-3744 - linux", findings[0].title)
             self.assertEqual("Medium", findings[0].severity)
             self.assertEqual("CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H", findings[0].cvssv3)
-            self.assertEqual(5.5, findings[0].cvssv3_score)
+            self.assertIsNone(findings[0].cvssv3_score)  # The score will be created by the finding save method
 
     def test_aws_inspector2_parser_with_many_vuln_has_many_findings(self):
         with (get_unit_tests_scans_path("aws_inspector2") / "aws_inspector2_many_vul.json").open(encoding="utf-8") as testfile:
@@ -44,7 +44,7 @@ class TestAWSInspector2Parser(TestCase):
             # 2024-06-14T04:03:53.051000+02:00
             self.assertEqual(datetime(2024, 6, 14, 4, 3, 53, 51000, tzinfo=tzoffset(None, 7200)), findings[0].mitigated)
             self.assertEqual("CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H", findings[0].cvssv3)
-            self.assertEqual(5.5, findings[0].cvssv3_score)
+            self.assertIsNone(findings[0].cvssv3_score)  # The score will be created by the finding save method
 
     def test_aws_inspector2_parser_empty_with_error(self):
         with self.assertRaises(TypeError) as context, \


### PR DESCRIPTION
Enhance the AWS Inspector2 parser to extract CVSS details from findings and update related tests to validate the new functionality. 