### PR TITLE
report builder: ensure at least one section is present

### DIFF
--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -203,8 +203,7 @@
 
             event.preventDefault();
         }
-        {% block report_functions %}
-        {% endblock %}
+        // placeholder for report widget scripts injected by Django blocks
         $(function () {
             $(".available-widgets > ul").sortable({
                 handle: "div.panel div.panel-heading",


### PR DESCRIPTION
Disable Run button until at least one section is added to the report builder at `.../reports/builder`

Fixes #8687

<img width="441" height="385" alt="Screenshot 2025-10-16 202604" src="https://github.com/user-attachments/assets/09d4e91b-90c5-48b0-8b31-7b81be966dff" />
