### PR TITLE
feat(async): Set "expires" for regular tasks

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1260,42 +1260,72 @@ CELERY_BEAT_SCHEDULE = {
         "task": "dojo.tasks.add_alerts",
         "schedule": timedelta(hours=1),
         "args": [timedelta(hours=1)],
+        "options": {
+            "expires": int(60 * 60 * 1 * 1.2),  # If a task is not executed within 72 minutes, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     "cleanup-alerts": {
         "task": "dojo.tasks.cleanup_alerts",
         "schedule": timedelta(hours=8),
+        "options": {
+            "expires": int(60 * 60 * 8 * 1.2),  # If a task is not executed within 9.6 hours, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     "dedupe-delete": {
         "task": "dojo.tasks.async_dupe_delete",
         "schedule": timedelta(minutes=1),
+        "options": {
+            "expires": int(60 * 1 * 1.2),  # If a task is not executed within 72 seconds, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     "flush_auditlog": {
         "task": "dojo.tasks.flush_auditlog",
         "schedule": timedelta(hours=8),
+        "options": {
+            "expires": int(60 * 60 * 8 * 1.2),  # If a task is not executed within 9.6 hours, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     "update-findings-from-source-issues": {
         "task": "dojo.tools.tool_issue_updater.update_findings_from_source_issues",
         "schedule": timedelta(hours=3),
+        "options": {
+            "expires": int(60 * 60 * 3 * 1.2),  # If a task is not executed within 9 hours, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     "compute-sla-age-and-notify": {
         "task": "dojo.tasks.async_sla_compute_and_notify_task",
         "schedule": crontab(hour=7, minute=30),
+        "options": {
+            "expires": int(60 * 60 * 24 * 1.2),  # If a task is not executed within 28.8 hours, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     "risk_acceptance_expiration_handler": {
         "task": "dojo.risk_acceptance.helper.expiration_handler",
-        "schedule": crontab(minute=0, hour="*/3"),  # every 3 hours
+        "schedule": crontab(minute=0, hour="*/3"),  # every 72 minutes
+        "options": {
+            "expires": int(60 * 60 * 3 * 1.2),  # If a task is not executed within 9 hours, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     "notification_webhook_status_cleanup": {
         "task": "dojo.notifications.helper.webhook_status_cleanup",
         "schedule": timedelta(minutes=1),
+        "options": {
+            "expires": int(60 * 1 * 1.2),  # If a task is not executed within 72 seconds, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     "trigger_evaluate_pro_proposition": {
         "task": "dojo.tasks.evaluate_pro_proposition",
         "schedule": timedelta(hours=8),
+        "options": {
+            "expires": int(60 * 60 * 8 * 1.2),  # If a task is not executed within 9.6 hours, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     "clear_sessions": {
         "task": "dojo.tasks.clear_sessions",
         "schedule": crontab(hour=0, minute=0, day_of_week=0),
+        "options": {
+            "expires": int(60 * 60 * 24 * 7 * 1.2),  # If a task is not executed within 8.4 days, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
+        },
     },
     # 'jira_status_reconciliation': {
     #     'task': 'dojo.tasks.jira_status_reconciliation_task',


### PR DESCRIPTION
I have been facing a situation where the processing of tasks has become stacked. The reason for the stack of tasks is irrelevant in this context; however, I noticed that many repetitive tasks were duplicated in the queue.

This PR sets an expiration time (to three times how often they should be scheduled), so if too many tasks get stacked in the queue, repetitive execution of old tasks (which had already been rescheduled with the same goal and parameters) will not occur.

## Full explanation of behaviour

As far as I found, redis do not support the expiration of items in the queue (only whole key). Because of this, stacked items will stay in the queue; however, as soon worker starts processing expired tasks, they are dropped. So they at least save processing time.

Not expired tasks:
```bash
[27/Jan/2026 21:27:52] INFO [celery.worker.strategy:161] Task dojo.notifications.helper.webhook_status_cleanup[ec7ddc79-6a03-403a-a497-793d08207d22] received
[27/Jan/2026 21:27:52] INFO [celery.app.trace:128] Task dojo.notifications.helper.webhook_status_cleanup[ec7ddc79-6a03-403a-a497-793d08207d22] succeeded in 0.025084527998842532s: None
[27/Jan/2026 21:27:52] INFO [celery.worker.strategy:161] Task dojo.tasks.async_dupe_delete[1bd57f73-5a76-4001-9343-bbdf87ecb7c9] received
[27/Jan/2026 21:27:52] INFO [celery.app.trace:128] Task dojo.tasks.async_dupe_delete[1bd57f73-5a76-4001-9343-bbdf87ecb7c9] succeeded in 0.027836107001348864s: None
```

Expired tasks:
```bash
[27/Jan/2026 21:27:51] INFO [celery.worker.strategy:161] Task dojo.notifications.helper.webhook_status_cleanup[89ece211-7450-4519-bb44-498642d538d6] received
[27/Jan/2026 21:27:51] INFO [celery.worker.request:496] Discarding revoked task: dojo.notifications.helper.webhook_status_cleanup[89ece211-7450-4519-bb44-498642d538d6]
[27/Jan/2026 21:27:51] INFO [celery.worker.strategy:161] Task dojo.tasks.async_dupe_delete[29713423-f53e-4d16-9c11-eaf14540cc28] received
[27/Jan/2026 21:27:51] INFO [celery.worker.request:496] Discarding revoked task: dojo.tasks.async_dupe_delete[29713423-f53e-4d16-9c11-eaf14540cc28]
```