### PR TITLE
remove libtiff install from Dockerfiles

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -45,7 +45,6 @@ RUN \
   apk add --no-cache \
     openjpeg \
     jpeg \
-    tiff \
     bind-tools \
     xmlsec \
     git \

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -44,10 +44,9 @@ RUN \
   # ugly fix to install postgresql-client without errors
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
   apt-get -y install --no-install-recommends \
-    # libopenjp2-7 libjpeg62 libtiff are required by the pillow package
+    # libopenjp2-7 libjpeg62 are required by the pillow package
     libopenjp2-7 \
     libjpeg62 \
-    libtiff6 \
     dnsutils \
     xmlsec1 \
     git \


### PR DESCRIPTION
This PR removes libtiff from the alpine/debian Dockerfiles. libtiff has some vulnerabilities; we don't allow tiff uploads anyway. Currently libtiff is installed as a dependency for pillow, but now [their documentation](https://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#tiff) suggests it's not necessary.