### PR TITLE
Ruff: use Python 3.14 compatible code

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -5,6 +5,7 @@ import logging
 import re
 import time
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import six
 import tagulous
@@ -36,7 +37,6 @@ from dojo.finding.helper import (
 from dojo.finding.queries import get_authorized_findings
 from dojo.group.utils import get_auth_group_name
 from dojo.importers.auto_create_context import AutoCreateContextManager
-from dojo.importers.base_importer import BaseImporter
 from dojo.importers.default_importer import DefaultImporter
 from dojo.importers.default_reimporter import DefaultReImporter
 from dojo.models import (
@@ -128,6 +128,9 @@ from dojo.user.queries import get_authorized_users
 from dojo.user.utils import get_configuration_permissions_codenames
 from dojo.utils import is_scan_file_too_large
 from dojo.validators import ImporterFileExtensionValidator, tag_validator
+
+if TYPE_CHECKING:
+    from dojo.importers.base_importer import BaseImporter
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -9,6 +9,7 @@ from functools import partial, reduce
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from time import strftime
+from typing import TYPE_CHECKING
 
 import pghistory
 from django.conf import settings
@@ -71,7 +72,6 @@ from dojo.forms import (
     TypedNoteForm,
     UploadThreatForm,
 )
-from dojo.importers.base_importer import BaseImporter
 from dojo.importers.default_importer import DefaultImporter
 from dojo.models import (
     Check_List,
@@ -118,6 +118,9 @@ from dojo.utils import (
     handle_uploaded_threat,
     redirect_to_return_url_or_else,
 )
+
+if TYPE_CHECKING:
+    from dojo.importers.base_importer import BaseImporter
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -1,11 +1,11 @@
 import logging
+from typing import TYPE_CHECKING
 
 from django.contrib import messages
 from django.contrib.admin.utils import NestedObjects
 from django.core.paginator import Page, Paginator
 from django.db.models import Count, Min, Q, QuerySet, Subquery
 from django.db.utils import DEFAULT_DB_ALIAS
-from django.http import HttpRequest
 from django.http.response import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls.base import reverse
@@ -26,6 +26,9 @@ from dojo.forms import DeleteFindingGroupForm, EditFindingGroupForm, FindingBulk
 from dojo.models import Engagement, Finding, Finding_Group, GITHUB_PKey, Global_Role, Product
 from dojo.product.queries import get_authorized_products
 from dojo.utils import Product_Tab, add_breadcrumb, get_page_items, get_setting, get_system_setting, get_words_for_field
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/group/views.py
+++ b/dojo/group/views.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 from django.contrib import messages
 from django.contrib.admin.utils import NestedObjects
@@ -7,7 +8,6 @@ from django.contrib.auth.models import Group
 from django.core.exceptions import PermissionDenied
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models.deletion import RestrictedError
-from django.db.models.query import QuerySet
 from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -48,6 +48,9 @@ from dojo.utils import (
     is_title_in_breadcrumbs,
     redirect_to_return_url_or_else,
 )
+
+if TYPE_CHECKING:
+    from django.db.models.query import QuerySet
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/importers/auto_create_context.py
+++ b/dojo/importers/auto_create_context.py
@@ -1,10 +1,9 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from crum import get_current_user
 from django.db import transaction
-from django.http.request import QueryDict
 from django.utils import timezone
 
 from dojo.models import (
@@ -17,6 +16,9 @@ from dojo.models import (
     Test,
 )
 from dojo.utils import get_last_object_or_none, get_object_or_none
+
+if TYPE_CHECKING:
+    from django.http.request import QueryDict
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -1,13 +1,12 @@
 import base64
 import logging
 import time
-from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from celery import chord, group
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
-from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.db import IntegrityError
 from django.urls import reverse
 from django.utils.timezone import make_aware
@@ -37,8 +36,14 @@ from dojo.models import (
 from dojo.notifications.helper import create_notification
 from dojo.tag_utils import bulk_add_tags_to_instances
 from dojo.tools.factory import get_parser
-from dojo.tools.parser_test import ParserTest
 from dojo.utils import max_safe
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from django.core.files.uploadedfile import TemporaryUploadedFile
+
+    from dojo.tools.parser_test import ParserTest
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -1,7 +1,7 @@
 import logging
+from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.core.serializers import serialize
 from django.db.models.query_utils import Q
 from django.urls import reverse
@@ -20,6 +20,9 @@ from dojo.models import (
 from dojo.notifications.helper import create_notification
 from dojo.utils import get_full_url, perform_product_grading
 from dojo.validators import clean_tags
+
+if TYPE_CHECKING:
+    from django.core.files.uploadedfile import TemporaryUploadedFile
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -1,7 +1,7 @@
 import logging
+from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.core.serializers import serialize
 from django.db.models.query_utils import Q
 
@@ -25,6 +25,9 @@ from dojo.models import (
 )
 from dojo.utils import perform_product_grading
 from dojo.validators import clean_tags
+
+if TYPE_CHECKING:
+    from django.core.files.uploadedfile import TemporaryUploadedFile
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")

--- a/dojo/importers/options.py
+++ b/dojo/importers/options.py
@@ -1,9 +1,8 @@
 import logging
-from collections.abc import Callable
 from datetime import datetime
 from functools import wraps
 from pprint import pformat as pp
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from django.contrib.auth.models import User
 from django.db.models import Model
@@ -21,6 +20,9 @@ from dojo.models import (
     Test_Import,
 )
 from dojo.utils import get_current_user, is_finding_groups_enabled
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/metrics/utils.py
+++ b/dojo/metrics/utils.py
@@ -1,18 +1,16 @@
 
 import logging
 import operator
-from collections.abc import Callable
 from datetime import date, datetime, timedelta
 from enum import Enum
 from functools import partial
-from typing import Any, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 from dateutil.relativedelta import relativedelta
 from django.contrib import messages
 from django.db.models import Case, Count, F, IntegerField, Q, Sum, Value, When
 from django.db.models.functions import Coalesce, ExtractDay, Now, TruncMonth, TruncWeek
 from django.db.models.query import QuerySet
-from django.http import HttpRequest
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
@@ -31,6 +29,11 @@ from dojo.utils import (
     get_system_setting,
     queryset_check,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from django.http import HttpRequest
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/query_utils.py
+++ b/dojo/query_utils.py
@@ -1,5 +1,9 @@
+from typing import TYPE_CHECKING
+
 from django.db.models import Count, IntegerField, Subquery
-from django.db.models.query import QuerySet
+
+if TYPE_CHECKING:
+    from django.db.models.query import QuerySet
 
 
 def build_count_subquery(model_qs: QuerySet, group_field: str) -> Subquery:

--- a/dojo/risk_acceptance/api.py
+++ b/dojo/risk_acceptance/api.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
-from django.db.models import QuerySet
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
@@ -13,6 +12,9 @@ from dojo.api_v2.serializers import RiskAcceptanceSerializer
 from dojo.authorization.roles_permissions import Permissions
 from dojo.engagement.queries import get_authorized_engagements
 from dojo.models import Risk_Acceptance, User, Vulnerability_Id
+
+if TYPE_CHECKING:
+    from django.db.models import QuerySet
 
 AcceptedRisk = NamedTuple("AcceptedRisk", (("vulnerability_id", str), ("justification", str), ("accepted_by", str)))
 

--- a/dojo/system_settings/views.py
+++ b/dojo/system_settings/views.py
@@ -1,15 +1,18 @@
 import logging
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views import View
 
 from dojo.forms import SystemSettingsForm
 from dojo.models import System_Settings
 from dojo.utils import add_breadcrumb, get_celery_worker_status
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest, HttpResponse
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -5,6 +5,7 @@ import operator
 import time
 from datetime import datetime, timedelta
 from functools import reduce
+from typing import TYPE_CHECKING
 
 import pghistory
 from django.contrib import messages
@@ -42,7 +43,6 @@ from dojo.forms import (
     TestForm,
     TypedNoteForm,
 )
-from dojo.importers.base_importer import BaseImporter
 from dojo.importers.default_reimporter import DefaultReImporter
 from dojo.models import (
     BurpRawRequestResponse,
@@ -83,6 +83,9 @@ from dojo.utils import (
     process_tag_notifications,
     redirect_to_return_url_or_else,
 )
+
+if TYPE_CHECKING:
+    from dojo.importers.base_importer import BaseImporter
 
 logger = logging.getLogger(__name__)
 parse_logger = logging.getLogger("dojo")

--- a/dojo/tools/appcheck_web_application_scanner/engines/appcheck.py
+++ b/dojo/tools/appcheck_web_application_scanner/engines/appcheck.py
@@ -1,7 +1,10 @@
 import re
+from typing import TYPE_CHECKING
 
-from dojo.models import Finding
 from dojo.tools.appcheck_web_application_scanner.engines.base import BaseEngineParser
+
+if TYPE_CHECKING:
+    from dojo.models import Finding
 
 
 class AppCheckScanningEngineParser(BaseEngineParser):

--- a/dojo/tools/appcheck_web_application_scanner/engines/nmap.py
+++ b/dojo/tools/appcheck_web_application_scanner/engines/nmap.py
@@ -1,7 +1,9 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from dojo.models import Endpoint
 from dojo.tools.appcheck_web_application_scanner.engines.base import BaseEngineParser
+
+if TYPE_CHECKING:
+    from dojo.models import Endpoint
 
 
 class NmapScanningEngineParser(BaseEngineParser):

--- a/dojo/tools/blackduck/importer.py
+++ b/dojo/tools/blackduck/importer.py
@@ -4,10 +4,13 @@ import re
 import zipfile
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .model import BlackduckFinding
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
 
 
 class Importer(ABC):

--- a/dojo/tools/blackduck_binary_analysis/importer.py
+++ b/dojo/tools/blackduck_binary_analysis/importer.py
@@ -2,10 +2,13 @@ import csv
 import io
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .model import BlackduckBinaryAnalysisFinding
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class Importer(ABC):

--- a/dojo/tools/blackduck_component_risk/importer.py
+++ b/dojo/tools/blackduck_component_risk/importer.py
@@ -2,7 +2,10 @@ import csv
 import io
 import logging
 import zipfile
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/tools/fortify/fpr_parser.py
+++ b/dojo/tools/fortify/fpr_parser.py
@@ -1,12 +1,15 @@
 import logging
 import re
 import zipfile
-from xml.etree.ElementTree import Element
+from typing import TYPE_CHECKING
 
 from defusedxml import ElementTree
 
 from dojo.models import Finding, Test
 from dojo.tools.fortify.fortify_data import DescriptionData, RuleData, SnippetData, VulnerabilityData
+
+if TYPE_CHECKING:
+    from xml.etree.ElementTree import Element
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/tools/h1/parser.py
+++ b/dojo/tools/h1/parser.py
@@ -4,15 +4,17 @@ import io
 import json
 from contextlib import suppress
 from datetime import datetime
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import cvss.parser
 from cvss.cvss3 import CVSS3
 from dateutil import parser as date_parser
-from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.utils import timezone
 
 from dojo.models import Finding, Test
+
+if TYPE_CHECKING:
+    from django.core.files.uploadedfile import TemporaryUploadedFile
 
 __author__ = "Kirill Gotsman"
 

--- a/dojo/tools/openvas/parser_v2/csv_parser.py
+++ b/dojo/tools/openvas/parser_v2/csv_parser.py
@@ -1,10 +1,10 @@
 import csv
 import io
 import logging
+from typing import TYPE_CHECKING
 
 from dateutil.parser import parse as parse_date
 
-from dojo.models import Finding
 from dojo.tools.openvas.parser_v2.common import (
     OpenVASFindingAuxData,
     cleanup_openvas_text,
@@ -13,6 +13,9 @@ from dojo.tools.openvas.parser_v2.common import (
     postprocess_finding,
     setup_finding,
 )
+
+if TYPE_CHECKING:
+    from dojo.models import Finding
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/tools/openvas/parser_v2/xml_parser.py
+++ b/dojo/tools/openvas/parser_v2/xml_parser.py
@@ -1,10 +1,10 @@
 import contextlib
 import logging
+from typing import TYPE_CHECKING
 from xml.dom import NamespaceErr
 
 from defusedxml import ElementTree
 
-from dojo.models import Finding
 from dojo.tools.openvas.parser_v2.common import (
     OpenVASFindingAuxData,
     cleanup_openvas_text,
@@ -14,6 +14,9 @@ from dojo.tools.openvas.parser_v2.common import (
     setup_finding,
 )
 from dojo.utils import parse_cvss_data
+
+if TYPE_CHECKING:
+    from dojo.models import Finding
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/tools/reversinglabs_spectraassure/parser.py
+++ b/dojo/tools/reversinglabs_spectraassure/parser.py
@@ -1,11 +1,13 @@
 # noqa: RUF100
 import hashlib
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from dojo.models import Finding
 from dojo.tools.reversinglabs_spectraassure.rlJsonInfo import RlJsonInfo
-from dojo.tools.reversinglabs_spectraassure.rlJsonInfo.cve_info_node import CveInfoNode
+
+if TYPE_CHECKING:
+    from dojo.tools.reversinglabs_spectraassure.rlJsonInfo.cve_info_node import CveInfoNode
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/tools/reversinglabs_spectraassure/rlJsonInfo/cve_info_node.py
+++ b/dojo/tools/reversinglabs_spectraassure/rlJsonInfo/cve_info_node.py
@@ -1,5 +1,8 @@
-import datetime
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import datetime
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/tools/whitehat_sentinel/parser.py
+++ b/dojo/tools/whitehat_sentinel/parser.py
@@ -173,7 +173,7 @@ class WhiteHatSentinelParser:
 
     def _convert_attack_vectors_to_endpoints(
         self, attack_vectors: list[dict],
-    ) -> list["Endpoint"]:
+    ) -> list[Endpoint]:
         """
         Takes a list of Attack Vectors dictionaries from the WhiteHat vuln API and converts them to Defect Dojo
         Endpoints

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -10,11 +10,11 @@ import random
 import re
 import time
 from calendar import monthrange
-from collections.abc import Callable
 from datetime import date, datetime, timedelta
 from functools import cached_property
 from math import pi, sqrt
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import bleach
 import crum
@@ -76,6 +76,9 @@ from dojo.models import (
     User,
 )
 from dojo.notifications.helper import create_notification
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
@@ -246,7 +249,7 @@ def match_finding_to_existing_findings(finding, product=None, engagement=None, t
     return None
 
 
-def count_findings(findings: QuerySet) -> tuple[dict["Product", list[int]], dict[str, int]]:
+def count_findings(findings: QuerySet) -> tuple[dict[Product, list[int]], dict[str, int]]:
     agg = (
         findings.values(prod_id=F("test__engagement__product_id"))
         .annotate(

--- a/dojo/validators.py
+++ b/dojo/validators.py
@@ -1,12 +1,15 @@
 import logging
 import re
-from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import cvss
 from cvss import CVSS2, CVSS3, CVSS4
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
-# Always generate Python 3.13-compatible code.
-target-version = "py313"
+# Always generate Python 3.14-compatible code.
+target-version = "py314"
 
 # Same as Black.
 line-length = 120


### PR DESCRIPTION
Using 3.14, we should also follow Ruff's recommendation for this version.