### PR TITLE
Add exact_title filter to findings API

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1643,6 +1643,7 @@ class ApiFindingFilter(DojoFilter):
     steps_to_reproduce = CharFilter(lookup_expr="icontains")
     unique_id_from_tool = CharFilter(lookup_expr="icontains")
     title = CharFilter(lookup_expr="icontains")
+    exact_title = CharFilter(field_name="title", lookup_expr="iexact", help_text="Finding title exact match (case-insensitive)")
     product_name = CharFilter(lookup_expr="engagement__product__name__iexact", field_name="test", label=labels.ASSET_FILTERS_NAME_EXACT_LABEL)
     product_name_contains = CharFilter(lookup_expr="engagement__product__name__icontains", field_name="test", label=labels.ASSET_FILTERS_NAME_CONTAINS_LABEL)
     product_lifecycle = CharFilter(method=custom_filter, lookup_expr="engagement__product__lifecycle",


### PR DESCRIPTION
**Description**

This PR adds a new optional query parameter exact_title to the /api/v2/findings endpoint to allow exact title matching.

Existing behavior remains unchanged:
 - title filter continues to use loose substring matching (icontains)
New behavior:
 - exact_title filter performs an exact match on Finding.title (case-insensitive, iexact)


Example:
GET /api/v2/findings?exact_title=TLS%20Certificate%20Expired


**Test results**

Ideally you extend the test suite in `tests/` and `dojo/unittests` to cover the changed in this PR.
Alternatively, describe what you have and haven't tested.

Manual testing using local DefectDojo docker-compose environment:
 - Verified GET /api/v2/findings?exact_title=<known title> returns only the finding(s) with that exact title
 - Verified GET /api/v2/findings?title=<partial title> still returns substring matches (unchanged)

**Documentation**

OpenAPI should include it via django-filter introspection; verified in swagger UI locally

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.
