### PR TITLE
docs: Update number of concurrent connections for uWSGI

### DIFF
--- a/docs/content/en/open_source/installation/running-in-production.md
+++ b/docs/content/en/open_source/installation/running-in-production.md
@@ -53,7 +53,7 @@ Media files for uploaded files, including threat models and risk acceptance, are
 ### uWSGI
 
 By default (except in `ptvsd` mode for debug purposes), uWSGI will
-handle 4 concurrent connections.
+handle 16 concurrent connections.
 
 Based on your resource settings, you can tweak:
 


### PR DESCRIPTION
**Description**

Changed the stated number of concurrent connections handled bb uWSGI by default.

Assuming the default values for `DD_UWSGI_NUM_OF_PROCESSES` and `DD_UWSGI_NUM_OF_THREADS` stated is correct (4 for both), then the number of concurrent connections should be 4*4 or 16. But the documentation indicates only 4.

Some resources:
- https://dev.to/devaaai/guide-to-tuning-your-uwsgi-server-for-optimal-performance-32oj
- https://serverfault.com/a/542723

I first discussed this [on Slack](https://owasp.slack.com/archives/C2P5BA8MN/p1763560864336219).

**Test results**

Haven't run the tests as the PR is really simple.

**Documentation**

This is the point of this PR.

**Checklist**

This checklist is for your information.

- [X] Make sure to rebase your PR against the very latest `dev`.
- [X] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [X] Your code is flake8 compliant.
- [X] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [X] Add the proper label to categorize your PR.

~docs
