### PR TITLE
fix(async): watchmedo was installed incorrectly

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,4 +12,4 @@ django-test-migrations==1.5.0
 parameterized==0.9.0
 
 # Development file watching (hot reload)
-watchdog==6.0.0
+watchdog[watchmedo]==6.0.0


### PR DESCRIPTION
The celery Worker was not working in dev/debug mode because the package was not installed correctly.