### PR TITLE
fix for ms defender parser: use endpoint instead of url when not v3

### DIFF
--- a/dojo/tools/ms_defender/parser.py
+++ b/dojo/tools/ms_defender/parser.py
@@ -194,7 +194,7 @@ class MSDefenderParser:
             # TODO: Delete this after the move to Locations
             if "computerDnsName" in machine and machine["computerDnsName"] is not None:
                 host = str(machine["computerDnsName"]).replace(" ", "").replace("(", "_").replace(")", "_")
-                locations.append(URL(host=host))
+                locations.append(Endpoint(host=host))
             if "lastIpAddress" in machine and machine["lastIpAddress"] is not None:
                 locations.append(Endpoint(host=str(machine["lastIpAddress"])))
             if "lastExternalIpAddress" in machine and machine["lastExternalIpAddress"] is not None:


### PR DESCRIPTION
Bug from the transition to V3. MSDefender parser changed to use a URL instead of Endpoint when V3 locations are disabled, which they should not.