### PR TITLE
Fix service field overwrite issue #13461

### DIFF
--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -204,7 +204,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
             # scan_date was provided, override value from parser
             if self.scan_date_override:
                 unsaved_finding.date = self.scan_date.date()
-            if self.service is not None:
+            if self.service is not None and self.service != "":
                 unsaved_finding.service = self.service
 
             # Force parsers to use unsaved_tags (stored in below after saving)
@@ -343,7 +343,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         else:
             old_findings = old_findings.filter(test__engagement=self.test.engagement)
         # Use the service to differentiate further
-        if self.service is not None:
+        if self.service is not None and self.service != "":
             old_findings = old_findings.filter(service=self.service)
         else:
             old_findings = old_findings.filter(Q(service__isnull=True) | Q(service__exact=""))


### PR DESCRIPTION
**Description**

This PR fixes issue #13461 where the service field set by parsers (like Trivy) gets overwritten with an empty string when the field is not specified in the UI.

**Root Cause**
The problem occurred in `dojo/importers/default_importer.py` where the code checked `if self.service is not None:` before overwriting the finding's service field. When the UI form left the service field empty, it passed an empty string ("") to the importer, which is not None, so the condition was True and the parser's value was overwritten with the empty string.

**Solution**
Modified the condition in two locations to check both:
- `if self.service is not None and self.service != "":`

This ensures that:
1. If service is None (not provided), the parser's value is preserved
2. If service is an empty string (left empty in UI), the parser's value is preserved
3. If service is a non-empty string (explicitly set in UI), it overwrites the parser's value

**Changes**
- Modified `dojo/importers/default_importer.py` at lines 207 and 346
- Applied the fix to both `process_findings` and `close_old_findings` methods

**Test Results**
The fix addresses the core issue where empty service fields in the UI were overwriting parser values. This is important because the service field is used for deduplication.

**Impact**
This change ensures that when uploading reports via the UI (e.g., Trivy reports), leaving the service field empty will preserve the value set by the parser, rather than overwriting it with an empty string.

**Checklist**
- [x] Give a meaningful name to the PR
- [x] Code changes are minimal and focused
- [x] Bugfix submitted against appropriate branch