### PR TITLE
bugfix(metrics): closed findings counter always shows 0 when no new findings are imported 

### DIFF
--- a/dojo/metrics/utils.py
+++ b/dojo/metrics/utils.py
@@ -76,11 +76,12 @@ def finding_queries(
 
     # Filter by the date ranges supplied
     all_findings_within_date_range = all_authorized_findings.filter(date__range=[start_date, end_date])
-    # Get the list of closed findings filtered by mitigated date (not discovery date)
-    # This ensures findings closed within the date range are included even if discovered outside it
+    # Filter closed findings by mitigated date (not discovery date).
+    # Use timezone.now() as the upper bound so findings closed after the latest
+    # discovery date are not excluded from the counter.
     closed_filtered_findings = all_authorized_findings.filter(
         CLOSED_FINDINGS_QUERY,
-        mitigated__range=[start_date, end_date],
+        mitigated__range=[start_date, timezone.now()],
         mitigated__isnull=False,
     )
     accepted_filtered_findings = all_findings_within_date_range.filter(ACCEPTED_FINDINGS_QUERY)

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -445,8 +445,10 @@ def finding_queries(request, prod):
     filters["new_verified"] = findings_qs.filter(finding_helper.VERIFIED_FINDINGS_QUERY).filter(date__range=[start_date, end_date]).order_by("date")
     filters["open"] = findings_qs.filter(finding_helper.OPEN_FINDINGS_QUERY).filter(date__range=[start_date, end_date]).order_by("date")
     filters["inactive"] = findings_qs.filter(finding_helper.INACTIVE_FINDINGS_QUERY).filter(date__range=[start_date, end_date]).order_by("date")
-    # Filter closed findings by mitigated date (not discovery date) to show findings closed within the date range
-    filters["closed"] = findings_qs.filter(finding_helper.CLOSED_FINDINGS_QUERY).filter(mitigated__range=[start_date, end_date], mitigated__isnull=False).order_by("mitigated")
+    # Filter closed findings by mitigated date (not discovery date).
+    # Use timezone.now() as the upper bound so findings closed after the latest
+    # discovery date are not excluded from the counter.
+    filters["closed"] = findings_qs.filter(finding_helper.CLOSED_FINDINGS_QUERY).filter(mitigated__range=[start_date, timezone.now()], mitigated__isnull=False).order_by("mitigated")
     filters["false_positive"] = findings_qs.filter(finding_helper.FALSE_POSITIVE_FINDINGS_QUERY).filter(date__range=[start_date, end_date]).order_by("date")
     filters["out_of_scope"] = findings_qs.filter(finding_helper.OUT_OF_SCOPE_FINDINGS_QUERY).filter(date__range=[start_date, end_date]).order_by("date")
     filters["all"] = findings_qs.order_by("date")

--- a/unittests/test_metrics_queries.py
+++ b/unittests/test_metrics_queries.py
@@ -240,9 +240,10 @@ class FindingQueriesTest(DojoTestCase):
             self.assertIn(finding_discovered_before.id, closed_ids,
                          "Finding discovered before range but closed within range should appear in closed metrics")
 
-            # The finding discovered within but closed after should NOT appear
-            self.assertNotIn(finding_closed_after.id, closed_ids,
-                            "Finding discovered within range but closed after range should NOT appear in closed metrics")
+            # The finding closed after the discovery date range but before now() should appear -
+            # the upper bound for mitigated is timezone.now(), not end_date derived from discovery dates.
+            self.assertIn(finding_closed_after.id, closed_ids,
+                          "Finding closed after discovery date range but before now() should appear in closed metrics")
 
             # The finding discovered and closed within should appear
             self.assertIn(finding_both_within.id, closed_ids,

--- a/unittests/test_product_metrics_closed_count.py
+++ b/unittests/test_product_metrics_closed_count.py
@@ -1,0 +1,131 @@
+"""
+Regression test for: Product Metrics shows 0 Closed Findings while the findings
+list displays them correctly.
+
+Root cause: finding_queries() in dojo/product/views.py used end_date (derived from
+the latest finding discovery date, built as midnight 00:00:00) as the upper bound
+for mitigated__range. This made no semantic sense - a finding can be closed at any
+time after discovery, so using the discovery date as the cutoff for mitigated is
+incorrect.
+
+Fix: replace end_date with timezone.now() as the upper bound so any finding closed
+up to the current moment is counted.
+"""
+
+import zoneinfo
+from datetime import date, datetime
+
+from django.test import RequestFactory
+
+from dojo.models import Engagement, Finding, Product, Product_Type, Test, Test_Type, User
+from dojo.product.views import finding_queries
+
+from .dojo_test_case import DojoTestCase
+
+UTC = zoneinfo.ZoneInfo("UTC")
+
+
+class ProductMetricsClosedCountTest(DojoTestCase):
+
+    """Regression tests for closed finding counter in Product Metrics."""
+
+    def setUp(self):
+        self.user = User.objects.create_superuser(username="admin_regression", password="test")  # noqa: S106
+        self.product_type = Product_Type.objects.create(name="Regression PT")
+        self.product = Product.objects.create(
+            name="Regression Product",
+            prod_type=self.product_type,
+            description="Regression test product",
+        )
+        self.engagement = Engagement.objects.create(
+            name="Regression Eng",
+            product=self.product,
+            target_start=date(2024, 1, 1),
+            target_end=date(2024, 12, 31),
+        )
+        self.test_type, _ = Test_Type.objects.get_or_create(name="Manual")
+        self.test = Test.objects.create(
+            engagement=self.engagement,
+            test_type=self.test_type,
+            target_start=datetime(2024, 1, 1, tzinfo=UTC),
+            target_end=datetime(2024, 12, 31, tzinfo=UTC),
+        )
+        # date=7 corresponds to "Any date" in MetricsDateRangeFilter
+        self.request = RequestFactory().get(f"/product/{self.product.id}/metrics", {"date": "7"})
+        self.request.user = self.user
+
+    def _make_closed(self, title, discovery_date, mitigated_dt, severity="High"):
+        return Finding.objects.create(
+            title=title,
+            test=self.test,
+            severity=severity,
+            active=False,
+            is_mitigated=True,
+            date=discovery_date,
+            mitigated=mitigated_dt,
+            reporter=self.user,
+            verified=True,
+        )
+
+    def test_closed_finding_same_day_after_midnight_is_counted(self):
+        """
+        A finding discovered on day X and closed on day X at 10:00 must appear
+        in the closed counter. Before the fix end_date was derived from the latest
+        discovery date as midnight, so this finding was silently excluded.
+        """
+        discovery = date(2024, 6, 15)
+        # closed on the same day but well after midnight
+        mitigated = datetime(2024, 6, 15, 10, 30, tzinfo=UTC)
+        self._make_closed("Closed same-day after midnight", discovery, mitigated)
+
+        filters = finding_queries(self.request, self.product)
+        closed_ids = list(filters["closed"].values_list("id", flat=True))
+        self.assertEqual(len(closed_ids), 1, "Expected exactly 1 closed finding in metrics")
+
+    def test_closed_finding_on_same_day_as_end_date_is_counted(self):
+        """
+        A finding with discovery date in the past but closed recently must appear
+        in the closed counter. Before the fix end_date was the latest discovery date
+        (midnight), so findings closed after that date were excluded.
+        """
+        today = date(2025, 6, 15)
+        # open finding - sets end_date to today
+        Finding.objects.create(
+            title="Open Finding - sets end_date",
+            test=self.test, severity="Low",
+            active=True, is_mitigated=False,
+            date=today, reporter=self.user,
+        )
+        # closed finding - mitigated today at 10:00 (after midnight)
+        closed = self._make_closed(
+            "Closed same day as end_date",
+            date(2024, 11, 27),
+            datetime(2025, 6, 15, 10, 0, tzinfo=UTC),
+        )
+
+        filters = finding_queries(self.request, self.product)
+        closed_ids = list(filters["closed"].values_list("id", flat=True))
+        self.assertIn(
+            closed.id, closed_ids,
+            "Finding mitigated on the same day as end_date (but after midnight) must appear in closed metrics",
+        )
+
+    def test_closed_count_matches_findings_list_count(self):
+        """
+        All closed findings whose mitigated date falls within [start_date, end_date_eod]
+        must be counted.  Specifically, findings closed on the same day as end_date
+        at any time (including 23:59) must appear.
+        """
+        # All three findings have the same discovery date, so end_date = 2024-03-01 23:59:59
+        self._make_closed("F1 - closed at 00:01", date(2024, 3, 1), datetime(2024, 3, 1, 0, 1, tzinfo=UTC))
+        self._make_closed("F2 - closed at 14:00", date(2024, 3, 1), datetime(2024, 3, 1, 14, 0, tzinfo=UTC))
+        self._make_closed("F3 - closed at 23:58", date(2024, 3, 1), datetime(2024, 3, 1, 23, 58, tzinfo=UTC))
+
+        filters = finding_queries(self.request, self.product)
+        metrics_count = filters["closed"].count()
+
+        self.assertEqual(
+            metrics_count,
+            3,
+            f"All 3 findings closed on end_date must be counted, got {metrics_count}",
+        )


### PR DESCRIPTION
The **Closed Findings** counter on the Product Metrics page shows `0` even when closed findings exist and are correctly displayed when clicking the link.

| Metrics page (counter) | Findings list (after clicking) |
|---|---|
| ![0 Closed Findings](https://github.com/user-attachments/assets/551e05ac-b1fe-4e83-8e6d-9ff9f4c4bbd6) | ![1 finding shown](https://github.com/user-attachments/assets/3662ed9a-60a5-4117-95d0-12fe62946778) |

Root cause: `finding_queries()` builds `end_date` from the latest finding discovery date (as midnight `00:00:00`) and uses it as the upper bound for `mitigated__range`. This is semantically incorrect
 - a finding can be closed at any time after discovery, including days or weeks after the last scan. Any finding closed after that midnight cutoff is silently excluded from the counter.

The bug "self-healed" only when a new finding with a later discovery date was imported - making it particularly hard to notice. In environments with stable finding profiles (re-imports without new findings), the counter stayed at `0` permanently.

Related historical issues: #9735, #2187.

Fix: replace `end_date` with `timezone.now()` as the upper bound so any finding closed up to the current moment is counted. Applied in both `dojo/product/views.py` and `dojo/metrics/utils.py`.

**Test results**

Added regression tests in `unittests/test_product_metrics_closed_count.py`:
- finding closed on the same day as discovery date (after midnight) is counted
- finding discovered in the past but closed recently is counted
- all findings closed at any time on the same day are counted

Updated `test_closed_findings_filtered_by_mitigated_date` in `unittests/test_metrics_queries.py` to reflect correct behavior: findings closed after the discovery date range but before `now()` should appear in closed metrics.

**Documentation**

No documentation changes needed.

**Checklist**

- [x] Rebased against latest `bugfix`
- [x] Bugfix submitted against `bugfix` branch
- [x] Code is ruff compliant
- [x] Code is Python 3.13 compliant
- [x] Unit tests added

**Unit tests**

<img width="825" height="101" alt="image" src="https://github.com/user-attachments/assets/12726d71-0ff5-45b9-8c98-c169613b3a56" />
