### PR TITLE
github action: allow detect merge conflicts to fail

### DIFF
--- a/.github/workflows/detect-merge-conflicts.yaml
+++ b/.github/workflows/detect-merge-conflicts.yaml
@@ -7,7 +7,7 @@ on:
       - master
       - bugfix
       - release/*
-      
+
   pull_request_target:
     types: [synchronize]
 
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check if prs are conflicted
+        # we experience a high error rate so we allow this to fail but still have the check become green on the PR
+        continue-on-error: true
         uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
         with:
           dirtyLabel: "conflicts-detected"


### PR DESCRIPTION
The detect merge conflicts action is failing a lot or almost every time. I suggest we ignore these errors and allow PRs to be merged with a green state.