### PR TITLE
fix: slight textual changes to update-sample-data workflow

### DIFF
--- a/.github/workflows/update-sample-data.yml
+++ b/.github/workflows/update-sample-data.yml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 1 1,4,7,10 *'
 
 jobs:
-  run-binary-and-create-pr:
+  run-script-and-create-pr:
     runs-on: ubuntu-latest
     steps:
       # Checkout the repository
@@ -40,4 +40,4 @@ jobs:
           branch: update-sample-data
           base: dev
           title: "Update sample data"
-          body: "This pull request updates the sample data."
+          body: "This pull request updates the timestamps in the sample data to keep them up to date."


### PR DESCRIPTION
## Summary

- Rename job `run-binary-and-create-pr` → `run-script-and-create-pr` to better reflect that it runs a script (not a binary)
- Update the auto-created PR body to clarify that the workflow updates timestamps in the sample data