### PR TITLE
fix(renovate): Drop Bitnami

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,8 +34,5 @@
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
-  ],
-  "registryAliases": {
-    "bitnami": "https://charts.bitnami.com/bitnami"
-  }
+  ]
 }


### PR DESCRIPTION
As we are not using officially bitnami, it does not need to be checked by renovate.