### PR TITLE
show social provider label in groups

### DIFF
--- a/dojo/templates/dojo/groups.html
+++ b/dojo/templates/dojo/groups.html
@@ -83,7 +83,7 @@
                                         </li>
                                     </ul>
                                 </td>
-                                <td><a href="{% url 'view_group' g.id %}">{{ g.name }}</a></td>
+                                <td><a href="{% url 'view_group' g.id %}">{{ g.name }}</a>{% if g.social_provider %} <div class="tag-label tag-color">{{ g.social_provider }}</div>{% endif %}</td>
                                 <td>{{ g.description }}</td>
                                 <td>{{ g.users.all|length }}</td>
                                 <td>{% if g.global_role.role %} {{ g.global_role.role }} {% endif %}</td>

--- a/dojo/templates/dojo/view_group.html
+++ b/dojo/templates/dojo/view_group.html
@@ -3,7 +3,7 @@
 {% load authorization_tags %}
 
 {% block content %}
-<h3 id="id_heading"> Group: {{ group.name }}</h3>
+<h3 id="id_heading"> Group: {{ group.name }}{% if group.social_provider %} <div class="tag-label tag-color">{{ group.social_provider }}</div>{% endif %}</h3>
 <div class="row">
     <div id="tests" class="col-md-8">
         <div class="panel panel-default">


### PR DESCRIPTION
**Description**

When groups are synchronized with a social provider (that supports it), group.social_provider is set.
There is no way to set it manually nor any other scenario that sets it.
There's no visual indiciation in the UI of a group that was created (and is maitained) by a social provider integration and a group that was created manually (exists only in Dojo / local).

This is missed as social groups should not be modified as (most) changes will be overwritten and it's good to be able to spot them besides the name prefix of the configuration.

**Test results**

* Logged in with a social provider to populate groups
* Logged in as admin and created a group (via UI)
* Check list of groups: verify provider groups have a label with its name and local group has no label
* Check details of group with and without provider: verify same as previous step
