### PR TITLE
feat(renovate): Wait 2 days to use latest k8s

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,17 @@
     "matchDatasources": "github-releases",
     "matchPackageNames": "renovatebot/renovate",
     "schedule": ["* * * * 0"]
+  },{
+    "description": "Minikube does not like freshly released k8s. We need to wait some time so it will be adopted",
+    "matchDatasources": [
+      "custom.endoflife-oldest-maintained",
+      "github-releases"
+    ],
+    "matchPackageNames": [
+      "kubernetes",
+      "kubernetes/kubernetes"
+    ],
+    "minimumReleaseAge": "2 days"
   }],
   "customDatasources": {
     "endoflife-oldest-maintained": {


### PR DESCRIPTION
When a new k8s is released, tests with Minikube are failing because it is not fully ready to use the latest version. If Renovate waits 2 days, nothing critical will happen, and the review process will be much smoother (no need to troubleshoot why tests are failing).