### PR TITLE
Use psycopg[binary] for faster and reproducable Docker builds

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -22,7 +22,6 @@ RUN \
     openssl \
     libffi-dev \
     python3-dev \
-    libpq-dev \
     && \
     rm -rf /var/cache/apk/* && \
   true

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -14,7 +14,6 @@ RUN \
     gcc \
     build-essential \
     dnsutils \
-    libpq-dev \
     postgresql-client \
     xmlsec1 \
     git \
@@ -50,7 +49,6 @@ RUN \
     xmlsec1 \
     git \
     uuid-runtime \
-    libpq-dev \
     # only required for the dbshell (used by the initializer job)
     postgresql-client \
     # libcurl4-openssl-dev is required for installing pycurl python package

--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -22,7 +22,6 @@ RUN \
     openssl \
     libffi-dev \
     python3-dev \
-    libpq-dev \
     && \
     rm -rf /var/cache/apk/* && \
   true

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ lxml==6.0.2
 Markdown==3.10
 openpyxl==3.1.5
 Pillow==12.0.0  # required by django-imagekit
-psycopg[c]==3.3.2
+psycopg[binary]==3.3.2
 cryptography==46.0.3
 python-dateutil==2.9.0.post0
 redis==7.1.0


### PR DESCRIPTION
## Description

Switch from `psycopg[c]` to `psycopg[binary]` to use pre-compiled wheels instead of compiling the C extension from source.
With psycopg3 this is actually the advised approach. It also means we also have the same binary and not risk having unpredictable results caused by the lib being build in different places, different runners, etc.

WIP until we have proof it works fine for alpine and arm64.

## Benefits

- **Faster Docker builds**: Eliminates the compilation step during `pip install`
- **No build dependencies needed**: No longer requires `gcc`, `libpq-dev`, `python3-dev` for psycopg installation
- **Same performance**: Both `[c]` and `[binary]` provide the fast C implementation

## Comparison

| Installation Option | Command | Compilation | Performance |
|---------------------|---------|-------------|-------------|
| Binary (new) | `pip install psycopg[binary]` | ❌ None | 🐇 Fast |
| Local (old) | `pip install psycopg[c]` | ✅ Required | 🐇 Fast |

## Reference

From the [psycopg3 installation documentation](https://www.psycopg.org/psycopg3/docs/basic/install.html):

> **Binary installation** (recommended for most users): Precompiled C extensions, packaged with client libraries. Fast performance, no local libpq needed, no build tools needed.
