### PR TITLE
UI: Add AND logic for tag filtering

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -532,23 +532,68 @@ class FindingTagFilter(DojoFilter):
         field_name="tags__name",
         to_field_name="name",
         queryset=Finding.tags.tag_model.objects.all().order_by("name"),
-        help_text="Filter Findings by the selected tags")
+        help_text="Filter Findings by the selected tags (OR logic)",
+    )
+
+    tags_and = ModelMultipleChoiceFilter(
+        field_name="tags__name",
+        to_field_name="name",
+        queryset=Finding.tags.tag_model.objects.all().order_by("name"),
+        help_text="Filter Findings by the selected tags (AND logic)",
+        label="Tags (AND)",
+        conjoined=True,
+    )
+
     test__tags = ModelMultipleChoiceFilter(
         field_name="test__tags__name",
         to_field_name="name",
         queryset=Test.tags.tag_model.objects.all().order_by("name"),
-        help_text="Filter Tests by the selected tags")
+        help_text="Filter Findings by the selected Test tags (OR logic)",
+        label="Test Tags",
+    )
+
+    test__tags_and = ModelMultipleChoiceFilter(
+        field_name="test__tags__name",
+        to_field_name="name",
+        queryset=Test.tags.tag_model.objects.all().order_by("name"),
+        help_text="Filter Findings by the selected Test tags (AND logic)",
+        label="Test Tags (AND)",
+        conjoined=True,
+    )
+
     test__engagement__tags = ModelMultipleChoiceFilter(
         field_name="test__engagement__tags__name",
         to_field_name="name",
         queryset=Engagement.tags.tag_model.objects.all().order_by("name"),
-        help_text="Filter Engagements by the selected tags")
+        help_text="Filter Findings by the selected Engagement tags (OR logic)",
+        label="Engagement Tags",
+    )
+
+    test__engagement__tags_and = ModelMultipleChoiceFilter(
+        field_name="test__engagement__tags__name",
+        to_field_name="name",
+        queryset=Engagement.tags.tag_model.objects.all().order_by("name"),
+        help_text="Filter Findings by the selected Engagement tags (AND logic)",
+        label="Engagement Tags (AND)",
+        conjoined=True,
+    )
+
     test__engagement__product__tags = ModelMultipleChoiceFilter(
         field_name="test__engagement__product__tags__name",
         to_field_name="name",
         queryset=Product.tags.tag_model.objects.all().order_by("name"),
-        label=labels.ASSET_FILTERS_TAGS_FILTER_LABEL,
-        help_text=labels.ASSET_FILTERS_TAGS_FILTER_HELP)
+        help_text="Filter Findings by the selected Product tags (OR logic)",
+        label="Product Tags",
+    )
+
+    test__engagement__product__tags_and = ModelMultipleChoiceFilter(
+        field_name="test__engagement__product__tags__name",
+        to_field_name="name",
+        queryset=Product.tags.tag_model.objects.all().order_by("name"),
+        help_text="Filter Findings by the selected Product tags (AND logic)",
+        label="Product Tags (AND)",
+        conjoined=True,
+    )
 
     not_tags = ModelMultipleChoiceFilter(
         field_name="tags__name",


### PR DESCRIPTION
Closes #13555

I have applied logic to filters.py, where OR logic is present. Review and address any required revisions. 

I have kept the existing code as is, so there are now two logics for filter OR and AND with label Tags (AND)

> I closed the previous PR as there were conflicts when I was asked to change the base, and to resolve those, I committed multiple times, and it looked quite messy.

**Test results**

Have performed manual verification using the UI with a local development instance:

<img width="376" height="531" alt="Screenshot 2025-11-29 163131" src="https://github.com/user-attachments/assets/989cf97f-0248-4925-91a6-eda94fa7cc23" /> 

**Setup:** Created findings with various tag combinations (e.g., `pci`, `pentest`, and `cloud`).
**Action:** Tested the new `Tags (AND)` filter with `pci` and `pentest`.. 
**Result:** The new filter works as expected without disrupting the existing functionality.

**Documentation**
N/A (UI enhancement).