### PR TITLE
feature: quick verify finding

### DIFF
--- a/dojo/finding/urls.py
+++ b/dojo/finding/urls.py
@@ -142,6 +142,8 @@ urlpatterns = [
         name="choose_finding_template_options"),
     re_path(r"^finding/(?P<fid>\d+)/(?P<tid>\d+)/apply_template_to_finding$",
         views.apply_template_to_finding, name="apply_template_to_finding"),
+    re_path(r"^finding/(?P<fid>\d+)/verify$", views.verify_finding,
+        name="verify_finding"),
     re_path(r"^finding/(?P<fid>\d+)/close$", views.close_finding,
         name="close_finding"),
     re_path(r"^finding/(?P<fid>\d+)/defect_review$",

--- a/dojo/templates/dojo/verify_finding.html
+++ b/dojo/templates/dojo/verify_finding.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block content %}
+    {{ block.super }}
+    <h3>{% trans "Verify Finding" %}</h3>
+    <h4>{{ finding.title }}</h4>
+    <p>{% trans "Use this form to mark the finding as verified. Adding a comment is optional." %}</p>
+    <form class="form-horizontal" action="{% url 'verify_finding' finding.id %}" method="post">
+        {% csrf_token %}
+        {% include "dojo/form_fields.html" with form=form %}
+        <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-10">
+                <input class="btn btn-primary" type="submit" value="{% trans "Verify Finding" %}" aria-label="{% trans "Verify Finding" %}"/>
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -126,6 +126,13 @@
                                         </a>
                                     </li>
                                 {% else %}
+                                {% if not finding.verified %}
+                                    <li role="presentation">
+                                        <a href="{% url 'verify_finding' finding.id %}">
+                                            <i class="fa-solid fa-circle-check"></i> Verify Finding
+                                        </a>
+                                    </li>
+                                {% endif %}
                                 <li role="presentation">
                                     <a href="{% url 'close_finding' finding.id %}">
                                         <i class="fa-solid fa-fire-extinguisher"></i> Close Finding


### PR DESCRIPTION
**Description**

When viewing a finding, the menu has the option to "Close finding" but no option to "Verify": one has to edit, scroll an endless form to get to status.

As (at least for me) triaging findings is either closing or verifying, I think it deserves a spot in the menu as well.

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.