### PR TITLE
Remove dead sync_process_findings / determine_process_method / process_results scaffolding

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -284,27 +284,6 @@ class BaseImporter(ImporterOptions):
         logger.info(f"Parsing findings took {elapsed_time:.2f} seconds ({len(parsed_findings) if parsed_findings else 0} findings parsed)")
         return parsed_findings
 
-    def sync_process_findings(
-        self,
-        parsed_findings: list[Finding],
-        **kwargs: dict,
-    ) -> tuple[list[Finding], list[Finding], list[Finding], list[Finding]]:
-        """
-        Processes findings in a synchronous manner such that all findings
-        will be processed in a worker/process/thread
-        """
-        return self.process_findings(parsed_findings, **kwargs)
-
-    def determine_process_method(
-        self,
-        parsed_findings: list[Finding],
-        **kwargs: dict,
-    ) -> list[Finding]:
-        return self.sync_process_findings(
-            parsed_findings,
-            **kwargs,
-        )
-
     def determine_deduplication_algorithm(self) -> str:
         """
         Determines what dedupe algorithm to use for the Test being processed.

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -110,8 +110,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         # Get the findings from the parser based on what methods the parser supplies
         # This could either mean traditional file parsing, or API pull parsing
         parsed_findings = self.parse_findings(scan, parser) or []
-        # process the findings in the foreground or background
-        new_findings = self.determine_process_method(parsed_findings, **kwargs)
+        new_findings = self.process_findings(parsed_findings, **kwargs)
         # Close any old findings in the processed list if the the user specified for that
         # to occur in the form that is then passed to the kwargs
         closed_findings = self.close_old_findings(self.test.finding_set.all(), **kwargs)


### PR DESCRIPTION
## Summary

Remove leftover code from the ASYNC_FINDING_IMPORT feature which was removed some time ago.

- Removes `sync_process_findings`, `determine_process_method` (from `base_importer.py`), and `process_results` (from `default_reimporter.py`) — three methods that were introduced to support the now-removed `ASYNC_FINDING_IMPORT` feature
- Collapses the call chain: `process_scan` now calls `process_findings` directly, and `process_findings` returns the finding lists directly instead of going through `process_results`
- No behaviour change: `sync_process_findings` was a pure pass-through to `process_findings`, `determine_process_method` was a pure pass-through to `sync_process_findings`, and `process_results` was a one-liner that returned the already-populated instance attributes
- Verified with the full `TestDojoImporterPerformanceSmall` test suite (5 tests, all pass, no query count regressions)

## Related

Pro companion PR DefectDojo-Inc/dojo-pro#1113