### PR TITLE
Add boto3 dependency to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     versions:
     - ">= 5.a"
     - "< 6"
+  - dependency-name: boto3
+    update-types: ["version-update:semver-minor"]
 - package-ecosystem: npm
   directory: "/components"
   schedule:


### PR DESCRIPTION
We are approving a boto3 rev almost every single day at this point. Let's skip the patches and only focus on the minor revs