### PR TITLE
Update migration notes for django-pghistory

### DIFF
--- a/docs/content/en/open_source/upgrading/2.54.md
+++ b/docs/content/en/open_source/upgrading/2.54.md
@@ -30,9 +30,9 @@ The switch to `django-pghistory` provides several advantages:
 
 ### Migration Notes
 
-- A one-time data migration will take place to populate the `django-pghistory` tables with the initial snapshot of the tracked models.
+- A one-time data migration will take place to "backfill" the `django-pghistory` tables with the initial snapshot of the tracked models.
 - The migration is designed to be fail-safe: if it fails for some reason, it will continue where it left off.
-- The migration can also be performed up front via
+- If it fails completely or for any other reason you want to trigger it manually, you can do so via:
   - `docker compose exec uwsgi bash -c "python manage.py pghistory_backfill_fast"`, or
   - `docker compose exec uwsgi bash -c "python manage.py pghistory_backfill_simple"`, or
   - `docker compose exec uwsgi bash -c "python manage.py pghistory_backfill"`


### PR DESCRIPTION
Clarify and remove the text about being able to run the backfill migration "up front".