### PR TITLE
Fix Content-Type header bugs in file downloads and MIME type handling

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -751,7 +751,7 @@ class RiskAcceptanceViewSet(
         # send file
         response = FileResponse(
             file_handle,
-            content_type=f"{mimetypes.guess_type(str(file_path))}",
+            content_type=mimetypes.guess_type(str(file_path))[0] or "application/octet-stream",
             status=status.HTTP_200_OK,
         )
         response["Content-Length"] = file_object.size

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -1568,7 +1568,7 @@ def download_risk_acceptance(request, eid, raid):
             (Path(settings.MEDIA_ROOT) / "risk_acceptance.path.name").open(mode="rb")))
     response["Content-Disposition"] = f'attachment; filename="{risk_acceptance.filename()}"'
     mimetype, _encoding = mimetypes.guess_type(risk_acceptance.path.name)
-    response["Content-Type"] = mimetype
+    response["Content-Type"] = mimetype or "application/octet-stream"
     return response
 
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -2175,7 +2175,7 @@ def templates(request):
 @user_has_global_permission(Permissions.Finding_Edit)
 def export_templates_to_json(request):
     leads_as_json = serializers.serialize("json", Finding_Template.objects.all())
-    return HttpResponse(leads_as_json, content_type="json")
+    return HttpResponse(leads_as_json, content_type="application/json")
 
 
 def ensure_template_tags_in_finding_model(template):
@@ -2444,7 +2444,7 @@ def download_finding_pic(request, token):
         response = StreamingHttpResponse(FileIterWrapper(image))
         response["Content-Disposition"] = "inline"
         mimetype, _encoding = mimetypes.guess_type(file_name)
-        response["Content-Type"] = mimetype
+        response["Content-Type"] = mimetype or "application/octet-stream"
         return response
 
 

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -452,7 +452,7 @@ def inline_image(image_file):
     # TODO: This code might need better exception handling or data processing
     if img_types := mimetypes.guess_type(image_file.file.name):
         img_type = img_types[0]
-        if img_type.startswith("image/"):
+        if img_type and img_type.startswith("image/"):
             img_data = base64.b64encode(image_file.file.read())
             return f"data:{img_type};base64, {img_data.decode('utf-8')}"
     return ""

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2404,7 +2404,7 @@ def generate_file_response_from_file_path(
     response = FileResponse(
         path.open("rb"),
         filename=full_file_name,
-        content_type=f"{mimetypes.guess_type(file_path)}",
+        content_type=mimetypes.guess_type(file_path)[0] or "application/octet-stream",
     )
     # Add some important headers
     response["Content-Disposition"] = f'attachment; filename="{full_file_name}"'


### PR DESCRIPTION
## Summary

Fixes #14118

This PR fixes multiple bugs related to MIME type handling in file downloads across the application:

- **Fixed tuple-as-string bug**: `mimetypes.guess_type()` returns a tuple `(type, encoding)`, but it was being used directly in f-strings, resulting in invalid `Content-Type` headers like `"('image/png', None)"` instead of `"image/png"`
- **Added fallback for unknown file types**: When MIME type cannot be determined (returns `None`), now falls back to `"application/octet-stream"` 
- **Fixed JSON content type**: Changed incorrect `content_type="json"` to proper `"application/json"`
- **Fixed potential crash**: Prevented `AttributeError` in template tag when attempting to call `.startswith()` on `None`

All file downloads now properly set `Content-Type` headers with appropriate fallbacks for unknown file types.