### PR TITLE
feat(docker): Manage images via renovate (not dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,10 +64,3 @@ updates:
     versions:
     - ">= 4.a"
     - "< 5"
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-  target-branch: dev
-  

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,8 +13,7 @@
     "components/package.json",
     "components/package-lock.json",
     "dojo/components/yarn.lock",
-    "dojo/components/package.json",
-    "Dockerfile**"
+    "dojo/components/package.json"
   ],
   "ignoreDeps": [],
   "packageRules": [{


### PR DESCRIPTION
DependaBot is not able to offer only an increase in `patch` version. It is offering only the latest version. Because of this
- Current version of python `3.13.7`
   -  https://github.com/DefectDojo/django-DefectDojo/blob/86fb00b02d52f225469bd06a42eb8d3b8b11ab74/Dockerfile.django-alpine#L8
   - https://github.com/DefectDojo/django-DefectDojo/blob/86fb00b02d52f225469bd06a42eb8d3b8b11ab74/Dockerfile.django-debian#L8
   - https://github.com/DefectDojo/django-DefectDojo/blob/86fb00b02d52f225469bd06a42eb8d3b8b11ab74/Dockerfile.integration-tests-debian#L6
   - https://github.com/DefectDojo/django-DefectDojo/blob/86fb00b02d52f225469bd06a42eb8d3b8b11ab74/Dockerfile.nginx-alpine#L8
- Has open PR by dependabot only with the latest version `3.14.2` https://github.com/DefectDojo/django-DefectDojo/pull/13950, which we are not able to use right now.
- Renovate would also be able to offer `3.13.11` (tested locally).

To be able to keep all images as up-to-date as possible (to keep them patched), it might be a better idea to use Renovate (instead of Dependabot)