### PR TITLE
feat(renovate): Do not split updates for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,7 @@
     "description": "Update renovate weekly (sundays) - They are releasing new versions too often, so it is a bit noisy, and keeping renovating a bit older does not create vulnerabilities in DD",
     "matchDatasources": "github-releases",
     "matchPackageNames": "renovatebot/renovate",
+    "separateMinorPatch": false,
     "schedule": ["* * * * 0"]
   },{
     "description": "Minikube does not like freshly released k8s. We need to wait some time so it will be adopted",


### PR DESCRIPTION
If there is a quite high cadence of releases of Renovate and we are updating it weekly, it does not make sense to open 2 PR for them. Like:
- https://github.com/DefectDojo/django-DefectDojo/pull/13712
- https://github.com/DefectDojo/django-DefectDojo/pull/13713

One is enough