### PR TITLE
updates to github workflows

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,10 +41,16 @@ jobs:
           "tests/notifications_test.py",
           "tests/tool_config.py",
           "openapi-validatator",
-
         ]
         os: [alpine, debian]
+        v3_feature_locations: [true, false]
+        exclude:
+          # standalone create endpoint page is gone in v3
+          - v3_feature_locations: true
+            test-case: "tests/endpoint_test.py"
       fail-fast: false
+    env:
+      DD_V3_FEATURE_LOCATIONS: ${{ matrix.v3_feature_locations }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -6,12 +6,14 @@ on:
         platform:
           type: string
           default: "linux/amd64"
+        v3_feature_locations:
+          type: boolean
+          default: false
 
 jobs:
   unit_tests:
     name: Rest Framework Unit Tests
     runs-on: ${{ inputs.platform ==  'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
-
     strategy:
       matrix:
         os: [alpine, debian]
@@ -53,10 +55,11 @@ jobs:
 
       # no celery or initializer needed for unit tests
       - name: Unit tests
-        timeout-minutes: 20
+        timeout-minutes: 25
         run: docker compose up --no-deps --exit-code-from uwsgi uwsgi
         env:
           DJANGO_VERSION: ${{ matrix.os }}
+          DD_V3_FEATURE_LOCATIONS: ${{ inputs.v3_feature_locations }}
 
       - name: Logs
         if: failure()

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,14 +23,16 @@ jobs:
 
   test-rest-framework:
     strategy:
-        matrix:
-            platform: ['linux/amd64', 'linux/arm64']
-        fail-fast: false
+      matrix:
+        platform: ['linux/amd64', 'linux/arm64']
+        v3_feature_locations: [ false, true ]
+      fail-fast: false
     needs: build-docker-containers
     uses: ./.github/workflows/rest-framework-tests.yml
     secrets: inherit
     with:
-      platform: ${{ matrix.platform}}
+      platform: ${{ matrix.platform }}
+      v3_feature_locations: ${{ matrix.v3_feature_locations }}
 
   # only run integration tests for linux/amd64 (default)
   test-user-interface:

--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -36,6 +36,7 @@ services:
       DD_SECURE_CROSS_ORIGIN_OPENER_POLICY: 'None'
       DD_SECRET_KEY: "${DD_SECRET_KEY:-.}"
       DD_EMAIL_URL: "smtp://mailhog:1025"
+      DD_V3_FEATURE_LOCATIONS: ${DD_V3_FEATURE_LOCATIONS:-False}
   celerybeat:
     environment:
       DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-postgresql://defectdojo:defectdojo@postgres:5432/test_defectdojo}
@@ -43,6 +44,7 @@ services:
     entrypoint: ['/wait-for-it.sh', '${DD_DATABASE_HOST:-postgres}:${DD_DATABASE_PORT:-5432}', '-t', '30', '--', '/entrypoint-celery-worker-dev.sh']
     environment:
       DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-postgresql://defectdojo:defectdojo@postgres:5432/test_defectdojo}
+      DD_V3_FEATURE_LOCATIONS: ${DD_V3_FEATURE_LOCATIONS:-False}
   initializer:
     environment:
       PYTHONWARNINGS: error  # We are strict about Warnings during testing

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -28,6 +28,7 @@ services:
       DD_CELERY_BROKER_PATH: '/dojo.celerydb.sqlite'
       DD_CELERY_BROKER_PARAMS: ''
       DD_JIRA_EXTRA_ISSUE_TYPES: 'Vulnerability' # Shouldn't trigger a migration error
+      DD_V3_FEATURE_LOCATIONS: ${DD_V3_FEATURE_LOCATIONS:-False}
   celerybeat: !reset
   celeryworker: !reset
   initializer: !reset


### PR DESCRIPTION
This PR updates some of the github workflows to run all tests (UI/integration and unittests) with locations both enabled and disabled.

Well, "all." Some will be skipped. Herein, the endpoint_test integration test is explicitly skipped when locations are enabled as the functionality it tests no longer exists. Additionally, subsequent PRs will include changes to unittests that skip some functionality, but it'll be handled within the class or as a decorator on it.

Big thanks to Val for having given me a pattern to follow in his pghistory work, and to Cody for directing me to that.