### PR TITLE
feat: allow sorting endpoints by active findings count

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1264,6 +1264,7 @@ class EndpointStatusSerializer(serializers.ModelSerializer):
 
 class EndpointSerializer(serializers.ModelSerializer):
     tags = TagListSerializerField(required=False)
+    active_finding_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Endpoint

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -12,7 +12,8 @@ from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
-from django.db.models import Count, Q
+from django.db.models import OuterRef, Value
+from django.db.models.functions import Coalesce
 from django.db.models.query import QuerySet as DjangoQuerySet
 from django.http import FileResponse, HttpResponse
 from django.shortcuts import get_object_or_404
@@ -167,6 +168,7 @@ from dojo.product_type.queries import (
     get_authorized_product_type_members,
     get_authorized_product_types,
 )
+from dojo.query_utils import build_count_subquery
 from dojo.reports.views import (
     prefetch_related_findings_for_report,
     report_url_resolver,
@@ -346,12 +348,12 @@ class EndPointViewSet(
     )
 
     def get_queryset(self):
+        active_finding_subquery = build_count_subquery(
+            Finding.objects.filter(endpoints=OuterRef("pk"), active=True),
+            group_field="endpoints",
+        )
         return get_authorized_endpoints(Permissions.Location_View).annotate(
-            active_finding_count=Count(
-                "findings",
-                filter=Q(findings__active=True),
-                distinct=True,
-            ),
+            active_finding_count=Coalesce(active_finding_subquery, Value(0)),
         ).distinct()
 
     @extend_schema(

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
+from django.db.models import Count, Q
 from django.db.models.query import QuerySet as DjangoQuerySet
 from django.http import FileResponse, HttpResponse
 from django.shortcuts import get_object_or_404
@@ -345,7 +346,13 @@ class EndPointViewSet(
     )
 
     def get_queryset(self):
-        return get_authorized_endpoints(Permissions.Location_View).distinct()
+        return get_authorized_endpoints(Permissions.Location_View).annotate(
+            active_finding_count=Count(
+                "findings",
+                filter=Q(findings__active=True),
+                distinct=True,
+            ),
+        ).distinct()
 
     @extend_schema(
         request=serializers.ReportGenerateOptionSerializer,

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -8,7 +8,7 @@ from django.contrib import messages
 from django.contrib.admin.utils import NestedObjects
 from django.core.exceptions import PermissionDenied
 from django.db import DEFAULT_DB_ALIAS
-from django.db.models import Count, OuterRef, Q, QuerySet, Value
+from django.db.models import OuterRef, QuerySet, Value
 from django.db.models.functions import Coalesce
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -59,12 +59,12 @@ def process_endpoints_view(request, *, host_view=False, vulnerable=False):
     else:
         endpoints = Endpoint.objects.all()
 
+    active_finding_subquery = build_count_subquery(
+        Finding.objects.filter(endpoints=OuterRef("pk"), active=True),
+        group_field="endpoints",
+    )
     endpoints = endpoints.prefetch_related("product", "product__tags", "tags").annotate(
-        active_finding_count=Count(
-            "findings",
-            filter=Q(findings__active=True),
-            distinct=True,
-        ),
+        active_finding_count=Coalesce(active_finding_subquery, Value(0)),
     ).distinct()
     endpoints = get_authorized_endpoints_for_queryset(Permissions.Location_View, endpoints, request.user)
     filter_string_matching = get_system_setting("filter_string_matching", False)

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -8,7 +8,7 @@ from django.contrib import messages
 from django.contrib.admin.utils import NestedObjects
 from django.core.exceptions import PermissionDenied
 from django.db import DEFAULT_DB_ALIAS
-from django.db.models import OuterRef, QuerySet, Value
+from django.db.models import Count, OuterRef, Q, QuerySet, Value
 from django.db.models.functions import Coalesce
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -59,7 +59,13 @@ def process_endpoints_view(request, *, host_view=False, vulnerable=False):
     else:
         endpoints = Endpoint.objects.all()
 
-    endpoints = endpoints.prefetch_related("product", "product__tags", "tags").distinct()
+    endpoints = endpoints.prefetch_related("product", "product__tags", "tags").annotate(
+        active_finding_count=Count(
+            "findings",
+            filter=Q(findings__active=True),
+            distinct=True,
+        ),
+    ).distinct()
     endpoints = get_authorized_endpoints_for_queryset(Permissions.Location_View, endpoints, request.user)
     filter_string_matching = get_system_setting("filter_string_matching", False)
     filter_class = EndpointFilterWithoutObjectLookups if filter_string_matching else EndpointFilter

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2866,7 +2866,11 @@ class EndpointFilterHelper(FilterSet):
             ("product", "product"),
             ("host", "host"),
             ("id", "id"),
+            ("active_finding_count", "active_finding_count"),
         ),
+        field_labels={
+            "active_finding_count": "Active Findings Count",
+        },
     )
 
 
@@ -3108,7 +3112,11 @@ class ApiEndpointFilter(DojoFilter):
             ("host", "host"),
             ("product", "product"),
             ("id", "id"),
+            ("active_finding_count", "active_finding_count"),
         ),
+        field_labels={
+            "active_finding_count": "Active Findings Count",
+        },
     )
 
     class Meta:

--- a/dojo/location/api/endpoint_compat.py
+++ b/dojo/location/api/endpoint_compat.py
@@ -6,7 +6,8 @@ models while using the new URL and LocationFindingReference models underneath.
 """
 import datetime
 
-from django.db.models import Count, Q
+from django.db.models import OuterRef, Value
+from django.db.models.functions import Coalesce
 from django_filters import BooleanFilter, CharFilter, NumberFilter
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from drf_spectacular.utils import extend_schema
@@ -33,6 +34,7 @@ from dojo.filters import CharFieldFilterANDExpression, CharFieldInFilter, Orderi
 from dojo.location.models import LocationFindingReference, LocationProductReference
 from dojo.location.queries import get_authorized_location_finding_reference, get_authorized_location_product_reference
 from dojo.location.status import FindingLocationStatus
+from dojo.query_utils import build_count_subquery
 from dojo.url.models import URL
 
 ##########
@@ -147,14 +149,17 @@ class V3EndpointCompatibleViewSet(PrefetchListMixin, PrefetchRetrieveMixin, view
 
     def get_queryset(self):
         """Get authorized URLs using Endpoint authorization logic."""
+        active_finding_subquery = build_count_subquery(
+            LocationFindingReference.objects.filter(
+                location=OuterRef("location"),
+                status=FindingLocationStatus.Active,
+            ),
+            group_field="location",
+        )
         return get_authorized_location_product_reference(Permissions.Location_View).filter(
             location__location_type=URL.LOCATION_TYPE,
         ).annotate(
-            active_finding_count=Count(
-                "location__findings",
-                filter=Q(location__findings__status=FindingLocationStatus.Active),
-                distinct=True,
-            ),
+            active_finding_count=Coalesce(active_finding_subquery, Value(0)),
         ).distinct()
 
     @extend_schema(

--- a/dojo/location/api/endpoint_compat.py
+++ b/dojo/location/api/endpoint_compat.py
@@ -6,6 +6,7 @@ models while using the new URL and LocationFindingReference models underneath.
 """
 import datetime
 
+from django.db.models import Count, Q
 from django_filters import BooleanFilter, CharFilter, NumberFilter
 from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from drf_spectacular.utils import extend_schema
@@ -101,7 +102,11 @@ class V3EndpointCompatibleFilterSet(FilterSet):
             ("location__url__host", "host"),
             ("product__id", "product"),
             ("id", "id"),
+            ("active_finding_count", "active_finding_count"),
         ),
+        field_labels={
+            "active_finding_count": "Active Findings Count",
+        },
     )
 
 
@@ -118,6 +123,7 @@ class V3EndpointCompatibleSerializer(ModelSerializer):
     fragment = CharField(source="location.url.fragment")
     tags = TagListSerializerField(source="location.tags")
     location_id = IntegerField(source="location.id")
+    active_finding_count = IntegerField(read_only=True)
 
     class Meta:
         model = LocationProductReference
@@ -141,7 +147,15 @@ class V3EndpointCompatibleViewSet(PrefetchListMixin, PrefetchRetrieveMixin, view
 
     def get_queryset(self):
         """Get authorized URLs using Endpoint authorization logic."""
-        return get_authorized_location_product_reference(Permissions.Location_View).filter(location__location_type=URL.LOCATION_TYPE).distinct()
+        return get_authorized_location_product_reference(Permissions.Location_View).filter(
+            location__location_type=URL.LOCATION_TYPE,
+        ).annotate(
+            active_finding_count=Count(
+                "location__findings",
+                filter=Q(location__findings__status=FindingLocationStatus.Active),
+                distinct=True,
+            ),
+        ).distinct()
 
     @extend_schema(
         request=serializers.ReportGenerateOptionSerializer,

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -87,7 +87,7 @@
                                 {% comment %} The display field is translated in the function. No need to translate here as well{% endcomment %}    
                                 <th scope="col">{% dojo_sort request 'Product' 'product' 'asc' %}</th>
                             {% endif %}
-							<th class="text-center" nowrap="nowrap" scope="col">Active (Verified) Findings</th>
+							<th class="text-center" nowrap="nowrap" scope="col">{% dojo_sort request 'Active (Verified) Findings' 'active_finding_count' %}</th>
 							<th scope="col">Status</th>
                         </tr>
 
@@ -119,7 +119,7 @@
                                   {% if host_view %}
                                        {{ e.host_active_findings_count }} ({{ e.host_active_verified_findings_count }})
                                   {% else %}
-                                      <a href="{% url 'open_findings' %}?endpoints={{ e.id }}">{{ e.active_findings_count }}</a>
+                                      <a href="{% url 'open_findings' %}?endpoints={{ e.id }}">{{ e.active_finding_count }}</a>
                                       <a href="{% url 'verified_findings' %}?endpoints={{ e.id }}">({{ e.active_verified_findings_count }})</a>
                                   {% endif %}
                                 </td>

--- a/dojo/templates/dojo/url/list.html
+++ b/dojo/templates/dojo/url/list.html
@@ -97,7 +97,7 @@
                                 <th>Endpoint</th>
                             {% endif %}
                             {% if not product_tab %}<th class="text-center" nowrap="nowrap">Active (Total) Products</th>{% endif %}
-                            <th class="text-center" nowrap="nowrap">Active (Total) Findings</th>
+                            <th class="text-center" nowrap="nowrap">{% dojo_sort request 'Active (Total) Findings' 'active_findings' %}</th>
                             <th class="text-center" nowrap="nowrap">Overall Status</th>
                         </tr>
                         {% for location in locations %}

--- a/dojo/templates/dojo/url/list.html
+++ b/dojo/templates/dojo/url/list.html
@@ -97,7 +97,7 @@
                                 <th>Endpoint</th>
                             {% endif %}
                             {% if not product_tab %}<th class="text-center" nowrap="nowrap">Active (Total) Products</th>{% endif %}
-                            <th class="text-center" nowrap="nowrap">{% dojo_sort request 'Active (Total) Findings' 'active_findings' %}</th>
+                            <th class="text-center" nowrap="nowrap">{% dojo_sort request 'Active (Total) Findings' 'active_findings' field='ordering' %}</th>
                             <th class="text-center" nowrap="nowrap">Overall Status</th>
                         </tr>
                         {% for location in locations %}

--- a/dojo/templatetags/navigation_tags.py
+++ b/dojo/templatetags/navigation_tags.py
@@ -38,8 +38,7 @@ def url_replace(request, field="page", value=1):
 
 
 @register.simple_tag
-def dojo_sort(request, display="Name", value="title", default=None):
-    field = "o"
+def dojo_sort(request, display="Name", value="title", default=None, field="o"):
     icon = '<i class="fa-solid fa-sort'
     title = "Click to sort "
     if field in request.GET:

--- a/dojo/url/api/filters.py
+++ b/dojo/url/api/filters.py
@@ -35,5 +35,6 @@ class URLFilter(AbstractedLocationFilter):
             "fragment",
             "created_at",
             "updated_at",
+            "active_findings",
         ),
     )

--- a/dojo/url/api/views.py
+++ b/dojo/url/api/views.py
@@ -1,9 +1,13 @@
-from django.db.models import QuerySet
+from django.db.models import OuterRef, QuerySet, Value
+from django.db.models.functions import Coalesce
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.permissions import DjangoModelPermissions
 
 from dojo.api_v2.permissions import IsSuperUser
 from dojo.api_v2.views import PrefetchDojoModelViewSet
+from dojo.location.models import LocationFindingReference
+from dojo.location.status import FindingLocationStatus
+from dojo.query_utils import build_count_subquery
 from dojo.url.api.filters import URLFilter
 from dojo.url.api.serializer import URLSerializer
 from dojo.url.models import URL
@@ -22,5 +26,13 @@ class URLViewSet(PrefetchDojoModelViewSet):
     lookup_url_kwarg = "pk"
 
     def get_queryset(self) -> QuerySet[URL]:
-        """Return the queryset of Vulnerabilities."""
-        return URL.objects.all()
+        active_finding_subquery = build_count_subquery(
+            LocationFindingReference.objects.filter(
+                location__url=OuterRef("pk"),
+                status=FindingLocationStatus.Active,
+            ),
+            group_field="location__url",
+        )
+        return URL.objects.annotate(
+            active_findings=Coalesce(active_finding_subquery, Value(0)),
+        )

--- a/dojo/url/filters.py
+++ b/dojo/url/filters.py
@@ -47,6 +47,7 @@ class URLFilter(StaticMethodFilters):
             "url__fragment",
             "created_at",
             "updated_at",
+            "active_findings",
         ),
     )
 

--- a/tests/endpoint_extended_test.py
+++ b/tests/endpoint_extended_test.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import time
 import unittest
@@ -26,6 +27,38 @@ class EndpointExtendedTest(BaseTestCase):
         driver = self.driver
         driver.get(self.base_url + "endpoint/host")
         self.assertTrue(self.is_text_present_on_page(text="All Hosts"))
+
+    def _active_findings_sort_field(self):
+        v3 = os.environ.get("DD_V3_FEATURE_LOCATIONS", "false").lower() == "true"
+        return "active_findings" if v3 else "active_finding_count"
+
+    @on_exception_html_source_logger
+    def test_endpoint_list_sort_by_active_findings_asc(self):
+        driver = self.driver
+        field = self._active_findings_sort_field()
+        driver.get(self.base_url + f"endpoint?o={field}")
+        self.assertTrue(self.is_text_present_on_page(text="Endpoint"))
+
+    @on_exception_html_source_logger
+    def test_endpoint_list_sort_by_active_findings_desc(self):
+        driver = self.driver
+        field = self._active_findings_sort_field()
+        driver.get(self.base_url + f"endpoint?o=-{field}")
+        self.assertTrue(self.is_text_present_on_page(text="Endpoint"))
+
+    @on_exception_html_source_logger
+    def test_endpoint_host_list_sort_by_active_findings_asc(self):
+        driver = self.driver
+        field = self._active_findings_sort_field()
+        driver.get(self.base_url + f"endpoint/host?o={field}")
+        self.assertTrue(self.is_text_present_on_page(text="Hosts"))
+
+    @on_exception_html_source_logger
+    def test_endpoint_host_list_sort_by_active_findings_desc(self):
+        driver = self.driver
+        field = self._active_findings_sort_field()
+        driver.get(self.base_url + f"endpoint/host?o=-{field}")
+        self.assertTrue(self.is_text_present_on_page(text="Hosts"))
 
     @on_exception_html_source_logger
     def test_add_endpoint_meta_data(self):
@@ -92,6 +125,10 @@ def suite():
     suite.addTest(EndpointExtendedTest("test_vulnerable_endpoints_page"))
     suite.addTest(EndpointExtendedTest("test_vulnerable_endpoint_hosts_page"))
     suite.addTest(EndpointExtendedTest("test_endpoint_host_list"))
+    suite.addTest(EndpointExtendedTest("test_endpoint_list_sort_by_active_findings_asc"))
+    suite.addTest(EndpointExtendedTest("test_endpoint_list_sort_by_active_findings_desc"))
+    suite.addTest(EndpointExtendedTest("test_endpoint_host_list_sort_by_active_findings_asc"))
+    suite.addTest(EndpointExtendedTest("test_endpoint_host_list_sort_by_active_findings_desc"))
     suite.addTest(EndpointExtendedTest("test_add_endpoint_meta_data"))
     suite.addTest(EndpointExtendedTest("test_edit_endpoint_meta_data"))
     suite.addTest(ProductTest("test_delete_product"))


### PR DESCRIPTION
## Summary

- Add ability to sort the endpoint list and host list by active findings count in the UI (ascending and descending)
- Annotate the endpoint queryset with `active_finding_count` before filtering so the sort operates at the database level
- Add `active_finding_count` to `EndpointFilterHelper` and `ApiEndpointFilter` ordering fields, and expose it in `EndpointSerializer`
- V3 Locations path: add `active_findings` ordering to `URLFilter` (UI) and `V3EndpointCompatibleFilterSet` (API compat); expose `active_finding_count` in `V3EndpointCompatibleSerializer`; the annotation is already provided by `annotate_location_counts_and_status` and `annotate_host_contents`
- Update `endpoints.html` and `url/list.html` templates to render the column header as a sortable link and use the annotated count directly from the queryset
- Add Selenium integration tests to `endpoint_extended_test.py` covering ascending and descending sort for both endpoint list and host list views; tests automatically select the correct sort field name based on `DD_V3_FEATURE_LOCATIONS`

Closes #10540