### PR TITLE
Add path filter for docs in gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,8 +3,11 @@ name: github-pages
 on:
   workflow_dispatch:
   push:
+    paths:
+      - 'docs/**'
     branches:
       - master
+      - bugfix
 
 # Taken from https://github.com/marketplace/actions/hugo-setup#%EF%B8%8F-workflow-for-autoprefixer-and-postcss-cli
 # Both builds have to be one worflow as otherwise one publish will overwrite the other


### PR DESCRIPTION
Publish documentation on pushes to bugfix in addition to master. This will be useful for fixing urgent documentation issues without waiting for a week for the next bugfix release
