### PR TITLE
feat(HELM): Make HPA more Argo-friendly

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -34,4 +34,6 @@ dependencies:
 #     description: Critical bug
 annotations:
   artifacthub.io/prerelease: "true"
-  artifacthub.io/changes: ""
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: Drop 'replicas' when HPA is in place

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -21,7 +21,9 @@ metadata:
   name: {{ $fullName }}-celery-worker
   namespace: {{ .Release.Namespace }}
 spec:
+  {{ if (not .Values.celery.worker.autoscaling.enabled) -}}
   replicas: {{ .Values.celery.worker.replicas }}
+  {{- end }}
   {{- with .Values.revisionHistoryLimit }}
   revisionHistoryLimit: {{ . }}
   {{- end }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -20,7 +20,9 @@ metadata:
   name: {{ $fullName }}-django
   namespace: {{ .Release.Namespace }}
 spec:
+  {{ if (not .Values.django.autoscaling.enabled) -}}
   replicas: {{ .Values.django.replicas }}
+  {{- end }}
   {{- with .Values.django.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
ArgoCD and similar systems do not like the usage of `replicas` and `HPA`. As soon as you use `HPA`, the number of `replicas` is irrelevant.
https://argo-cd.readthedocs.io/en/stable/user-guide/best_practices/#leaving-room-for-imperativeness