### PR TITLE
feat(renovate): track oldest maintained k8s

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,15 @@
     "commitMessageSuffix": "({{packageFile}})",
     "labels": ["dependencies"]
   }],
+  "customDatasources": {
+    "endoflife-oldest-maintained": {
+      "defaultRegistryUrlTemplate": "https://endoflife.date/api/v1/products/{{packageName}}",
+      "format": "json",
+      "transformTemplates": [
+        "{ \"releases\": [$.result.releases[isMaintained = true]^(<eolFrom)[0].latest.{\"version\": name, \"releaseTimestamp\": date, \"changelogUrl\": link}], \"sourceUrl\": \"https://github.com/kubernetes/kubernetes\", \"homepage\": \"https://kubernetes.io/\" }"
+      ]
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -18,7 +18,7 @@ jobs:
           # are tested (https://kubernetes.io/releases/)
           - k8s: 'v1.34.0' # renovate: datasource=github-releases depName=kubernetes/kubernetes versioning=loose
             os: debian
-          - k8s: 'v1.31.13' # Do not track with renovate as we likely want to rev this manually
+          - k8s: 'v1.31.13' # renovate: datasource=custom.endoflife-oldest-maintained depName=kubernetes
             os: debian
     steps:
       - name: Checkout


### PR DESCRIPTION
Thanks to this PR, the oldest maintained version of k8s will be automatically updated (based on official information).

Local test-run offered following changes:
```json
{
 "depName": "kubernetes",
 "currentValue": "v1.31.12",
 "datasource": "custom.endoflife-oldest-maintained",
 "versioning": "semver",
 "replaceString": "k8s: 'v1.31.12' # renovate: datasource=custom.endoflife-oldest-maintained depName=kubernetes\n",
 "updates": [
   {
     "bucket": "minor",
     "newVersion": "1.32.9",
     "newValue": "1.32.9",
     "releaseTimestamp": "2025-09-09T00:00:00.000Z",
     "newVersionAgeInDays": 56,
     "newMajor": 1,
     "newMinor": 32,
     "newPatch": 9,
     "updateType": "minor",
     "isBreaking": false,
     "branchName": "renovate/kubernetes-1.x"
   }
 ],
 "packageName": "kubernetes",
 "warnings": [],
 "sourceUrl": "https://github.com/kubernetes/kubernetes",
 "homepage": "https://kubernetes.io/",
 "mostRecentTimestamp": "2025-09-09T00:00:00.000Z",
 "currentVersion": "v1.31.12",
 "isSingleVersion": true,
 "fixedVersion": "v1.31.12"
},
```