### PR TITLE
[docs] create sitemap at root on Hugo deploy

### DIFF
--- a/docs/config/_default/hugo.toml
+++ b/docs/config/_default/hugo.toml
@@ -22,7 +22,7 @@ copyRight = "Copyright (c) 2020-2024 Thulite"
   enable = true
 
 [outputs]
-  home = ["HTML", "RSS", "searchIndex"]
+  home = ["HTML", "RSS", "searchIndex", "SITEMAP"]
   section = ["HTML", "RSS", "SITEMAP"]
 
 [outputFormats.searchIndex]
@@ -41,7 +41,7 @@ copyRight = "Copyright (c) 2020-2024 Thulite"
   rel  = "sitemap"
 
 [sitemap]
-  changefreq = "monthly"
+  changefreq = "weekly"
   filename = "sitemap.xml"
   priority = 0.5
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,0 +1,5 @@
+---
+title: "DefectDojo Documentation"
+date: 2021-02-02T20:46:29+01:00
+draft: false
+---

--- a/docs/layouts/_default/sitemap.xml
+++ b/docs/layouts/_default/sitemap.xml
@@ -1,0 +1,13 @@
+{{- /* sitemap for all pages */ -}}
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {{ range .Site.RegularPages }}
+  <url>
+    <loc>{{ .Permalink }}</loc>
+    <changefreq>weekly</changefreq>
+    {{ with .Lastmod }}
+    <lastmod>{{ .Format "2006-01-02T15:04:05-07:00" | safeHTML }}</lastmod>
+    {{ end }}
+  </url>
+  {{ end }}
+</urlset>


### PR DESCRIPTION
Hugo is not creating a sitemap at the root of our docs (which should be at https://docs.defectdojo.com/sitemap.xml)

This PR fixes that issue and will create an XML sitemap in our root folder, listing all active URLs.