### PR TITLE
fix(GHA): Fix annotation for renovate and dependabot

### DIFF
--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -124,7 +124,7 @@ jobs:
           for c in $(echo "$chars" | grep -o .); do
             title="${title//"$c"/_}"
           done
-          yq -i '.annotations."artifacthub.io/changes" += "- kind: changed\n  description: '$title'\n"' helm/defectdojo/Chart.yaml
+          yq -i '.annotations."artifacthub.io/changes" += "- kind: changed\n  description: '"$title"'\n"' helm/defectdojo/Chart.yaml
           git add helm/defectdojo/Chart.yaml
           git commit -m "ci: update Chart annotations from PR #${{ github.event.pull_request.number }}" || echo "No changes to commit"
 


### PR DESCRIPTION
I hope this will finally fix errors like
<img width="1061" height="304" alt="image" src="https://github.com/user-attachments/assets/4e71cf57-2827-48ef-ad20-9ab661fd595d" />
