### PR TITLE
fix(tests): prevent tag inheritance tests from polluting dev Celery queue

### DIFF
--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import Client
+from django.test import Client, override_settings
 from django.urls import reverse
 
 from dojo.models import Finding, Product, Test
@@ -454,6 +454,7 @@ class TagImportTestUI(DojoAPITestCase, TagImportMixin):
             return {"test": new_test_id}
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @versioned_fixtures
 class InheritedTagsTests(DojoAPITestCase):
 
@@ -610,6 +611,7 @@ class InheritedTagsImportMixin:
         self.assertEqual(product_tags_post_addition, self._convert_instance_tags_to_list(objects.get("finding")))
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @versioned_fixtures
 class InheritedTagsImportTestAPI(DojoAPITestCase, InheritedTagsImportMixin):
 
@@ -626,6 +628,7 @@ class InheritedTagsImportTestAPI(DojoAPITestCase, InheritedTagsImportMixin):
         InheritedTagsImportMixin.setUp(self)
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 @versioned_fixtures
 class InheritedTagsImportTestUI(DojoAPITestCase, InheritedTagsImportMixin):
 


### PR DESCRIPTION
## Summary

When you are running DD locally in dev mode and run the test_tags unit test, it will dispatch a celery task via `propagate_tags_on_product(4)`. In dev mode this means the celery worker will pick it up and apply it to product 4 in the local DD (non-test) database. In my case this was a product with 10002 findings from the JFrog Unified unit test sample file. If you have tag inheritance enabled, this task will run for hours on end updating each finding with the inherited tags.
This PR ensures all celery tasks are executed synchronously in test_tags.py so that it gets executed in the test database.

- `product_tags_post_add_remove` dispatches `propagate_tags_on_product` via `dojo_dispatch_task`. When the signal fires outside a request context (e.g. during test `setUp`), `get_current_user()` returns `None`, so `we_want_async()` always returns `True` regardless of `block_execution` — the task goes to the **shared Redis queue**
- The real Celery worker then picks it up and runs against the live database, causing multi-hour tag propagation runs over large products (observed: 84–88 minute runs over ~10,000 JFrog Xray Unified findings)
- Fix: add `@override_settings(CELERY_TASK_ALWAYS_EAGER=True)` to the three test classes that enable system-wide product tag inheritance (`InheritedTagsTests`, `InheritedTagsImportTestAPI`, `InheritedTagsImportTestUI`). This makes Celery run tasks inline in the test process, keeping tasks off the shared Redis queue and ensuring assertions see the results of tag propagation before checking them