### PR TITLE
disable group post signal default user for any social provider

### DIFF
--- a/dojo/group/utils.py
+++ b/dojo/group/utils.py
@@ -1,5 +1,4 @@
 from crum import get_current_user
-from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -32,7 +31,7 @@ def group_post_save_handler(sender, **kwargs):
         group.auth_group = auth_group
         group.save()
         user = get_current_user()
-        if user and not settings.AZUREAD_TENANT_OAUTH2_GET_GROUPS:
+        if user and not group.social_provider:
             # Add the current user as the owner of the group
             member = Dojo_Group_Member()
             member.user = user


### PR DESCRIPTION
**Description**

While https://github.com/DefectDojo/django-DefectDojo/pull/13328 was not merged (and it's fine), I believe this small change is useful to allow any other "locally added social providers with group support" (in a fork).