### PR TITLE
Fix bulk risk acceptance for active findings

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -2793,14 +2793,10 @@ def _bulk_update_simple_fields(finds, form):
 def _bulk_update_risk_acceptance(finds, form, request, prods):
     """Helper function to handle risk acceptance updates."""
     skipped_risk_accept_count = 0
-    skipped_active_risk_accept_count = 0
 
     if form.cleaned_data["risk_acceptance"]:
         for finding in finds:
-            if finding.active:
-                skipped_active_risk_accept_count += 1
-            # Allow risk acceptance for inactive findings (whether duplicate or not)
-            elif form.cleaned_data["risk_accept"]:
+            if form.cleaned_data["risk_accept"]:
                 if (
                     not finding.test.engagement.product.enable_simple_risk_acceptance
                 ):
@@ -2822,15 +2818,7 @@ def _bulk_update_risk_acceptance(finds, form, request, prods):
             extra_tags="alert-warning",
         )
 
-    if skipped_active_risk_accept_count > 0:
-        messages.add_message(
-            request,
-            messages.WARNING,
-            f"Skipped risk acceptance of {skipped_active_risk_accept_count} active findings. Active findings cannot be risk accepted.",
-            extra_tags="alert-warning",
-        )
-
-    return skipped_risk_accept_count, skipped_active_risk_accept_count
+    return skipped_risk_accept_count
 
 
 def _bulk_update_finding_groups(finds, form):
@@ -3095,7 +3083,7 @@ def finding_bulk_update_all(request, pid=None):
 
             _bulk_update_simple_fields(finds, form)
 
-            _skipped_risk_accept_count, _skipped_active_risk_accept_count = _bulk_update_risk_acceptance(
+            _skipped_risk_accept_count = _bulk_update_risk_acceptance(
                 finds, form, request, prods,
             )
 


### PR DESCRIPTION
## Summary

Fixes #14281

This PR fixes a bug where active findings could not be risk accepted via the bulk edit menu, even though individual risk acceptance worked fine and simple risk acceptance was enabled on the product. This now matches the Pro UI.

## Changes

- **Remove invalid restriction**: Removed the check that prevented active findings from being risk accepted in bulk operations
- **Update tests**: Modified `test_bulk_edit_active_finding_can_accept_risk` to verify that active findings can now be risk accepted successfully in bulk
- **Update test**: Modified `test_bulk_edit_shows_multiple_warning_messages` to verify no warning appears when risk accepting active findings
- **Remove obsolete code**: Removed the warning message about "active findings cannot be risk accepted"
- **Simplify return value**: Updated `_bulk_update_risk_acceptance` helper function to return only the count of skipped findings

## Root Cause

The bulk update function incorrectly checked `if finding.active:` and skipped risk acceptance for active findings, showing a warning message. However:

1. The individual risk acceptance endpoint (`simple_risk_accept` view) has NO such restriction
2. The `simple_risk_accept` helper function automatically sets `finding.active = False` when accepting risk
3. DefectDojo Pro allows bulk risk acceptance of active findings

This was an inconsistency between bulk and individual operations that had no technical justification.

## Behavior Change

**Before**: Bulk risk acceptance of active findings failed with error message "Active findings cannot be risk accepted"

**After**: Bulk risk acceptance of active findings works correctly, matching individual behavior. The finding becomes inactive (risk_accepted=True, active=False) after risk acceptance.

