### PR TITLE
feat(helm): Add support for automountServiceAccountToken

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -19,4 +19,6 @@ dependencies:
     condition: redis.enabled
 annotations:
   artifacthub.io/prerelease: "true"
-  artifacthub.io/changes: ""
+  artifacthub.io/changes: |
+    - kind: added
+      description: Add support for automountServiceAccountToken

--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -528,6 +528,7 @@ A Helm chart for Kubernetes to install DefectDojo
 | celery.annotations | object | `{}` |  |
 | celery.beat.affinity | object | `{}` |  |
 | celery.beat.annotations | object | `{}` |  |
+| celery.beat.automountServiceAccountToken | bool | `false` |  |
 | celery.beat.extraEnv | list | `[]` |  |
 | celery.beat.extraInitContainers | list | `[]` |  |
 | celery.beat.extraVolumeMounts | list | `[]` |  |
@@ -548,6 +549,7 @@ A Helm chart for Kubernetes to install DefectDojo
 | celery.worker.affinity | object | `{}` |  |
 | celery.worker.annotations | object | `{}` |  |
 | celery.worker.appSettings.poolType | string | `"solo"` |  |
+| celery.worker.automountServiceAccountToken | bool | `false` |  |
 | celery.worker.extraEnv | list | `[]` |  |
 | celery.worker.extraInitContainers | list | `[]` |  |
 | celery.worker.extraVolumeMounts | list | `[]` |  |
@@ -582,6 +584,7 @@ A Helm chart for Kubernetes to install DefectDojo
 | disableHooks | bool | `false` |  |
 | django.affinity | object | `{}` |  |
 | django.annotations | object | `{}` |  |
+| django.automountServiceAccountToken | bool | `false` |  |
 | django.extraInitContainers | list | `[]` |  |
 | django.extraVolumes | list | `[]` |  |
 | django.ingress.activateTLS | bool | `true` |  |
@@ -656,6 +659,7 @@ A Helm chart for Kubernetes to install DefectDojo
 | imagePullSecrets | string | `nil` |  |
 | initializer.affinity | object | `{}` |  |
 | initializer.annotations | object | `{}` |  |
+| initializer.automountServiceAccountToken | bool | `false` |  |
 | initializer.extraEnv | list | `[]` |  |
 | initializer.extraVolumeMounts | list | `[]` |  |
 | initializer.extraVolumes | list | `[]` |  |
@@ -722,6 +726,7 @@ A Helm chart for Kubernetes to install DefectDojo
 | serviceAccount.create | bool | `true` |  |
 | serviceAccount.labels | object | `{}` |  |
 | tag | string | `"latest"` |  |
+| tests.unitTests.automountServiceAccountToken | bool | `false` |  |
 | tests.unitTests.resources.limits.cpu | string | `"500m"` |  |
 | tests.unitTests.resources.limits.memory | string | `"512Mi"` |  |
 | tests.unitTests.resources.requests.cpu | string | `"100m"` |  |

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "defectdojo.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.celery.beat.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ . }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "defectdojo.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.celery.worker.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ . }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -59,6 +59,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "defectdojo.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.django.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ quote . }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -39,6 +39,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "defectdojo.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.initializer.automountServiceAccountToken }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ . }}

--- a/helm/defectdojo/templates/tests/unit-tests.yaml
+++ b/helm/defectdojo/templates/tests/unit-tests.yaml
@@ -12,6 +12,7 @@ metadata:
     helm.sh/hook: test-success
 spec:
   serviceAccountName: {{ include "defectdojo.serviceAccountName" . }}
+  automountServiceAccountToken: {{ .Values.tests.unitTests.automountServiceAccountToken }}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:
     - name: {{ . }}

--- a/helm/defectdojo/values.schema.json
+++ b/helm/defectdojo/values.schema.json
@@ -49,6 +49,9 @@
                         "annotations": {
                             "type": "object"
                         },
+                        "automountServiceAccountToken": {
+                            "type": "boolean"
+                        },
                         "extraEnv": {
                             "type": "array"
                         },
@@ -133,6 +136,9 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "automountServiceAccountToken": {
+                            "type": "boolean"
                         },
                         "extraEnv": {
                             "type": "array"
@@ -287,6 +293,9 @@
                 },
                 "annotations": {
                     "type": "object"
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean"
                 },
                 "extraInitContainers": {
                     "type": "array"
@@ -615,6 +624,9 @@
                 },
                 "annotations": {
                     "type": "object"
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean"
                 },
                 "extraEnv": {
                     "type": "array"
@@ -968,6 +980,9 @@
                 "unitTests": {
                     "type": "object",
                     "properties": {
+                        "automountServiceAccountToken": {
+                            "type": "boolean"
+                        },
                         "resources": {
                             "type": "object",
                             "properties": {

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -114,6 +114,7 @@ dbMigrationChecker:
 
 tests:
   unitTests:
+    automountServiceAccountToken: false
     resources:
       requests:
         cpu: 100m
@@ -153,6 +154,7 @@ celery:
   # Common annotations to worker and beat deployments and pods.
   annotations: {}
   beat:
+    automountServiceAccountToken: false
     # Annotations for the Celery beat deployment.
     annotations: {}
     affinity: {}
@@ -192,6 +194,7 @@ celery:
     startupProbe: {}
     tolerations: []
   worker:
+    automountServiceAccountToken: false
     # Annotations for the Celery worker deployment.
     annotations: {}
     affinity: {}
@@ -241,6 +244,7 @@ celery:
       # prefetchMultiplier: 128
 
 django:
+  automountServiceAccountToken: false
   annotations: {}
   service:
     annotations: {}
@@ -364,6 +368,7 @@ django:
 
 initializer:
   run: true
+  automountServiceAccountToken: false
   jobAnnotations: {}
   annotations: {}
   labels: {}


### PR DESCRIPTION
Fixes #10289
Add support for automountServiceAccountToken and set it to `false` - safer option.
