### PR TITLE
make alert order explicit

### DIFF
--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -171,7 +171,7 @@ def logout_view(request):
 
 @user_passes_test(lambda u: u.is_active)
 def alerts(request):
-    alerts = Alerts.objects.filter(user_id=request.user)
+    alerts = Alerts.objects.filter(user_id=request.user).order_by("-id")
 
     if request.method == "POST":
         removed_alerts = request.POST.getlist("alert_select")
@@ -190,7 +190,7 @@ def alerts(request):
 
 
 def delete_alerts(request):
-    alerts = Alerts.objects.filter(user_id=request.user)
+    alerts = Alerts.objects.filter(user_id=request.user).order_by("-id")
 
     if request.method == "POST":
         alerts.filter().delete()


### PR DESCRIPTION
In #13273 it's reported that the ordering of alerts can be different depending on the context. Let's make it explicit.