### PR TITLE
use tags.add() instead of tags.set() on reimport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,6 @@ docs/.devcontainer/Dockerfile
 docs/LICENSE
 docs/.hugo_build.lock
 .cursor-rules
+
+# claude etc
+MEMORY.md

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -243,9 +243,9 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
             # Parsers must use unsaved_tags to store tags, so we can clean them
             cleaned_tags = clean_tags(finding.unsaved_tags)
             if isinstance(cleaned_tags, list):
-                finding.tags.set(cleaned_tags)
+                finding.tags.add(*cleaned_tags)
             elif isinstance(cleaned_tags, str):
-                finding.tags.set([cleaned_tags])
+                finding.tags.add(cleaned_tags)
             # Process any files
             self.process_files(finding)
             # Process vulnerability IDs

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -945,9 +945,9 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         if finding_from_report.unsaved_tags:
             cleaned_tags = clean_tags(finding_from_report.unsaved_tags)
             if isinstance(cleaned_tags, list):
-                finding.tags.set(cleaned_tags)
+                finding.tags.add(*cleaned_tags)
             elif isinstance(cleaned_tags, str):
-                finding.tags.set([cleaned_tags])
+                finding.tags.add(cleaned_tags)
         # Process any files
         if finding_from_report.unsaved_files:
             finding.unsaved_files = finding_from_report.unsaved_files

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -306,7 +306,8 @@ class TagImportMixin:
             self.assertIn(tag, response["tags"])
 
     def test_manually_set_tags_preserved_on_reimport(self):
-        """Manually set tags on findings must survive a reimport.
+        """
+        Manually set tags on findings must survive a reimport.
 
         Regression test for finding_post_processing() using tags.set() instead of
         tags.add(), which caused manually-set tags to be silently wiped when reimporting

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -279,6 +279,7 @@ class TagImportMixin:
         self.zap_sample5_filename = get_unit_tests_scans_path("zap") / "5_zap_sample_one.xml"
         self.generic_sample_with_tags_filename = get_unit_tests_scans_path("generic") / "generic_report1.json"
         self.generic_sample_with_more_tags_filename = get_unit_tests_scans_path("generic") / "generic_report1_more_tags.json"
+        self.trivy_filename = get_unit_tests_scans_path("trivy") / "scheme_2_many_vulns.json"
 
     def test_import_and_reimport_with_tags(self):
         """Test that tags passed as import parameter are applied to the test."""
@@ -303,6 +304,53 @@ class TagImportMixin:
         self.assertEqual(len(tags), len(response.get("tags")))
         for tag in tags:
             self.assertIn(tag, response["tags"])
+
+    def test_manually_set_tags_preserved_on_reimport(self):
+        """Manually set tags on findings must survive a reimport.
+
+        Regression test for finding_post_processing() using tags.set() instead of
+        tags.add(), which caused manually-set tags to be silently wiped when reimporting
+        with parsers that populate unsaved_tags (Trivy, SARIF, SonarQube, etc.).
+        """
+        # 1. Import a Trivy scan
+        import0 = self.import_scan_with_params(
+            self.trivy_filename,
+            scan_type="Trivy Scan",
+            minimum_severity="Info",
+        )
+        test_id = import0["test"]
+
+        # 2. Fetch findings and manually tag each one with "bla_bla"
+        findings_before = self.get_test_findings_api(test_id)["results"]
+        self.assertGreater(len(findings_before), 0, "Expected findings from Trivy scan")
+        for finding in findings_before:
+            self.patch_finding_api(finding["id"], {"tags": ["bla_bla"]})
+
+        # 3. Confirm the tag was applied before reimport
+        findings_before = self.get_test_findings_api(test_id)["results"]
+        for finding in findings_before:
+            self.assertIn(
+                "bla_bla",
+                finding["tags"],
+                f"Tag 'bla_bla' was not set on finding {finding['id']} before reimport",
+            )
+
+        # 4. Reimport the same scan
+        self.reimport_scan_with_params(
+            test_id,
+            self.trivy_filename,
+            scan_type="Trivy Scan",
+            minimum_severity="Info",
+        )
+
+        # 5. Confirm manually set tags survived — reimport must not overwrite them
+        findings_after = self.get_test_findings_api(test_id)["results"]
+        for finding in findings_after:
+            self.assertIn(
+                "bla_bla",
+                finding["tags"],
+                f"Manually set tag 'bla_bla' was overwritten on finding {finding['id']} during reimport",
+            )
 
     def test_import_report_with_tags(self):
         """Test that parser-generated tags on findings are preserved during import/reimport."""


### PR DESCRIPTION
This fixes an issue introduced in 2.54.2 by commit [9c4f51e70f](https://github.com/DefectDojo/django-DefectDojo/commit/9c4f51e70f) ("tags from parser: fix parsers, add tests and fallback"). That commit correctly fixed parsers (Trivy, SARIF, SonarQube, etc.) to use unsaved_tags instead of finding.tags directly.

But a side effect, the tags.set() line in finding_post_processing — which previously never fired for those parsers because unsaved_tags was always empty — now fires on every reimport, **replacing all tags on the matched existing finding**.

This causes problems with manually created Finding Tags being overwritten on reimport.  Instead I recommend calling finding.tags.add() which does not replace any tags on the Finding that may exist previously.  IMO is something that should be handled by PATCHing or bulk-editing the Findings, not reimporting.

