### PR TITLE
fixture-updater: change missed in conflict resolution

### DIFF
--- a/.github/workflows/update-sample-data.yml
+++ b/.github/workflows/update-sample-data.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           scripts/fixture-updater.py dojo/fixtures/defect_dojo_sample_data.json
           mv output.json dojo/fixtures/defect_dojo_sample_data.json
-          ./fixture-updater dojo/fixtures/defect_dojo_sample_data_locations.json
+          scripts/fixture-updater.py dojo/fixtures/defect_dojo_sample_data_locations.json
           mv output.json dojo/fixtures/defect_dojo_sample_data_locations.json
 
       - name: Configure git


### PR DESCRIPTION
**Description**

#14336 renamed fixture-updater and https://github.com/DefectDojo/django-DefectDojo/pull/14391 added a new entry in the workflow but before the merge

Probably no conflict was raised due to being independent lines however `fixture-updater` binary no longer exists.

Quick fix to address that