### PR TITLE
docs: remove info about optional service key

### DIFF
--- a/docs/content/supported_tools/parsers/api/sonarqube.md
+++ b/docs/content/supported_tools/parsers/api/sonarqube.md
@@ -22,11 +22,8 @@ separate the items in the "Extras" field by a vertical bar (e.g.
 In `Add API Scan Configuration`
 -   `Service key 1` must
     be the SonarQube project key, which can be found by navigating to a specific project and
-    selecting the value from the url
-    `https://<sonarqube_host>/dashboard?id=key`.
-    When you do not provide a SonarQube project key, DefectDojo will
-    use the name of the Product as the project key in SonarQube. If you would like to
-    import findings from multiple projects, you can specify multiple keys as
+    selecting the value from the url `https://<sonarqube_host>/dashboard?id=key`.
+    If you would like to import findings from multiple projects, you can specify multiple keys as
     separated `API Scan Configuration` in the `Product` settings.
 -   If using SonarCloud, the organization ID can be used from step 1, but it
     can be overridden by supplying a different organization ID in the `Service key 2` input field.


### PR DESCRIPTION
**Description**

"Service key 1" for the SonarQube Tool Configuration is said to be optional. However, I tested adding a configuration without it and got the following error:
<img width="1063" height="392" alt="image showing an error when adding a SonarQube Tool Configuration" src="https://github.com/user-attachments/assets/adaa30de-bf38-443b-accc-a5e7688e9739" />

Therefore, I would suggest to remove this sentence. Or, if such behavior is desirable, add the missing functionality that uses the product name (DefectDojo) as the project key (SonarQube) if "Service key 1" is left empty.

**Test results**

N/A

**Documentation**

This is a docs-only PR