### PR TITLE
apiv2: fix schema for engagements endpoint

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -398,7 +398,8 @@ class EndpointStatusViewSet(
 # @extend_schema_view(**schema_with_prefetch())
 # Nested models with prefetch make the response schema too long for Swagger UI
 class EngagementViewSet(
-    PrefetchDojoModelViewSet,
+    # PrefetchDojoModelViewSet,
+    DojoModelViewSet,
     ra_api.AcceptedRisksMixin,
 ):
     serializer_class = serializers.EngagementSerializer


### PR DESCRIPTION
The `Prefetch` functionality for the `engagements` endpoint was only partially commented out, resulting in response violating the schema. 