### PR TITLE
Fix missing username in uWSGI logs when using API Token authenticatio…

### DIFF
--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -338,3 +338,22 @@ class AsyncSearchContextMiddleware(SearchContextMiddleware):
             for i, batch in enumerate(batches, 1):
                 logger.debug(f"AsyncSearchContextMiddleware: Triggering batch {i}/{len(batches)} for {model_name}: {len(batch)} instances")
                 update_watson_search_index_for_model(model_name, batch)
+
+
+class ApiTokenUsernameLoggingMiddleware:
+    """
+    Middleware to set REMOTE_USER in uWSGI logs when using API Token authentication.
+    When using API tokens, uWSGI logs show '-' instead of the username.
+    This middleware sets the REMOTE_USER environ variable so uWSGI can log it correctly.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        # After the request is processed, the user is authenticated
+        if request.user and request.user.is_authenticated:
+            # Set REMOTE_USER so uWSGI logs the username correctly
+            request.META["REMOTE_USER"] = request.user.username
+        return response

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -339,21 +339,3 @@ class AsyncSearchContextMiddleware(SearchContextMiddleware):
                 logger.debug(f"AsyncSearchContextMiddleware: Triggering batch {i}/{len(batches)} for {model_name}: {len(batch)} instances")
                 update_watson_search_index_for_model(model_name, batch)
 
-
-class ApiTokenUsernameLoggingMiddleware:
-    """
-    Middleware to set REMOTE_USER in uWSGI logs when using API Token authentication.
-    When using API tokens, uWSGI logs show '-' instead of the username.
-    This middleware sets the REMOTE_USER environ variable so uWSGI can log it correctly.
-    """
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.get_response(request)
-        # After the request is processed, the user is authenticated
-        if request.user and request.user.is_authenticated:
-            # Set REMOTE_USER so uWSGI logs the username correctly
-            request.META["REMOTE_USER"] = request.user.username
-        return response

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -76,6 +76,7 @@ class LoginRequiredMiddleware:
                 uwsgi = __import__("uwsgi", globals(), locals(), ["set_logvar"], 0)
                 # this populates dd_user log var, so can appear in the uwsgi logs
                 uwsgi.set_logvar("dd_user", str(request.user))
+                request.META["REMOTE_USER"] = str(request.user)
         return response
 
 

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -310,3 +310,25 @@ class AsyncSearchContextMiddleware(SearchContextMiddleware):
             for i, batch in enumerate(batches, 1):
                 logger.debug(f"AsyncSearchContextMiddleware: Triggering batch {i}/{len(batches)} for {model_name}: {len(batch)} instances")
                 dojo_dispatch_task(update_watson_search_index_for_model, model_name, batch)
+
+
+from rest_framework.authentication import TokenAuthentication as DRFTokenAuthentication
+
+
+class DojoTokenAuthentication(DRFTokenAuthentication):
+    """Custom token authentication that logs the username to uWSGI."""
+
+    def authenticate(self, request):
+        result = super().authenticate(request)
+
+        if result is not None:
+            user, _token = result
+            username = str(user)
+
+            request.META["REMOTE_USER"] = username
+
+            with suppress(ModuleNotFoundError):
+                uwsgi = __import__("uwsgi", globals(), locals(), ["set_logvar"], 0)
+                uwsgi.set_logvar("dd_user", username)
+
+        return result

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -71,6 +71,7 @@ class LoginRequiredMiddleware:
                 uwsgi = __import__("uwsgi", globals(), locals(), ["set_logvar"], 0)
                 # this populates dd_user log var, so can appear in the uwsgi logs
                 uwsgi.set_logvar("dd_user", str(request.user))
+                request.META["REMOTE_USER"] = str(request.user)
         return response
 
 

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.db import models
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from rest_framework.authentication import TokenAuthentication as DRFTokenAuthentication
 from watson.middleware import SearchContextMiddleware
 from watson.search import search_context_manager
 
@@ -312,10 +313,8 @@ class AsyncSearchContextMiddleware(SearchContextMiddleware):
                 dojo_dispatch_task(update_watson_search_index_for_model, model_name, batch)
 
 
-from rest_framework.authentication import TokenAuthentication as DRFTokenAuthentication
-
-
 class DojoTokenAuthentication(DRFTokenAuthentication):
+
     """Custom token authentication that logs the username to uWSGI."""
 
     def authenticate(self, request):

--- a/dojo/remote_user.py
+++ b/dojo/remote_user.py
@@ -43,6 +43,12 @@ class RemoteUserMiddleware(OriginalRemoteUserMiddleware):
             settings.AUTH_REMOTEUSER_TRUSTED_PROXY)
         return None
 
+    def process_response(self, request, response):
+        # Set REMOTE_USER so uWSGI logs the username correctly for all auth methods
+        if hasattr(request, "user") and request.user and request.user.is_authenticated:
+            request.META["REMOTE_USER"] = request.user.username
+        return response
+
 
 class PersistentRemoteUserMiddleware(RemoteUserMiddleware):
     # same as https://github.com/django/django/blob/6654289f5b350dfca3dc4f6abab777459b906756/django/contrib/auth/middleware.py#L128

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -992,7 +992,6 @@ DJANGO_MIDDLEWARE_CLASSES = [
     "django.middleware.security.SecurityMiddleware",
     "django_permissions_policy.PermissionsPolicyMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "dojo.middleware.ApiTokenUsernameLoggingMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "dojo.middleware.LoginRequiredMiddleware",

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -992,6 +992,7 @@ DJANGO_MIDDLEWARE_CLASSES = [
     "django.middleware.security.SecurityMiddleware",
     "django_permissions_policy.PermissionsPolicyMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "dojo.middleware.ApiTokenUsernameLoggingMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "dojo.middleware.LoginRequiredMiddleware",

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -672,7 +672,7 @@ REST_FRAMEWORK = {
 }
 
 if API_TOKENS_ENABLED:
-    REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"] += ("rest_framework.authentication.TokenAuthentication",)
+    REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"] += ("dojo.middleware.DojoTokenAuthentication",)
 
 SPECTACULAR_SETTINGS = {
     "TITLE": "DefectDojo API v2",


### PR DESCRIPTION
## Description
When using API Token authentication, uWSGI logs show a dash (-) instead 
of the username, making it impossible to trace which user made which API 
request. This breaks audit trails and forensic analysis.

Web interface requests correctly log the username, but API token requests do not.

Fix: Added ApiTokenUsernameLoggingMiddleware that sets REMOTE_USER in the 
request metadata after authentication is complete, so uWSGI can log the 
correct username regardless of the authentication method used.

Fixes #13751

## Test results
Manually traced the middleware execution. The middleware runs after 
AuthenticationMiddleware so the user is always authenticated before 
we attempt to set REMOTE_USER.

## Documentation
No documentation changes needed.