### PR TITLE
Skip dispatching endpoint/location tasks when lists are empty

### DIFF
--- a/dojo/importers/endpoint_manager.py
+++ b/dojo/importers/endpoint_manager.py
@@ -114,6 +114,8 @@ class EndpointManager:
         endpoints: list[Endpoint],
         **kwargs: dict,
     ) -> None:
+        if not endpoints:
+            return
         dojo_dispatch_task(EndpointManager.add_endpoints_to_unsaved_finding, finding, endpoints, sync=True)
 
     @staticmethod

--- a/dojo/importers/location_manager.py
+++ b/dojo/importers/location_manager.py
@@ -84,6 +84,8 @@ class LocationManager:
         locations: list[AbstractLocation],
         **kwargs: dict,
     ) -> None:
+        if not locations:
+            return
         dojo_dispatch_task(LocationManager.add_locations_to_unsaved_finding, finding, locations, sync=True)
 
     @staticmethod


### PR DESCRIPTION
## Summary

- Add early return in `chunk_endpoints_and_disperse` and `chunk_locations_and_disperse` when the endpoint/location list is empty
- Previously, one Celery task was dispatched per finding regardless.
- This optimization avoids unnecessary task creation, serialization, and execution

Some Pro unit tests may need updated counts for any asserts on celery task counts.