### PR TITLE
Add Report Builder submenu and improve form validation error messages

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -343,7 +343,7 @@
                                                 <i class="fa-solid fa-triangle-exclamation fa-fw"></i>
                                                 <span>{% trans "Finding Groups" %}</span>
                                                 <span class="glyphicon arrow"></span>
-                                            </a> 
+                                            </a>
                                             <ul class="nav nav-second-level">
                                                 <li>
                                                     <a href="{% url 'open_finding_groups' %}">
@@ -419,6 +419,13 @@
                                                 <span>{% trans "Reports" %}</span>
                                                 <span class="glyphicon arrow"></span>
                                             </a>
+                                            <ul class="nav nav-second-level">
+                                                <li>
+                                                    <a href="{% url 'report_builder' %}">
+                                                        {% trans "Report Builder" %}
+                                                    </a>
+                                                </li>
+                                            </ul>
                                             <!-- /.nav-second-level -->
                                         </li>
                                         {% endblock %}

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -166,11 +166,20 @@
                 return;
             }
 
+            const missingFields = [];
+
             $('.in-use-widgets .form-control').not('#finding-list .form-control')
                 .not('#endpoint-list .form-control').not('#wysiwyg-content .form-control')
                 .not('.bs-searchbox .form-control').not('div').each(function () {
-                if ($(this).val() === '')
+                if ($(this).val() === '') {
+                    const $el = $(this);
+                    const $parentForm = $el.closest('form');
+                    const $label = $el.closest('.form-group').find('label');
+                    const fieldLabel = $label.text().trim().replace(/\*$/, '').trim() || $el.attr('name') || $el.attr('id') || 'Unknown field';
+                    const formTitle = $parentForm.closest('.panel-available-widget').find('.panel-heading h5').text().trim() || $parentForm.attr('id') || 'Unknown form';
+                    missingFields.push(`${fieldLabel} (${formTitle})`);
                     valid = false;
+                }
             });
 
             if (valid) {
@@ -198,7 +207,13 @@
                 $('form#custom_report').removeClass('hidden').submit();
             }
             else {
-                alert('Please complete all forms.')
+                let errorMessage = 'Please complete all required fields:\n\n';
+                if (missingFields.length > 0) {
+                    errorMessage += missingFields.join('\n');
+                } else {
+                    errorMessage += 'One or more required fields are empty.';
+                }
+                alert(errorMessage);
             }
 
             event.preventDefault();


### PR DESCRIPTION
## Summary

This PR improves the UX of the report builder by:

1. **Adding explicit 'Report Builder' submenu**: The Reports menu item now has a submenu with 'Report Builder' as an explicit item, making it clearer what the menu item does. This matches the pattern used by other menu items like Findings and Products.

2. **Improved form validation error messages**: The JavaScript validation now shows which specific fields are missing instead of just a generic 'Please complete all forms' message. This helps users identify what needs to be filled in.


Quick backport of [sc-12449]