### PR TITLE
Add test to ensure duplicate findings are deleted in the proper order

### DIFF
--- a/unittests/test_duplication_loops.py
+++ b/unittests/test_duplication_loops.py
@@ -403,7 +403,7 @@ class TestDuplicationLoops(DojoTestCase):
             Finding.objects.filter(id=self.finding_b.id).exists(),
             "The newest duplicate (Finding B) should still exist.",
         )
-        # Finding A should now only have 2 duplicate in its set
+        # Finding A should now only have 1 duplicate in its set
         self.finding_a.refresh_from_db()
         self.assertEqual(self.finding_a.duplicate_finding_set().count(), 1)
 


### PR DESCRIPTION
Add test to ensure that when a maximum duplicate value is surpassed, the oldest finding (based on date attribute on finding) is deleted. We want to avoid duplicate findings being deleted in order of finding id.

[sc-12742]
