### PR TITLE
fix: enable uwsgi DD_UWSGI_EXTRA_ARGS passthrough

### DIFF
--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -27,9 +27,9 @@ python3 manage.py check
 
 DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
 
-EXTRA_ARGS="${EXTRA_ARGS:-}"
+DD_UWSGI_EXTRA_ARGS="${DD_UWSGI_EXTRA_ARGS:-}"
 if [ -n "${DD_UWSGI_MAX_FD}" ]; then
-    EXTRA_ARGS="${EXTRA_ARGS} --max-fd ${DD_UWSGI_MAX_FD}"
+    DD_UWSGI_EXTRA_ARGS="${DD_UWSGI_EXTRA_ARGS} --max-fd ${DD_UWSGI_MAX_FD}"
 fi
 
 exec uwsgi \
@@ -42,5 +42,5 @@ exec uwsgi \
   --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
   --http 0.0.0.0:8081 --http-to "${DD_UWSGI_ENDPOINT}" \
   --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}" \
-  $EXTRA_ARGS
+  $DD_UWSGI_EXTRA_ARGS
   # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.


### PR DESCRIPTION
### **Description**
Prevent resetting `DD_UWSGI_EXTRA_ARGS` variable in uwsgi entry point

### **What problem does it solve?**
Allows you to passthrough your startup parameters to the uwsgi binary