### PR TITLE
reimport: support pro compute hash code method

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -772,4 +772,6 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         self,
         unsaved_finding: Finding,
     ) -> str:
+        # this is overridden in Pro, but will still call this via super()
+        deduplicationLogger.debug("Calculating hash code for unsaved finding")
         return unsaved_finding.compute_hash_code()

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2908,6 +2908,11 @@ class Finding(models.Model):
         return None
 
     def compute_hash_code(self):
+        # Allow Pro to overwrite compute hash_code which gets dedupe settings from a database instead of django.settings
+        from dojo.utils import get_custom_method  # noqa: PLC0415 circular import
+        if compute_hash_code_method := get_custom_method("FINDING_COMPUTE_HASH_METHOD"):
+            deduplicationLogger.debug("using custom compute_hash_code method")
+            return compute_hash_code_method(self)
 
         # Check if all needed settings are defined
         if not hasattr(settings, "HASHCODE_FIELDS_PER_SCANNER") or not hasattr(settings, "HASHCODE_ALLOWS_NULL_CWE") or not hasattr(settings, "HASHCODE_ALLOWED_FIELDS"):


### PR DESCRIPTION
Pro uses a custom implementation for hashing as it stores its settings differently and has some extra hash_code fields. The reimporter was not using this when calculating hashes, causing deduplication to fail for **findings that are _created_ during a reimport**.