### PR TITLE
docs: edits to deduplication-tuning docs

### DIFF
--- a/docs/content/en/working_with_findings/finding_deduplication/deduplication_tuning_os.md
+++ b/docs/content/en/working_with_findings/finding_deduplication/deduplication_tuning_os.md
@@ -135,13 +135,12 @@ To help troubleshooting deduplication use the following tools:
 - Observe log out in the `dojo.specific-loggers.deduplication` category. This is a class independant logger that outputs details about the deduplication process and settings when processing findings.
 - Observe the `unique_id_from_tool` and `hash_code` values by hovering over the `ID` field or `Status` column:
 
-  ![Unique ID from Tool and Hash Code on the View Finding page](/docs/assets/images//hash_code_id_field.png)
+  ![Unique ID from Tool and Hash Code on the View Finding page](images/hash_code_id_field.png)
 
-  ![Unique ID from Tool and Hash Code on the Finding List Status Column](/docs/assets/images/hash_code_status_column.png)
+  ![Unique ID from Tool and Hash Code on the Finding List Status Column](images/hash_code_status_column.png)
 
 ## Related documentation
 
 - [Deduplication Algorithms](deduplication_algorithms): conceptual overview and endpoint behavior.
 - [Avoiding duplicates via reimport](avoiding_duplicates_via_reimport).
-
 


### PR DESCRIPTION
**Description**

Minor edits to the documentation:
- added missing backticks
- fixed image path to point to correct asset
