### PR TITLE
fix(dedupe): prevent duplicate test processing in batch dedupe command

### DIFF
--- a/dojo/management/commands/dedupe.py
+++ b/dojo/management/commands/dedupe.py
@@ -171,7 +171,11 @@ class Command(BaseCommand):
         logger.info(f"Processing {total_findings} findings in batches of max {batch_max_size} per test ({mode_str})")
 
         # Group findings by test_id to process them in batches per test
-        test_ids = findings_queryset.values_list("test_id", flat=True).distinct()
+        # Use order_by("test_id") to override the Finding model's default ordering
+        # (numerical_severity, date, title, ...). Without this, Django includes those
+        # ordering columns in the SELECT for DISTINCT, making test_ids non-unique and
+        # causing the same test to be processed multiple times.
+        test_ids = findings_queryset.order_by("test_id").values_list("test_id", flat=True).distinct()
         total_tests = len(test_ids)
         total_processed = 0
 


### PR DESCRIPTION
## Summary

- `Finding.Meta.ordering` defines multiple columns (`numerical_severity`, `date`, `title`, `epss_score`, `epss_percentile`). When Django generates `SELECT DISTINCT test_id ... ORDER BY <those columns>`, PostgreSQL requires all `ORDER BY` columns to appear in the `SELECT` list — so Django silently adds them to the projection. As a result, `DISTINCT` operates on the full tuple `(test_id, numerical_severity, date, title, epss_score, epss_percentile)` instead of `test_id` alone.
- This causes the same test to appear multiple times in the `test_ids` iterator inside `_dedupe_batch_mode`, so findings for that test are submitted to Celery over and over — visible as the dedupe command appearing to loop indefinitely on the same test.
- Fix: call `.order_by("test_id")` before `.values_list("test_id", flat=True).distinct()` to override the model-level ordering. The resulting query is `SELECT DISTINCT test_id ORDER BY test_id`, which correctly deduplicates by test only.