### PR TITLE
Add scan_date to import settings if overridden

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -463,7 +463,7 @@ class BaseImporter(ImporterOptions):
         import_settings["close_old_findings"] = self.close_old_findings_toggle
         import_settings["push_to_jira"] = self.push_to_jira
         import_settings["tags"] = self.tags
-        import_settings["scan_date"] = self.scan_date if self.scan_date_override else None
+        import_settings["scan_date"] = self.scan_date.isoformat() if self.scan_date_override else None
         if settings.V3_FEATURE_LOCATIONS:
             # Add the list of locations that were added exclusively at import time
             if len(self.endpoints_to_add) > 0:

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -463,6 +463,7 @@ class BaseImporter(ImporterOptions):
         import_settings["close_old_findings"] = self.close_old_findings_toggle
         import_settings["push_to_jira"] = self.push_to_jira
         import_settings["tags"] = self.tags
+        import_settings["scan_date"] = self.scan_date if self.scan_date_override else None
         if settings.V3_FEATURE_LOCATIONS:
             # Add the list of locations that were added exclusively at import time
             if len(self.endpoints_to_add) > 0:

--- a/unittests/test_update_import_history.py
+++ b/unittests/test_update_import_history.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime, timezone as dt_timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 from django.contrib.auth.models import User as DjangoUser
@@ -154,7 +154,7 @@ class UpdateImportHistoryTests(TransactionTestCase):
 
     def test_import_settings_scan_date_when_user_supplies_scan_date(self):
         """When the user supplies a scan_date, import_settings should contain the ISO-formatted date."""
-        user_scan_date = datetime(2025, 6, 15, 12, 0, 0, tzinfo=dt_timezone.utc)
+        user_scan_date = datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
         self.importer.scan_date = user_scan_date
         self.importer.scan_date_override = True
 

--- a/unittests/test_update_import_history.py
+++ b/unittests/test_update_import_history.py
@@ -1,4 +1,6 @@
+import json
 import logging
+from datetime import datetime
 from unittest.mock import patch
 
 from django.contrib.auth.models import User as DjangoUser
@@ -149,3 +151,29 @@ class UpdateImportHistoryTests(TransactionTestCase):
         expected = (len(new_findings) - 1) + (len(closed_findings) - 1)
         created = Test_Import_Finding_Action.objects.filter(test_import=test_import).count()
         self.assertEqual(created, expected)
+
+    def test_import_settings_scan_date_when_user_supplies_scan_date(self):
+        """When the user supplies a scan_date, import_settings should contain the ISO-formatted date."""
+        user_scan_date = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        self.importer.scan_date = user_scan_date
+        self.importer.scan_date_override = True
+
+        new_findings = self._create_findings(1)
+        test_import = self.importer.update_import_history(new_findings=new_findings)
+
+        settings = test_import.import_settings
+        # Verify import_settings is JSON-serializable (the original bug)
+        json.dumps(settings)
+        self.assertEqual(settings["scan_date"], user_scan_date.isoformat())
+
+    def test_import_settings_scan_date_when_no_scan_date_supplied(self):
+        """When no scan_date override is provided, import_settings should have scan_date as None."""
+        self.importer.scan_date_override = False
+
+        new_findings = self._create_findings(1)
+        test_import = self.importer.update_import_history(new_findings=new_findings)
+
+        settings = test_import.import_settings
+        # Verify import_settings is JSON-serializable
+        json.dumps(settings)
+        self.assertIsNone(settings["scan_date"])

--- a/unittests/test_update_import_history.py
+++ b/unittests/test_update_import_history.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone as dt_timezone
 from unittest.mock import patch
 
 from django.contrib.auth.models import User as DjangoUser
@@ -154,7 +154,7 @@ class UpdateImportHistoryTests(TransactionTestCase):
 
     def test_import_settings_scan_date_when_user_supplies_scan_date(self):
         """When the user supplies a scan_date, import_settings should contain the ISO-formatted date."""
-        user_scan_date = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        user_scan_date = datetime(2025, 6, 15, 12, 0, 0, tzinfo=dt_timezone.utc)
         self.importer.scan_date = user_scan_date
         self.importer.scan_date_override = True
 


### PR DESCRIPTION
This pull request introduces a minor update to the import settings logic in the `update_import_history` method of `base_importer.py`. The change ensures that the `scan_date` is included in the import settings only if the `scan_date_override` flag is set; otherwise, it is set to `None`.

* Import Settings Update:
  * [`dojo/importers/base_importer.py`](diffhunk://#diff-718a51f6068657cc0025bc378a9b6e8a803a106b49ff8a7a0ce941e12d30343cR466): Modified `update_import_history` to conditionally set `import_settings["scan_date"]` based on the `scan_date_override` flag.