### PR TITLE
Add Permissions-Policy header settings and tests

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -817,6 +817,25 @@ if env("DD_SECURE_HSTS_INCLUDE_SUBDOMAINS"):
 SESSION_EXPIRE_AT_BROWSER_CLOSE = env("DD_SESSION_EXPIRE_AT_BROWSER_CLOSE")
 SESSION_EXPIRE_WARNING = env("DD_SESSION_EXPIRE_WARNING")
 SESSION_COOKIE_AGE = env("DD_SESSION_COOKIE_AGE")
+# Permission-Policy header settings
+# See docs at https://pypi.org/project/django-permissions-policy/
+PERMISSIONS_POLICY = {
+    "accelerometer": [],
+    "ambient-light-sensor": [],
+    "autoplay": [],
+    "camera": [],
+    "display-capture": [],
+    "encrypted-media": [],
+    "fullscreen": [],
+    "geolocation": [],
+    "gyroscope": [],
+    "interest-cohort": [],
+    "magnetometer": [],
+    "microphone": [],
+    "midi": [],
+    "payment": [],
+    "usb": [],
+}
 
 # ------------------------------------------------------------------------------
 # DEFECTDOJO SPECIFIC
@@ -966,6 +985,7 @@ DJANGO_MIDDLEWARE_CLASSES = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "django_permissions_policy.PermissionsPolicyMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django-crispy-forms==2.5
 django_extensions==4.1
 django-slack==5.19.0
 django-watson==1.6.3
+django-permissions-policy==4.28.0
 django-prometheus==2.4.1
 Django==5.2.9
 django-single-session==0.2.0

--- a/unittests/test_permission_policy_headers.py
+++ b/unittests/test_permission_policy_headers.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+from django.urls import reverse
+
+
+class EmptyPermissionsPolicyTests(TestCase):
+    def test_empty_policy_still_sets_header(self):
+        response = self.client.get(reverse("login"))
+        self.assertIn("Permissions-Policy", response.headers)
+        # Header may be empty or minimal, but must exist
+        self.assertIsNotNone(response["Permissions-Policy"])
+        self.assertGreaterEqual(len(response["Permissions-Policy"]), 2)


### PR DESCRIPTION
Implement Permissions-Policy header settings to enhance security and privacy controls. Include corresponding tests to ensure the header is correctly set in responses. Update dependencies to include the necessary package for this feature.

