### PR TITLE
fix(helm/dependabot/renovate): Fix broken automatic update

### DIFF
--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -107,6 +107,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
   
       - name: Update values in HELM chart
         if: startsWith(github.head_ref, 'renovate/') || startsWith(github.head_ref, 'dependabot/')


### PR DESCRIPTION
Finish #13520
Fix #13530 & #13612
GHA is failing because action wasn't initialized correctly (https://github.com/DefectDojo/django-DefectDojo/actions/runs/19070470968/job/54486644356#step:4:21) - it needs to be checked out on the branch.