### PR TITLE
Implement authorization for class Risk_Acceptance

### DIFF
--- a/dojo/authorization/authorization.py
+++ b/dojo/authorization/authorization.py
@@ -23,6 +23,7 @@ from dojo.models import (
     Product_Type,
     Product_Type_Group,
     Product_Type_Member,
+    Risk_Acceptance,
     Stub_Finding,
     Test,
 )
@@ -95,6 +96,9 @@ def user_has_permission(user, obj, permission):
     if (
         isinstance(obj, Test)
         and permission in Permissions.get_test_permissions()
+    ) or (
+        isinstance(obj, Risk_Acceptance)
+        and permission == Permissions.Risk_Acceptance
     ):
         return user_has_permission(user, obj.engagement.product, permission)
     if ((


### PR DESCRIPTION
**Description**

This fixes #13468

Add condition to run `user_has_permission` for risk acceptance entities based on the product associated with the engagement of the accepted findings.

**Test results**

Successfully made all the API requests that were affected by the bug.
