### PR TITLE
Fix: Apply tags to findings/endpoints when TRACK_IMPORT_HISTORY is disabled

### DIFF
--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -129,6 +129,11 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
             new_findings=new_findings,
             closed_findings=closed_findings,
         )
+        # Apply tags to findings and endpoints
+        self.apply_import_tags(
+            new_findings=new_findings,
+            closed_findings=closed_findings,
+        )
         # Send out some notifications to the user
         logger.debug("IMPORT_SCAN: Generating notifications")
         create_notification(

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -132,6 +132,13 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             reactivated_findings=reactivated_findings,
             untouched_findings=untouched_findings,
         )
+        # Apply tags to findings and endpoints
+        self.apply_import_tags(
+            new_findings=new_findings,
+            closed_findings=closed_findings,
+            reactivated_findings=reactivated_findings,
+            untouched_findings=untouched_findings,
+        )
         # Send out som notifications to the user
         logger.debug("REIMPORT_SCAN: Generating notifications")
         updated_count = (


### PR DESCRIPTION
Fixes #13312

## Problem
When `TRACK_IMPORT_HISTORY` is disabled, tags were not being applied to findings and endpoints during import because the tag application logic was inside `update_import_history()` which returned early when the setting was disabled.

## Solution
Refactored the code to:
- Extract tag application into a dedicated `apply_import_tags()` method
- Call `apply_import_tags()` from importers after `update_import_history()`
- Remove tag application logic from `update_import_history()`

This ensures tags are applied regardless of the `TRACK_IMPORT_HISTORY` setting while maintaining separation of concerns and eliminating code duplication.

## Changes
- `dojo/importers/base_importer.py`: Added `apply_import_tags()` method and removed tag logic from `update_import_history()`
- `dojo/importers/default_importer.py`: Added call to `apply_import_tags()` after `update_import_history()`
- `dojo/importers/default_reimporter.py`: Added call to `apply_import_tags()` after `update_import_history()`