### PR TITLE
Ruff: PT - simplify rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -58,7 +58,7 @@ select = [
    "PIE",
    "T20",
    "PYI",
-   "PT001", "PT002", "PT003", "PT006", "PT007", "PT008", "PT01", "PT020", "PT021", "PT022", "PT023", "PT024", "PT025", "PT026", "PT028", "PT029", "PT03",
+   "PT",
    "Q",
    "RSE",
    "RET",
@@ -101,6 +101,8 @@ ignore = [
     "FIX002",  # TODOs need some love but we will probably not get of them
     "D211",  # `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible.
     "D212",  # `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible.
+    "PT009",  # We are using a different style of tests (official Django tests), so it does not make sense to try to fix it
+    "PT027",  # Same ^
 ]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
We are using a different style of tests (official Django tests), so it does not make sense to try to fix it.