### PR TITLE
feat(async): Drop args from async_dupe_delete

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1241,7 +1241,6 @@ CELERY_BEAT_SCHEDULE = {
     "dedupe-delete": {
         "task": "dojo.tasks.async_dupe_delete",
         "schedule": timedelta(minutes=1),
-        "args": [timedelta(minutes=1)],
     },
     "flush_auditlog": {
         "task": "dojo.tasks.flush_auditlog",


### PR DESCRIPTION
`timedelta(minutes=1)` is not used by `dojo.tasks.async_dupe_delete` so it can be removed. Only raises confusion.