### PR TITLE
Handle System_Settings errors better in middleware

### DIFF
--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -114,6 +114,12 @@ class DojoSytemSettingsMiddleware:
     def __call__(self, request):
         self.load()
         try:
+            # Store error in request for context processor to display
+            # (We can't use messages here because MessageMiddleware runs after this middleware)
+            if hasattr(self._thread_local, "system_settings_error"):
+                request.system_settings_error = self._thread_local.system_settings_error
+                # Clear from thread-local after copying to request
+                delattr(self._thread_local, "system_settings_error")
             return self.get_response(request)
         finally:
             # ensure cleanup happens even if an exception occurs
@@ -132,6 +138,8 @@ class DojoSytemSettingsMiddleware:
     def cleanup(cls, *args, **kwargs):  # noqa: ARG003
         if hasattr(cls._thread_local, "system_settings"):
             del cls._thread_local.system_settings
+        if hasattr(cls._thread_local, "system_settings_error"):
+            delattr(cls._thread_local, "system_settings_error")
 
     @classmethod
     def load(cls):
@@ -150,7 +158,16 @@ class System_Settings_Manager(models.Manager):
         from dojo.models import System_Settings  # noqa: PLC0415 circular import
         try:
             from_db = super().get(*args, **kwargs)
-        except System_Settings.DoesNotExist:
+        except Exception as e:
+            # Store error message in thread-local for middleware to display
+            error_msg = str(e)
+            if hasattr(DojoSytemSettingsMiddleware._thread_local, "system_settings_error"):
+                # Only store the first error to avoid duplicates
+                pass
+            else:
+                DojoSytemSettingsMiddleware._thread_local.system_settings_error = error_msg
+            # Return defaults so app can still start - error will be displayed as warning message
+            # logger.debug('unable to get system_settings from database, returning defaults. Exception was:', exc_info=True)
             return System_Settings()
         return from_db
 


### PR DESCRIPTION
The try-except here was catching all exceptions which would hide any structural problems like missing columns due to migration problems as it was swallowing the errors and return a default System_Settings object.

I tried catching only specific errors or returning `None` instead, but this would break startup in too many places and would prevent users from being able to start any container to go into and fix problems.

This PR now adds displaying of error messages in the UI to make it clear "something is wrong".

<img width="2971" height="120" alt="image" src="https://github.com/user-attachments/assets/146525ad-5c7e-40e4-85f3-d9f76cc5edb7" />
