### PR TITLE
feat(releases): Add section for GHA

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -65,3 +65,8 @@ lint:
   - changed-files:
     - any-glob-to-any-file:
       - ruff.toml
+
+gha:
+  - changed-files:
+    - any-glob-to-any-file:
+      - .github/workflows

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -43,6 +43,8 @@ categories:
     label: 'localization'
   - title: '🔧 Improved code quality with linters'
     label: 'lint'
+  - title: '⚙️ Improvemets of GitHub Actions'
+    label: 'gha'
   - title: '🧰 Maintenance'
     collapse-after: 3
     labels:


### PR DESCRIPTION
To improve the readability of release notes, it might be a good idea to separate GHA-related changes to an extra section because it does not changing application itself.