### PR TITLE
Fix JIRA form processing logic to not skip pushing new findings when finding_jira_sync is enabled

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -958,7 +958,7 @@ class EditFinding(View):
 
         return finding, request, False
 
- def process_jira_form(self, request: HttpRequest, finding: Finding, context: dict):
+    def process_jira_form(self, request: HttpRequest, finding: Finding, context: dict):
         # Capture case if the jira not being enabled
         if context["jform"] is None:
             return request, True, False


### PR DESCRIPTION
Findings were not pushed to JIRA if:
- user edits finding, chooses `push_to_jira` as `True`
- `finding_jira_sync` was enabled but no JIRA issues was created for the finding yet.

This PR simplifies the logic by reusing the helper method `is_keep_in_sync_with_jira` from the JIRA helper.
