### PR TITLE
Fix CycloneDX XML import failing when vulnerability description is missing

### DIFF
--- a/dojo/tools/cyclonedx/xml_parser.py
+++ b/dojo/tools/cyclonedx/xml_parser.py
@@ -194,6 +194,15 @@ class CycloneDXXMLParser:
             "b:ratings/b:rating/b:severity", namespaces=ns,
         )
         severity = Cyclonedxhelper().fix_severity(severity)
+        # by the schema, only id is mandatory, even the severity and description are
+        # optional
+        if not description:
+            description = "\n".join(
+                [
+                    f"**Id:** {vuln_id}",
+                    f"**Severity:** {severity}",
+                ],
+            )
         references = ""
         for advisory in vulnerability.findall(
             "b:advisories/b:advisory", namespaces=ns,


### PR DESCRIPTION
Fixes #10249

## Description
When uploading a CycloneDX report to DefectDojo, an error was thrown when the vulnerability description field was missing. The CycloneDX specification does not mandate the description field to be present, but DefectDojo requires it in the database.

## Root Cause
The `_manage_vulnerability_xml()` function (used for CycloneDX 1.4+) did not set a default value for missing descriptions, while `manage_vulnerability_legacy()` (used for CycloneDX 1.0) already had this fix applied in version 2.31.0.

## Solution
Added a default description when both `description` and `detail` fields are missing, similar to the legacy function. The default description includes the vulnerability ID and severity.

## Testing
- Verified the fix handles missing descriptions correctly
- No linting errors introduced
- Follows the same pattern as the legacy function