### PR TITLE
when deleting a URL via API, perform_delete should call delete on the…

### DIFF
--- a/dojo/url/api/views.py
+++ b/dojo/url/api/views.py
@@ -36,3 +36,6 @@ class URLViewSet(PrefetchDojoModelViewSet):
         return URL.objects.annotate(
             active_findings=Coalesce(active_finding_subquery, Value(0)),
         )
+
+    def perform_destroy(self, instance):
+        instance.location.delete()

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1612,6 +1612,19 @@ class URLTest(BaseClass.BaseClassTest):
         response = self.client.put(relative_url, self.payload)
         self.assertEqual(403, response.status_code, response.content[:1000])
 
+    def test_delete_removes_location(self):
+        """Verify that deleting a URL via the API also deletes the associated Location."""
+        url_obj = URL.objects.get(pk=self.delete_id)
+        location_id = url_obj.location_id
+        self.assertTrue(Location.objects.filter(pk=location_id).exists())
+
+        relative_url = f"{self.url}{location_id}/"
+        response = self.client.delete(relative_url)
+        self.assertEqual(204, response.status_code, response.content[:1000])
+
+        self.assertFalse(Location.objects.filter(pk=location_id).exists())
+        self.assertFalse(URL.objects.filter(pk=self.delete_id).exists())
+
 
 @versioned_fixtures
 class EngagementTest(BaseClass.RelatedObjectsTest, BaseClass.BaseClassTest):


### PR DESCRIPTION
This PR updates the `URL` API endpoint to correct a bug discovered by @blakeaowens; it implements his solution.

Previously, deleting a URL object through the API deleted the URL object itself, leaving a dangling AbstractLocation entry. The fix is simple enough: override the URLViewSet's `perform_destroy()` method to call `.delete()` on the instance's AbstractLocation reference instead. This will cascade to the URL.