### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize line endings to LF
+*.sh     text eol=lf
+*.expect text eol=lf
+*.py     text eol=lf
+*.yml    text eol=lf
+*.yaml   text eol=lf
+*.md     text eol=lf
+
+# Binary files — never touch line endings
+*.png    binary
+*.jpg    binary
+*.gif    binary
+*.ico    binary
+*.pdf    binary


### PR DESCRIPTION
## Summary

- Adds a `.gitattributes` file to enforce LF line endings for text files checked into the repository
- Prevents Windows users with `core.autocrlf=true` from checking out shell scripts with CRLF endings, which causes `env: 'bash\r': No such file or directory` errors when running Docker containers (fixes #14444)
- Marks binary files (images, PDFs) to prevent Git from touching their line endings