### PR TITLE
Fix Tenable CSV import fails with 'Version of CPE not implemented'

### DIFF
--- a/dojo/tools/tenable/csv_format.py
+++ b/dojo/tools/tenable/csv_format.py
@@ -228,17 +228,23 @@ class TenableCSVParser:
                         LOGGER.debug(
                             "more than one CPE for a finding. NOT supported by Nessus CSV parser",
                         )
-                    cpe_decoded = CPE(detected_cpe[0])
-                    find.component_name = (
-                        cpe_decoded.get_product()[0]
-                        if len(cpe_decoded.get_product()) > 0
-                        else None
-                    )
-                    find.component_version = (
-                        cpe_decoded.get_version()[0]
-                        if len(cpe_decoded.get_version()) > 0
-                        else None
-                    )
+                    try:
+                        cpe_decoded = CPE(detected_cpe[0])
+                        find.component_name = (
+                            cpe_decoded.get_product()[0]
+                            if len(cpe_decoded.get_product()) > 0
+                            else None
+                        )
+                        find.component_version = (
+                            cpe_decoded.get_version()[0]
+                            if len(cpe_decoded.get_version()) > 0
+                            else None
+                        )
+                    except Exception as e:
+                        LOGGER.debug(
+                            f"Failed to parse CPE '{detected_cpe[0]}': {e}. "
+                            "Skipping component_name and component_version.",
+                        )
 
                 find.unsaved_endpoints = []
                 find.unsaved_vulnerability_ids = []


### PR DESCRIPTION
## Description
Fixes issue #11243

Tenable CSV import was failing when encountering CPE fields with unsupported versions (e.g., CPE 2.3 format). The `cpe` library throws a "Version of CPE not implemented" exception which was not caught, causing the entire import to crash.

## Changes
- Added exception handling around CPE parsing in `TenableCSVParser`
- Log unsupported CPE versions at DEBUG level instead of crashing
- Import now continues processing other findings when encountering unsupported CPE formats

## Testing
- Import will no longer crash on unsupported CPE versions
- Findings with unsupported CPE will skip component_name/component_version extraction but continue processing
- Other findings in the same import are unaffected

## Related Issue
Closes #11243