### PR TITLE
Fix release workflow: ensure helm chart is uploaded before release-drafter

### DIFF
--- a/.github/workflows/release-2-tag-docker-push.yml
+++ b/.github/workflows/release-2-tag-docker-push.yml
@@ -71,7 +71,7 @@ jobs:
     secrets: inherit
 
   release-drafter:
-    needs: publish-container-digests
+    needs: [publish-container-digests, release-helm-chart]
     uses: ./.github/workflows/release-drafter.yml
     with:
       version: ${{ inputs.release_number }}


### PR DESCRIPTION
## Summary

- Add `release-helm-chart` as a dependency for `release-drafter` in the Release-2 workflow
- Ensures the Helm chart is always uploaded to the release before release-drafter updates it with release notes
- Prevents race conditions where release-drafter could create the release first, causing `softprops/action-gh-release` to fail with `already_exists` and the helm chart to be missing from the release

Fixes #14337