### PR TITLE
fix: wrap markdown_styles in CSSSanitizer for bleach.clean()

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -91,7 +91,7 @@ def markdown_render(value):
                                                       "markdown.extensions.fenced_code",
                                                       "markdown.extensions.toc",
                                                       "markdown.extensions.tables"])
-        return mark_safe(bleach.clean(markdown_text, tags=markdown_tags, attributes=markdown_attrs, css_sanitizer=markdown_styles))
+        return mark_safe(bleach.clean(markdown_text, tags=markdown_tags, attributes=markdown_attrs, css_sanitizer=CSSSanitizer(allowed_css_properties=markdown_styles)))
     return None
 
 


### PR DESCRIPTION
## Summary

Found this sanitization bug while testing something else, not even the `nh3` migration.

- Fix `AttributeError: 'list' object has no attribute 'sanitize_css'` crash when viewing findings with inline CSS styles in their description.
- `bleach.clean()` expects `css_sanitizer` to be a `CSSSanitizer` instance, not a plain list. The `markdown_styles` list is now wrapped in `CSSSanitizer(allowed_css_properties=markdown_styles)`, matching the pattern already used in `bleach_with_a_tags`.

## Root cause

Back in September 2022, commit `18f588eb35` changed `bleach.clean()` from positional args to keyword args and renamed `styles` → `css_sanitizer`, but forgot to wrap the list in `CSSSanitizer()`.

This has been broken since 2022. The reason nobody noticed is that the error only triggers when a finding's description contains HTML with inline `style` attributes (e.g. `<div style="background-color: red">`). For plain text or markdown without inline CSS, bleach never hits the `css_sanitizer` code path, so the bug stays dormant. Most findings don't have inline styles, so this page worked fine for virtually everyone — until someone viewed a finding that did.

## Traceback

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.13/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.13/site-packages/django/views/generic/base.py", line 105, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/django/views/generic/base.py", line 144, in dispatch
    return handler(request, *args, **kwargs)
  File "/app/dojo/finding/views.py", line 710, in get
    return render(request, self.get_template(), context)
  File "/usr/local/lib/python3.13/site-packages/django/shortcuts.py", line 25, in render
    content = loader.render_to_string(template_name, context, request, using=using)
  ...
  File "/app/dojo/templatetags/display_tags.py", line 94, in markdown_render
    return mark_safe(bleach.clean(markdown_text, tags=markdown_tags, attributes=markdown_attrs, css_sanitizer=markdown_styles))
  ...
  File "/usr/local/lib/python3.13/site-packages/bleach/sanitizer.py", line 585, in allow_token
    val = self.css_sanitizer.sanitize_css(val)
AttributeError: 'list' object has no attribute 'sanitize_css'
```