### PR TITLE
Change pghistory backfill log level from ERROR to DEBUG for missing event tables

### DIFF
--- a/dojo/auditlog.py
+++ b/dojo/auditlog.py
@@ -774,7 +774,16 @@ def process_model_backfill(
     """
     if progress_callback is None:
         def progress_callback(msg, style=None):
-            logger.info(msg)
+            if style == "ERROR":
+                logger.error(msg)
+            elif style == "WARNING":
+                logger.warning(msg)
+            elif style == "SUCCESS":
+                logger.info(msg)
+            elif style == "DEBUG":
+                logger.debug(msg)
+            else:
+                logger.info(msg)
 
     try:
         table_name, event_table_name = get_table_names(model_name)
@@ -790,7 +799,7 @@ def process_model_backfill(
             progress_callback(
                 f"  Event table {event_table_name} not found. "
                 f"Is {model_name} tracked by pghistory?",
-                "ERROR",
+                "DEBUG",
             )
             return 0, 0.0
 

--- a/dojo/db_migrations/0250_pghistory_backfill.py
+++ b/dojo/db_migrations/0250_pghistory_backfill.py
@@ -43,6 +43,8 @@ def backfill_pghistory_tables(apps, schema_editor):
             logger.warning(msg)
         elif style == "SUCCESS":
             logger.info(msg)
+        elif style == "DEBUG":
+            logger.debug(msg)
         else:
             logger.info(msg)
 

--- a/dojo/db_migrations/0257_pghistory_tags_backfill.py
+++ b/dojo/db_migrations/0257_pghistory_tags_backfill.py
@@ -56,6 +56,8 @@ def backfill_pghistory_tag_tables(apps, schema_editor):
             logger.warning(msg)
         elif style == "SUCCESS":
             logger.info(msg)
+        elif style == "DEBUG":
+            logger.debug(msg)
         else:
             logger.info(msg)
 


### PR DESCRIPTION
## Summary
Changes log level from ERROR to DEBUG when pghistory backfill encounters missing event tables during migrations.

## Details
Migration 0250 runs before migration 0256 creates tags event tables, causing ERROR logs that are expected and should be DEBUG level.