### PR TITLE
feat(renovate): track oldest maintained k8s

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,15 @@
     "matchPackageNames": "renovatebot/renovate",
     "schedule": ["* * * * 0"]
   }],
+  "customDatasources": {
+    "endoflife-oldest-maintained": {
+      "defaultRegistryUrlTemplate": "https://endoflife.date/api/v1/products/{{packageName}}",
+      "format": "json",
+      "transformTemplates": [
+        "{ \"releases\": [$.result.releases[isMaintained = true]^(<eolFrom)[0].latest.{\"version\": name, \"releaseTimestamp\": date, \"changelogUrl\": link}], \"sourceUrl\": \"https://github.com/kubernetes/kubernetes\", \"homepage\": \"https://kubernetes.io/\" }"
+      ]
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -18,7 +18,7 @@ jobs:
           # are tested (https://kubernetes.io/releases/)
           - k8s: 'v1.34.0' # renovate: datasource=github-releases depName=kubernetes/kubernetes versioning=loose
             os: debian
-          - k8s: 'v1.31.13' # Do not track with renovate as we likely want to rev this manually
+          - k8s: 'v1.31.13' # renovate: datasource=custom.endoflife-oldest-maintained depName=kubernetes
             os: debian
     steps:
       - name: Checkout


### PR DESCRIPTION
This is duplicity of #13545. But as soon as the config in `master` and `dev` is not the same, we can see Warnings like:

> Some dependencies could not be looked up. Check the Dependency Dashboard for more information.

And 

>Renovate failed to look up the following dependencies: Failed to look up custom.endoflife-oldest-maintained package kubernetes.
> Files affected: .github/workflows/k8s-tests.yml

By merging this to the `master` sooner, warnings should disappear.