### PR TITLE
Include Trufflehog verified secret info in report

### DIFF
--- a/dojo/tools/trufflehog/parser.py
+++ b/dojo/tools/trufflehog/parser.py
@@ -144,8 +144,6 @@ class TruffleHogParser:
             description += f"**Reason:** {detector_name}\n"
             description += f"**Path:** {file}\n"
             description += f"**Contents:** {redacted_info}\n"
-            if verified:
-                description += f"**Verified:** {verified}\n"
 
             if structured_data:
                 description += f"**Structured Data:**\n{self.walk_dict(structured_data)}\n"


### PR DESCRIPTION
Trufflehog will verify certain secrets if it has a detector and they are valid.  Here's a trivial patch to include the verified info in the title and description.