### PR TITLE
fix(unittest): avoid ResourceWarning: unclosed file

### DIFF
--- a/unittests/tools/test_snyk_issue_api_parser_with_json.py
+++ b/unittests/tools/test_snyk_issue_api_parser_with_json.py
@@ -7,9 +7,9 @@ from unittests.dojo_test_case import DojoTestCase, get_unit_tests_scans_path
 
 class TestSnykIssueApiParserWithJson(DojoTestCase):
     def parse_json(self, filename):
-        testfile = (get_unit_tests_scans_path("snyk_issue_api") / filename).open(encoding="utf-8")
-        parser = SnykIssueApiParser()
-        return parser.get_findings(testfile, Test())
+        with (get_unit_tests_scans_path("snyk_issue_api") / filename).open(encoding="utf-8") as testfile:
+            parser = SnykIssueApiParser()
+            return parser.get_findings(testfile, Test())
 
     def test_parse_sca_single_finding(self):
         findings = self.parse_json("snyk_sca_scan_api_single_vuln.json")


### PR DESCRIPTION
Avoid warnings like:
```

2025-12-05T17:58:52.3074364Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3075193Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 492, in test_deduplication_fields_match_other_snyk_scans_for_code
2025-12-05T17:58:52.3076283Z uwsgi-1  |     findings = self.parse_json("snyk_code_scan_api_many_vuln.json")
2025-12-05T17:58:52.3077462Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3107713Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3108828Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3110098Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 482, in test_deduplication_fields_match_other_snyk_scans_for_sca
2025-12-05T17:58:52.3111380Z uwsgi-1  |     findings = self.parse_json("snyk_sca_scan_api_many_vuln.json")
2025-12-05T17:58:52.3112755Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3140285Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3141511Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3142545Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 27, in test_parse_code_finding_csrf_open
2025-12-05T17:58:52.3143476Z uwsgi-1  |     findings = self.parse_json("snyk_code_scan_api_many_vuln.json")
2025-12-05T17:58:52.3144563Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3172041Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3173381Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3174536Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 124, in test_parse_code_finding_hardcoded_password_temp_ignored
2025-12-05T17:58:52.3175863Z uwsgi-1  |     findings = self.parse_json("snyk_code_scan_api_many_vuln.json")
2025-12-05T17:58:52.3177315Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3202148Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3203902Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3205119Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 83, in test_parse_code_finding_xss_ignored
2025-12-05T17:58:52.3206315Z uwsgi-1  |     findings = self.parse_json("snyk_code_scan_api_many_vuln.json")
2025-12-05T17:58:52.3207262Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3234193Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3235304Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3236235Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 23, in test_parse_code_findings_count
2025-12-05T17:58:52.3237322Z uwsgi-1  |     findings = self.parse_json("snyk_code_scan_api_many_vuln.json")
2025-12-05T17:58:52.3238744Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_code_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3270995Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3271967Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3272544Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 19, in test_parse_sca_finding_count
2025-12-05T17:58:52.3273160Z uwsgi-1  |     findings = self.parse_json("snyk_sca_scan_api_many_vuln.json")
2025-12-05T17:58:52.3273943Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3307060Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3308281Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3309326Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 234, in test_parse_sca_findings_status_ignored_not_vuln
2025-12-05T17:58:52.3310794Z uwsgi-1  |     findings = self.parse_json("snyk_sca_scan_api_many_vuln.json")
2025-12-05T17:58:52.3312209Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3341963Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3343169Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3344300Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 298, in test_parse_sca_findings_status_ignored_temporary
2025-12-05T17:58:52.3345973Z uwsgi-1  |     findings = self.parse_json("snyk_sca_scan_api_many_vuln.json")
2025-12-05T17:58:52.3347247Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3379015Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3380334Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3381301Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 167, in test_parse_sca_findings_status_open
2025-12-05T17:58:52.3382000Z uwsgi-1  |     findings = self.parse_json("snyk_sca_scan_api_many_vuln.json")
2025-12-05T17:58:52.3382764Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3413677Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3414775Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3415769Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 416, in test_parse_sca_findings_status_resolved
2025-12-05T17:58:52.3416860Z uwsgi-1  |     findings = self.parse_json("snyk_sca_scan_api_many_vuln.json")
2025-12-05T17:58:52.3417877Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3450418Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3451821Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3452907Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 357, in test_parse_sca_findings_status_wont_be_fixed
2025-12-05T17:58:52.3453879Z uwsgi-1  |     findings = self.parse_json("snyk_sca_scan_api_many_vuln.json")
2025-12-05T17:58:52.3454658Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_many_vuln.json' mode='r' encoding='utf-8'>
2025-12-05T17:58:52.3478165Z uwsgi-1  | .Exception ignored in: <_io.FileIO name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_single_vuln.json' mode='rb' closefd=True>
2025-12-05T17:58:52.3479232Z uwsgi-1  | Traceback (most recent call last):
2025-12-05T17:58:52.3480460Z uwsgi-1  |   File "/app/unittests/tools/test_snyk_issue_api_parser_with_json.py", line 15, in test_parse_sca_single_finding
2025-12-05T17:58:52.3481628Z uwsgi-1  |     findings = self.parse_json("snyk_sca_scan_api_single_vuln.json")
2025-12-05T17:58:52.3482986Z uwsgi-1  | ResourceWarning: unclosed file <_io.TextIOWrapper name='/app/unittests/scans/snyk_issue_api/snyk_sca_scan_api_single_vuln.json' mode='r' encoding='utf-8'>
```