### PR TITLE
Silence polymorphic.W001 and polymorphic.W002 system checks

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -34,7 +34,7 @@ env = environ.FileAwareEnv(
     # django-jsonfield-backport raises a warning that can be ignored,
     # see https://github.com/laymonage/django-jsonfield-backport
     # debug_toolbar.E001 is raised when running tests in dev mode via run-unittests.sh
-    DD_SILENCED_SYSTEM_CHECKS=(list, ["debug_toolbar.E001", "django_jsonfield_backport.W001"]),
+    DD_SILENCED_SYSTEM_CHECKS=(list, ["debug_toolbar.E001", "django_jsonfield_backport.W001", "polymorphic.W001", "polymorphic.W002"]),
     DD_TEMPLATE_DEBUG=(bool, False),
     DD_LOG_LEVEL=(str, ""),
     DD_DJANGO_METRICS_ENABLED=(bool, False),


### PR DESCRIPTION
The Question and Answer models intentionally use models.Manager() as their default objects manager instead of PolymorphicManager(). This is a deliberate trade-off introduced in #9574 to fix cascade deletion failures (ForeignKeyViolation on dojo_choiceanswer and ValueError during Product/ProductType deletion) caused by Django's inability to correctly order polymorphic child row deletions before parent row deletions when using PolymorphicManager as the default.

Using models.Manager() as the default ensures Django's collector can walk the full object graph and delete child rows (TextAnswer, ChoiceAnswer) before their parent Answer rows, satisfying FK constraints. A named polymorphic manager is retained on both models for all queryset operations that require polymorphic behavior (used throughout dojo/survey/views.py and dojo/forms.py).

The resulting polymorphic.W001 and polymorphic.W002 warnings are therefore expected and benign — they describe the intentional configuration, not a bug. Silencing them here prevents noise in CI and local development output without masking any real misconfiguration.