### PR TITLE
Update package versions for consistency by removing caret (^)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,18 +9,18 @@
       "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@docsearch/css": "^4.2.0",
-        "@docsearch/js": "^4.2.0",
-        "@tabler/icons": "^3.34.1",
-        "@thulite/doks-core": "^1.8.3",
-        "@thulite/images": "^3.3.1",
-        "@thulite/inline-svg": "^1.2.0",
-        "@thulite/seo": "^2.4.1",
-        "thulite": "^2.6.3"
+        "@docsearch/css": "4.2.0",
+        "@docsearch/js": "4.2.0",
+        "@tabler/icons": "3.35.0",
+        "@thulite/doks-core": "1.8.3",
+        "@thulite/images": "3.3.3",
+        "@thulite/inline-svg": "1.2.1",
+        "@thulite/seo": "2.4.2",
+        "thulite": "2.6.3"
       },
       "devDependencies": {
-        "prettier": "^3.6.2",
-        "vite": "^7.0.6"
+        "prettier": "3.6.2",
+        "vite": "7.1.11"
       },
       "engines": {
         "node": ">=20.11.0"
@@ -2120,7 +2120,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -2727,7 +2726,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3799,7 +3797,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4456,7 +4453,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4660,7 +4656,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,18 +16,18 @@
     "preview": "vite preview --outDir public"
   },
   "dependencies": {
-    "@docsearch/css": "^4.2.0",
-    "@docsearch/js": "^4.2.0",
-    "@tabler/icons": "^3.34.1",
-    "@thulite/doks-core": "^1.8.3",
-    "@thulite/images": "^3.3.1",
-    "@thulite/inline-svg": "^1.2.0",
-    "@thulite/seo": "^2.4.1",
-    "thulite": "^2.6.3"
+    "@docsearch/css": "4.2.0",
+    "@docsearch/js": "4.2.0",
+    "@tabler/icons": "3.35.0",
+    "@thulite/doks-core": "1.8.3",
+    "@thulite/images": "3.3.3",
+    "@thulite/inline-svg": "1.2.1",
+    "@thulite/seo": "2.4.2",
+    "thulite": "2.6.3"
   },
   "devDependencies": {
-    "prettier": "^3.6.2",
-    "vite": "^7.0.6"
+    "prettier": "3.6.2",
+    "vite": "7.1.11"
   },
   "engines": {
     "node": ">=20.11.0"


### PR DESCRIPTION
Standardize package versioning in `package.json` and `package-lock.json` by removing caret symbols to ensure consistent installations across environments.