### PR TITLE
Fix Jira webhook race condition when closing ticket with comment

### DIFF
--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -285,7 +285,9 @@ def check_for_and_create_comment(parsed_json):
             finding.notes.add(new_note)
             finding.jira_issue.jira_change = timezone.now()
             finding.jira_issue.save()
-            finding.save()
+            # Only update the timestamp, not other fields like 'active' to avoid
+            # race conditions with concurrent webhook events (e.g. issue_updated)
+            finding.save(update_fields=["updated"])
     return None
 
 


### PR DESCRIPTION
## Summary
- Fixes race condition when closing a Jira ticket with a comment (#14200)
- When both `issue.updated` and `comment.created` webhooks arrive simultaneously, the `comment_created` handler was overwriting the `active=False` status set by `issue.updated`
- Changed `finding.save()` to `finding.save(update_fields=["updated"])` to only update the timestamp without overwriting other fields

## Root Cause
When a Jira issue is closed with a comment, Jira sends two webhooks nearly simultaneously:
1. `jira:issue_updated` - sets `finding.active = False` via `process_resolution_from_jira()`
2. `comment_created` - was calling `finding.save()` which overwrote `active` back to `True`

## Fix
Use `update_fields=["updated"]` to only update the timestamp field, preventing the race condition from overwriting the `active` status. This is the simplest fix without having to change the locking behaviour.

Fixes #14200