### PR TITLE
Show unique id from tool together with hash_code in title elements

### DIFF
--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -664,7 +664,7 @@
                                                 title="Test: {{ finding.test }}">{{ finding.test.test_type }}</a>
                                             {% endif %}
                                         </td>
-                                        <td class="nowrap">
+                                        <td class="nowrap" title="unique_id_from_tool: {{ finding.unique_id_from_tool }}, hash_code: {{ finding.hash_code }}">
                                             {{ finding|finding_display_status|safe }}&nbsp;{{ finding|import_history }}
                                         </td>
                                         {% if system_settings.enable_jira %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -285,7 +285,7 @@
                 </tr>
                 <tr>
                     {% block header_body %}
-                        <td title="unique_id_from_tool: {{ finding.unique_id_from_tool }}, hash_code: {{ finding.hash_code }}"">{{ finding.id }}</td>
+                        <td title="unique_id_from_tool: {{ finding.unique_id_from_tool }}, hash_code: {{ finding.hash_code }}">{{ finding.id }}</td>
                         <td>
                             <span class="label severity severity-{{ finding.severity }}">
                                 {% if finding.severity %}

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -36,7 +36,7 @@
                             id="dropdownMenu1"
                             data-toggle="dropdown"
                             aria-expanded="true"
-                            aria-label="Test options"        
+                            aria-label="Test options"
                             >
                         <span class="fa-solid fa-bars"></span>
                         <span class="caret"></span>
@@ -697,7 +697,7 @@
                                 <input id="id_bulk_planned_remediation_version"
                                     name="planned_remediation_version"
                                     style="font-size: 100%; border: 1px solid #ccc;"/>
-                                <br/>        
+                                <br/>
                                 <label>
                                     <b>{% trans "Status" %}</b>
                                     <input id="id_bulk_status"
@@ -1238,7 +1238,7 @@
                                             {{ finding.reporter }}
                                         {% endif %}
                                     </td>
-                                    <td class="nowrap">
+                                    <td class="nowrap" title="unique_id_from_tool: {{ finding.unique_id_from_tool }}, hash_code: {{ finding.hash_code }}">
                                         {{ finding|finding_display_status|safe }}&nbsp;{{ finding|import_history }}
                                     </td>
                                     {% if system_settings.enable_jira %}


### PR DESCRIPTION
To help with understanding deduplication, the `hash_code` was already shown when hovering over the ID in the view finding screen. This PR adds the `unique_id_from_tool` to help the user understand deduplication. Both are also shown when hovering over the status in the list of findings.