### PR TITLE
fix(awssecurityhub): extract CVSS v3/v4 scores from Inspector findings

### DIFF
--- a/dojo/tools/awssecurityhub/inspector.py
+++ b/dojo/tools/awssecurityhub/inspector.py
@@ -4,6 +4,7 @@ from django.conf import settings
 
 from dojo.models import Endpoint, Finding
 from dojo.tools.locations import LocationData
+from dojo.utils import parse_cvss_data
 
 SEVERITY_MAP = {
     "INFORMATIONAL": "Info",
@@ -31,6 +32,7 @@ class Inspector:
         references = []
         unsaved_vulnerability_ids = []
         epss_score = finding.get("EpssScore")
+        cvss_data = {}
         description = f"This is an Inspector Finding\n{finding.get('Description', '')}" + "\n"
         description += f"**AWS Finding ARN:** {finding_id}\n"
         description += f"**AwsAccountId:** {finding.get('AwsAccountId', '')}\n"
@@ -52,6 +54,10 @@ class Inspector:
                     references.append(vendor_url)
             if vulnerability.get("EpssScore") is not None:
                 epss_score = vulnerability.get("EpssScore")
+            # Extract and validate CVSS vectors using the common parse_cvss_data helper
+            for cvss_entry in vulnerability.get("Cvss", []):
+                if not cvss_data and cvss_entry.get("BaseVector"):
+                    cvss_data = parse_cvss_data(cvss_entry.get("BaseVector"))
         if finding.get("ProductFields", {}).get("aws/inspector/FindingStatus", "ACTIVE") == "ACTIVE":
             mitigated = None
             is_Mitigated = False
@@ -120,6 +126,22 @@ class Inspector:
             result.unsaved_endpoints = locations
         if epss_score is not None:
             result.epss_score = epss_score
+        if cvss_data:
+            if cvss_data.get("cvssv3"):
+                result.cvssv3 = cvss_data["cvssv3"]
+            if cvss_data.get("cvssv4"):
+                result.cvssv4 = cvss_data["cvssv4"]
+        # Build severity justification from available CVSS data
+        severity_parts = []
+        if cvss_data.get("cvssv3"):
+            severity_parts.append(f"CVSS v3 vector: {cvss_data['cvssv3']}")
+        if cvss_data.get("cvssv4"):
+            severity_parts.append(f"CVSS v4 vector: {cvss_data['cvssv4']}")
+        severity_label = finding.get("Severity", {}).get("Label", "")
+        if severity_label:
+            severity_parts.append(f"AWS severity: {severity_label}")
+        if severity_parts:
+            result.severity_justification = "\n".join(severity_parts)
         # Add the unsaved vulnerability ids
         result.unsaved_vulnerability_ids = unsaved_vulnerability_ids
         return result

--- a/unittests/tools/test_awssecurityhub_parser.py
+++ b/unittests/tools/test_awssecurityhub_parser.py
@@ -72,6 +72,10 @@ class TestAwsSecurityHubParser(DojoTestCase):
             self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
             self.assertEqual("CVE-2022-3643", finding.unsaved_vulnerability_ids[0])
             self.assertEqual("- Update kernel-4.14.301\n\t- yum update kernel\n", finding.mitigation)
+            # Verify CVSS v3 extraction via parse_cvss_data helper
+            self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", finding.cvssv3)
+            self.assertIn("CVSS v3 vector:", finding.severity_justification)
+            self.assertIn("AWS severity: CRITICAL", finding.severity_justification)
             location = self.get_unsaved_locations(finding)[0]
             self.assertEqual("AwsEc2Instance_arn_aws_ec2_us-east-1_XXXXXXXXXXXX_i-11111111111111111".lower(), location.host.lower())
 
@@ -97,6 +101,8 @@ class TestAwsSecurityHubParser(DojoTestCase):
             self.assertIn("GHSA-p98r-538v-jgw5", finding.title)
             self.assertSetEqual({"CVE-2023-34256", "GHSA-p98r-538v-jgw5"}, set(finding.unsaved_vulnerability_ids))
             self.assertEqual("https://github.com/bottlerocket-os/bottlerocket/security/advisories/GHSA-p98r-538v-jgw5", finding.references)
+            # Verify backward compatibility: no CVSS data in this fixture
+            self.assertIsNone(finding.cvssv3)
             location = self.get_unsaved_locations(finding)[0]
             self.assertEqual("AwsEc2Instance_arn_aws_ec2_eu-central-1_012345678912_instance_i-07c11cc535d830123".lower(), location.host.lower())
 
@@ -115,6 +121,8 @@ class TestAwsSecurityHubParser(DojoTestCase):
             self.assertIn("repo-os/sha256:af965ef68c78374a5f987fce98c0ddfa45801df2395bf012c50b863e65978d74", finding.impact)
             self.assertIn("Repository: repo-os", finding.impact)
             self.assertEqual(0.0014, finding.epss_score)
+            # Verify CVSS v3 extraction from the ECR fixture
+            self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H", finding.cvssv3)
             location = self.get_unsaved_locations(finding)[0]
             self.assertEqual("AwsEcrContainerImage_arn_aws_ecr_eu-central-1_123456789012_repository_repo-os_sha256_af965ef68c78374a5f987fce98c0ddfa45801df2395bf012c50b863e65978d74".lower(), location.host.lower())
 


### PR DESCRIPTION

**Description**

Fixes #14191 - AWS Security Hub Inspector parser did not extract CVSS v3/v4 scores or vectors, despite them being available in the AWS ASFF `Vulnerabilities.Cvss` array.
This PR implements:
- Extraction of `cvssv3` vector and `cvssv3_score` from the `Cvss` array (when version starts with 3).
- Extraction of `cvssv4` vector and `cvssv4_score` from the `Cvss` array (when version starts with 4).
- Construction of `severity_justification` appending the extracted CVSS vectors and base scores to the AWS Severity label, following established patterns established by other parsers (e.g., Twistlock).


### Implementation Details: Initialization of CVSS Variables
In the parser iteration, `cvssv3`, `cvssv3_score`, `cvssv4`, and `cvssv4_score` are deliberately initialized to `None` before checking the vulnerability array. This serves several critical purposes:

**1. Backward Compatibility (Missing Data)**
AWS Security Hub findings (e.g., ECR container images or GuardDuty) frequently omit the `Cvss` array entirely. If not initialized to `None`, referencing these variables later would raise an `UnboundLocalError`.
```python
for cvss_entry in vulnerability.get("Cvss", []):
    pass
if cvssv3 is not None:
    result.cvssv3 = cvssv3
```
**2. Deduplication Guard**
AWS findings often contain duplicate entries within the `Cvss` array. We verify `and cvssv3 is None` to ensure only the first valid base vector is extracted.
```python
for cvss_entry in vulnerability.get("Cvss", []):
    version = cvss_entry.get("Version", "")
    
    if version.startswith("3") and cvssv3 is None:
        cvssv3 = cvss_entry.get("BaseVector")
        cvssv3_score = cvss_entry.get("BaseScore")
```

**3. Null Fields on the Django Model**
In `dojo.models.Finding`, these fields explicitly accept `null=True`. Persisting `None` ensures we don't accidentally save false positives (like an empty string or `0.0` which represents Informational impact) to the database when the underlying API provides no data.
```python
if cvssv3 is not None:
    result.cvssv3 = cvssv3
```

**Test results**

- Executed `ruff` linting and all formatting/checks passed.
- Extended assertions in `dojo/unittests/tools/test_aws_security_hub_parser.py` (renamed file) to explicitly verify correct extraction of `cvssv3`/`cvssv3_score` and `severity_justification` against the existing `inspector_ec2_cve.json` fixture.
- Added negative test assertions to ensure backward compatibility and graceful handling for findings that omit the `Cvss` object (e.g., `inspector_ec2_ghsa.json`, `inspector_ecr.json`).
- Validated CVSS score float typing logic and vector string assignment matching the Django `dojo.models.Finding` target properties.

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.


