### PR TITLE
helm chart: use valkey instead of redis

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -13,8 +13,9 @@ dependencies:
     version: ~16.7.0
     repository: "oci://us-docker.pkg.dev/os-public-container-registry/defectdojo"
     condition: postgresql.enabled
-  - name: redis
-    version: ~19.6.4
+  - name: valkey
+    alias: redis
+    version: ">= 1.0.0"
     repository: "oci://us-docker.pkg.dev/os-public-container-registry/defectdojo"
     condition: redis.enabled
 annotations:

--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -393,8 +393,8 @@ Sample secret template (replace the placeholders with your PostgreSQL credential
 ```YAML
 apiversion: v1
 kind: Secret
-metadata: 
-  name: defectdojo-postgresql-specific 
+metadata:
+  name: defectdojo-postgresql-specific
 type: Opaque
 stringData:  # I chose stringData for better visualization of the credentials for debugging
   password: <user-password>
@@ -510,7 +510,7 @@ A Helm chart for Kubernetes to install DefectDojo
 | Repository | Name | Version |
 |------------|------|---------|
 | oci://us-docker.pkg.dev/os-public-container-registry/defectdojo | postgresql | ~16.7.0 |
-| oci://us-docker.pkg.dev/os-public-container-registry/defectdojo | redis | ~19.6.4 |
+| oci://us-docker.pkg.dev/os-public-container-registry/defectdojo | valkey (aliased as `redis`) | >= 1.0.0 |
 
 ## Values
 

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -462,7 +462,9 @@ gke:
   # Only works with serviceAccount.create = true
   workloadIdentityEmail: ""
 
-# For more advance options check the bitnami chart documentation: https://github.com/bitnami/charts/tree/main/bitnami/redis
+# For more advanced options check the chart documentation for Valkey (drop-in Redis replacement).
+# If you continue to use the bundled dependency, the PVC name and values key remain under `redis`.
+# Valkey chart docs: https://github.com/bitnami/charts/tree/main/bitnami/valkey
 redis:
   # To use an external instance, switch enabled to `false`` and set the address in `redisServer` below
   enabled: true


### PR DESCRIPTION
GPT5 generated PR