### PR TITLE
Add null check for engagement in permission validation

### DIFF
--- a/dojo/authorization/authorization.py
+++ b/dojo/authorization/authorization.py
@@ -100,7 +100,9 @@ def user_has_permission(user, obj, permission):
         isinstance(obj, Risk_Acceptance)
         and permission == Permissions.Risk_Acceptance
     ):
-        return user_has_permission(user, obj.engagement.product, permission)
+        if obj.engagement is not None:
+            return user_has_permission(user, obj.engagement.product, permission)
+        return user_has_global_permission(user, permission)
     if ((
         isinstance(obj, Finding | Stub_Finding)
     ) and permission in Permissions.get_finding_permissions()) or (


### PR DESCRIPTION
Implement a null check for the engagement object in the permission validation for Risk Acceptance to prevent potential errors when accessing its properties. This change enhances the robustness of the permission checking logic.

[sc-12218]