### PR TITLE
updated ui tests: dedupe_test and product_test

### DIFF
--- a/tests/dedupe_test.py
+++ b/tests/dedupe_test.py
@@ -55,6 +55,12 @@ class DedupeTest(BaseTestCase):
         driver.get(self.base_url + "system_settings")
         if not driver.find_element(By.ID, "id_enable_deduplication").is_selected():
             driver.find_element(By.XPATH, '//*[@id="id_enable_deduplication"]').click()
+            # Disable false positive history if enabled (conflicts with dedupe)
+            if driver.find_element(By.ID, "id_false_positive_history").is_selected():
+                driver.find_element(By.XPATH, '//*[@id="id_false_positive_history"]').click()
+            # Disable false positive history retroactivity if enabled (conflicts with dedupe)
+            if driver.find_element(By.ID, "id_retroactive_false_positive_history").is_selected():
+                driver.find_element(By.XPATH, '//*[@id="id_retroactive_false_positive_history"]').click()
             # save settings
             driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
             # check if it's enabled after reload

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -315,15 +315,36 @@ class ProductTest(BaseTestCase):
         driver.find_element(By.PARTIAL_LINK_TEXT, "Endpoints").click()
         # 'click' the Add New Endpoint option
         driver.find_element(By.LINK_TEXT, "Add New Endpoint").click()
-        # Keep a good practice of clearing field before entering value
-        # Endpoints
-        driver.find_element(By.ID, "id_endpoint").clear()
-        driver.find_element(By.ID, "id_endpoint").send_keys("strange.prod.dev\n123.45.6.30")
-        # submit
-        driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
+        # V2 Endpoints
+        if self.is_element_by_id_present("id_endpoint"):
+            # TODO: Delete this after the move to Locations
+            # Keep a good practice of clearing field before entering value
+            # Endpoints
+            driver.find_element(By.ID, "id_endpoint").clear()
+            driver.find_element(By.ID, "id_endpoint").send_keys("strange.prod.dev\n123.45.6.30")
+            # submit
+            driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
+        # V3 Locations -- the freeform text box is gone, need to add each individually
+        else:
+            # Keep a good practice of clearing field before entering value
+            # Endpoints
+            driver.find_element(By.ID, "id_host").clear()
+            driver.find_element(By.ID, "id_host").send_keys("strange.prod.dev")
+            # submit
+            driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
+            # Assert ot the query to determine status of failure
+            self.assertTrue(self.is_success_message_present(text="Endpoint added successfully"))
+            # it was so fun let's do it again!
+            driver.find_element(By.PARTIAL_LINK_TEXT, "Endpoints").click()
+            # 'click' the Add New Endpoint option
+            driver.find_element(By.LINK_TEXT, "Add New Endpoint").click()
+            # Keep a good practice of clearing field before entering value
+            driver.find_element(By.ID, "id_host").clear()
+            driver.find_element(By.ID, "id_host").send_keys("123.45.6.30")
+            # submit
+            driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
         # Query the site to determine if the finding has been added
-
-        # Assert ot the query to dtermine status of failure
+        # Assert ot the query to determine status of failure
         self.assertTrue(self.is_success_message_present(text="Endpoint added successfully"))
 
     @on_exception_html_source_logger
@@ -341,18 +362,18 @@ class ProductTest(BaseTestCase):
         driver.find_element(By.LINK_TEXT, "Add Custom Fields").click()
         # Keep a good practice of clearing field before entering value
         # Custom Name
-        driver.find_element(By.ID, "id_name").clear()
-        driver.find_element(By.ID, "id_name").send_keys("Security Level")
+        driver.find_element(By.ID, "id_form-0-name").clear()
+        driver.find_element(By.ID, "id_form-0-name").send_keys("Security Level")
         # Custom Value
-        driver.find_element(By.ID, "id_value").clear()
-        driver.find_element(By.ID, "id_value").send_keys("Loose")
+        driver.find_element(By.ID, "id_form-0-value").clear()
+        driver.find_element(By.ID, "id_form-0-value").send_keys("Loose")
         # submit
-        driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
+        driver.find_element(By.CSS_SELECTOR, "button.btn-success").click()
         # Query the site to determine if the finding has been added
 
         # Assert ot the query to dtermine status of failure
         # Also confirm success even if variable is returned as already exists for test sake
-        self.assertTrue(self.is_success_message_present(text="Metadata added successfully")
+        self.assertTrue(self.is_success_message_present(text="Metadata updated successfully.")
             or self.is_success_message_present(text="A metadata entry with the same name exists already for this object."))
 
     @on_exception_html_source_logger
@@ -373,11 +394,11 @@ class ProductTest(BaseTestCase):
         driver.find_element(By.XPATH, "//input[@value='Loose']").clear()
         driver.find_element(By.XPATH, "//input[@value='Loose']").send_keys("Strong")
         # submit
-        driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
+        driver.find_element(By.CSS_SELECTOR, "button.btn-success").click()
         # Query the site to determine if the finding has been added
 
         # Assert ot the query to dtermine success or failure
-        self.assertTrue(self.is_success_message_present(text="Metadata edited successfully")
+        self.assertTrue(self.is_success_message_present(text="Metadata updated successfully.")
             or self.is_success_message_present(text="A metadata entry with the same name exists already for this object."))
 
     @on_exception_html_source_logger


### PR DESCRIPTION
This PR includes some updates to UI/integration tests to work with V3.

The first, to dedupe_test, isn't strictly necessary but more a quality-of-life-for-my-local-dev thing. I noticed when running several of the tests in sequence, sometimes the false positive history setting gets enabled, causing the subsequent dedupe test that attempts to enable dedupe to fail as these setting conflict. The edit to that test deselects false positive history/retroactive application of it as necessary when enabling dedupe to prevent that conflict. Again, not necessary if you don't want it.

The edits to product_test are more necessary. One of the changes made to the UI for inputting URLs in V3 is that there is no longer a single freeform textbox that can take multiple entries. The test has been updated to detect whether the single input exists and use it (for V2 Endpoints) or use the new UI if not. The product custom fields UI has also been changed (though the change is the same for both V2 and V3), so the tests for add/edit custom fields have been correspondingly updated.