### PR TITLE
api: load jira custom_fields as json

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1428,6 +1428,12 @@ class JIRAProjectSerializer(serializers.ModelSerializer):
             msg = "Either engagement or product has to be set."
             raise serializers.ValidationError(msg)
 
+        if "custom_fields" in data and isinstance(data["custom_fields"], str):
+            try:
+                data["custom_fields"] = json.loads(data["custom_fields"])
+            except json.JSONDecodeError as e:
+                raise serializers.ValidationError({"custom_fields": f"Invalid JSON: {e}"}) from e
+
         return data
 
 


### PR DESCRIPTION
Currently when passing `custom_fields` to `/jira_product_configurations` those entries are stored in the database as an escaped block of text rather than JSON.

This method uses json.loads() to parse the data sent over and will raise a 400 if the json is invalid.