### PR TITLE
add notes endpoint to RiskAcceptanceViewSet

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1139,6 +1139,13 @@ class EngagementToNotesSerializer(serializers.Serializer):
     notes = NoteSerializer(many=True)
 
 
+class RiskAcceptanceToNotesSerializer(serializers.Serializer):
+    risk_acceptance_id = serializers.PrimaryKeyRelatedField(
+        queryset=Risk_Acceptance.objects.all(), many=False, allow_null=True,
+    )
+    notes = NoteSerializer(many=True)
+
+
 class EngagementToFilesSerializer(serializers.Serializer):
     engagement_id = serializers.PrimaryKeyRelatedField(
         queryset=Engagement.objects.all(), many=False, allow_null=True,

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -762,6 +762,61 @@ class RiskAcceptanceViewSet(
     @extend_schema(
         methods=["GET"],
         responses={
+            status.HTTP_200_OK: serializers.RiskAcceptanceToNotesSerializer,
+        },
+    )
+    @extend_schema(
+        methods=["POST"],
+        request=serializers.AddNewNoteOptionSerializer,
+        responses={status.HTTP_201_CREATED: serializers.NoteSerializer},
+    )
+    @action(detail=True, methods=["get", "post"], permission_classes=(IsAuthenticated, permissions.UserHasRiskAcceptanceRelatedObjectPermission))
+    def notes(self, request, pk=None):
+        risk_acceptance = self.get_object()
+        if request.method == "POST":
+            new_note = serializers.AddNewNoteOptionSerializer(data=request.data)
+            if new_note.is_valid():
+                entry = new_note.validated_data["entry"]
+                private = new_note.validated_data.get("private", False)
+                note_type = new_note.validated_data.get("note_type", None)
+            else:
+                return Response(new_note.errors, status=status.HTTP_400_BAD_REQUEST)
+
+            notes = risk_acceptance.notes.filter(note_type=note_type).first()
+            if notes and note_type and note_type.is_single:
+                return Response("Only one instance of this note_type allowed on a risk acceptance.", status=status.HTTP_400_BAD_REQUEST)
+
+            author = request.user
+            note = Notes(entry=entry, author=author, private=private, note_type=note_type)
+            note.save()
+            history = NoteHistory.objects.create(data=note.entry, time=note.date, current_editor=note.author)
+            note.history.add(history)
+            risk_acceptance.notes.add(note)
+            engagement = risk_acceptance.engagement
+            if engagement:
+                process_tag_notifications(
+                    request=request,
+                    note=note,
+                    parent_url=request.build_absolute_uri(
+                        reverse("view_risk_acceptance", args=(engagement.id, risk_acceptance.id)),
+                    ),
+                    parent_title=f"Risk Acceptance: {risk_acceptance.name}",
+                )
+
+            serialized_note = serializers.NoteSerializer(
+                {"author": author, "entry": entry, "private": private},
+            )
+            return Response(serialized_note.data, status=status.HTTP_201_CREATED)
+
+        notes = risk_acceptance.notes.all()
+        serialized_notes = serializers.RiskAcceptanceToNotesSerializer(
+            {"risk_acceptance_id": risk_acceptance, "notes": notes},
+        )
+        return Response(serialized_notes.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        methods=["GET"],
+        responses={
             status.HTTP_200_OK: serializers.RiskAcceptanceProofSerializer,
         },
     )


### PR DESCRIPTION
RiskAcceptanceViewSet was never given a notes() action, unlike every other major viewset (Engagement, Finding, Test). The notes M2M field exists on the model but was never exposed via the API.

- dojo/api_v2/serializers.py — Added RiskAcceptanceToNotesSerializer, matching the pattern of EngagementToNotesSerializer and FindingToNotesSerializer.

- dojo/api_v2/views.py — Added notes() action to RiskAcceptanceViewSet supporting GET (list notes) and POST (add note), with note type singleton validation, note history tracking, and @mention notifications.

This also fixes a UI issue in Pro.