### PR TITLE
scan_added_empty.tpl: fix symlink problem

### DIFF
--- a/dojo/templates/notifications/alert/scan_added_empty.tpl
+++ b/dojo/templates/notifications/alert/scan_added_empty.tpl
@@ -1,1 +1,1 @@
-{% include "notifications/alert/scan_added.tpl" %}
+{% include notifications/alert/scan_added.tpl %}


### PR DESCRIPTION
Fixes #13493 scan_added_empty had turned into a symlink to nothing. Fixed by adding original content.