### PR TITLE
[docs] scheduling for rules engine

### DIFF
--- a/docs/content/admin/user_management/user_permission_chart.md
+++ b/docs/content/admin/user_management/user_permission_chart.md
@@ -63,10 +63,12 @@ The majority of Configuration Permissions give users access to certain pages in 
 | Login Banner | n/a | n/a | Edit the login banner, located under **⚙️Configuration \> Login Banner** | n/a |
 | Announcements | n/a | n/a | Configure Announcements, located under  **⚙️Configuration \> Announcements** | n/a |
 | Note Types | Access the ⚙️Configuration \> Note Types page | Add a Note Type | Edit a Note Type | Delete a Note Type |
+| Prioritization Engines | Access the Prioritization Engine configuration page | Add a new Prioritization Engine | Edit an existing Prioritization Engine | Delete a Prioritization Engine |
 | Product Types | n/a | Add a new Product Type (under Products \> Product Type) | n/a | n/a |
 | Questionnaires | Access the **Questionnaires \> All Questionnaires** page | Add a new Questionnaire | Edit an existing Questionnaire | Delete a Questionnaire |
 | Questions | Access the **Questionnaires \> Questions** page | Add a new Question | Edit an existing Question | n/a |
 | Regulations | n/a | Add a Regulation to the **⚙️Configuration \> Regulations** page | Edit an existing Regulation | Delete a Regulation |
+| Scheduling Service Schedule | Access the **Scheduling** page | Superuser only | Edit an existing Schedule (change trigger, enable/disable) | Delete a Schedule |
 | SLA Configuration | Access the **⚙️Configuration \> SLA Configuration** page | Add a new SLA Configuration | Edit an existing SLA Configuration | Delete an SLA Configuration |
 | Test Types | n/a | Add a new Test Type (under **Engagements \> Test Types**) | Edit an existing Test Type | n/a |
 | Tool Configuration | Access the **⚙️Configuration \> Tool Configuration** page | Add a new Tool Configuration | Edit an existing Tool Configuration | Delete a Tool Configuration |

--- a/docs/content/automation/rules_engine/about.md
+++ b/docs/content/automation/rules_engine/about.md
@@ -14,17 +14,28 @@ Rules Engine can only be accessed through the [Pro UI](/get_started/about/ui_pro
 
 Currently, Rules can only be created for Findings, however more object types will be supported in the future.
 
-Rules always need to be manually triggered from the **All Rules** page.  When a rule is triggered, it will be applied to all existing Findings that match the filter conditions set.
+Rules can be triggered manually from the **All Rules** page, or scheduled to run automatically on a recurring schedule.  When a rule is triggered, it will be applied to all existing Findings that match the filter conditions set.
 
 ## Possible Rule Actions
 Each Rule can apply one or more of these changes to a Finding when it is triggered successfully (i.e. matches the set Filter conditions).
 
-* Modify or append one or more informational fields on a Finding, including Title, Description, Severity, CVSSv3 Vector, Active, Verified, Risk Accepted, False Positive, Mitigated
-* Set a User to Review a Finding
-* Assign a Group as Owners for a Finding
-* Add Tags to a Finding
-* Add a Note to a Finding
-* Create an Alert in DefectDojo with custom text
+### Field Modifications
+* **Set a field** on a Finding, including Title, Description, Severity, CVSSv3 Vector, Active, Verified, Risk Accepted, False Positive, Mitigated
+* **Append or Prepend text** to a Finding's Title or Description
+* **Set Priority** — override the calculated Priority value on a Finding (overrides automatic priority calculation)
+* **Set Risk** — override the calculated Risk level on a Finding (overrides automatic risk calculation)
+* **Add, Subtract, Multiply, or Divide** the Priority value on a Finding by a given number
+
+### Assignments & Ownership
+* **Set a User to Review** a Finding
+* **Assign a Group as Owners** for a Finding
+* **Set a Mitigation Policy** on a Finding — assigns a pre-configured Mitigation Policy to the Finding
+* **Add to Risk Acceptance** — adds a Finding to an existing Risk Acceptance record (sets risk_accepted=True, active=False, and handles Jira integration and endpoint statuses)
+
+### Tags, Notes & Alerts
+* **Add Tags** to a Finding
+* **Add a Note** to a Finding
+* **Create an Alert** in DefectDojo with custom text
 
 ### Filter conditions
 Rules are automatically triggered when a Finding meets specific Filter conditions. For more information on Filters that can be used to create Rule Actions, see the [Filter Index](/navigation/pro__filter_index) page.

--- a/docs/content/automation/rules_engine/scheduling.md
+++ b/docs/content/automation/rules_engine/scheduling.md
@@ -1,0 +1,51 @@
+---
+title: "Scheduling Rules"
+description: "Automatically run Rules Engine rules on a recurring or one-time schedule"
+weight: 2
+audience: pro
+---
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Rules Engine Scheduling is a DefectDojo Pro-only feature.</span>
+
+Rules can be scheduled to run automatically rather than triggered manually each time.  A scheduled rule will execute against all Findings that match its filter conditions at the configured time.
+
+The user setting up the schedule must have the **Change Scheduling Service Schedule** configuration permission.
+
+## Schedule Types
+
+### Single Run
+
+A Single Run schedule executes the rule once at a specific date and time.  After the run completes, the schedule is not repeated.
+
+### Repeated Run
+
+A Repeated Run schedule allows you to trigger a rule on a recurring basis — for example, every day at 9:00 AM, or every Monday at 15:00.
+
+**Note:** Rules Engine schedules are limited to quarter-hour marks.  The minute field of a cron schedule must be one of: **0, 15, 30, or 45**.  Other minute values are not permitted.
+
+Examples of valid schedules:
+- Every hour on the hour: `0 * * * *`
+- Every day at 9:15 AM: `15 9 * * *`
+- Every Monday at 3:00 PM: `0 15 * * 1`
+- Every 15 minutes: `0,15,30,45 * * * *`
+
+## Creating a Schedule for a Rule
+
+1. Navigate to the **All Rules** page from the **Rules Engine** menu in the sidebar.
+2. Find the rule you want to schedule, and open its action menu (**⋮**).
+3. Click **Schedule Rule**.  This option is only visible if the Scheduling Service is enabled and you have the required permission.
+4. In the **Schedule Rule** modal, fill in the following fields:
+
+| Field | Description |
+|---|---|
+| **Name** | A unique name for this schedule (required, max 100 characters). |
+| **Description** | Optional description of the schedule's purpose. |
+| **Trigger Type** | Choose **Single Run** for a one-time execution, or **Repeated Run** for a recurring cron schedule. |
+| **Frequency** | For Repeated Run: use the cron builder to select the period (hourly, daily, weekly, etc.) and the specific minute, hour, and day values. For Single Run: select a date and time using the date picker. |
+| **Enable Schedule** | Toggle to enable or disable the schedule.  A disabled schedule will not run until re-enabled. |
+
+5. Click **Submit** to save the schedule.  The rule will run automatically at the next scheduled time.
+
+
+## Permissions
+
+Access to scheduling within Rules Engine requires Superuser permissions or the appropriate Configuration Permission.  See [User Permission Chart](/admin/user_management/user_permission_chart) for details.  

--- a/docs/content/releases/pro/changelog.md
+++ b/docs/content/releases/pro/changelog.md
@@ -12,11 +12,17 @@ For Open Source release notes, please see the [Releases page on GitHub](https://
 
 ## Feb 2026: v2.55
 
+### Feb 26, 2026: v2.55.5
+
+* **(Rules Engine)** Rules Engine now automatically retries when encountering database lock contention or serialization conflicts, reducing the likelihood of a rule run failing due to temporary load on the system.
+
 ### Feb 24, 2026: v2.55.4
 
 * **(Connectors)** Added Akamai API Security, JFrog Xray to Connectors.
 * **(Surveys)** Anonymous surveys: users can now access surveys without logging in when anonymous surveys are enabled.
 * **(Pro UI)** The Pro UI editor now uses Markdown-based editing for text fields.  This resolves issues with HTML-string encoding, especially when Findings were manually entered or edited.
+* **(Rules Engine)** Added **Set Mitigation Policy** action type: Rules can now assign a pre-configured Mitigation Policy to matching Findings.
+* **(Rules Engine)** Added **Add to Risk Acceptance** action type: Rules can now add matching Findings to an existing Risk Acceptance record, automatically setting them as risk-accepted and inactive, and handling Jira integration and endpoint statuses.
 
 ### Feb 17, 2026: v2.55.3
 
@@ -126,6 +132,7 @@ No significant UX changes.
 #### Oct 20, 2025: v2.51.2
 
 * **(Connectors)** Added Anchore Enterprise Connector.
+* **(Rules Engine)** Rules can now be scheduled to run automatically on a recurring or one-time basis.  From the Rules list, use the **⋮** menu on any rule to open the **Schedule Rule** form.
 
 
 #### Oct 14, 2025: v2.51.1


### PR DESCRIPTION
Adds documentation for Rules Engine scheduling.  This feature is still in Beta so these are subject to change.