### PR TITLE
Closing DB connections that are unused

### DIFF
--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -3,7 +3,7 @@ import os
 from logging.config import dictConfig
 
 from celery import Celery, Task
-from celery.signals import setup_logging, task_postrun, task_prerun
+from celery.signals import setup_logging, task_postrun
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -119,15 +119,12 @@ def config_loggers(*args, **kwags):
     dictConfig(settings.LOGGING)
 
 
-@task_prerun.connect
-def close_old_db_connections_before_task(**kwargs):
-    from django.db import close_old_connections  # noqa: PLC0415
-    close_old_connections()
-
-
 @task_postrun.connect
 def close_old_db_connections_after_task(**kwargs):
+    from celery import current_app  # noqa: PLC0415
     from django.db import close_old_connections  # noqa: PLC0415
+    if current_app.conf.task_always_eager:
+        return
     close_old_connections()
 
 

--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -120,19 +120,17 @@ def config_loggers(*args, **kwags):
 
 
 @task_prerun.connect
-def close_old_db_connections_before_task(**kwargs):
-    from celery import current_app  # noqa: PLC0415
+def close_old_db_connections_before_task(task=None, **kwargs):
     from django.db import close_old_connections  # noqa: PLC0415
-    if current_app.conf.task_always_eager:
+    if task is not None and getattr(task.request, "is_eager", False):
         return
     close_old_connections()
 
 
 @task_postrun.connect
-def close_old_db_connections_after_task(**kwargs):
-    from celery import current_app  # noqa: PLC0415
+def close_old_db_connections_after_task(task=None, **kwargs):
     from django.db import close_old_connections  # noqa: PLC0415
-    if current_app.conf.task_always_eager:
+    if task is not None and getattr(task.request, "is_eager", False):
         return
     close_old_connections()
 

--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -5,6 +5,7 @@ from logging.config import dictConfig
 from celery import Celery, Task
 from celery.signals import setup_logging, task_postrun, task_prerun
 from django.conf import settings
+from django.db import close_old_connections
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +122,6 @@ def config_loggers(*args, **kwags):
 
 @task_prerun.connect
 def close_old_db_connections_before_task(task=None, **kwargs):
-    from django.db import close_old_connections  # noqa: PLC0415
     if task is not None and getattr(task.request, "is_eager", False):
         return
     close_old_connections()
@@ -129,7 +129,6 @@ def close_old_db_connections_before_task(task=None, **kwargs):
 
 @task_postrun.connect
 def close_old_db_connections_after_task(task=None, **kwargs):
-    from django.db import close_old_connections  # noqa: PLC0415
     if task is not None and getattr(task.request, "is_eager", False):
         return
     close_old_connections()

--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -3,7 +3,7 @@ import os
 from logging.config import dictConfig
 
 from celery import Celery, Task
-from celery.signals import setup_logging
+from celery.signals import setup_logging, task_postrun, task_prerun
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -117,6 +117,18 @@ def debug_task(self):
 @setup_logging.connect
 def config_loggers(*args, **kwags):
     dictConfig(settings.LOGGING)
+
+
+@task_prerun.connect
+def close_old_db_connections_before_task(**kwargs):
+    from django.db import close_old_connections  # noqa: PLC0415
+    close_old_connections()
+
+
+@task_postrun.connect
+def close_old_db_connections_after_task(**kwargs):
+    from django.db import close_old_connections  # noqa: PLC0415
+    close_old_connections()
 
 
 # from celery import current_app

--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -3,7 +3,7 @@ import os
 from logging.config import dictConfig
 
 from celery import Celery, Task
-from celery.signals import setup_logging, task_postrun
+from celery.signals import setup_logging, task_postrun, task_prerun
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -117,6 +117,15 @@ def debug_task(self):
 @setup_logging.connect
 def config_loggers(*args, **kwags):
     dictConfig(settings.LOGGING)
+
+
+@task_prerun.connect
+def close_old_db_connections_before_task(**kwargs):
+    from celery import current_app  # noqa: PLC0415
+    from django.db import close_old_connections  # noqa: PLC0415
+    if current_app.conf.task_always_eager:
+        return
+    close_old_connections()
 
 
 @task_postrun.connect

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -463,6 +463,7 @@ else:
     }
 
 DATABASES["default"]["CONN_MAX_AGE"] = 3600
+DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
 
 # Track migrations through source control rather than making migrations locally
 if env("DD_TRACK_MIGRATIONS"):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -462,7 +462,7 @@ else:
         },
     }
 
-DATABASES["default"]["CONN_MAX_AGE"] = 300
+DATABASES["default"]["CONN_MAX_AGE"] = 3600
 
 # Track migrations through source control rather than making migrations locally
 if env("DD_TRACK_MIGRATIONS"):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -462,6 +462,8 @@ else:
         },
     }
 
+DATABASES["default"]["CONN_MAX_AGE"] = 300
+
 # Track migrations through source control rather than making migrations locally
 if env("DD_TRACK_MIGRATIONS"):
     MIGRATION_MODULES = {"dojo": "dojo.db_migrations"}

--- a/unittests/test_celery_db_connections.py
+++ b/unittests/test_celery_db_connections.py
@@ -1,0 +1,63 @@
+import logging
+from unittest.mock import Mock, patch
+
+from dojo.celery import (
+    close_old_db_connections_after_task,
+    close_old_db_connections_before_task,
+)
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+class TestCloseOldDbConnectionsBeforeTask(DojoTestCase):
+    """Tests for the task_prerun signal handler that closes stale DB connections."""
+
+    @patch("django.db.close_old_connections")
+    def test_eager_task_skips_close(self, mock_close):
+        """Eager tasks (used in unit tests) should not close DB connections."""
+        task = Mock()
+        task.request.is_eager = True
+        close_old_db_connections_before_task(task=task)
+        mock_close.assert_not_called()
+
+    @patch("django.db.close_old_connections")
+    def test_non_eager_task_closes_connections(self, mock_close):
+        """Non-eager (normal async) tasks should close stale DB connections."""
+        task = Mock()
+        task.request.is_eager = False
+        close_old_db_connections_before_task(task=task)
+        mock_close.assert_called_once()
+
+    @patch("django.db.close_old_connections")
+    def test_none_task_closes_connections(self, mock_close):
+        """If task is None, connections should still be closed."""
+        close_old_db_connections_before_task(task=None)
+        mock_close.assert_called_once()
+
+
+class TestCloseOldDbConnectionsAfterTask(DojoTestCase):
+    """Tests for the task_postrun signal handler that closes stale DB connections."""
+
+    @patch("django.db.close_old_connections")
+    def test_eager_task_skips_close(self, mock_close):
+        """Eager tasks (used in unit tests) should not close DB connections."""
+        task = Mock()
+        task.request.is_eager = True
+        close_old_db_connections_after_task(task=task)
+        mock_close.assert_not_called()
+
+    @patch("django.db.close_old_connections")
+    def test_non_eager_task_closes_connections(self, mock_close):
+        """Non-eager (normal async) tasks should close stale DB connections."""
+        task = Mock()
+        task.request.is_eager = False
+        close_old_db_connections_after_task(task=task)
+        mock_close.assert_called_once()
+
+    @patch("django.db.close_old_connections")
+    def test_none_task_closes_connections(self, mock_close):
+        """If task is None, connections should still be closed."""
+        close_old_db_connections_after_task(task=None)
+        mock_close.assert_called_once()

--- a/unittests/test_celery_db_connections.py
+++ b/unittests/test_celery_db_connections.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestCloseOldDbConnectionsBeforeTask(DojoTestCase):
+
     """Tests for the task_prerun signal handler that closes stale DB connections."""
 
     @patch("django.db.close_old_connections")
@@ -38,6 +39,7 @@ class TestCloseOldDbConnectionsBeforeTask(DojoTestCase):
 
 
 class TestCloseOldDbConnectionsAfterTask(DojoTestCase):
+
     """Tests for the task_postrun signal handler that closes stale DB connections."""
 
     @patch("django.db.close_old_connections")


### PR DESCRIPTION
**Description**

Celery workers are long-lived processes without Django's request/response lifecycle. Django normally closes stale DB connections via its request middleware, but Celery never triggers that. As a result:

- Connections accumulate and are never returned to the pool
- CONN_MAX_AGE timeouts are never enforced between tasks

For users with high frequency usage, this can cause the DB to consume a high amount of resources due to idle connection build up. 

Fix: Two signal handlers on task_prerun and task_postrun that call close_old_connections():

- task_prerun — closes stale connections before each task runs. This handles the case where a connection was left open by a previous task and may have timed out at the DB level (e.g., PostgreSQL idle_in_transaction_session_timeout). Using a dead connection would cause an error; this preempts it.
- task_postrun — closes connections after each task. This is the primary cleanup path, ensuring connections aren't held open between tasks.
- close_old_connections() respects CONN_MAX_AGE: with the default of 0 it closes all connections; with a non-zero value it only closes connections older than the configured age.

I've set this to 300s versus the default of 0. I should note that it will not close a connection thats older than 300, rather, a connection that hasnt been used in 300s. An important distinction. 
