### PR TITLE
Downgrade django-tagulous to 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,8 @@ packageurl-python==0.17.5
 django-crum==0.7.9
 JSON-log-formatter==1.1.1
 django-split-settings==1.3.2
-django-tagulous==2.1.1
+# do not upgrade to 2.1.1 - https://github.com/DefectDojo/django-DefectDojo/issues/12918
+django-tagulous==2.1.0
 PyJWT==2.10.1
 cvss==3.6
 django-fieldsignals==0.7.0


### PR DESCRIPTION
Reapply changes from https://github.com/DefectDojo/django-DefectDojo/pull/13250

This is a twin PR to https://github.com/DefectDojo/django-DefectDojo/pull/13440 that goes into bugfix.

Adding this PR to go into `dev` to make sure it won't get lost.

Fixes #12918