### PR TITLE
Fix update-sample-data workflow pushing to protected master branch

### DIFF
--- a/.github/workflows/update-sample-data.yml
+++ b/.github/workflows/update-sample-data.yml
@@ -30,24 +30,12 @@ jobs:
           git config --global user.name "${{ env.GIT_USERNAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
 
-      - name: Create and switch to a new branch
-        run: |
-          git checkout -b update-file-$(date +%Y%m%d%H%M%S)
-          git add dojo/fixtures/defect_dojo_sample_data.json
-          git commit -m "Update sample data"
-
-      - name: Push branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update sample data"
-          branch: ${{ github.ref_name || 'dev'}}
+          branch: update-sample-data
           base: dev
           title: "Update sample data"
           body: "This pull request updates the sample data."


### PR DESCRIPTION
## Summary
The workflow that runs the new python script to update sample data still fails because of invalid handling of branches.

- The `branch` parameter in the `Create Pull Request` step used `${{ github.ref_name || 'dev' }}`, which resolves to `master` when triggered via `workflow_dispatch` from the master branch
- This caused the action to attempt a force-push directly to `master`, which is blocked by the repository's branch protection rule ("Changes must be made through a pull request")
- Fixed by removing the redundant manual branch creation/push steps and using a fixed branch name `update-sample-data` for the `create-pull-request` action
- The `peter-evans/create-pull-request` is supposed to handle things gracefully if the `update-sample-data` branch already exists. It will update the existing branch and PR, or, if the PR is already merged, it will create a new PR.

