### PR TITLE
[Docs] Changes Group.Read.All to GroupMember.Read.All in docs

### DIFF
--- a/docs/content/en/customize_dojo/user_management/configure_sso.md
+++ b/docs/content/en/customize_dojo/user_management/configure_sso.md
@@ -133,7 +133,7 @@ The Azure AD token need to be configured to include Group IDs. Without this step
 To update the format of the token, add a [Group Claim](https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-fed-group-claims) that applies to whatever Group type you are using.
 If unsure of what type that is, select `All Groups`. Do not activate `Emit groups as role claims` within the Azure AD "Token configuration" page.
 
-Application API permissions need to be updated with the `Group.Read.All` permission so that groups can be read on behalf of the user that has successfully signed in.
+Application API permissions need to be updated with the `GroupMember.Read.All` permission so that groups can be read on behalf of the user that has successfully signed in.
 
 ##### Group Cleaning
 
@@ -169,7 +169,7 @@ The Azure AD token returned by Azure will also need to be configured to include 
 
 If unsure of what type that is, select `All Groups`. Do not activate `Emit groups as role claims` within the Azure AD "Token configuration" page.
 
-Application API permissions need to be updated with the `Group.Read.All` permission so that groups can be read on behalf of the user that has successfully signed in.
+Application API permissions need to be updated with the `GroupMember.Read.All` permission so that groups can be read on behalf of the user that has successfully signed in.
 
 To limit the amount of groups imported from Azure AD, a regular expression can be used as the following:
 


### PR DESCRIPTION
**Description**

This PR changes the recommended Entra Id API permission from Group.Read.All to GroupMember.Read.All. The reason for this is that with Group.* permission the application can also access MS Teams APIs (see [here](https://graphpermissions.merill.net/permission/Group.Read.All). For least privileges it is better to use the GroupMember.Read.All permission. This permission still allows to read basic group properties and group member (see [here](https://graphpermissions.merill.net/permission/GroupMember.Read.All)) but prevents the application from reading e.g., Teams chats or shared files.

- Group.Read.All: "Allows the app to list groups, and to read their properties and all group memberships on behalf of the signed-in user. Also allows the app to read calendar, conversations, files, and other group content for all groups the signed-in user can access."
- GroupMember.Read.All: "Allows the app to list groups, read basic group properties and read membership of all groups the signed-in user has access to."

