### PR TITLE
docs: edits to deduplication-tuning docs

### DIFF
--- a/docs/content/en/working_with_findings/finding_deduplication/deduplication_tuning_os.md
+++ b/docs/content/en/working_with_findings/finding_deduplication/deduplication_tuning_os.md
@@ -112,7 +112,7 @@ docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --hash_code_only
 ```
 
 Help/usage:
-
+```
 options:
   --parser PARSER       List of parsers for which hash_code needs recomputing
                         (defaults to all parsers)


### PR DESCRIPTION
## Description

Minor edits to the documentation:
- added missing backticks

This is a simple fix of an earlier PR https://github.com/DefectDojo/django-DefectDojo/pull/13898 that mistakenly modified image path