### PR TITLE
fix(helm/media-pvc): add root context access to some values

### DIFF
--- a/helm/defectdojo/templates/media-pvc.yaml
+++ b/helm/defectdojo/templates/media-pvc.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  {{- with .Values.extraAnnotations }}
+  {{- with $.Values.extraAnnotations }}
   annotations:
     {{- range $key, $value := . }}
     {{ $key }}: {{ quote $value }}
@@ -16,18 +16,18 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ include "defectdojo.chart" $ }}
-    {{- range $key, $value := .Values.extraLabels }}
+    {{- range $key, $value := $.Values.extraLabels }}
     {{ $key }}: {{ quote $value }}
     {{- end }}
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
 spec:
   accessModes: 
   {{- toYaml .persistentVolumeClaim.accessModes | nindent 4 }}
   resources:
     requests:
       storage: {{ .persistentVolumeClaim.size }}
-  {{- if .persistentVolumeClaim.storageClassName }}
+  {{- with .persistentVolumeClaim.storageClassName }}
   storageClassName: {{ .persistentVolumeClaim.storageClassName }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Fix for helm:
```sh
Error: INSTALLATION FAILED: template: defectdojo/templates/media-pvc.yaml:7:18: executing "defectdojo/templates/media-pvc.yaml" at <.Values.extraAnnotations>: nil pointer evaluating interface {}.extraAnnotations
helm.go:86: 2025-11-07 19:05:55.421875 +0100 CET m=+1.012420001 [debug] template: defectdojo/templates/media-pvc.yaml:7:18: executing "defectdojo/templates/media-pvc.yaml" at <.Values.extraAnnotations>: nil pointer evaluating interface {}.extraAnnotations
INSTALLATION FAILED
```