### PR TITLE
fix front matter in PingCastle docs

### DIFF
--- a/docs/content/supported_tools/parsers/file/pingcastle.md
+++ b/docs/content/supported_tools/parsers/file/pingcastle.md
@@ -1,3 +1,4 @@
+---
 title: "PingCastle"
 toc_hide: true
 ---


### PR DESCRIPTION
Hugo isn't rendering this correctly in our docs because of a missing line: see [here](https://docs.defectdojo.com/supported_tools/parsers/file/pingcastle/)

This patch addresses that issue