### PR TITLE
Run import performance test also for v3 Locations

### DIFF
--- a/dojo/base_models/base.py
+++ b/dojo/base_models/base.py
@@ -42,7 +42,7 @@ class BaseModelWithoutTimeMeta(Model):
 
         abstract = True
 
-    def save(self, *args: list, skip_validation: bool = not settings.V3_FEATURE_LOCATIONS, **kwargs: dict) -> None:
+    def save(self, *args: list, skip_validation: bool | None = None, **kwargs: dict) -> None:
         """
         Override save method to call the `full_clean()` validation function each save.
 
@@ -53,6 +53,9 @@ class BaseModelWithoutTimeMeta(Model):
         - Validate the field uniqueness - `validate_unique()`
         All three steps are performed when you call a model's full_clean() method in the order above
         """
+        # make sure this is evaluated at runtime, not at class definition time which would be the case if we used it in the parameter default value
+        if skip_validation is None:
+            skip_validation = not settings.V3_FEATURE_LOCATIONS
         # Run the pre save logic, if enabled
         self.pre_save_logic()
         # Call the validations

--- a/readme-docs/CONTRIBUTING.md
+++ b/readme-docs/CONTRIBUTING.md
@@ -55,6 +55,24 @@ Please use [these test scripts](../tests) to test your changes. These are the sc
 
 For changes that require additional settings, you can now use local_settings.py file. See the logging section below for more information.
 
+## Updating Performance Test Query Counts
+
+The importer performance tests in `unittests/test_importers_performance.py` assert on expected database query and async task counts. If your changes affect import behavior (e.g., adding queries or changing celery task usage), these counts may need to be updated.
+
+Run the update script to refresh expected counts:
+
+```bash
+python3 scripts/update_performance_test_counts.py
+```
+
+The script runs both `TestDojoImporterPerformanceSmall` (v2 endpoints) and `TestDojoImporterPerformanceSmallLocations` (v3 locations), captures actual counts, and updates the test file when they differ from expectations.
+
+To verify all tests pass after updating:
+
+```bash
+python3 scripts/update_performance_test_counts.py --verify
+```
+
 ## Python3 Version
 For compatibility reasons, the code in dev branch should be python3.13 compliant.
 

--- a/scripts/update_performance_test_counts.py
+++ b/scripts/update_performance_test_counts.py
@@ -11,11 +11,12 @@ This script:
 
 How to run:
 
-    # Default: Update the test file (uses TestDojoImporterPerformanceSmall by default)
+    # Default: Update both v2 and v3 test classes
     python3 scripts/update_performance_test_counts.py
 
-    # Or specify a different test class:
+    # Or update a specific test class:
     python3 scripts/update_performance_test_counts.py --test-class TestDojoImporterPerformanceSmall
+    python3 scripts/update_performance_test_counts.py --test-class TestDojoImporterPerformanceSmallLocations
 
     # Step 1: Run tests and generate report only (without updating)
     python3 scripts/update_performance_test_counts.py --report-only
@@ -23,7 +24,8 @@ How to run:
     # Step 2: Verify all tests pass
     python3 scripts/update_performance_test_counts.py --verify
 
-The script defaults to TestDojoImporterPerformanceSmall if --test-class is not provided.
+By default (no --test-class) the script runs and updates both
+TestDojoImporterPerformanceSmall (v2) and TestDojoImporterPerformanceSmallLocations (v3).
 The script defaults to --update behavior if no action flag is provided.
 """
 
@@ -36,13 +38,20 @@ from pathlib import Path
 # Path to the test file
 TEST_FILE = Path(__file__).parent.parent / "unittests" / "test_importers_performance.py"
 
+# All performance test classes, in run order
+TEST_CLASSES = [
+    "TestDojoImporterPerformanceSmall",
+    "TestDojoImporterPerformanceSmallLocations",
+]
+
 
 class TestCount:
 
     """Represents a test's expected and actual counts."""
 
-    def __init__(self, test_name: str, step: str, metric: str):
+    def __init__(self, test_name: str, step: str, metric: str, class_name: str | None = None):
         self.test_name = test_name
+        self.class_name = class_name
         self.step = step
         self.metric = metric
         self.expected = None
@@ -51,7 +60,7 @@ class TestCount:
 
     def __repr__(self):
         return (
-            f"TestCount({self.test_name}, {self.step}, {self.metric}, "
+            f"TestCount({self.class_name}.{self.test_name}, {self.step}, {self.metric}, "
             f"expected={self.expected}, actual={self.actual})"
         )
 
@@ -227,15 +236,16 @@ def parse_test_output(output: str) -> list[TestCount]:
     # Parse failures by splitting into individual FAIL blocks, to avoid accidentally
     # associating an assertion from a different FAIL with the wrong metric.
     fail_header = re.compile(
-        r"^FAIL:\s+(test_\w+)\s+\([^)]+\)\s+\(step=['\"](\w+)['\"],\s*metric=['\"](\w+)['\"]\)\s*$",
+        r"^FAIL:\s+(test_\w+)\s+\((?:[^)]*\.)?(\w+)\.\w+\)\s+\(step=['\"](\w+)['\"],\s*metric=['\"](\w+)['\"]\)\s*$",
         re.MULTILINE,
     )
 
     headers = list(fail_header.finditer(output))
     for idx, match in enumerate(headers):
         test_name = match.group(1)
-        step = match.group(2)
-        metric = match.group(3)
+        class_name = match.group(2)
+        step = match.group(3)
+        metric = match.group(4)
 
         block_start = match.end()
         block_end = headers[idx + 1].start() if idx + 1 < len(headers) else len(output)
@@ -270,7 +280,7 @@ def parse_test_output(output: str) -> list[TestCount]:
         if actual is None or expected is None:
             continue
 
-        count = TestCount(test_name, step, metric)
+        count = TestCount(test_name, step, metric, class_name=class_name)
         count.actual = actual
         count.expected = expected
         count.difference = expected - actual
@@ -395,13 +405,14 @@ def update_test_file(counts: list[TestCount]):
                     return start, idx + 1
         return None
 
-    # Create a mapping of test_name -> step_metric -> new_value
+    # Create a mapping of (class_name, test_name) -> step_metric -> new_value
     updates = {}
     for count in counts:
-        if count.test_name not in updates:
-            updates[count.test_name] = {}
+        key = (count.class_name, count.test_name)
+        if key not in updates:
+            updates[key] = {}
         step_metric = f"{count.step}_{count.metric}"
-        updates[count.test_name][step_metric] = count.actual
+        updates[key][step_metric] = count.actual
 
     # Map step_metric to parameter name for different methods
     param_map_import_reimport = {
@@ -419,22 +430,35 @@ def update_test_file(counts: list[TestCount]):
         "second_import_async_tasks": "expected_num_async_tasks2",
     }
 
-    # Update each test method
-    for test_name, test_updates in updates.items():
-        print(f"  Updating {test_name}...")
-        # Find the test method boundaries
+    for (class_name, test_name), test_updates in updates.items():
+        print(f"  Updating {class_name}.{test_name}...")
+
+        # Scope search to the class block (if class_name is known) to avoid
+        # matching identically-named methods in sibling classes.
+        search_content = content
+        class_offset = 0
+        if class_name:
+            class_pattern = re.compile(
+                rf"(class {re.escape(class_name)}\b.*?)(?=^class |\Z)",
+                re.DOTALL | re.MULTILINE,
+            )
+            class_match = class_pattern.search(content)
+            if class_match:
+                search_content = class_match.group(1)
+                class_offset = class_match.start()
+
         test_method_pattern = re.compile(
             rf"(def {re.escape(test_name)}\([^)]*\):.*?)(?=def test_|\Z)",
             re.DOTALL,
         )
-        test_match = test_method_pattern.search(content)
+        test_match = test_method_pattern.search(search_content)
         if not test_match:
-            print(f"⚠️  Warning: Could not find test method {test_name}")
+            print(f"⚠️  Warning: Could not find test method {class_name}.{test_name}")
             continue
 
         test_method_content = test_match.group(1)
-        test_method_start = test_match.start()
-        test_method_end = test_match.end()
+        test_method_start = class_offset + test_match.start()
+        test_method_end = class_offset + test_match.end()
 
         call_span = _extract_call_span(test_method_content, "self._import_reimport_performance")
         param_map = param_map_import_reimport
@@ -442,11 +466,11 @@ def update_test_file(counts: list[TestCount]):
             call_span = _extract_call_span(test_method_content, "self._deduplication_performance")
             if call_span is not None:
                 param_map = param_map_deduplication
-            else:
-                print(
-                    f"⚠️  Warning: Could not find _import_reimport_performance or _deduplication_performance call in {test_name}",
-                )
-                continue
+        if call_span is None:
+            print(
+                f"⚠️  Warning: Could not find _import_reimport_performance or _deduplication_performance call in {test_name}",
+            )
+            continue
 
         call_start, call_end = call_span
         original_call = test_method_content[call_start:call_end]
@@ -474,20 +498,13 @@ def update_test_file(counts: list[TestCount]):
         if updated_params:
             print(f"    Updated: {', '.join(updated_params)}")
 
-        # Replace the method call within the test method content (in-place; do not reformat)
-        updated_method_content = (
-            test_method_content[:call_start]
-            + updated_call
-            + test_method_content[call_end:]
-        )
-
-        # Replace the entire test method in the original content
+        updated_method_content = test_method_content[:call_start] + updated_call + test_method_content[call_end:]
         content = content[:test_method_start] + updated_method_content + content[test_method_end:]
 
     # Write back to file
     TEST_FILE.write_text(content)
     print(f"✅ Updated {TEST_FILE}")
-    print(f"   Updated {len(counts)} count(s) across {len(updates)} test(s)")
+    print(f"   Updated {len(counts)} count(s) across {len(updates)} test method(s)")
 
 
 def verify_tests(test_class: str) -> bool:
@@ -508,9 +525,9 @@ def verify_tests(test_class: str) -> bool:
             print(f"  {count.test_name} - {count.step} {count.metric}: "
                   f"expected {count.expected}, got {count.actual}")
         return False
-    else:  # noqa: RET505
-        print("\n✅ All tests pass!")
-        return True
+
+    print("\n✅ All tests pass!")
+    return True
 
 
 def verify_and_get_mismatches(test_class: str) -> tuple[bool, list[TestCount]]:
@@ -537,6 +554,50 @@ def verify_and_get_mismatches(test_class: str) -> tuple[bool, list[TestCount]]:
     return True, []
 
 
+def process_class(test_class: str, *, report_only: bool) -> list[TestCount]:
+    """Run update (or report-only) for a single test class. Returns all parsed counts."""
+    test_methods = extract_test_methods(test_class)
+    if not test_methods:
+        print(f"⚠️  No test methods found in {test_class}")
+        return []
+
+    print(f"\nFound {len(test_methods)} test method(s) in {test_class}")
+    print("=" * 80)
+
+    all_counts = []
+    for test_method in test_methods:
+        print(f"\n{'=' * 80}")
+        output, return_code = run_test_method(test_class, test_method)
+        success, error_msg = check_test_execution_success(output, return_code)
+        if not success:
+            print(f"\n⚠️  Test execution failed for {test_method}: {error_msg}")
+            print("Skipping this test method...")
+            continue
+
+        counts = parse_test_output(output)
+
+        if counts:
+            all_counts.extend(counts)
+            if not report_only:
+                update_test_file(counts)
+                print(f"⚠️  {test_method}: Found {len(counts)} count mismatch(es) - updated file")
+        else:
+            test_passed = "OK" in output or ("Ran" in output and "FAILED" not in output and return_code == 0)
+            if test_passed:
+                print(f"✅ {test_method}: Test passed, all counts match")
+            elif return_code != 0:
+                print(f"⚠️  {test_method}: Test failed (exit code {return_code}) but no count mismatches parsed")
+                fail_lines = [
+                    line for line in output.split("\n") if "FAIL" in line or "Error" in line or "Exception" in line
+                ]
+                if fail_lines:
+                    print("   Relevant error lines:")
+                    for line in fail_lines[:5]:
+                        print(f"     {line}")
+
+    return all_counts
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Update performance test query counts",
@@ -546,18 +607,16 @@ def main():
     parser.add_argument(
         "--test-class",
         required=False,
-        default="TestDojoImporterPerformanceSmall",
-        help="Test class name (e.g., TestDojoImporterPerformanceSmall). Defaults to TestDojoImporterPerformanceSmall if not provided.",
+        default=None,
+        help=(
+            "Test class name (e.g., TestDojoImporterPerformanceSmall). "
+            "Defaults to both TestDojoImporterPerformanceSmall and TestDojoImporterPerformanceSmallLocations."
+        ),
     )
     parser.add_argument(
         "--report-only",
         action="store_true",
         help="Only generate a report, don't update the file",
-    )
-    parser.add_argument(
-        "--update",
-        action="store_true",
-        help="Update the test file with new counts (default behavior if no action flag is provided)",
     )
     parser.add_argument(
         "--verify",
@@ -567,100 +626,53 @@ def main():
 
     args = parser.parse_args()
 
+    test_classes = [args.test_class] if args.test_class else TEST_CLASSES
+
+    if args.verify:
+        all_passed = True
+        for test_class in test_classes:
+            if not verify_tests(test_class):
+                all_passed = False
+        sys.exit(0 if all_passed else 1)
+
+    # Default: update (or report-only)
+    all_counts = []
+    for test_class in test_classes:
+        counts = process_class(test_class, report_only=args.report_only)
+        all_counts.extend(counts)
+
     if args.report_only:
-        # Step 1: Run tests and generate report
-        # Run each test method individually
-        test_methods = extract_test_methods(args.test_class)
-        if not test_methods:
-            print(f"⚠️  No test methods found in {args.test_class}")
-            sys.exit(1)
-
-        print(f"\nFound {len(test_methods)} test method(s) in {args.test_class}")
-        print("=" * 80)
-
-        all_counts = []
-        for test_method in test_methods:
-            print(f"\n{'=' * 80}")
-            output, return_code = run_test_method(args.test_class, test_method)
-            success, error_msg = check_test_execution_success(output, return_code)
-            if not success:
-                print(f"\n⚠️  Test execution failed for {test_method}: {error_msg}")
-                print("Skipping this test method...")
-                continue
-
-            counts = parse_test_output(output)
-            if counts:
-                all_counts.extend(counts)
-
-        expected_counts = extract_expected_counts_from_file(args.test_class)
+        expected_counts = {}
+        for test_class in test_classes:
+            expected_counts.update(extract_expected_counts_from_file(test_class))
         generate_report(all_counts, expected_counts)
+        return
 
-    elif args.verify:
-        # Step 3: Verify
-        success = verify_tests(args.test_class)
-        sys.exit(0 if success else 1)
-
-    else:
-        # Default: Update the file (--update is the default behavior)
-        # Run each test method individually
-        test_methods = extract_test_methods(args.test_class)
-        if not test_methods:
-            print(f"⚠️  No test methods found in {args.test_class}")
-            sys.exit(1)
-
-        print(f"\nFound {len(test_methods)} test method(s) in {args.test_class}")
-        print("=" * 80)
-
-        all_counts = []
-        for test_method in test_methods:
-            print(f"\n{'=' * 80}")
-            output, return_code = run_test_method(args.test_class, test_method)
-            success, error_msg = check_test_execution_success(output, return_code)
-            if not success:
-                print(f"\n⚠️  Test execution failed for {test_method}: {error_msg}")
-                print("Skipping this test method...")
-                continue
-
-            counts = parse_test_output(output)
-
-            # Check if test actually passed
-            test_passed = "OK" in output or ("Ran" in output and "FAILED" not in output and return_code == 0)
-
-            if counts:
-                all_counts.extend(counts)
-                # Update immediately after each test
-                update_test_file(counts)
-                print(f"⚠️  {test_method}: Found {len(counts)} count mismatch(es) - updated file")
-            elif test_passed:
-                print(f"✅ {test_method}: Test passed, all counts match")
-            elif return_code != 0:
-                # Test might have failed for other reasons
-                print(f"⚠️  {test_method}: Test failed (exit code {return_code}) but no count mismatches parsed")
-                print("   This might indicate a parsing issue or a different type of failure")
-                # Show a snippet of the output to help debug
-                fail_lines = [line for line in output.split("\n") if "FAIL" in line or "Error" in line or "Exception" in line]
-                if fail_lines:
-                    print("   Relevant error lines:")
-                    for line in fail_lines[:5]:
-                        print(f"     {line}")
-
-        if all_counts:
-            print(f"\n{'=' * 80}")
-            print(f"✅ Updated {len(all_counts)} count(s) across {len({c.test_name for c in all_counts})} test(s)")
-            # Some performance counts can vary depending on test ordering / keepdb state.
-            # Do a final full-suite pass and apply any remaining mismatches so the suite passes as run in CI.
-            print("\nRunning a final verify pass for stability...")
-            success, suite_mismatches = verify_and_get_mismatches(args.test_class)
+    if all_counts:
+        print(f"\n{'=' * 80}")
+        print(f"✅ Updated {len(all_counts)} count(s) across {len({c.test_name for c in all_counts})} test(s)")
+        # Do a final full-suite pass to catch any ordering-dependent mismatches
+        print("\nRunning a final verify pass for stability...")
+        had_suite_mismatches = False
+        for test_class in test_classes:
+            success, suite_mismatches = verify_and_get_mismatches(test_class)
             if not success and suite_mismatches:
-                print("\nApplying remaining mismatches from full-suite run...")
+                print(f"\nApplying remaining mismatches from full-suite run of {test_class}...")
                 update_test_file(suite_mismatches)
-                print("\nRe-running verify...")
-                success, _ = verify_and_get_mismatches(args.test_class)
-                sys.exit(0 if success else 1)
-            sys.exit(0 if success else 1)
-        else:
-            print(f"\n{'=' * 80}")
-            print("\n✅ No differences found. All tests are already up to date.")
+                had_suite_mismatches = True
+
+        if had_suite_mismatches:
+            print("\nRe-running verify...")
+
+        all_passed = True
+        for test_class in test_classes:
+            success, _ = verify_and_get_mismatches(test_class)
+            if not success:
+                all_passed = False
+        sys.exit(0 if all_passed else 1)
+    else:
+        print(f"\n{'=' * 80}")
+        print("\n✅ No differences found. All tests are already up to date.")
 
 
 if __name__ == "__main__":

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -30,6 +30,7 @@ from dojo.auditlog import configure_audit_system, configure_pghistory_triggers
 from dojo.decorators import dojo_async_task_counter
 from dojo.importers.default_importer import DefaultImporter
 from dojo.importers.default_reimporter import DefaultReImporter
+from dojo.location.models import Location, LocationFindingReference
 from dojo.models import (
     Development_Environment,
     Dojo_User,
@@ -228,7 +229,6 @@ class TestDojoImporterPerformanceBase(DojoTestCase):
                             test, _, _len_new_findings, _len_closed_findings, _, _, _ = reimporter.process_scan(scan)
 
 
-# TODO: Implement Locations
 @skip_unless_v2
 class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
 
@@ -460,5 +460,229 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
             expected_num_queries1=271,
             expected_num_async_tasks1=7,
             expected_num_queries2=183,
+            expected_num_async_tasks2=7,
+        )
+
+
+@override_settings(V3_FEATURE_LOCATIONS=True)
+class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase):
+
+    r"""
+    Performance tests using small sample files (StackHawk, ~6 findings) with v3 locations enabled.
+
+    These mirror TestDojoImporterPerformanceSmall but run with V3_FEATURE_LOCATIONS=True.
+    Query counts are specific to the locations code path and will differ from the v2 endpoint counts.
+
+    To determine or update the expected counts, run:
+        python3 scripts/update_performance_test_counts.py
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Warm up ContentType cache for Location models so these queries don't
+        # count against the measured sections.
+        for model in [Location, LocationFindingReference]:
+            ContentType.objects.get_for_model(model)
+
+    def _import_reimport_performance(self, expected_num_queries1, expected_num_async_tasks1, expected_num_queries2, expected_num_async_tasks2, expected_num_queries3, expected_num_async_tasks3):
+        r"""
+        Log output can be quite large as when the assertNumQueries fails, all queries are printed.
+        It could be useful to capture the output in `less`:
+            ./run-unittest.sh --test-case unittests.test_importers_performance.TestDojoImporterPerformanceSmallLocations 2>&1 | less
+        Then search for `expected` to find the lines where the expected number of queries is printed.
+        Or you can use `grep` to filter the output:
+            ./run-unittest.sh --test-case unittests.test_importers_performance.TestDojoImporterPerformanceSmallLocations 2>&1 | grep expected -B 10
+        """
+        return super()._import_reimport_performance(
+            expected_num_queries1,
+            expected_num_async_tasks1,
+            expected_num_queries2,
+            expected_num_async_tasks2,
+            expected_num_queries3,
+            expected_num_async_tasks3,
+            scan_file1=STACK_HAWK_SUBSET_FILENAME,
+            scan_file2=STACK_HAWK_FILENAME,
+            scan_file3=STACK_HAWK_SUBSET_FILENAME,
+            scan_type=STACK_HAWK_SCAN_TYPE,
+            product_name="TestDojoDefaultImporterLocations",
+            engagement_name="Test Create Engagement Locations",
+        )
+
+    @override_settings(ENABLE_AUDITLOG=True)
+    def test_import_reimport_reimport_performance_pghistory_async(self):
+        """
+        This test checks the performance of the importers when using django-pghistory with async enabled.
+        Query counts will need to be determined by running the test initially.
+        """
+        configure_audit_system()
+        configure_pghistory_triggers()
+
+        self._import_reimport_performance(
+            expected_num_queries1=1225,
+            expected_num_async_tasks1=6,
+            expected_num_queries2=715,
+            expected_num_async_tasks2=17,
+            expected_num_queries3=345,
+            expected_num_async_tasks3=16,
+        )
+
+    @override_settings(ENABLE_AUDITLOG=True)
+    def test_import_reimport_reimport_performance_pghistory_no_async(self):
+        """
+        This test checks the performance of the importers when using django-pghistory with async disabled.
+        Query counts will need to be determined by running the test initially.
+        """
+        configure_audit_system()
+        configure_pghistory_triggers()
+
+        testuser = User.objects.get(username="admin")
+        testuser.usercontactinfo.block_execution = True
+        testuser.usercontactinfo.save()
+
+        self._import_reimport_performance(
+            expected_num_queries1=1232,
+            expected_num_async_tasks1=6,
+            expected_num_queries2=722,
+            expected_num_async_tasks2=17,
+            expected_num_queries3=352,
+            expected_num_async_tasks3=16,
+        )
+
+    @override_settings(ENABLE_AUDITLOG=True)
+    def test_import_reimport_reimport_performance_pghistory_no_async_with_product_grading(self):
+        """
+        This test checks the performance of the importers when using django-pghistory with async disabled and product grading enabled.
+        Query counts will need to be determined by running the test initially.
+        """
+        configure_audit_system()
+        configure_pghistory_triggers()
+
+        testuser = User.objects.get(username="admin")
+        testuser.usercontactinfo.block_execution = True
+        testuser.usercontactinfo.save()
+        self.system_settings(enable_product_grade=True)
+
+        self._import_reimport_performance(
+            expected_num_queries1=1242,
+            expected_num_async_tasks1=8,
+            expected_num_queries2=732,
+            expected_num_async_tasks2=19,
+            expected_num_queries3=356,
+            expected_num_async_tasks3=18,
+        )
+
+    def _deduplication_performance(self, expected_num_queries1, expected_num_async_tasks1, expected_num_queries2, expected_num_async_tasks2, *, check_duplicates=True):
+        """
+        Test method to measure deduplication performance by importing the same scan twice.
+        Mirrors TestDojoImporterPerformanceSmall._deduplication_performance but uses
+        Locations-specific product/engagement names for test isolation.
+        """
+        _, engagement, lead, environment = self._create_test_objects(
+            "TestDojoDeduplicationPerformanceLocations",
+            "Test Deduplication Performance Engagement Locations",
+        )
+
+        with (  # noqa: SIM117
+            self.subTest("first_import"), impersonate(Dojo_User.objects.get(username="admin")),
+            STACK_HAWK_FILENAME.open(encoding="utf-8") as scan,
+        ):
+            with self.subTest(step="first_import", metric="queries"):
+                with self.assertNumQueries(expected_num_queries1):
+                    with self.subTest(step="first_import", metric="async_tasks"):
+                        with self._assertNumAsyncTask(expected_num_async_tasks1):
+                            import_options = {
+                                "user": lead,
+                                "lead": lead,
+                                "scan_date": None,
+                                "environment": environment,
+                                "minimum_severity": "Info",
+                                "active": True,
+                                "verified": True,
+                                "scan_type": STACK_HAWK_SCAN_TYPE,
+                                "engagement": engagement,
+                            }
+                            importer = DefaultImporter(**import_options)
+                            _, _, len_new_findings1, len_closed_findings1, _, _, _ = importer.process_scan(scan)
+
+        with (  # noqa: SIM117
+            self.subTest("second_import"), impersonate(Dojo_User.objects.get(username="admin")),
+            STACK_HAWK_FILENAME.open(encoding="utf-8") as scan,
+        ):
+            with self.subTest(step="second_import", metric="queries"):
+                with self.assertNumQueries(expected_num_queries2):
+                    with self.subTest(step="second_import", metric="async_tasks"):
+                        with self._assertNumAsyncTask(expected_num_async_tasks2):
+                            import_options = {
+                                "user": lead,
+                                "lead": lead,
+                                "scan_date": None,
+                                "environment": environment,
+                                "minimum_severity": "Info",
+                                "active": True,
+                                "verified": True,
+                                "scan_type": STACK_HAWK_SCAN_TYPE,
+                                "engagement": engagement,
+                            }
+                            importer = DefaultImporter(**import_options)
+                            _, _, len_new_findings2, len_closed_findings2, _, _, _ = importer.process_scan(scan)
+
+        logger.debug(f"First import: {len_new_findings1} new findings, {len_closed_findings1} closed findings")
+        logger.debug(f"Second import: {len_new_findings2} new findings, {len_closed_findings2} closed findings")
+
+        self.assertEqual(len_new_findings1, 6, "First import should create 6 new findings")
+        self.assertEqual(len_closed_findings1, 0, "First import should not close any findings")
+        self.assertEqual(len_new_findings2, 6, "Second import should report 6 new findings initially (before deduplication)")
+        self.assertEqual(len_closed_findings2, 0, "Second import should not close any findings")
+
+        if check_duplicates:
+            active_findings = Finding.objects.filter(
+                test__engagement=engagement,
+                active=True,
+                duplicate=False,
+            ).count()
+            duplicate_findings = Finding.objects.filter(
+                test__engagement=engagement,
+                duplicate=True,
+            ).count()
+            self.assertEqual(active_findings, 6, f"Expected 6 active findings, got {active_findings}")
+            self.assertEqual(duplicate_findings, 6, f"Expected 6 duplicate findings, got {duplicate_findings}")
+            total_findings = Finding.objects.filter(test__engagement=engagement).count()
+            self.assertEqual(total_findings, 12, f"Expected 12 total findings, got {total_findings}")
+        else:
+            total_findings = Finding.objects.filter(test__engagement=engagement).count()
+            self.assertEqual(total_findings, 12, f"Expected 12 total findings, got {total_findings}")
+
+    @override_settings(ENABLE_AUDITLOG=True)
+    def test_deduplication_performance_pghistory_async(self):
+        """Test deduplication performance with django-pghistory and async tasks enabled."""
+        configure_audit_system()
+        configure_pghistory_triggers()
+
+        self.system_settings(enable_deduplication=True)
+
+        self._deduplication_performance(
+            expected_num_queries1=1445,
+            expected_num_async_tasks1=7,
+            expected_num_queries2=1016,
+            expected_num_async_tasks2=7,
+            check_duplicates=False,  # Async mode - deduplication happens later
+        )
+
+    @override_settings(ENABLE_AUDITLOG=True)
+    def test_deduplication_performance_pghistory_no_async(self):
+        """Test deduplication performance with django-pghistory and async tasks disabled."""
+        configure_audit_system()
+        configure_pghistory_triggers()
+
+        self.system_settings(enable_deduplication=True)
+
+        testuser = User.objects.get(username="admin")
+        testuser.usercontactinfo.block_execution = True
+        testuser.usercontactinfo.save()
+
+        self._deduplication_performance(
+            expected_num_queries1=1452,
+            expected_num_async_tasks1=7,
+            expected_num_queries2=1289,
             expected_num_async_tasks2=7,
         )


### PR DESCRIPTION
## Summary

- Add `TestDojoImporterPerformanceSmallLocations` with `V3_FEATURE_LOCATIONS` for v3 importer performance testing
- Update `update_performance_test_counts.py` to support multiple test classes with identical method names
  - Extract `class_name` from FAIL header to scope updates to the correct class
  - Default to running both v2 and v3 classes when no `--test-class` is specified
  - Add `process_class()` helper to reduce duplication
- Added instructions to CONTRIBUTING.md on how to automagically update the query counts after code changes
- Fix `BaseModelWithoutTimeMeta.save()` default parameter `skip_validation` to evaluate at runtime instead of class definition time. The old code `skip_validation: bool = not settings.V3_FEATURE_LOCATIONS` baked in the value at import, causing `full_clean()` validation to be skipped when `@override_settings(V3_FEATURE_LOCATIONS=True)` was used in tests while the startup setting was `False`.