### PR TITLE
fix(trivy_operator): fix compliance severity logic and checkID comparison

### DIFF
--- a/dojo/tools/trivy_operator/checks_handler.py
+++ b/dojo/tools/trivy_operator/checks_handler.py
@@ -23,9 +23,9 @@ class TrivyChecksHandler:
         for check in checks:
             check_title = check.get("title")
             check_severity = TRIVY_SEVERITIES[check.get("severity")]
-            check_id = check.get("checkID", "0")
+            check_id = check.get("checkID") or "0"
             check_references = ""
-            if check_id != 0:
+            if check_id != "0":
                 check_references = (
                     "https://avd.aquasec.com/misconfig/kubernetes/"
                     + check_id.lower()
@@ -49,7 +49,7 @@ class TrivyChecksHandler:
             )
             if resource_namespace:
                 finding.unsaved_tags = [resource_namespace]
-            if check_id:
+            if check_id != "0":
                 finding.unsaved_vulnerability_ids = [UniformTrivyVulnID().return_uniformed_vulnid(check_id)]
             findings.append(finding)
         return findings

--- a/dojo/tools/trivy_operator/compliance_handler.py
+++ b/dojo/tools/trivy_operator/compliance_handler.py
@@ -31,10 +31,7 @@ class TrivyComplianceHandler:
                     check_severity = check.get("severity", "")
                     check_target = check.get("target", "")
                     check_title = check.get("title", "")
-                    if not check_severity:
-                        severity = TRIVY_SEVERITIES[check_severity]
-                    else:
-                        severity = TRIVY_SEVERITIES[result_severity]
+                    severity = TRIVY_SEVERITIES[check_severity] if check_severity else TRIVY_SEVERITIES[result_severity]
                     description += "**result description:** " + result_description + "\n"
                     description += "**result id:** " + result_id + "\n"
                     description += "**result name:** " + result_name + "\n"

--- a/unittests/scans/trivy_operator/compliance_severity.json
+++ b/unittests/scans/trivy_operator/compliance_severity.json
@@ -1,0 +1,78 @@
+{
+    "apiVersion": "aquasecurity.github.io/v1alpha1",
+    "kind": "ClusterComplianceReport",
+    "metadata": {
+        "creationTimestamp": "2024-03-05T10:38:15Z",
+        "generation": 1,
+        "labels": {
+            "app.kubernetes.io/instance": "trivy-operator",
+            "app.kubernetes.io/managed-by": "kubectl",
+            "app.kubernetes.io/name": "trivy-operator",
+            "app.kubernetes.io/version": "0.18.5"
+        },
+        "name": "cis",
+        "resourceVersion": "1649372",
+        "uid": "test-compliance-severity"
+    },
+    "spec": {
+        "compliance": {
+            "controls": [],
+            "description": "Test Compliance Severity",
+            "id": "test",
+            "title": "Test Compliance Severity Report",
+            "version": "1.0"
+        },
+        "cron": "0 */6 * * *",
+        "reportType": "all"
+    },
+    "status": {
+        "detailReport": {
+            "description": "Test report for compliance severity logic",
+            "id": "test",
+            "relatedResources": [],
+            "results": [
+                {
+                    "checks": [
+                        {
+                            "category": "Kubernetes Security Check",
+                            "checkID": "AVD-KSV-0001",
+                            "description": "Check with its own severity",
+                            "messages": [
+                                "Test message 1"
+                            ],
+                            "remediation": "Fix it",
+                            "severity": "MEDIUM",
+                            "success": false,
+                            "target": "/test-target-1",
+                            "title": "Check with severity"
+                        },
+                        {
+                            "category": "Kubernetes Security Check",
+                            "checkID": "AVD-KSV-0002",
+                            "description": "Check without severity",
+                            "messages": [
+                                "Test message 2"
+                            ],
+                            "remediation": "Fix it too",
+                            "severity": "",
+                            "success": false,
+                            "target": "/test-target-2",
+                            "title": "Check without severity"
+                        }
+                    ],
+                    "description": "Test result",
+                    "id": "1.1.1",
+                    "name": "Test result name",
+                    "severity": "HIGH"
+                }
+            ],
+            "title": "Test Compliance Severity Report",
+            "version": "1.0"
+        },
+        "summary": {
+            "failCount": 2,
+            "passCount": 0
+        },
+        "updateTimestamp": "2024-03-05T10:38:15Z"
+    }
+}

--- a/unittests/scans/trivy_operator/configauditreport_missing_checkid.json
+++ b/unittests/scans/trivy_operator/configauditreport_missing_checkid.json
@@ -1,0 +1,48 @@
+{
+    "apiVersion": "aquasecurity.github.io/v1alpha1",
+    "kind": "ConfigAuditReport",
+    "metadata": {
+        "annotations": {
+            "trivy-operator.aquasecurity.github.io/report-ttl": "24h0m0s"
+        },
+        "creationTimestamp": "2023-03-23T16:22:54Z",
+        "generation": 1,
+        "labels": {
+            "plugin-config-hash": "659b7b9c46",
+            "resource-spec-hash": "fc85b485f",
+            "trivy-operator.resource.kind": "ReplicaSet",
+            "trivy-operator.resource.name": "test-deployment-12345",
+            "trivy-operator.resource.namespace": "default"
+        },
+        "name": "replicaset-test-deployment-12345",
+        "namespace": "default",
+        "resourceVersion": "1268",
+        "uid": "test-missing-checkid"
+    },
+    "report": {
+        "checks": [
+            {
+                "category": "Kubernetes Security Check",
+                "description": "A check without a checkID field",
+                "messages": [
+                    "Container 'test' of ReplicaSet 'test-deployment-12345' has an issue"
+                ],
+                "severity": "MEDIUM",
+                "success": false,
+                "title": "Missing checkID test"
+            }
+        ],
+        "scanner": {
+            "name": "Trivy",
+            "vendor": "Aqua Security",
+            "version": "dev"
+        },
+        "summary": {
+            "criticalCount": 0,
+            "highCount": 0,
+            "lowCount": 0,
+            "mediumCount": 1
+        },
+        "updateTimestamp": "2023-03-23T16:22:54Z"
+    }
+}

--- a/unittests/tools/test_trivy_operator_parser.py
+++ b/unittests/tools/test_trivy_operator_parser.py
@@ -138,7 +138,7 @@ class TestTrivyOperatorParser(DojoTestCase):
             self.assertEqual(len(findings), 795)
             finding = findings[0]
             self.assertEqual("5.1.2 AVD-KSV-0041 /clusterrole-admin", finding.title)
-            self.assertEqual("High", finding.severity)
+            self.assertEqual("Critical", finding.severity)
             self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
             self.assertEqual("AVD-KSV-0041", finding.unsaved_vulnerability_ids[0])
             finding = findings[40]
@@ -169,3 +169,24 @@ class TestTrivyOperatorParser(DojoTestCase):
             parser = TrivyOperatorParser()
             findings = parser.get_findings(test_file, Test())
             self.assertEqual(len(findings), 2)
+
+    def test_compliance_severity_logic(self):
+        with sample_path("compliance_severity.json").open(encoding="utf-8") as test_file:
+            parser = TrivyOperatorParser()
+            findings = parser.get_findings(test_file, Test())
+            self.assertEqual(len(findings), 2)
+            # First check has severity MEDIUM, result has severity HIGH -> uses check's MEDIUM
+            self.assertEqual("Medium", findings[0].severity)
+            # Second check has empty severity, result has severity HIGH -> falls back to HIGH
+            self.assertEqual("High", findings[1].severity)
+
+    def test_configauditreport_missing_checkid(self):
+        with sample_path("configauditreport_missing_checkid.json").open(encoding="utf-8") as test_file:
+            parser = TrivyOperatorParser()
+            findings = parser.get_findings(test_file, Test())
+            self.assertEqual(len(findings), 1)
+            finding = findings[0]
+            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("0 - Missing checkID test", finding.title)
+            # When checkID is "0", references should be empty (not a bogus URL)
+            self.assertEqual("", finding.references)


### PR DESCRIPTION
**Description**

Fix two bugs in the Trivy Operator parser.

### Bug 1: Compliance severity logic is inverted (`compliance_handler.py`)

The severity selection logic is inverted — when `check_severity` is present, the code discards it and uses `result_severity` instead. When `check_severity` is empty, the code tries to use it, causing a `KeyError` crash.

**Example — the existing `cis_benchmark.json` test fixture already proves this:**
```
Input data:
  result.severity = "HIGH"
  check.severity  = "CRITICAL"

Original code path:
  check_severity = "CRITICAL"
  if not check_severity:          # not "CRITICAL" → False
      ...                         # skipped
  else:
      severity = TRIVY_SEVERITIES[result_severity]  # uses "HIGH" ← wrong!

Expected: "Critical" (check-level severity should take precedence)
Actual:   "High" (result-level severity used instead)
```

When `check_severity` is empty (e.g., a compliance pass sentinel), the original code crashes:
```
  check_severity = ""
  if not check_severity:          # not "" → True
      severity = TRIVY_SEVERITIES[""]  # KeyError: ""
```

**Fix:** Use check-level severity when present, fall back to result-level otherwise:
```python
severity = TRIVY_SEVERITIES[check_severity] if check_severity else TRIVY_SEVERITIES[result_severity]
```

**Reference:** In the Trivy Operator Go source ([compliance_types.go:237-240](https://github.com/aquasecurity/trivy-operator/blob/main/pkg/apis/aquasecurity/v1alpha1/compliance_types.go#L237-L240)), when a control has zero misconfigurations, a `ComplianceCheck{Success: true}` sentinel is created with empty severity — confirming the empty-severity path is reachable.

### Bug 2: checkID string/int comparison (`checks_handler.py`)

Three related issues with `checkID` handling:

1. **`check_id != 0` — string vs int comparison** (always `True` in Python):
```python
check_id = check.get("checkID", "0")  # returns string "0"
if check_id != 0:                      # "0" != 0 → always True (different types)
    check_references = ".../kubernetes/0"  # bogus URL generated
```

2. **`check.get("checkID", "0")` — doesn't guard against `null`**: Python's `dict.get(key, default)` only uses the default when the key is absent. If the JSON contains `"checkID": null`, Python returns `None`, not `"0"`.

3. **`if check_id:` — string `"0"` is truthy**: When checkID is missing (defaulted to `"0"`), a bogus vulnerability ID is still generated because `bool("0")` is `True` in Python.

**Fix:** `check.get("checkID") or "0"` for null-safety, `!= "0"` for proper string comparison.

**Reference:** In the Trivy Operator Go source ([config_audit_types.go:111](https://github.com/aquasecurity/trivy-operator/blob/main/pkg/apis/aquasecurity/v1alpha1/config_audit_types.go#L111)), `checkID` is defined as `string` (not `*string`), so Go serializes it as `""` not `null`. The CRD schema marks it as required. The `or "0"` guard is defensive for manual JSON uploads to DefectDojo.

**Test results**

- Updated `test_cis_benchmark` — first finding now correctly asserts `"Critical"` (check-level) instead of `"High"` (result-level). The test data in `cis_benchmark.json` already had `check.severity = "CRITICAL"` and `result.severity = "HIGH"` — the original assertion matched the buggy output.
- Added `test_compliance_severity_logic` — two checks: one with `severity="MEDIUM"` (should use it), one with `severity=""` (should fall back to result's `"HIGH"`)
- Added `test_configauditreport_missing_checkid` — check with no `checkID` field: verifies references is `""` (no bogus URL)
- All existing tests pass
- `ruff check` passes

**Documentation**

No documentation changes needed — bug fixes to existing parser behavior.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.13 compliant.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.