### PR TITLE
Re order Jira Alert Description

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -602,7 +602,7 @@ def log_jira_alert(error, obj):
     create_notification(
         event="jira_update",
         title="Error pushing to JIRA " + "(" + truncate_with_dots(prod_name(obj), 25) + ")",
-        description=to_str_typed(obj) + ", " + error,
+        description=error + "\n" + to_str_typed(obj),
         url=obj.get_absolute_url(),
         icon="bullseye",
         source="Push to JIRA",
@@ -614,7 +614,7 @@ def log_jira_cannot_be_pushed_reason(error, obj):
     create_notification(
         event="jira_update",
         title="Error pushing to JIRA " + "(" + truncate_with_dots(prod_name(obj), 25) + ")",
-        description=obj.__class__.__name__ + ": " + error,
+        description=error + "\n" + obj.__class__.__name__,
         url=obj.get_absolute_url(),
         icon="bullseye",
         source="Push to JIRA",


### PR DESCRIPTION
[sc-12181]

The goal is to have the error appear above the finding details because oftentimes the error will get trimmed from the alert.

Before:
<img width="1258" height="229" alt="tmp4" src="https://github.com/user-attachments/assets/9e8001a3-b779-4b6f-89de-3f34f90d1dd5" />

After:
<img width="1199" height="327" alt="tmp3" src="https://github.com/user-attachments/assets/aee0a6a1-e8ac-4d1a-a8fe-150b3e6b8391" />
