### PR TITLE
Also update defect_dojo_sample_data_locations.json in sample data workflow

### DIFF
--- a/.github/workflows/update-sample-data.yml
+++ b/.github/workflows/update-sample-data.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           ./fixture-updater dojo/fixtures/defect_dojo_sample_data.json
           mv output.json dojo/fixtures/defect_dojo_sample_data.json
+          ./fixture-updater dojo/fixtures/defect_dojo_sample_data_locations.json
+          mv output.json dojo/fixtures/defect_dojo_sample_data_locations.json
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary

- The `update-sample-data` workflow previously only updated `defect_dojo_sample_data.json`
- Added the same update step for `defect_dojo_sample_data_locations.json`, which is used when the v3 feature locations flag is enabled