### PR TITLE
bulk edit: push groups to JIRA when sync is enabled

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -2962,7 +2962,11 @@ def _bulk_push_to_jira(finds, form, note):
     )
     logger.debug("finding_groups: %s", finding_groups)
     for group in finding_groups:
-        if form.cleaned_data.get("push_to_jira"):
+        if (
+            form.cleaned_data.get("push_to_jira")
+            or jira_helper.is_push_all_issues(group)
+            or jira_helper.is_keep_in_sync_with_jira(group)
+        ):
             (
                 can_be_pushed_to_jira,
                 error_message,


### PR DESCRIPTION
Fixes #12631

Push groups to JIRA if "push_all_issues" or "keep_in_sync_with_jira" is enabeld.

Merges into #14262 so we have all changes related to these fields in one PR.