### PR TITLE
Fix finding title HTML encoding inconsistency in All Findings view fi…

### DIFF
--- a/dojo/templates/dojo/add_findings_as_accepted.html
+++ b/dojo/templates/dojo/add_findings_as_accepted.html
@@ -16,7 +16,7 @@
           </td>
           <td>
             {% if finding.title %}
-                <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars_html:60 }}</a>
+                <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars:60 }}</a>
             {% else %}
                 <a title="{{ finding.id }}" href="{% url 'view_finding' finding.id %}">{{ finding.id }}</a>
             {% endif %}

--- a/dojo/templates/dojo/breadcrumbs/finding_breadcrumb.html
+++ b/dojo/templates/dojo/breadcrumbs/finding_breadcrumb.html
@@ -3,7 +3,7 @@
   <ol class="breadcrumb">
   <li><a data-toggle="tooltip" data-placement="top" title="Engagement" href="{% url 'view_engagement' finding.test.engagement.id %}">{{finding.test.engagement.name}}</a></li>
   <li><a data-toggle="tooltip" data-placement="top" title="Test" href="{% url 'view_test' finding.test.id %}">{{finding.test}}</a></li>
-  <li><a data-toggle="tooltip" data-placement="top" title="Finding" href="{% url 'view_finding' finding.id %}">{{finding.title|truncatechars_html:60}}</a></li>
+  <li><a data-toggle="tooltip" data-placement="top" title="Finding" href="{% url 'view_finding' finding.id %}">{{finding.title|truncatechars:60}}</a></li>
   {% if product_tab.title %}
     <li class="breadcrumb-item active" aria-current="page">{{product_tab.title}}</li>
   {% endif %}

--- a/dojo/templates/dojo/finding_related_row.html
+++ b/dojo/templates/dojo/finding_related_row.html
@@ -19,7 +19,7 @@
         </span>
     </td>
     <td>
-        <a title="{{ similar_finding.title }}" href="{% url 'view_finding' similar_finding.id %}">{{ similar_finding.title|truncatechars_html:80 }}</a>
+        <a title="{{ similar_finding.title }}" href="{% url 'view_finding' similar_finding.id %}">{{ similar_finding.title|truncatechars:80 }}</a>
         {% if similar_finding.tags %}
         <small>
             {% include "dojo/snippets/tags.html" with tags=similar_finding.tags.all %}

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -543,7 +543,7 @@
                                         </td>
                                         <td>
                                             {% if finding.title %}
-                                                <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars_html:60 }}</a>
+                                                <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars:60 }}</a>
                                             {% else %}
                                                 <a title="{{ finding.id }}" href="{% url 'view_finding' finding.id %}">{{ finding.id }}</a>
                                             {% endif %}

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -554,7 +554,7 @@
                                                         {{ finding.epss_percentile|format_epss }}
                                                     </td>
                                                     <td><a href="{% url 'view_finding' finding.id %}"
-                                                           title="{{ finding.title }}">{{ finding.title|truncatechars_html:20 }}</a>
+                                                           title="{{ finding.title }}">{{ finding.title|truncatechars:20 }}</a>
                                                     </td>
                                                     <td class="text-right">{{ finding.age }}</td>
                                                     <td>{{ finding.status }}</td>

--- a/dojo/templates/dojo/request_report.html
+++ b/dojo/templates/dojo/request_report.html
@@ -79,7 +79,7 @@
                         {% for finding in paged_findings %}
                             <tr>
                                 <td>
-                                    <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars_html:50 }}</a>
+                                    <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars:50 }}</a>
                                     {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
                                 </td>
                                 <td class="nowrap">{{ finding.date }}</td>

--- a/dojo/templates/dojo/templates.html
+++ b/dojo/templates/dojo/templates.html
@@ -79,7 +79,7 @@
                                     {% if add_from_template %}
                                         <a href="{% url 'add_finding_from_template' tid finding.id %}"
                                            class="template-popover" data-placement="auto bottom" data-toggle="popover"
-                                           data-trigger="hover" title="{{ finding.title|truncatechars_html:100 }}"
+                                           data-trigger="hover" title="{{ finding.title|truncatechars:100 }}"
                                            data-content="{{ finding.description|truncatechars_html:500 }}">
                                             {{ finding.title }}
                                             {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
@@ -87,7 +87,7 @@
                                     {% elif apply_template %}
                                         <a href="{% url 'choose_finding_template_options' finding.id fid %}"
                                            class="template-popover" data-placement="auto bottom" data-toggle="popover"
-                                           data-trigger="hover" title="{{ finding.title|truncatechars_html:100 }}"
+                                           data-trigger="hover" title="{{ finding.title|truncatechars:100 }}"
                                            data-content="{{ finding.description|truncatechars_html:500 }}">
                                             {{ finding.title }}
                                             {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}

--- a/dojo/templates/dojo/view_risk_acceptance.html
+++ b/dojo/templates/dojo/view_risk_acceptance.html
@@ -185,7 +185,7 @@
                             {{ finding.epss_percentile|format_epss }}
                         </td>
                         <td><a href="{% url 'view_finding' finding.id %}"
-                               title="{{ finding.title }}">{{ finding.title|truncatechars_html:140 }}</a></td>
+                               title="{{ finding.title }}">{{ finding.title|truncatechars:140 }}</a></td>
                         <td>{{ finding.date }}</td>
                         <td>{{ finding.active }}</td>
 

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1145,7 +1145,7 @@
                                     </td>
                                     <td>
                                         {% if finding.title %}
-                                            <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars_html:60 }}</a>
+                                            <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars:60 }}</a>
                                         {% else %}
                                             <a title="{{ finding.id }}" href="{% url 'view_finding' finding.id %}">{{ finding.id }}</a>
                                         {% endif %}


### PR DESCRIPTION
## Description
In the "All Findings" view and several other views, finding titles 
containing special characters like & were displayed as HTML encoded 
(&amp;) due to the truncatechars_html filter being used.

The detail view uses plain {{ finding.title }} without this filter, 
causing inconsistent display between views.

Fix: replaced truncatechars_html with truncatechars across 9 templates 
since finding titles are plain text, not HTML. This also closes a 
potential XSS vector as truncatechars_html is registered with is_safe=True 
in Django, meaning its output bypasses auto-escaping.

Files updated:
- findings_list_snippet.html
- request_report.html
- templates.html
- breadcrumbs/finding_breadcrumb.html
- add_findings_as_accepted.html
- finding_related_row.html
- view_risk_acceptance.html
- view_test.html
- metrics.html

Fixes #14514