### PR TITLE
Refactor vulnerability ID and endpoint retrieval in Finding model

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2966,7 +2966,7 @@ class Finding(models.Model):
                 return "".join(sorted(vulnerability_id_str_list))
             return ""
 
-        return _get_unsaved_vulnearbility_ids(self) or _get_saved_vulnerability_ids(self)
+        return _get_saved_vulnerability_ids(self) or _get_unsaved_vulnearbility_ids(self) 
 
     # Get endpoints to use for hash_code computation
     # (This sometimes reports "None")
@@ -2994,7 +2994,7 @@ class Finding(models.Model):
                 return "".join(sorted(endpoint_str_list))
             return ""
 
-        return _get_unsaved_endpoints(self) or _get_saved_endpoints(self)
+        return _get_saved_endpoints(self) or _get_unsaved_endpoints(self)
 
     # Compute the hash_code from the fields to hash
     def hash_fields(self, fields_to_hash):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2945,53 +2945,56 @@ class Finding(models.Model):
 
     # Get vulnerability_ids to use for hash_code computation
     def get_vulnerability_ids(self):
-        vulnerability_id_str = ""
-        if self.id is None:
-            if self.unsaved_vulnerability_ids:
+
+        def _get_unsaved_vulnearbility_ids(finding) -> str:
+            if finding.unsaved_vulnerability_ids:
                 deduplicationLogger.debug("get_vulnerability_ids before the finding was saved")
                 # convert list of unsaved vulnerability_ids to the list of their canonical representation
-                vulnerability_id_str_list = [str(vulnerability_id) for vulnerability_id in self.unsaved_vulnerability_ids]
+                vulnerability_id_str_list = [str(vulnerability_id) for vulnerability_id in finding.unsaved_vulnerability_ids]
                 # deduplicate (usually done upon saving finding) and sort endpoints
-                vulnerability_id_str = "".join(sorted(dict.fromkeys(vulnerability_id_str_list)))
-            else:
-                deduplicationLogger.debug("finding has no unsaved vulnerability references")
-        else:
-            vulnerability_ids = Vulnerability_Id.objects.filter(finding=self)
-            deduplicationLogger.debug("get_vulnerability_ids after the finding was saved. Vulnerability references count: " + str(vulnerability_ids.count()))
-            # convert list of vulnerability_ids to the list of their canonical representation
-            vulnerability_id_str_list = [str(vulnerability_id) for vulnerability_id in vulnerability_ids.all()]
-            # sort vulnerability_ids strings
-            vulnerability_id_str = "".join(sorted(vulnerability_id_str_list))
-        return vulnerability_id_str
+                return "".join(sorted(dict.fromkeys(vulnerability_id_str_list)))
+            deduplicationLogger.debug("finding has no unsaved vulnerability references")
+            return ""
+
+        def _get_saved_vulnerability_ids(finding) -> str:
+            if finding.id is not None:
+                vulnerability_ids = Vulnerability_Id.objects.filter(finding=finding)
+                deduplicationLogger.debug("get_vulnerability_ids after the finding was saved. Vulnerability references count: " + str(vulnerability_ids.count()))
+                # convert list of vulnerability_ids to the list of their canonical representation
+                vulnerability_id_str_list = [str(vulnerability_id) for vulnerability_id in vulnerability_ids.all()]
+                # sort vulnerability_ids strings
+                return "".join(sorted(vulnerability_id_str_list))
+            return ""
+
+        return _get_unsaved_vulnearbility_ids(self) or _get_saved_vulnerability_ids(self)
 
     # Get endpoints to use for hash_code computation
     # (This sometimes reports "None")
     def get_endpoints(self):
-        endpoint_str = ""
-        if (self.id is None):
-            if len(self.unsaved_endpoints) > 0:
+
+        def _get_unsaved_endpoints(finding) -> str:
+            if len(finding.unsaved_endpoints) > 0:
                 deduplicationLogger.debug("get_endpoints before the finding was saved")
                 # convert list of unsaved endpoints to the list of their canonical representation
-                endpoint_str_list = [str(endpoint) for endpoint in self.unsaved_endpoints]
+                endpoint_str_list = [str(endpoint) for endpoint in finding.unsaved_endpoints]
                 # deduplicate (usually done upon saving finding) and sort endpoints
-                endpoint_str = "".join(
-                    sorted(
-                        dict.fromkeys(endpoint_str_list)))
-            else:
-                # we can get here when the parser defines static_finding=True but leaves dynamic_finding defaulted
-                # In this case, before saving the finding, both static_finding and dynamic_finding are True
-                # After saving dynamic_finding may be set to False probably during the saving process (observed on Bandit scan before forcing dynamic_finding=False at parser level)
-                deduplicationLogger.debug("trying to get endpoints on a finding before it was saved but no endpoints found (static parser wrongly identified as dynamic?")
-        else:
-            deduplicationLogger.debug("get_endpoints: after the finding was saved. Endpoints count: " + str(self.endpoints.count()))
-            # convert list of endpoints to the list of their canonical representation
-            endpoint_str_list = [str(endpoint) for endpoint in self.endpoints.all()]
-            # sort endpoints strings
-            endpoint_str = "".join(
-                sorted(
-                    endpoint_str_list,
-                ))
-        return endpoint_str
+                return "".join(dict.fromkeys(endpoint_str_list))
+            # we can get here when the parser defines static_finding=True but leaves dynamic_finding defaulted
+            # In this case, before saving the finding, both static_finding and dynamic_finding are True
+            # After saving dynamic_finding may be set to False probably during the saving process (observed on Bandit scan before forcing dynamic_finding=False at parser level)
+            deduplicationLogger.debug("trying to get endpoints on a finding before it was saved but no endpoints found (static parser wrongly identified as dynamic?")
+            return ""
+
+        def _get_saved_endpoints(finding) -> str:
+            if finding.id is not None:
+                deduplicationLogger.debug("get_endpoints: after the finding was saved. Endpoints count: " + str(finding.endpoints.count()))
+                # convert list of endpoints to the list of their canonical representation
+                endpoint_str_list = [str(endpoint) for endpoint in finding.endpoints.all()]
+                # sort endpoints strings
+                return "".join(sorted(endpoint_str_list))
+            return ""
+
+        return _get_unsaved_endpoints(self) or _get_saved_endpoints(self)
 
     # Compute the hash_code from the fields to hash
     def hash_fields(self, fields_to_hash):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2966,7 +2966,7 @@ class Finding(models.Model):
                 return "".join(sorted(vulnerability_id_str_list))
             return ""
 
-        return _get_saved_vulnerability_ids(self) or _get_unsaved_vulnearbility_ids(self) 
+        return _get_saved_vulnerability_ids(self) or _get_unsaved_vulnearbility_ids(self)
 
     # Get endpoints to use for hash_code computation
     # (This sometimes reports "None")

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2966,7 +2966,7 @@ class Finding(models.Model):
                 return "".join(sorted(vulnerability_id_str_list))
             return ""
 
-        return _get_saved_vulnerability_ids(self) or _get_unsaved_vulnearbility_ids(self)
+        return _get_saved_vulnerability_ids(self) or _get_unsaved_vulnerability_ids(self)
 
     # Get endpoints to use for hash_code computation
     # (This sometimes reports "None")

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2946,7 +2946,7 @@ class Finding(models.Model):
     # Get vulnerability_ids to use for hash_code computation
     def get_vulnerability_ids(self):
 
-        def _get_unsaved_vulnearbility_ids(finding) -> str:
+        def _get_unsaved_vulnerability_ids(finding) -> str:
             if finding.unsaved_vulnerability_ids:
                 deduplicationLogger.debug("get_vulnerability_ids before the finding was saved")
                 # convert list of unsaved vulnerability_ids to the list of their canonical representation


### PR DESCRIPTION
Streamline the retrieval process for vulnerability IDs and endpoints in the Finding model by separating logic for unsaved and saved states, improving code clarity and maintainability.