### PR TITLE
Add python-logstash for ELK logging configuration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,4 @@ PyYAML==6.0.3
 pyopenssl==25.3.0
 parameterized==0.9.0
 setuptools==80.9.0
+python-logstash==0.4.8 # Required to configure logstash logging to elk


### PR DESCRIPTION
**Description**

Currently, logs are being sent tothe  console using StreamLogger. We would like to send the logs to our ELK stack so we can better investigate on them. To configure it for Django apps there is this [answer from elk support](https://discuss.elastic.co/t/configure-elasticsearch-on-django-app/326320). Nevertheless, after following the proposal we got the following exception starting up the application
`ModuleNotFoundError: No module named ‘logstash’` 

**Resolution**

Add python-logstash library to the requirements when we build the image.


