### PR TITLE
JIRA: add retry/rate limit support

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -433,14 +433,19 @@ def has_jira_configured(obj):
 
 
 def connect_to_jira(jira_server, jira_username, jira_password):
+    max_retries = getattr(settings, "JIRA_MAX_RETRIES", 3)
+    timeout = getattr(settings, "JIRA_TIMEOUT", (10, 30))
+
     return JIRA(
         server=jira_server,
         basic_auth=(jira_username, jira_password),
-        max_retries=0,
+        max_retries=max_retries,
+        timeout=timeout,
         options={
             "verify": settings.JIRA_SSL_VERIFY,
             "headers": settings.ADDITIONAL_HEADERS,
-        })
+        },
+    )
 
 
 def get_jira_connect_method():

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -249,6 +249,16 @@ env = environ.FileAwareEnv(
     # When interacting with jira tickets that attached finding groups, we should no be opening any findings
     # on the DefectDojo side because jira has no way of knowing if a finding really should be reopened or not
     DD_JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN=(bool, False),
+    # JIRA connection retry and timeout settings: https://developer.atlassian.com/cloud/jira/platform/rate-limiting/
+    # Maximum number of retry attempts for recoverable errors (429, 503, ConnectionError)
+    # See https://jira.readthedocs.io/ for more in the jira library used by DefectDojo
+    # Note: The jira library has a built-in maximum wait time of 60s for rate limiting retries.
+    # If JIRA's Retry-After header indicates a wait time longer than 60s, the request will fail and not be retried.
+    DD_JIRA_MAX_RETRIES=(int, 3),
+    # Connection timeout (seconds) for establishing a connection to the JIRA server
+    DD_JIRA_CONNECT_TIMEOUT=(int, 10),
+    # Read timeout (seconds) for waiting for a response from the JIRA server
+    DD_JIRA_READ_TIMEOUT=(int, 30),
     # You can set extra Jira issue types via a simple env var that supports a csv format, like "Work Item,Vulnerability"
     DD_JIRA_EXTRA_ISSUE_TYPES=(str, ""),
     # if you want to keep logging to the console but in json format, change this here to 'json_console'
@@ -1714,6 +1724,12 @@ if env("DD_JIRA_EXTRA_ISSUE_TYPES"):
 JIRA_SSL_VERIFY = env("DD_JIRA_SSL_VERIFY")
 JIRA_DESCRIPTION_MAX_LENGTH = env("DD_JIRA_DESCRIPTION_MAX_LENGTH")
 JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN = env("DD_JIRA_WEBHOOK_ALLOW_FINDING_GROUP_REOPEN")
+# JIRA connection retry and timeout settings
+JIRA_MAX_RETRIES = env("DD_JIRA_MAX_RETRIES")
+JIRA_CONNECT_TIMEOUT = env("DD_JIRA_CONNECT_TIMEOUT")
+JIRA_READ_TIMEOUT = env("DD_JIRA_READ_TIMEOUT")
+# Combine timeouts into a tuple for the JIRA library: (connect_timeout, read_timeout)
+JIRA_TIMEOUT = (JIRA_CONNECT_TIMEOUT, JIRA_READ_TIMEOUT)
 
 # ------------------------------------------------------------------------------
 # LOGGING


### PR DESCRIPTION
fixes #13769

# Enable JIRA Connection Retries and Rate Limiting Support

<img width="1111" height="314" alt="image" src="https://github.com/user-attachments/assets/6d339e19-b14a-48a5-90e9-74a2059d937e" />


## Summary

This PR enables configurable retry and timeout settings for JIRA connections to handle rate limiting (HTTP 429) and connection errors gracefully. Previously, JIRA connections had retries disabled (`max_retries=0`), causing immediate failures on rate limits or transient network issues.

## Changes

### Configuration

Added three new environment variables:

- **`DD_JIRA_MAX_RETRIES`** (default: `3`): Maximum number of retry attempts for recoverable errors (429, 503, ConnectionError)
- **`DD_JIRA_CONNECT_TIMEOUT`** (default: `10` seconds): Connection timeout for establishing a connection to the JIRA server
- **`DD_JIRA_READ_TIMEOUT`** (default: `30` seconds): Read timeout for waiting for a response from the JIRA server

## Technical Details

### Retry Behavior

The jira library automatically retries on:
- HTTP 429 (Too Many Requests) - Rate limiting
- HTTP 503 (Service Unavailable) - Temporary server errors
- ConnectionError - Network connectivity issues

## Migration Notes

No migration required. The new settings use sensible defaults that match the previous behavior for retries (now enabled with 3 retries instead of 0) and add timeout configuration.

## Testing

Tested with:
- Management command to push finding 1 finding 500 times with 10 parallel celery workers

```
celeryworker-10     | [29/Nov/2025 13:30:49] WARNING [jira.resilientsession:381] Request rate limited by Jira. Request should be retried after 1 seconds.
celeryworker-10     | [29/Nov/2025 13:30:49] WARNING [jira.resilientsession:334] Got recoverable error from GET https://xx.atlassian.net/rest/api/2/issue/22871, will retry [1/3] in 1.5314574809826222s. Err: 429 Too Many Requests
celeryworker-6      | [29/Nov/2025 13:30:50] WARNING [jira.resilientsession:381] Request rate limited by Jira. Request should be retried after 1 seconds.
celeryworker-6      | [29/Nov/2025 13:30:50] WARNING [jira.resilientsession:334] Got recoverable error from GET https://xxx.atlassian.net/rest/api/2/issue/22871, will retry [1/3] in 1.8632971142324433s. Err: 429 Too Many Requests
celeryworker-9      | [29/Nov/2025 13:30:49] WARNING [jira.resilientsession:381] Request rate limited by Jira. Request should be retried after 1 seconds.
celeryworker-9      | [29/Nov/2025 13:30:49] WARNING [jira.resilientsession:334] Got recoverable error from GET https://xx.atlassian.net/rest/api/2/issue/22871, will retry [1/3] in 1.635605867089348s. Err: 429 Too Many Requests
```

## Future improvements
If we encounter retry delays of over 60s, we may consider adding another layer of retries in our celery task where we just reschedule the task with a delay. This avoids blocking other waiting tasks, but has other challenges. 