### PR TITLE
Exclude async_user from celery task

### DIFF
--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -56,8 +56,10 @@ class DojoAsyncTask(Task):
         if kwargs is None:
             kwargs = {}
 
-        # Inject user context if not already present
-        if "async_user" not in kwargs:
+        # Inject user context for Dojo tasks only. Celery built-in tasks (e.g.
+        # celery.backend_cleanup) do not accept custom kwargs.
+        task_name = self.name or ""
+        if not task_name.startswith("celery.") and "async_user" not in kwargs:
             kwargs["async_user"] = get_current_user()
 
         # Control flag used for sync/async decision; never pass into the task itself


### PR DESCRIPTION
**Description**

There was an error in our celery beat logs on recent upgrade:
```
[13/Mar/2026 04:00:00] ERROR [celery.beat:284] Message Error: Couldn't apply scheduled task celery.backend_cleanup: backend_cleanup() got an unexpected keyword argument 'async_user'
['  File "/usr/local/bin/celery", line 7, in <module>\n    sys.exit(main())\n', '  File "/usr/local/lib/python3.13/site-packages/celery/__main__.py", line 15, in main\n    sys.exit(_main())\n', '  File "/usr/local/lib/python3.13/site-packages/celery/bin/celery.py", line 227, in main\n    return celery(auto_envvar_prefix="CELERY")\n', '  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1485, in __call__\n    return self.main(*args, **kwargs)\n', '  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1406, in main\n    rv = self.invoke(ctx)\n', '  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1873, in invoke\n    return _process_result(sub_ctx.command.invoke(sub_ctx))\n', '  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1269, in invoke\n    return ctx.invoke(self.callback, **ctx.params)\n', '  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 824, in invoke\n    return callback(*args, **kwargs)\n', '  File "/usr/local/lib/python3.13/site-packages/click/decorators.py", line 34, in new_func\n    return f(get_current_context(), *args, **kwargs)\n', '  File "/usr/local/lib/python3.13/site-packages/celery/bin/base.py", line 135, in caller\n    return f(ctx, *args, **kwargs)\n', '  File "/usr/local/lib/python3.13/site-packages/celery/bin/beat.py", line 72, in beat\n    return beat().run()\n', '  File "/usr/local/lib/python3.13/site-packages/celery/apps/beat.py", line 84, in run\n    self.start_scheduler()\n', '  File "/usr/local/lib/python3.13/site-packages/celery/apps/beat.py", line 113, in start_scheduler\n    service.start()\n', '  File "/usr/local/lib/python3.13/site-packages/celery/beat.py", line 645, in start\n    interval = self.scheduler.tick()\n', '  File "/usr/local/lib/python3.13/site-packages/celery/beat.py", line 355, in tick\n    self.apply_entry(entry, producer=self.producer)\n', '  File "/usr/local/lib/python3.13/site-packages/celery/beat.py", line 285, in apply_entry\n    exc, traceback.format_stack(), exc_info=True)\n']
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/celery/beat.py", line 404, in apply_async
    return task.apply_async(entry_args, entry_kwargs,
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
                            producer=producer,
                            ^^^^^^^^^^^^^^^^^^
                            **entry.options)
```

Celery Beat injects async_user into celery.backend_cleanup, which doesn’t accept that kwarg.