### PR TITLE
fix: remove django-linear-migrations

### DIFF
--- a/dojo/db_migrations/max_migration.txt
+++ b/dojo/db_migrations/max_migration.txt
@@ -1,1 +1,0 @@
-0263_language_type_unique_language

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -2116,14 +2116,7 @@ if DJANGO_DEBUG_TOOLBAR_ENABLED:
 
     MIDDLEWARE = ["debug_toolbar.middleware.DebugToolbarMiddleware", *MIDDLEWARE]
 
-# Linear migrations for development
-# Helps avoid merge migration conflicts by tracking the latest migration
 if DEBUG:
-    INSTALLED_APPS = (
-        "django_linear_migrations",  # Must be before dojo to override makemigrations
-        *INSTALLED_APPS,
-    )
-
     def show_toolbar(request):
         return True
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,3 @@ parameterized==0.9.0
 
 # Development file watching (hot reload)
 watchdog[watchmedo]==6.0.0
-
-# Migration management - allows for easy rebasing via manage.py rebase_migration
-django-linear-migrations==2.19.0


### PR DESCRIPTION
Removes `django-linear-migrations` from the project. The tool caused startup failures when `DD_DEBUG=True` but the package was not installed (e.g. production images). Too much hassle with low gains. Any non-linear migration will be caught on startup by django anyway during unit tests.