### PR TITLE
Fix FileUpload.copy() to prevent title length exceeding 100 chars

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -803,7 +803,12 @@ class FileUpload(models.Model):
     def copy(self):
         copy = copy_model_util(self)
         # Add unique modifier to file name
-        copy.title = f"{self.title} - clone-{str(uuid4())[:8]}"
+        # Truncate title to ensure it doesn't exceed max_length (100) when appending suffix
+        # Suffix " - clone-{8 chars}" is 17 characters, so truncate to 83 chars
+        clone_suffix = f" - clone-{str(uuid4())[:8]}"
+        max_title_length = 100 - len(clone_suffix)
+        truncated_title = self.title[:max_title_length] if len(self.title) > max_title_length else self.title
+        copy.title = f"{truncated_title}{clone_suffix}"
         # Create new unique file name
         current_url = self.file.url
         _, current_full_filename = current_url.rsplit("/", 1)


### PR DESCRIPTION
Not sure if we want to keep the copy functionality, but here's a quick fix for Fixes #11314

## Problem
When copying a Test with attached files, the copy operation fails with a database error if any file has a title that is 84+ characters long. The error occurs because the `FileUpload.copy()` method appends ` - clone-{hash}` (17 characters) to the title without checking if it would exceed the database `max_length` constraint of 100 characters.

## Solution
Modified the `copy()` method in `FileUpload` to truncate the original title before appending the clone suffix, ensuring the total length never exceeds 100 characters.

## Changes
- Calculate the clone suffix length dynamically
- Truncate the original title to ensure total length ≤ 100 characters
- Append the suffix to create a unique title within database constraints

## Testing
- Verified the fix handles edge cases where titles are already at or near the limit
- Works correctly even when copying files that were already copied (which may already have clone suffixes)

## Error Before Fix
```
django.db.utils.DataError: value too long for type character varying(100)
```

## After Fix
File titles are properly truncated to fit within the 100 character limit, allowing tests to be copied successfully with all attached files.