### PR TITLE
Update dockerfiles to ensure underlying OS is always running the late…

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -10,6 +10,7 @@ FROM base AS build
 WORKDIR /app
 RUN \
   apk update && \
+  apk upgrade --no-cache && \
   apk add --no-cache \
     gcc \
     build-base \
@@ -40,6 +41,7 @@ ARG appuser=defectdojo
 ENV appuser=${appuser}
 RUN \
   apk update && \
+  apk upgrade --no-cache && \
   apk add --no-cache \
     openjpeg \
     jpeg \

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -10,6 +10,7 @@ FROM base AS build
 WORKDIR /app
 RUN \
   apt-get -y update && \
+  apt-get -y upgrade && \
   apt-get -y install --no-install-recommends \
     gcc \
     build-essential \
@@ -39,6 +40,7 @@ ARG appuser=defectdojo
 ENV appuser=${appuser}
 RUN \
   apt-get -y update && \
+  apt-get -y upgrade && \
   # ugly fix to install postgresql-client without errors
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
   apt-get -y install --no-install-recommends \

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -7,6 +7,7 @@ FROM python:3.13.11-slim-trixie@sha256:51e1a0a317fdb6e170dc791bbeae63fac5272c82f
 WORKDIR /app
 RUN \
   apt-get -y update && \
+  apt-get -y upgrade && \
   apt-get -y install \
     git \
     wget \
@@ -20,6 +21,7 @@ RUN \
     xvfb \
     && \
   apt-get clean && \
+  rm -rf /var/lib/apt/lists && \
   true
 
 RUN pip install --no-cache-dir selenium==4.9.0 requests

--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -10,6 +10,7 @@ FROM base AS build
 WORKDIR /app
 RUN \
   apk update && \
+  apk upgrade --no-cache && \
   apk add --no-cache \
     gcc \
     build-base \
@@ -70,12 +71,14 @@ COPY --from=collectstatic /app/static/ /usr/share/nginx/html/static/
 COPY wsgi_params nginx/nginx.conf nginx/nginx_TLS.conf /etc/nginx/
 COPY docker/entrypoint-nginx.sh /
 RUN \
+  apk upgrade --no-cache && \
   apk add --no-cache openssl && \
   chmod -R g=u /var/cache/nginx && \
   mkdir /var/run/defectdojo && \
   chmod -R g=u /var/run/defectdojo && \
   mkdir -p /etc/nginx/ssl && \
   chmod -R g=u /etc/nginx && \
+  rm -rf /var/cache/apk/* && \
   true
 ENV \
   DD_UWSGI_PASS="uwsgi_server" \


### PR DESCRIPTION
We're not consistently updating the packages in the underlying container OSes when we build containers. Some steps in the multi-step builds didn't apply OS updates and/or the package index was updated but the packages weren't upgraded.

This PR make sure that all dockerfiles for DefectDojo images pull the latest OS packages when building images to that we have the latest possible versions of OS packages which should reduce any bugs/reported issues in the OS packages in the containers.

Only dockerfiles where changed in this PR, no Python source for DefectDojo itself were modified.