### PR TITLE
fix: use bool type for DD_DUPLICATE_CLUSTER_CASCADE_DELETE env var

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -302,7 +302,7 @@ env = environ.FileAwareEnv(
     # Initial behaviour in Defect Dojo was to delete all duplicates when an original was deleted
     # New behaviour is to leave the duplicates in place, but set the oldest of duplicates as new original
     # Set to True to revert to the old behaviour where all duplicates are deleted
-    DD_DUPLICATE_CLUSTER_CASCADE_DELETE=(str, False),
+    DD_DUPLICATE_CLUSTER_CASCADE_DELETE=(bool, False),
     # Enable Rate Limiting for the login page
     DD_RATE_LIMITER_ENABLED=(bool, False),
     # Examples include 5/m 100/h and more https://django-ratelimit.readthedocs.io/en/stable/rates.html#simple-rates


### PR DESCRIPTION
The `DD_DUPLICATE_CLUSTER_CASCADE_DELETE` env var was declared as `str` instead of `bool` in `settings.dist.py`, meaning it was never properly parsed as a boolean.

This means it was always parsed as True (ot at least Truthy) so the behaviour was always to delete the full duplicate cluster when an original finding was deleted. This is not only very slow as it triggers all signals, it might also not be what users expect.

This PR fixes the bug. But this also means the default behaviour changes because the flag is now correctly parsed as `False`. This might surprise users. Since we have never had any complaints of bug reports, we may be better off changing the default to `True`? From a performance point of view `False` is much better :-)

Let me know your thoughts @Maffooch @mtesauro 