### PR TITLE
Handle missing severity field in CycloneDX parser

### DIFF
--- a/dojo/tools/cyclonedx/json_parser.py
+++ b/dojo/tools/cyclonedx/json_parser.py
@@ -36,7 +36,10 @@ class CycloneDXJSONParser:
             # better than always 'Medium'
             ratings = vulnerability.get("ratings")
             if ratings:
-                severity = ratings[0]["severity"]
+                # Determine if we can use the severity field
+                # In some cases, the severity field is missing, so we can rely on either the Medium severity
+                # or the CVSS vector (retrieved further down below) to determine the severity:
+                severity = ratings[0].get("severity", "Medium")
                 severity = Cyclonedxhelper().fix_severity(severity)
             else:
                 severity = "Medium"

--- a/unittests/scans/cyclonedx/no-severity.json
+++ b/unittests/scans/cyclonedx/no-severity.json
@@ -1,0 +1,35 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-10-28T14:38:10Z"
+  },
+  "vulnerabilities": [
+    {
+      "id": "CVE-2021-44228",
+      "source": {
+        "name": "NVD",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
+      },
+      "ratings": [
+        {
+          "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
+          },
+          "score": 10.0,
+          "method": "CVSSv3",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+        }
+      ],
+      "created": "2025-09-05T05:05:47Z",
+      "updated": "2025-03-03T16:51:00Z",
+      "affects": [
+        {
+          "ref": "gerbwetbqt"
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/tools/test_cyclonedx_parser.py
+++ b/unittests/tools/test_cyclonedx_parser.py
@@ -357,3 +357,17 @@ class TestCyclonedxParser(DojoTestCase):
                 self.assertIn(finding.severity, Finding.SEVERITIES)
                 finding.clean()
             self.assertEqual(1, len(findings))
+
+    def test_cyclonedx_no_severity(self):
+        """CycloneDX version 1.4 JSON format"""
+        with (get_unit_tests_scans_path("cyclonedx") / "no-severity.json").open(encoding="utf-8") as file:
+            parser = CycloneDXParser()
+            findings = parser.get_findings(file, Test())
+            self.assertEqual(1, len(findings))
+            finding = findings[0]
+            # There is so little information in the vulnerability, that we cannot build a proper title
+            self.assertEqual("None:None | CVE-2021-44228", finding.title)
+            self.assertEqual("Critical", finding.severity)
+            # The score will be evaluated when the finding save method is ran
+            # self.assertEqual(10.0, finding.cvssv3_score)
+            self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", finding.cvssv3)


### PR DESCRIPTION
Default the severity to "Medium" when the severity field is missing in the CycloneDX JSON input. Add a test case to verify this behavior with a sample JSON file lacking the severity field.