### PR TITLE
Fix DataError when Finding_Group name exceeds 255 chars

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -214,14 +214,14 @@ def create_finding_group(finds, finding_group_name):
     finding_group.creator = get_current_user()
 
     if finding_group_name:
-        finding_group.name = finding_group_name
+        finding_group.name = finding_group_name[:255]
     elif finding_group.components:
-        finding_group.name = finding_group.components
+        finding_group.name = finding_group.components[:255]
     try:
         finding_group.save()
     except IntegrityError as ie:
         if "already exists" in str(ie):
-            finding_group.name = finding_group_name + finding_group_name_dummy
+            finding_group.name = finding_group_name[:255 - len(finding_group_name_dummy)] + finding_group_name_dummy
             finding_group.save()
         else:
             raise
@@ -362,7 +362,7 @@ def add_findings_to_auto_group(name, findings, group_by, *, create_finding_group
 
         if create_finding_groups_for_all_findings or len(findings) > 1:
             # Only create a finding group if we have more than one finding for a given finding group, unless configured otherwise
-            finding_group, created = Finding_Group.objects.get_or_create(test=test, creator=creator, name=name)
+            finding_group, created = Finding_Group.objects.get_or_create(test=test, creator=creator, name=name[:255])
             if created:
                 logger.debug("Created Finding Group %d:%s for test %d:%s", finding_group.id, finding_group, test.id, test)
                 # See if we have old findings in the same test that were created without a finding group
@@ -388,7 +388,7 @@ def add_findings_to_auto_group(name, findings, group_by, *, create_finding_group
                 for f in old_findings:
                     f_group_name = get_group_by_group_name(f, group_by)
                     if f_group_name == name and f not in findings:
-                        finding_group, created = Finding_Group.objects.get_or_create(test=test, creator=creator, name=name)
+                        finding_group, created = Finding_Group.objects.get_or_create(test=test, creator=creator, name=name[:255])
                         finding_group.findings.add(f)
                 if created:
                     finding_group.findings.add(*findings)


### PR DESCRIPTION
## Description

Fixes #14367

## Fix

Truncate finding group name to 255 characters.