### PR TITLE
fix(HELM): Use renovate-compatible format

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -10,11 +10,11 @@ maintainers:
     url: https://github.com/DefectDojo/django-DefectDojo
 dependencies:
   - name: postgresql
-    version: ~16.7.0
+    version: 16.7.27
     repository: "oci://us-docker.pkg.dev/os-public-container-registry/defectdojo"
     condition: postgresql.enabled
   - name: valkey
-    version: ~0.10.0
+    version: 0.10.2
     repository: "oci://registry-1.docker.io/cloudpirates"
     condition: valkey.enabled
 # For correct syntax, check https://artifacthub.io/docs/topics/annotations/helm/
@@ -34,4 +34,6 @@ dependencies:
 #     description: Critical bug
 annotations:
   artifacthub.io/prerelease: "true"
-  artifacthub.io/changes: ""
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: Use non-tilde notation of versions in subcharts

--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -525,8 +525,8 @@ A Helm chart for Kubernetes to install DefectDojo
 
 | Repository | Name | Version |
 |------------|------|---------|
-| oci://registry-1.docker.io/cloudpirates | valkey | ~0.10.0 |
-| oci://us-docker.pkg.dev/os-public-container-registry/defectdojo | postgresql | ~16.7.0 |
+| oci://registry-1.docker.io/cloudpirates | valkey | 0.10.2 |
+| oci://us-docker.pkg.dev/os-public-container-registry/defectdojo | postgresql | 16.7.27 |
 
 ## Values
 


### PR DESCRIPTION
Renovate was not able to recognise that there is a new version HELM chart. Syntax was valid but renovate has some bug there (https://github.com/renovatebot/renovate/discussions/30678).
Now it works, and a "more strict" version pinning is in place.

This is one of the reasons why HELM related GHA were failing.