### PR TITLE
feat(helm): Split image locations+tags, allow digest pinning

### DIFF
--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -69,6 +69,8 @@ jobs:
                defectdojo \
                ./helm/defectdojo \
                --set django.ingress.enabled=true \
+               --set images.django.image.tag=latest \
+               --set images.nginx.image.tag=latest \
                --set imagePullPolicy=Never \
                --set initializer.keepSeconds="-1" \
                --set redis.enabled=true \

--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -69,16 +69,6 @@ jobs:
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
 
-      - name: Add yq
-        uses: mikefarah/yq@0ecdce24e83f0fa127940334be98c86b07b0c488 # v4.48.1
-
-      - name: Pin version docker version
-        id: pin_image
-        run: |-
-          yq --version
-          yq -i '.tag="${{ inputs.release_number }}"'  helm/defectdojo/values.yaml
-          echo "Current image tag:`yq -r '.tag' helm/defectdojo/values.yaml`"
-
       - name: Package Helm chart
         id: package-helm-chart
         run: |

--- a/docs/content/en/open_source/upgrading/2.52.md
+++ b/docs/content/en/open_source/upgrading/2.52.md
@@ -2,8 +2,12 @@
 title: 'Upgrading to DefectDojo Version 2.52.x'
 toc_hide: true
 weight: -20251006
-description: Helm chart changes.
+description: MobSF parsers & Helm chart changes.
 ---
+
+## Merge of MobSF parsers
+
+Mobsfscan Scan" has been merged into the "MobSF Scan" parser. The "Mobsfscan Scan" scan_type has been retained to keep deduplication working for existing Tests, but users are encouraged to move to the "MobSF Scan" scan_type.
 
 ## Helm Chart Changes
 
@@ -11,9 +15,12 @@ This release introduces more important changes to the Helm chart configuration:
 
 ### Breaking changes
 
-#### Merge of MobSF parsers
+#### Tags
 
-Mobsfscan Scan" has been merged into the "MobSF Scan" parser. The "Mobsfscan Scan" scan_type has been retained to keep deduplication working for existing Tests, but users are encouraged to move to the "MobSF Scan" scan_type.
+`tag` and `repositoryPrefix` fields have been deprecated. Currently, image tags used in containers are derived by default from the `appVersion` defined in the Chart.  
+This behavior can be overridden by setting the `tag` value in `images.django` and `images.nginx`.  
+If fine-tuning is necessary, each container’s image value can also be customized individually (`celery.beat.image`, `celery.worker.image`, `django.nginx.image`, `django.uwsgi.image`, `initializer.image`, and `dbMigrationChecker.image`).  
+Digest pinning is now supported as well.
 
 #### Security context
 

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.52.0-dev"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.7.2-dev
+version: 1.8.0-dev
 icon: https://defectdojo.com/hubfs/DefectDojo_favicon.png
 maintainers:
   - name: madchap
@@ -22,5 +22,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: DRY cloudsql-proxy
+    - kind: changed
+      description: Each component allow to specific image + allow digest pinning
     - kind: added
       description: Testing on the oldest officially supported k8s

--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -495,7 +495,7 @@ kubectl delete pvc data-defectdojo-redis-0 data-defectdojo-postgresql-0
 
 # General information about chart values
 
-![Version: 1.7.2-dev](https://img.shields.io/badge/Version-1.7.2--dev-informational?style=flat-square) ![AppVersion: 2.52.0-dev](https://img.shields.io/badge/AppVersion-2.52.0--dev-informational?style=flat-square)
+![Version: 1.8.0-dev](https://img.shields.io/badge/Version-1.8.0--dev-informational?style=flat-square) ![AppVersion: 2.52.0-dev](https://img.shields.io/badge/AppVersion-2.52.0--dev-informational?style=flat-square)
 
 A Helm chart for Kubernetes to install DefectDojo
 
@@ -534,6 +534,10 @@ A Helm chart for Kubernetes to install DefectDojo
 | celery.beat.extraInitContainers | list | `[]` |  |
 | celery.beat.extraVolumeMounts | list | `[]` |  |
 | celery.beat.extraVolumes | list | `[]` |  |
+| celery.beat.image.digest | string | `""` |  |
+| celery.beat.image.registry | string | `""` |  |
+| celery.beat.image.repository | string | `""` |  |
+| celery.beat.image.tag | string | `""` |  |
 | celery.beat.livenessProbe | object | `{}` |  |
 | celery.beat.nodeSelector | object | `{}` |  |
 | celery.beat.podAnnotations | object | `{}` |  |
@@ -557,6 +561,10 @@ A Helm chart for Kubernetes to install DefectDojo
 | celery.worker.extraInitContainers | list | `[]` |  |
 | celery.worker.extraVolumeMounts | list | `[]` |  |
 | celery.worker.extraVolumes | list | `[]` |  |
+| celery.worker.image.digest | string | `""` |  |
+| celery.worker.image.registry | string | `""` |  |
+| celery.worker.image.repository | string | `""` |  |
+| celery.worker.image.tag | string | `""` |  |
 | celery.worker.livenessProbe | object | `{}` |  |
 | celery.worker.nodeSelector | object | `{}` |  |
 | celery.worker.podAnnotations | object | `{}` |  |
@@ -588,6 +596,10 @@ A Helm chart for Kubernetes to install DefectDojo
 | dbMigrationChecker.enabled | bool | `true` |  |
 | dbMigrationChecker.extraEnv | list | `[]` |  |
 | dbMigrationChecker.extraVolumeMounts | list | `[]` |  |
+| dbMigrationChecker.image.digest | string | `""` |  |
+| dbMigrationChecker.image.registry | string | `""` |  |
+| dbMigrationChecker.image.repository | string | `""` |  |
+| dbMigrationChecker.image.tag | string | `""` |  |
 | dbMigrationChecker.resources.limits.cpu | string | `"200m"` |  |
 | dbMigrationChecker.resources.limits.memory | string | `"200Mi"` |  |
 | dbMigrationChecker.resources.requests.cpu | string | `"100m"` |  |
@@ -617,6 +629,10 @@ A Helm chart for Kubernetes to install DefectDojo
 | django.nginx.containerSecurityContext.runAsUser | int | `1001` |  |
 | django.nginx.extraEnv | list | `[]` |  |
 | django.nginx.extraVolumeMounts | list | `[]` |  |
+| django.nginx.image.digest | string | `""` |  |
+| django.nginx.image.registry | string | `""` |  |
+| django.nginx.image.repository | string | `""` |  |
+| django.nginx.image.tag | string | `""` |  |
 | django.nginx.resources.limits.cpu | string | `"2000m"` |  |
 | django.nginx.resources.limits.memory | string | `"256Mi"` |  |
 | django.nginx.resources.requests.cpu | string | `"100m"` |  |
@@ -641,6 +657,10 @@ A Helm chart for Kubernetes to install DefectDojo
 | django.uwsgi.enableDebug | bool | `false` |  |
 | django.uwsgi.extraEnv | list | `[]` |  |
 | django.uwsgi.extraVolumeMounts | list | `[]` |  |
+| django.uwsgi.image.digest | string | `""` |  |
+| django.uwsgi.image.registry | string | `""` |  |
+| django.uwsgi.image.repository | string | `""` |  |
+| django.uwsgi.image.tag | string | `""` |  |
 | django.uwsgi.livenessProbe.enabled | bool | `true` |  |
 | django.uwsgi.livenessProbe.failureThreshold | int | `6` |  |
 | django.uwsgi.livenessProbe.initialDelaySeconds | int | `0` |  |
@@ -674,6 +694,14 @@ A Helm chart for Kubernetes to install DefectDojo
 | host | string | `"defectdojo.default.minikube.local"` |  |
 | imagePullPolicy | string | `"Always"` |  |
 | imagePullSecrets | string | `nil` |  |
+| images.django.image.digest | string | `""` |  |
+| images.django.image.registry | string | `""` |  |
+| images.django.image.repository | string | `"defectdojo/defectdojo-django"` |  |
+| images.django.image.tag | string | `""` |  |
+| images.nginx.image.digest | string | `""` |  |
+| images.nginx.image.registry | string | `""` |  |
+| images.nginx.image.repository | string | `"defectdojo/defectdojo-nginx"` |  |
+| images.nginx.image.tag | string | `""` |  |
 | initializer.affinity | object | `{}` |  |
 | initializer.annotations | object | `{}` |  |
 | initializer.automountServiceAccountToken | bool | `false` |  |
@@ -681,6 +709,10 @@ A Helm chart for Kubernetes to install DefectDojo
 | initializer.extraEnv | list | `[]` |  |
 | initializer.extraVolumeMounts | list | `[]` |  |
 | initializer.extraVolumes | list | `[]` |  |
+| initializer.image.digest | string | `""` |  |
+| initializer.image.registry | string | `""` |  |
+| initializer.image.repository | string | `""` |  |
+| initializer.image.tag | string | `""` |  |
 | initializer.jobAnnotations | object | `{}` |  |
 | initializer.keepSeconds | int | `60` |  |
 | initializer.labels | object | `{}` |  |
@@ -699,7 +731,10 @@ A Helm chart for Kubernetes to install DefectDojo
 | monitoring.prometheus.enabled | bool | `false` |  |
 | monitoring.prometheus.extraEnv | list | `[]` |  |
 | monitoring.prometheus.extraVolumeMounts | list | `[]` |  |
-| monitoring.prometheus.image | string | `"nginx/nginx-prometheus-exporter:1.4.2"` |  |
+| monitoring.prometheus.image.digest | string | `""` |  |
+| monitoring.prometheus.image.registry | string | `""` |  |
+| monitoring.prometheus.image.repository | string | `"nginx/nginx-prometheus-exporter"` |  |
+| monitoring.prometheus.image.tag | string | `"1.4.2"` |  |
 | monitoring.prometheus.imagePullPolicy | string | `"IfNotPresent"` |  |
 | monitoring.prometheus.resources | object | `{}` |  |
 | networkPolicy.annotations | object | `{}` |  |
@@ -739,7 +774,6 @@ A Helm chart for Kubernetes to install DefectDojo
 | redis.tls.enabled | bool | `false` |  |
 | redisParams | string | `""` |  |
 | redisServer | string | `nil` |  |
-| repositoryPrefix | string | `"defectdojo"` |  |
 | revisionHistoryLimit | int | `10` |  |
 | secrets.annotations | object | `{}` |  |
 | securityContext.containerSecurityContext.runAsNonRoot | bool | `true` |  |
@@ -750,8 +784,11 @@ A Helm chart for Kubernetes to install DefectDojo
 | serviceAccount.labels | object | `{}` |  |
 | serviceAccount.name | string | `""` |  |
 | siteUrl | string | `""` |  |
-| tag | string | `"latest"` |  |
 | tests.unitTests.automountServiceAccountToken | bool | `false` |  |
+| tests.unitTests.image.digest | string | `""` |  |
+| tests.unitTests.image.registry | string | `""` |  |
+| tests.unitTests.image.repository | string | `""` |  |
+| tests.unitTests.image.tag | string | `""` |  |
 | tests.unitTests.resources.limits.cpu | string | `"500m"` |  |
 | tests.unitTests.resources.limits.memory | string | `"512Mi"` |  |
 | tests.unitTests.resources.requests.cpu | string | `"100m"` |  |

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -99,7 +99,7 @@ spec:
       - command:
         - /entrypoint-celery-beat.sh
         name: celery
-        image: "{{ template "celery.repository" . }}:{{ .Values.tag }}"
+        image: "{{ template "celery.beat.image" . }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- with .Values.celery.beat.livenessProbe }}
         livenessProbe: {{ toYaml . | nindent 10 }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -95,7 +95,7 @@ spec:
       {{- end }}
       containers:
       - name: celery
-        image: "{{ template "celery.repository" . }}:{{ .Values.tag }}"
+        image: "{{ template "celery.worker.image" . }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- with .Values.celery.worker.livenessProbe }}
         livenessProbe: {{ toYaml . | nindent 10 }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -116,7 +116,7 @@ spec:
       containers:
       {{- if and .Values.monitoring.enabled .Values.monitoring.prometheus.enabled }}
       - name: metrics
-        image: {{ .Values.monitoring.prometheus.image }}
+        image: '{{ template "monitoring.prometheus.image" . }}'
         imagePullPolicy: {{ .Values.monitoring.prometheus.imagePullPolicy }}
         command:
         - /usr/bin/nginx-prometheus-exporter
@@ -152,7 +152,7 @@ spec:
         {{- end }}
       {{- end }}
       - name: uwsgi
-        image: '{{ template "django.uwsgi.repository" . }}:{{ .Values.tag }}'
+        image: '{{ template "django.uwsgi.image" . }}'
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
@@ -254,7 +254,7 @@ spec:
         resources:
           {{- toYaml .Values.django.uwsgi.resources | nindent 10 }}
       - name: nginx
-        image: '{{ template "django.nginx.repository" . }}:{{ .Values.tag }}'
+        image: '{{ template "django.nginx.image" . }}'
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if .Values.securityContext.enabled }}
         securityContext:

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -82,7 +82,7 @@ spec:
         - '/bin/bash'
         - '-c'
         - '/wait-for-it.sh ${DD_DATABASE_HOST:-postgres}:${DD_DATABASE_PORT:-5432} -t 300 -s -- /bin/echo Database is up'
-        image: '{{ template "django.uwsgi.repository" . }}:{{ .Values.tag }}'
+        image: "{{ template "initializer.image" . }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
@@ -113,7 +113,7 @@ spec:
         {{- end }}
       containers:
       - name: initializer
-        image: "{{ template "initializer.repository" . }}:{{ .Values.tag }}"
+        image: "{{ template "initializer.image" . }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if .Values.securityContext.enabled }}
         securityContext:

--- a/helm/defectdojo/templates/tests/unit-tests.yaml
+++ b/helm/defectdojo/templates/tests/unit-tests.yaml
@@ -19,7 +19,7 @@ spec:
   {{- end }}
   containers:
     - name: unit-tests
-      image: '{{ .Values.repositoryPrefix }}/defectdojo-django:{{ .Values.tag }}'
+      image: '{{ template "unitTests.image" . }}'
       imagePullPolicy: {{ .Values.imagePullPolicy }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/helm/defectdojo/values.schema.json
+++ b/helm/defectdojo/values.schema.json
@@ -67,6 +67,23 @@
                         "extraVolumes": {
                             "type": "array"
                         },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "livenessProbe": {
                             "type": "object"
                         },
@@ -160,6 +177,23 @@
                         },
                         "extraVolumes": {
                             "type": "array"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
                         },
                         "livenessProbe": {
                             "type": "object"
@@ -285,6 +319,23 @@
                 },
                 "extraVolumeMounts": {
                     "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "digest": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "resources": {
                     "type": "object",
@@ -419,6 +470,23 @@
                         "extraVolumeMounts": {
                             "type": "array"
                         },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "resources": {
                             "type": "object",
                             "properties": {
@@ -540,6 +608,23 @@
                         },
                         "extraVolumeMounts": {
                             "type": "array"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
                         },
                         "livenessProbe": {
                             "type": "object",
@@ -682,6 +767,55 @@
                 "null"
             ]
         },
+        "images": {
+            "type": "object",
+            "properties": {
+                "django": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "nginx": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "initializer": {
             "type": "object",
             "properties": {
@@ -705,6 +839,23 @@
                 },
                 "extraVolumes": {
                     "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "digest": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "jobAnnotations": {
                     "type": "object"
@@ -784,7 +935,21 @@
                             "type": "array"
                         },
                         "image": {
-                            "type": "string"
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
                         },
                         "imagePullPolicy": {
                             "type": "string"
@@ -1003,9 +1168,6 @@
                 "null"
             ]
         },
-        "repositoryPrefix": {
-            "type": "string"
-        },
         "revisionHistoryLimit": {
             "type": "integer"
         },
@@ -1061,9 +1223,6 @@
         "siteUrl": {
             "type": "string"
         },
-        "tag": {
-            "type": "string"
-        },
         "tests": {
             "type": "object",
             "properties": {
@@ -1072,6 +1231,23 @@
                     "properties": {
                         "automountServiceAccountToken": {
                             "type": "boolean"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "digest": {
+                                    "type": "string"
+                                },
+                                "registry": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
                         },
                         "resources": {
                             "type": "object",

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -27,6 +27,20 @@ extraAnnotations: {}
 # Labels globally added to all resources
 extraLabels: {}
 
+images:
+  django:
+    image:
+      registry: ""
+      repository: defectdojo/defectdojo-django
+      tag: ""  # If empty, use appVersion
+      digest: ""
+  nginx:
+    image:
+      registry: ""
+      repository: defectdojo/defectdojo-nginx
+      tag: ""  # If empty, use appVersion
+      digest: ""
+
 # Enables application network policy
 # For more info follow https://kubernetes.io/docs/concepts/services-networking/network-policies/
 networkPolicy:
@@ -73,13 +87,10 @@ siteUrl: ""
 alternativeHosts: []
 #  - defectdojo.example.com
 imagePullPolicy: Always
-# Where to pull the defectDojo images from. Defaults to "defectdojo/*" repositories on hub.docker.com
-repositoryPrefix: defectdojo
 # When using a private registry, name of the secret that holds the registry secret (eg deploy token from gitlab-ci project)
 # Create secrets as: kubectl create secret docker-registry defectdojoregistrykey --docker-username=registry_username --docker-password=registry_password --docker-server='https://index.docker.io/v1/'
 # @schema type:[string, null]
 imagePullSecrets: ~
-tag: latest
 
 # Additional labels to add to the pods:
 # podLabels:
@@ -104,6 +115,11 @@ serviceAccount:
   labels: {}
 
 dbMigrationChecker:
+  image:  # If empty, uses values from images.django.image
+    registry: ""
+    repository: ""
+    tag: ""
+    digest: ""
   # Enable/disable the DB migration checker.
   enabled: true
   # Container security context for the DB migration checker.
@@ -123,6 +139,11 @@ dbMigrationChecker:
 
 tests:
   unitTests:
+    image:  # If empty, uses values from images.django.image
+      registry: ""
+      repository: ""
+      tag: ""
+      digest: ""
     automountServiceAccountToken: false
     resources:
       requests:
@@ -147,7 +168,11 @@ monitoring:
   prometheus:
     # Add the nginx prometheus exporter sidecar
     enabled: false
-    image: nginx/nginx-prometheus-exporter:1.4.2
+    image:
+      registry: ""
+      repository: nginx/nginx-prometheus-exporter
+      tag: "1.4.2"
+      digest: ""
     imagePullPolicy: IfNotPresent
     # Optional: container security context for nginx prometheus exporter
     containerSecurityContext: {}
@@ -169,6 +194,11 @@ celery:
   # Common annotations to worker and beat deployments and pods.
   annotations: {}
   beat:
+    image:  # If empty, uses values from images.django.image
+      registry: ""
+      repository: ""
+      tag: ""
+      digest: ""
     automountServiceAccountToken: false
     # Annotations for the Celery beat deployment.
     annotations: {}
@@ -213,6 +243,11 @@ celery:
     startupProbe: {}
     tolerations: []
   worker:
+    image:  # If empty, uses values from images.django.image
+      registry: ""
+      repository: ""
+      tag: ""
+      digest: ""
     automountServiceAccountToken: false
     # Annotations for the Celery worker deployment.
     annotations: {}
@@ -288,6 +323,11 @@ django:
       # nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
       # nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
   nginx:
+    image:  # If empty, uses values from images.nginx.image
+      registry: ""
+      repository: ""
+      tag: ""
+      digest: ""
     # Container security context for the nginx containers.
     containerSecurityContext:
       # nginx dockerfile sets USER=1001
@@ -317,6 +357,11 @@ django:
   strategy: {}
   tolerations: []
   uwsgi:
+    image:  # If empty, uses values from images.django.image
+      registry: ""
+      repository: ""
+      tag: ""
+      digest: ""
     containerSecurityContext:
       # django dockerfile sets USER=1001
       runAsUser: 1001
@@ -413,6 +458,11 @@ initializer:
   affinity: {}
   nodeSelector: {}
   tolerations: []
+  image:  # If empty, uses values from images.django.image
+    registry: ""
+    repository: ""
+    tag: ""
+    digest: ""
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
`tag` and `repositoryPrefix` fields have been deprecated. Currently, image tags used in containers are derived by default from the `appVersion` defined in the Chart.  
This behavior can be overridden by setting the `tag` value in `images.django` and `images.nginx`.  
If fine-tuning is necessary, each container’s image value can also be customized individually (`celery.beat.image`, `celery.worker.image`, `django.nginx.image`, `django.uwsgi.image`, `initializer.image`, and `dbMigrationChecker.image`).  
Digest pinning is now supported as well.

