### PR TITLE
Added Ability to Edit found_by value in API

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1779,16 +1779,14 @@ class FindingSerializer(serializers.ModelSerializer):
 
         # Get found_by from validated_data
         found_by = validated_data.pop("found_by", None)
-
         # Handle updates to found_by data
         if found_by:
-            instance.found_by.clear()
-            instance.found_by.add(*found_by)
+            instance.found_by.set(found_by)
         # If there is no argument entered for found_by, the user would like to clear out the values on the Finding's found_by field
         # Findings still maintain original found_by value associated with their test
-        else:
+        # In the event the user does not supply the found_by field at all, we do not modify it
+        elif isinstance(found_by, list) and len(found_by) == 0:
             instance.found_by.clear()
-
         instance = super().update(
             instance, validated_data,
         )


### PR DESCRIPTION
[sc-11934]

Tested and functional in API & Pro UI

**Not able to remove found_by value associated with finding's test.** 

- Ex: If finding was imported with Semgrep parser, you are unable to remove Semgrep from the found_by field. 
- A separate portion of code must check to make sure that this value is always present in found_by. 
- Let me know if you want me to look into this further and allow this functionality.