### PR TITLE
serialize the location id as id in url body

### DIFF
--- a/dojo/location/api/serializers.py
+++ b/dojo/location/api/serializers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from rest_framework.relations import PrimaryKeyRelatedField
 from rest_framework.serializers import CharField
 
 from dojo.api_helpers.serializers import BaseModelSerializer
@@ -13,6 +14,7 @@ from dojo.location.models import (
 
 
 class AbstractedLocationSerializer(BaseModelSerializer):
+    id = PrimaryKeyRelatedField(source="location.id", read_only=True)
     string = CharField(source="location.location_value", read_only=True)
     type = CharField(source="location.location_type", read_only=True)
     tags = TagListSerializerField(source="location.tags", required=False)

--- a/dojo/url/api/serializer.py
+++ b/dojo/url/api/serializer.py
@@ -11,4 +11,4 @@ class URLSerializer(AbstractedLocationSerializer):
         """Meta class for URLSerializer."""
 
         model = URL
-        fields = "__all__"
+        exclude = ("location", "hash")


### PR DESCRIPTION
This PR updates AbstractedLocationSerializer to return the the ID of the Location object rather than the object itself (e.g., the URL).

URLs have a 1-1 with Location; the ID of the Location is used when accessing individual URLs via the API (`/url`) to keep consistency with the quick-lookup `/location` API endpoint. However, the body of the `/url` endpoint returns the ID of the URL object itself in the `.id` attribute, and the ID of the Location object in a `.location` field. This is a little weird (sorry!), since we never use the URL's ID anywhere else from a user's perspective and I'm sure it'll give someone an unnecessary headache down the road.

Thus, this PR updates the AbstractedLocationSerializer to return the Location's ID under the `.id` attribute; similarly, URLSerializer is updated to exclude the `.location` attribute as it's now redundant. At the same time, I've excluded the `.hash` field; it's used internally for uniqueness checks, there's no real reason to return it at this time.