### PR TITLE
Remove prefetched tags in FindingViewSet

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -933,6 +933,8 @@ class FindingViewSet(
                 context={"request": request},
             )
             if finding_close.is_valid():
+                # Remove the prefetched tags to avoid issues with delegating to celery
+                finding.tags._remove_prefetched_objects()
                 # Use shared helper to perform close operations
                 finding_helper.close_finding(
                     finding=finding,


### PR DESCRIPTION
Eliminate prefetched tags to prevent issues with celery delegation during finding closure operations.

```python
[29/Oct/2025 17:45:00] DEBUG [dojo.decorators:76] dojo_async_task <@task: dojo.notifications.helper.send_mail_notification of dojo at 0x7ffffd054560>: running task in the background as user has not set block_execution to True for admin
[29/Oct/2025 17:45:00] ERROR [dojo.api_v2.exception_handler:49] Can't pickle <class 'dojo.models.Tagulous_Finding_tags'>: attribute lookup Tagulous_Finding_tags on dojo.models failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/kombu/serialization.py", line 41, in _reraise_errors
    yield
  File "/usr/local/lib/python3.12/site-packages/kombu/serialization.py", line 220, in dumps
    payload = encoder(data)
              ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kombu/serialization.py", line 347, in pickle_dumps
    return dumper(obj, protocol=pickle_protocol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_pickle.PicklingError: Can't pickle <class 'dojo.models.Tagulous_Finding_tags'>: attribute lookup Tagulous_Finding_tags on dojo.models failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/rest_framework/views.py", line 512, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/api_v2/views.py", line 937, in close
    finding_helper.close_finding(
  File "/app/dojo/finding/helper.py", line 822, in close_finding
    create_notification(
  File "/app/dojo/notifications/helper.py", line 81, in create_notification
    notification_manager_class().create_notification(
  File "/app/dojo/notifications/helper.py", line 636, in create_notification
    self._process_notifications(
  File "/app/dojo/notifications/helper.py", line 855, in _process_notifications
    self._get_manager_instance("mail").send_mail_notification(
  File "/app/dojo/decorators.py", line 103, in __wrapper__
    return func.apply_async(args=args, kwargs=kwargs, countdown=countdown)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/celery/app/task.py", line 601, in apply_async
    return app.send_task(
           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/celery/app/base.py", line 930, in send_task
    amqp.send_task_message(P, name, message, **options)
  File "/usr/local/lib/python3.12/site-packages/celery/app/amqp.py", line 523, in send_task_message
    ret = producer.publish(
          ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kombu/messaging.py", line 178, in publish
    body, content_type, content_encoding = self._prepare(
                                           ^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kombu/messaging.py", line 280, in _prepare
    body) = dumps(body, serializer=serializer)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kombu/serialization.py", line 219, in dumps
    with _reraise_errors(EncodeError):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/usr/local/lib/python3.12/site-packages/kombu/serialization.py", line 45, in _reraise_errors
    reraise(wrapper, wrapper(exc), sys.exc_info()[2])
  File "/usr/local/lib/python3.12/site-packages/kombu/exceptions.py", line 34, in reraise
    raise value.with_traceback(tb)
  File "/usr/local/lib/python3.12/site-packages/kombu/serialization.py", line 41, in _reraise_errors
    yield
  File "/usr/local/lib/python3.12/site-packages/kombu/serialization.py", line 220, in dumps
    payload = encoder(data)
              ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/kombu/serialization.py", line 347, in pickle_dumps
    return dumper(obj, protocol=pickle_protocol)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
kombu.exceptions.EncodeError: Can't pickle <class 'dojo.models.Tagulous_Finding_tags'>: attribute lookup Tagulous_Finding_tags on dojo.models failed
```

[sc-11996]