### PR TITLE
fix(gha): Run Release-Nightly only once a day

### DIFF
--- a/.github/workflows/release-nightly-dev.yml
+++ b/.github/workflows/release-nightly-dev.yml
@@ -8,7 +8,7 @@ on:
   schedule:
     # every day at 5:00 UTC
     # in this case inputs are all null/empty, hence the default values are used below
-    - cron: "* 5 * * *"
+    - cron: "0 5 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Until now, `Release-Nightly: Build & Push DEV` has been triggered multiple times between 5:00 and 5:59 UTC. But we needed it only once.

<img width="1069" height="626" alt="image" src="https://github.com/user-attachments/assets/1a4ee88e-e245-424e-b96a-6e1d20e36ec0" />
https://github.com/DefectDojo/django-DefectDojo/actions/workflows/release-nightly-dev.yml