### PR TITLE
fix the way bulk update endpoints in finding view works in v3

### DIFF
--- a/dojo/templates/dojo/snippets/endpoints.html
+++ b/dojo/templates/dojo/snippets/endpoints.html
@@ -147,7 +147,7 @@
                 <div class="col-md-12">
                     <div class="panel panel-default table-responsive">
                         <div class="panel-heading">
-                            <h4>Vulnerable Endpoints / Systems ({{ finding.active_endpoint_count }}) </h4>
+                            <h4>Vulnerable Endpoints / Systems ({{ finding.active_endpoint_count }})
                                 <span class="pull-right"><a data-toggle="collapse" href="#vuln_endpoints"><i
                                         class="glyphicon glyphicon-chevron-up"></i></a></span>
                             </h4>
@@ -255,7 +255,7 @@
                                                 <a data-toggle="tooltip" data-placement="top" data-original-title="{{ endpoint.location }}" title="{{ endpoint.location }}" href="{% url 'view_endpoint' endpoint.object_id %}">{{ endpoint.location|url_shortener }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</a>
                                                 {% include "dojo/snippets/tags.html" with tags=endpoint.location.tags.all %}
                                             </td>
-                                            <td>{{ endpoint.status }}</td>
+                                            <td>{{ endpoint.get_status_display }}</td>
                                             <td>{{ endpoint.auditor|safe }}</td>
                                             <td>{{ endpoint.audit_time|date }}</td>
                                         {% else %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -758,48 +758,6 @@
         <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />
     </form>
 
-    <div class="hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
-        <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
-            <div class="btn-group mr-2" role="group" aria-label="Second group">
-                <button class="btn btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"
-                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" aria-label="Bulk Edit">
-                    Bulk Edit
-                    <span class="caret"></span>
-                </button>
-                <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" id="bulk_edit">
-                    <li style="padding-left: 8px;">
-                        <form action="{% url 'endpoints_status_bulk' finding.id %}" method="post" id="bulk_change_form">
-                            {% csrf_token %}
-                            <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />
-                            <label style="font-size: 80%; font-weight: normal; display: block">
-                                <input id="id_bulk_active" label="active "name="active" type="checkbox"/>
-                                <span>Active</span>
-                            </label>
-                            <label style="font-size: 80%; font-weight: normal; display: block">
-                                <input id="id_bulk_false_p" label="false_positive" name="false_positive" type="checkbox"/>
-                                <span>False Positive</span>
-                            </label>
-                            <label style="font-size: 80%; font-weight: normal; display: block">
-                                <input id="id_bulk_out_of_scope" label="out_of_scope" name="out_of_scope" type="checkbox"/>
-                                <span>Out of scope</span>
-                            </label>
-                            <label style="font-size: 80%; font-weight: normal; display: block">
-                                <input id="id_bulk_mitigated" label="mitigated" name="mitigated" type="checkbox"/>
-                                <span>Mitigated</span>
-                            </label>
-                            <label style="font-size: 80%; font-weight: normal; display: block">
-                                <input id="id_bulk_risk_accepted" label="risk_accepted" name="risk_accepted" type="checkbox"/>
-                                <span>Risk Accepted</span>
-                            </label>
-                            <br/>
-                            <input type="submit" class="btn btn-sm btn-primary" label="Submit" name="Submit" value="Submit"/>
-                        </form>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </div>
-
     <!--Import History begin -->
     {% if 'TRACK_IMPORT_HISTORY'|setting_enabled and latest_test_import_finding_action %}
         <div class="panel panel-default collapse in">
@@ -906,6 +864,72 @@
         </div>
     {% endif %}
     <!--Import activity end -->
+
+    <div class="hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
+        <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
+            <div class="btn-group mr-2" role="group" aria-label="Second group">
+                <button class="btn btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"
+                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="true" aria-label="Bulk Edit">
+                    Bulk Edit
+                    <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" id="bulk_edit">
+                    <li style="padding-left: 8px;">
+                        <form action="{% url 'endpoints_status_bulk' finding.id %}" method="post" id="bulk_change_form">
+                            {% csrf_token %}
+                            <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />
+                            {% if V3_FEATURE_LOCATIONS %}
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_active_location" name="bulk_status" type="radio" value="Active"/>
+                                    <span>Active</span>
+                                </label>
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_false_p_location" name="bulk_status" type="radio" value="FalsePositive"/>
+                                    <span>False Positive</span>
+                                </label>
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_out_of_scope_location" name="bulk_status" type="radio" value="OutOfScope"/>
+                                    <span>Out of scope</span>
+                                </label>
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_mitigated_location" name="bulk_status" type="radio" value="Mitigated"/>
+                                    <span>Mitigated</span>
+                                </label>
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_risk_accepted_location" name="bulk_status" type="radio" value="RiskAccepted"/>
+                                    <span>Risk Accepted</span>
+                                </label>
+                            {% else %}
+                                {% comment %} TODO: Delete this after the move to Locations {% endcomment %}
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_active" label="active" name="active" type="checkbox"/>
+                                    <span>Active</span>
+                                </label>
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_false_p" label="false_positive" name="false_positive" type="checkbox"/>
+                                    <span>False Positive</span>
+                                </label>
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_out_of_scope" label="out_of_scope" name="out_of_scope" type="checkbox"/>
+                                    <span>Out of scope</span>
+                                </label>
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_mitigated" label="mitigated" name="mitigated" type="checkbox"/>
+                                    <span>Mitigated</span>
+                                </label>
+                                <label style="font-size: 80%; font-weight: normal; display: block">
+                                    <input id="id_bulk_risk_accepted" label="risk_accepted" name="risk_accepted" type="checkbox"/>
+                                    <span>Risk Accepted</span>
+                                </label>
+                            {% endif %}
+                            <br/>
+                            <input type="submit" class="btn btn-sm btn-primary" label="Submit" name="Submit" value="Submit"/>
+                        </form>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
 
     {% include "dojo/snippets/endpoints.html" with finding=finding destination="UI" %}
 

--- a/dojo/url/ui/views.py
+++ b/dojo/url/ui/views.py
@@ -559,26 +559,14 @@ def finding_location_bulk_update(request, finding_id):
     if request.method == "POST":
         # Get the list of endpoint IDs to update and the statuses to enable
         finding_locations_to_update = request.POST.getlist("endpoints_to_update")
-        status_list = FindingLocationStatus.values
-        enable = [item for item in status_list if item in list(request.POST.keys())]
+        # Get the status
+        status = request.POST.get("bulk_status")
         # Check that endpoints and statuses are selected before proceeding
-        if finding_locations_to_update and len(enable) > 0:
+        if finding_locations_to_update and status in FindingLocationStatus:
             # Iterate over selected locations and update their finding location references
-            for location in Location.objects.filter(id__in=finding_locations_to_update):
-                finding_location = LocationFindingReference.objects.get(location=location, finding__id=finding_id)
-                for status in status_list:
-                    # Set the status attribute based on whether it is enabled in the POST request
-                    if status in enable:
-                        # Enable this status
-                        finding_location.__setattr__(status, True)  # noqa: PLC2801
-                        # If the status is 'Mitigated', record the auditor and audit time
-                        if status == FindingLocationStatus.Mitigated:
-                            finding_location.auditor = request.user
-                            finding_location.audit_time = timezone.now()
-                    else:
-                        # Disable this status
-                        finding_location.__setattr__(status, False)  # noqa: PLC2801
-                finding_location.save()
+            for location_ref in LocationFindingReference.objects.filter(location__in=finding_locations_to_update, finding__id=finding_id):
+                # Set the status
+                location_ref.set_status(FindingLocationStatus(status), request.user, timezone.now())
             # Add a success message after bulk editing endpoints
             messages.add_message(
                 request,


### PR DESCRIPTION
This PR updates the 'bulk update endpoints' functionality in the Finding view to work when V3/Locations are enabled. When using V3, the bulk edit options change to being radio buttons instead of checksbox since only one status can be set at a time in the new model.