### PR TITLE
fix(helm): Drop djnago.mediaPersistentVolume.fsGroup

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -34,4 +34,6 @@ dependencies:
 #     description: Critical bug
 annotations:
   artifacthub.io/prerelease: "true"
-  artifacthub.io/changes: ""
+  artifacthub.io/changes: |
+    - kind: deprecated
+      description: djnago.mediaPersistentVolume.fsGroup was removed because it was replaced with django.podSecurityContext.fsGroup

--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -623,7 +623,7 @@ A Helm chart for Kubernetes to install DefectDojo
 | django.ingress.enabled | bool | `true` |  |
 | django.ingress.ingressClassName | string | `""` |  |
 | django.ingress.secretName | string | `"defectdojo-tls"` |  |
-| django.mediaPersistentVolume | object | `{"enabled":true,"fsGroup":1001,"name":"media","persistentVolumeClaim":{"accessModes":["ReadWriteMany"],"create":false,"name":"","size":"5Gi","storageClassName":""},"type":"emptyDir"}` | This feature needs more preparation before can be enabled, please visit KUBERNETES.md#media-persistent-volume |
+| django.mediaPersistentVolume | object | `{"enabled":true,"name":"media","persistentVolumeClaim":{"accessModes":["ReadWriteMany"],"create":false,"name":"","size":"5Gi","storageClassName":""},"type":"emptyDir"}` | This feature needs more preparation before can be enabled, please visit KUBERNETES.md#media-persistent-volume |
 | django.mediaPersistentVolume.name | string | `"media"` | any name |
 | django.mediaPersistentVolume.persistentVolumeClaim | object | `{"accessModes":["ReadWriteMany"],"create":false,"name":"","size":"5Gi","storageClassName":""}` | in case if pvc specified, should point to the already existing pvc |
 | django.mediaPersistentVolume.persistentVolumeClaim.accessModes | list | `["ReadWriteMany"]` | check KUBERNETES.md doc first for option to choose |

--- a/helm/defectdojo/values.schema.json
+++ b/helm/defectdojo/values.schema.json
@@ -539,9 +539,6 @@
                         "enabled": {
                             "type": "boolean"
                         },
-                        "fsGroup": {
-                            "type": "integer"
-                        },
                         "name": {
                             "description": "any name",
                             "type": "string"

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -495,7 +495,6 @@ django:
   # -- This feature needs more preparation before can be enabled, please visit KUBERNETES.md#media-persistent-volume
   mediaPersistentVolume:
     enabled: true
-    fsGroup: 1001
     # -- any name
     name: media
     # -- could be emptyDir (not for production) or pvc


### PR DESCRIPTION
During investigation of https://owasp.slack.com/archives/C2P5BA8MN/p1764769477266379?thread_ts=1764760595.773229&cid=C2P5BA8MN
I noticed that one value is not used in templates anymore because it was replaced.
