### PR TITLE
Expose `has_any_jira_issue` filter for findings

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -518,6 +518,7 @@ def get_finding_filterset_fields(*, metrics=False, similar=False, filter_string_
         if get_system_setting("enable_jira"):
             fields.extend([
                 "has_jira_group_issue",
+                "has_any_jira_issue",
             ])
 
     return fields
@@ -1916,7 +1917,10 @@ class FindingFilterHelper(FilterSet):
                 lookup_expr="isnull",
                 exclude=True,
                 label="Has Group JIRA")
-        has_any_jira = FindingHasJIRAFilter(label="Has Any JIRA")
+        has_any_jira_issue = FindingHasJIRAFilter(
+            label="Has Any JIRA Issue",
+            help_text="Matches JIRA issues linked to the finding itself or to the finding's group.",
+        )
 
     outside_of_sla = FindingSLAFilter(label="Outside of SLA")
     has_tags = BooleanFilter(field_name="tags", lookup_expr="isnull", exclude=True, label="Has tags")


### PR DESCRIPTION
## Summary
- The `has_jira_issue` filter on the finding list page only checks if the finding itself has a JIRA issue. For findings in a group where the group has a JIRA issue, this filter doesn't match.
- A `FindingHasJIRAFilter` class that checks both the finding and the finding group already existed (`has_any_jira`) but was never included in `get_finding_filterset_fields()`, so it was invisible in the UI and API.
- This PR renames it to `has_any_jira_issue`, adds descriptive `help_text`, and exposes it in the finding filter fields when both JIRA and finding groups are enabled.

Closes #12670