### PR TITLE
Fix SonarQube API: raise clear error when project_name is None fixes …

### DIFF
--- a/dojo/tools/api_sonarqube/api_client.py
+++ b/dojo/tools/api_sonarqube/api_client.py
@@ -1,5 +1,6 @@
 import requests
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 
 from dojo.utils import prepare_for_view
@@ -62,6 +63,9 @@ class SonarQubeAPI:
         :param project_name:
         :return:
         """
+        if not project_name:
+            msg = "Project name is required. Please provide a Service Key 1 or ensure the Product name is set."
+            raise ValidationError(msg)
         parameters = {"q": project_name, "qualifiers": "TRK"}
 
         if branch:


### PR DESCRIPTION
## Description
When a SonarQube API Scan Configuration is added without a Service Key 1,
the find_project method was called with None as the project name, causing
a confusing 400 error from SonarQube saying the component parameter is missing.

This fix adds a clear ValidationError with a helpful message when project_name
is None, so the user knows exactly what to fix instead of getting a cryptic error.
Also added the missing ValidationError import to api_client.py.

Fixes #13959

## Test results
Manually traced the code path. The fix raises a clear ValidationError before
the API call is made when project_name is None.

## Documentation
No documentation changes needed.