### PR TITLE
feat: add additional_banners support to base template

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -665,6 +665,11 @@
                     {{ announcement.message|bleach_with_a_tags }}
                     </div>
                 {% endif %}
+                {% for banner in additional_banners %}
+                    <div role="alert" class="announcement-banner alert alert-{{ banner.style }} show">
+                        {{ banner.message }} <a href="{{ banner.url }}">{{ banner.link_text }}</a>
+                    </div>
+                {% endfor %}
                 <div class="container-fluid">
                     <!-- start of tabs -->
                     {% block tab_bar %}


### PR DESCRIPTION
## Summary
- Add support for rendering additional banners in the base template
- Banners are rendered via the `additional_banners` template context variable, after the existing announcement banner
- Each banner supports `message`, `style`, `url`, and `link_text` fields
- No-op when `additional_banners` is not provided by a context processor
