### PR TITLE
feat(helm): Valkey: use dedicated service account

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -34,4 +34,6 @@ dependencies:
 #     description: Critical bug
 annotations:
   artifacthub.io/prerelease: "true"
-  artifacthub.io/changes: ""
+  artifacthub.io/changes: |
+    - kind: added
+      description: Valkey - use dedicated service account

--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -767,9 +767,10 @@ A Helm chart for Kubernetes to install DefectDojo
 | tests.unitTests.resources.requests.cpu | string | `"100m"` |  |
 | tests.unitTests.resources.requests.memory | string | `"128Mi"` |  |
 | trackConfig | string | `"disabled"` | Track configuration (trackConfig): will automatically respin application pods in case of config changes detection can be: 1. disabled (default) 2. enabled, enables tracking configuration changes based on SHA256 |
-| valkey | object | `{"auth":{"existingSecret":"defectdojo-valkey-specific","existingSecretPasswordKey":"valkey-password","password":""},"enabled":true,"sentinel":{"enabled":false},"service":{"port":6379},"tls":{"enabled":false}}` | For more advance options check the bitnami chart documentation: https://artifacthub.io/packages/helm/cloudpirates-valkey/valkey |
+| valkey | object | `{"auth":{"existingSecret":"defectdojo-valkey-specific","existingSecretPasswordKey":"valkey-password","password":""},"enabled":true,"sentinel":{"enabled":false},"service":{"port":6379},"serviceAccount":{"create":true},"tls":{"enabled":false}}` | For more advance options check the bitnami chart documentation: https://artifacthub.io/packages/helm/cloudpirates-valkey/valkey |
 | valkey.enabled | bool | `true` | To use an external instance, switch enabled to `false` and set the address in `redisServer` below |
 | valkey.service | object | `{"port":6379}` | To use a different port for Redis (default: 6379) |
+| valkey.serviceAccount.create | bool | `true` | Autocreate dedicated service account (as part of the best practice) |
 | valkey.tls.enabled | bool | `false` | If TLS is enabled, the Redis broker will use the redis:// and optionally mount the certificates from an existing secret. |
 | valkeyParams | string | `""` | Parameters attached to the valkey connection string, defaults to "ssl_cert_reqs=optional" if `valkey.tls.enabled` |
 

--- a/helm/defectdojo/values.schema.json
+++ b/helm/defectdojo/values.schema.json
@@ -1500,6 +1500,15 @@
                         }
                     }
                 },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "create": {
+                            "description": "Autocreate dedicated service account (as part of the best practice)",
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "tls": {
                     "type": "object",
                     "properties": {

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -652,6 +652,9 @@ valkey:
     # certFilename: tls.crt
     # certKeyFilename: tls.key
     # certCAFilename: ca.crt
+  serviceAccount:
+    # -- Autocreate dedicated service account (as part of the best practice)
+    create: true
 
 # -- To add extra variables not predefined by helm config it is possible to define in extraConfigs block, e.g. below:
 # NOTE  Do not store any kind of sensitive information inside of it


### PR DESCRIPTION
Valkey chart does not enforce the existence of a dedicated service account. But it is a good idea to have it because of the best practice.