### PR TITLE
user mentioning: diplay author instead of recipient

### DIFF
--- a/dojo/templates/notifications/alert/user_mentioned.tpl
+++ b/dojo/templates/notifications/alert/user_mentioned.tpl
@@ -1,4 +1,4 @@
 {% load i18n %}{% blocktranslate trimmed %}
-User {{ user }} jotted a note on {{ section }}{% endblocktranslate %}:
+User {{ requested_by }} jotted a note on {{ section }}{% endblocktranslate %}:
 
     {{ note }}

--- a/dojo/templates/notifications/mail/user_mentioned.tpl
+++ b/dojo/templates/notifications/mail/user_mentioned.tpl
@@ -9,7 +9,7 @@
             </p>
             <p>
               {% blocktranslate trimmed %}
-                User {{ user }} jotted a note on {{ section }}:<br/>
+                User {{ requested_by }} jotted a note on {{ section }}:<br/>
                 <br/>
                 {{ note }}<br/>
                 <br/>

--- a/dojo/templates/notifications/msteams/user_mentioned.tpl
+++ b/dojo/templates/notifications/msteams/user_mentioned.tpl
@@ -54,7 +54,7 @@ NOTE: This template is currently NOT USED in practice because:
                     },
                     {
                         "type": "TextBlock",
-                        "text": "{% trans 'User' %} {{ user }} {% trans 'mentioned you in' %} {{ section }}.",
+                        "text": "{% trans 'User' %} {{ requested_by }} {% trans 'mentioned you in' %} {{ section }}.",
                         "wrap": true,
                         "spacing": "Medium"
                     },
@@ -63,7 +63,7 @@ NOTE: This template is currently NOT USED in practice because:
                         "facts": [
                             {
                                 "title": "{% trans 'User' %}:",
-                                "value": "{{ user }}"
+                                "value": "{{ requested_by }}"
                             },
                             {
                                 "title": "{% trans 'Section' %}:",

--- a/dojo/templates/notifications/slack/user_mentioned.tpl
+++ b/dojo/templates/notifications/slack/user_mentioned.tpl
@@ -1,12 +1,12 @@
 {% load i18n %}{% blocktranslate trimmed %}
-User {{ user }} jotted a note on {{ section }}:
+User {{ requested_by }} jotted a note on {{ section }}:
 
 {{ note }}
 
 Full details of the note can be reviewed at {{ url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer_notifications and system_settings.disclaimer_notifications.strip %}
-    
+
     {% trans "Disclaimer" %}:
     {{ system_settings.disclaimer_notifications }}
 {% endif %}

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1461,7 +1461,8 @@ def process_tag_notifications(request, note, parent_url, parent_title):
         title=f"{request.user} jotted a note",
         url=parent_url,
         icon="commenting",
-        recipients=users_to_notify)
+        recipients=users_to_notify,
+        requested_by=get_current_user())
 
 
 def encrypt(key, iv, plaintext):


### PR DESCRIPTION
Fixes #10104

When a user mentioned another user, the contents of the notification contained the recipient as the "author" of the mentioning.

Example for where `admin` mentioned `user1`: On top is the new correct content, on the bottom the old incorrect content.

<img width="1516" height="442" alt="Screenshot 2025-10-05 202459" src="https://github.com/user-attachments/assets/682a8cc7-5bc8-4556-ae53-8b3608f399c4" />


Ideally we have a global/generic way of setting the author/actor on a notification. But for now this fixes at least the most obvious notification where the author is really needed.