### PR TITLE
fix(GHA/HELM): Bump yamale & yamllint

### DIFF
--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
         with:
-          yamale_version: 4.0.4
-          yamllint_version: 1.35.1
+          yamale_version: 6.0.0
+          yamllint_version: 1.37.1
 
       - name: Determine target branch
         id: ct-branch-target


### PR DESCRIPTION
#13374 broke processing of HELM charts. It wasn't possible to see in that PR because it did not contain all the steps (they are triggered only in the case of a change to the chart itself).
I found out that the upgrade of `yamale` & `yamllint` fixes the issues (and also resolves all failing GHA in HELM-related PRs).