### PR TITLE
fix(importers): keep dedup stats in sync with API responses

### DIFF
--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -157,6 +157,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         parsed_findings: list[Finding],
         **kwargs: dict,
     ) -> list[Finding]:
+        sync_requested = kwargs.get("sync", True)
         # Progressive batching for chord execution
         post_processing_task_signatures = []
         current_batch_number = 1
@@ -253,7 +254,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
             post_processing_task_signatures.append(post_processing_task_signature)
 
             # Check if we should launch a chord (batch full or end of findings)
-            if we_want_async(async_user=self.user) and post_processing_task_signatures:
+            if we_want_async(async_user=self.user, sync=sync_requested) and post_processing_task_signatures:
                 post_processing_task_signatures, current_batch_number, _ = self.maybe_launch_post_processing_chord(
                     post_processing_task_signatures,
                     current_batch_number,
@@ -283,8 +284,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         # Always perform an initial grading, even though it might get overwritten later.
         perform_product_grading(self.test.engagement.product)
 
-        sync = kwargs.get("sync", True)
-        if not sync:
+        if not sync_requested:
             return [serialize("json", [finding]) for finding in new_findings]
         return new_findings
 

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -164,6 +164,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         the finding may be appended to a new or existing group based upon user selection
         at import time
         """
+        sync_requested = kwargs.get("sync", True)
         self.deduplication_algorithm = self.determine_deduplication_algorithm()
         # Only process findings with the same service value (or None)
         # Even though the service values is used in the hash_code calculation,
@@ -271,7 +272,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                 post_processing_task_signatures.append(post_processing_task_signature)
 
             # Check if we should launch a chord (batch full or end of findings)
-            if we_want_async(async_user=self.user) and post_processing_task_signatures:
+            if we_want_async(async_user=self.user, sync=sync_requested) and post_processing_task_signatures:
                 post_processing_task_signatures, current_batch_number, _ = self.maybe_launch_post_processing_chord(
                     post_processing_task_signatures,
                     current_batch_number,
@@ -772,6 +773,4 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         self,
         unsaved_finding: Finding,
     ) -> str:
-        # this is overridden in Pro, but will still call this via super()
-        deduplicationLogger.debug("Calculating hash code for unsaved finding")
         return unsaved_finding.compute_hash_code()


### PR DESCRIPTION
### Description

**Type:** bugfix
**Base branch:** bugfix
**Scope / Area:** importers

---

### Problem (what’s wrong)

As an API consumer I expect import post-processing (dedup, rules) to complete before the response is serialized so the counts match what the UI later shows. Currently `/api/v2/import-scan` and `/api/v2/reimport-scan` can return “new” findings that are immediately flipped to duplicates once Celery finishes, so before/after/delta disagree with the final state.

---

### Evidence (API vs UI)

<details>
  <summary>Immediate API Response</summary>
  
```json
"after": {
  "info": {
    "active": 0,
    "verified": 0,
    "duplicate": 0,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 0
  },
  "low": {
    "active": 2,
    "verified": 2,
    "duplicate": 0,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 2
  },
  "medium": {
    "active": 5,
    "verified": 5,
    "duplicate": 4,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 9
  },
  "high": {
    "active": 1,
    "verified": 1,
    "duplicate": 3,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 4
  },
  "critical": {
    "active": 0,
    "verified": 0,
    "duplicate": 1,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 1
  },
  "total": {
    "active": 8,
    "verified": 8,
    "duplicate": 8,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 16
  }
}
```

</details>

<details>
  <summary>Actual final result</summary>
  
  <img width="225" height="697" alt="image" src="https://github.com/user-attachments/assets/c0517eeb-fcd3-4a8e-83af-2b84a62dc1a1" />

</details>

---

### Steps to Reproduce

1. Import or re-import a scan through the API using default user settings.
2. Include findings that should deduplicate.
3. Observe that the API response lists them as new, but after a short delay the UI/test history shows them as duplicates.

---

### Root Cause (why it happens)

DefaultImporter and DefaultReImporter ignore the incoming `sync` kwarg when calling `we_want_async(...)`. Even when callers explicitly request synchronous mode, post-processing is dispatched to Celery and finishes after the serializer has already read `Test_Import.statistics`.

---

### Fix (what changed)

`dojo/importers/default_importer.py`, `dojo/importers/default_reimporter.py`: cache `sync` as `sync_requested`, pass it to `we_want_async(...)`, and reuse it when deciding how to return the result. When `sync=True`, post-processing now stays inline so statistics always reflect the final deduped state. No API schema or behavior changes beyond improved consistency.

---

### Impact / Risk

Touches import/reimport dedup flows. Main risk is around async scheduling, but async callers keep the existing behavior.

---

### Test Results

**Automated**

* Tests added/updated: no

**Local run:**

```bash
docker compose build && docker compose up -d
docker compose exec uwsgi bash -lc "python manage.py test unittests.test_importers_deduplication --keepdb"
```

Result: OK (50 tests)

**Manual validation**

Scenarios validated:

* Import scan with duplicate findings via `/api/v2/import-scan/` and `sync=true`: API now returns counts that match the test’s final deduped state.
* Reimport scan with duplicate findings via `/api/v2/reimport-scan/`: statistics in the JSON response equal what UI shows immediately after the call.


<details>
  <summary>API Response after fix</summary>

```json
"after": {
  "info": {
    "active": 0,
    "verified": 0,
    "duplicate": 0,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 0
  },
  "low": {
    "active": 0,
    "verified": 0,
    "duplicate": 2,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 2
  },
  "medium": {
    "active": 0,
    "verified": 0,
    "duplicate": 9,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 9
  },
  "high": {
    "active": 0,
    "verified": 0,
    "duplicate": 4,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 4
  },
  "critical": {
    "active": 0,
    "verified": 0,
    "duplicate": 1,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 1
  },
  "total": {
    "active": 0,
    "verified": 0,
    "duplicate": 16,
    "false_p": 0,
    "out_of_scope": 0,
    "is_mitigated": 0,
    "risk_accepted": 0,
    "total": 16
  }
}
```

</details>

---

### Documentation

* Docs updates needed? no
* Release notes: `fix(importers): API statistics now reflect deduplicated results when sync execution is requested`