### PR TITLE
Add authorization check to link_engagement action

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -3387,6 +3387,8 @@ class QuestionnaireEngagementSurveyViewSet(
         engagement_survey = self.get_object()
         # Safely get the engagement
         engagement = get_object_or_404(Engagement.objects, pk=engagement_id)
+        # Verify the user has permission to edit the engagement
+        user_has_permission_or_403(request.user, engagement, Permissions.Engagement_Edit)
         # Link the engagement
         answered_survey, _ = Answered_Survey.objects.get_or_create(engagement=engagement, survey=engagement_survey)
         # Send a favorable response


### PR DESCRIPTION
## Summary
- Added missing permission check in `QuestionnaireEngagementSurveyViewSet.link_engagement` to verify the user has `Engagement_Edit` permission on the target engagement before linking

## Test plan
- [ ] Verify that users with `Engagement_Edit` permission can still link engagements successfully
- [ ] Verify that users without `Engagement_Edit` permission receive a 403 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)