### PR TITLE
feat(helm): Simplify k8s-tests.yml

### DIFF
--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -5,15 +5,6 @@ on:
 
 env:
   DD_HOSTNAME: defectdojo.default.minikube.local
-  HELM_REDIS_BROKER_SETTINGS: " \
-    --set redis.enabled=true \
-    --set celery.broker=redis \
-    --set createRedisSecret=true \
-    "
-  HELM_PG_DATABASE_SETTINGS: " \
-    --set postgresql.enabled=true \
-    --set createPostgresqlSecret=true \
-   "
 jobs:
   setting_minikube_cluster:
     name: Kubernetes Deployment
@@ -25,9 +16,7 @@ jobs:
           # databases, broker and k8s are independent, so we don't need to test each combination
           # lastest k8s version (https://kubernetes.io/releases/) and oldest supported version from aws
           # are tested (https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#available-versions)
-          - databases: pgsql
-            brokers: redis
-            k8s: 'v1.34.0'
+          - k8s: 'v1.34.0'
             os: debian
     steps:
       - name: Checkout
@@ -68,12 +57,6 @@ jobs:
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
 
-      - name: Set confings into Outputs
-        id: set
-        run: |-
-              echo "pgsql=${{ env.HELM_PG_DATABASE_SETTINGS }}" >> $GITHUB_ENV
-              echo "redis=${{ env.HELM_REDIS_BROKER_SETTINGS }}" >> $GITHUB_ENV
-
       - name: Deploying Django application with ${{ matrix.databases }} ${{ matrix.brokers }}
         timeout-minutes: 15
         run: |-
@@ -86,8 +69,10 @@ jobs:
                --set django.ingress.enabled=true \
                --set imagePullPolicy=Never \
                --set initializer.keepSeconds="-1" \
-               ${{ env[matrix.databases] }} \
-               ${{ env[matrix.brokers] }} \
+               --set redis.enabled=true \
+               --set createRedisSecret=true \
+               --set postgresql.enabled=true \
+               --set createPostgresqlSecret=true \
                --set createSecret=true
 
       - name: Check deployment status


### PR DESCRIPTION
Separation made sense when different DB and MB were supported. Now it just increases complexity and decreases readability.