### PR TITLE
fix(reimport): do not update finding tags on reimport for matched findings

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -409,6 +409,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                     finding = self.finding_post_processing(
                         finding,
                         unsaved_finding,
+                        is_matched_finding=bool(matched_findings),
                     )
                     # all data is already saved on the finding, we only need to trigger post processing in batches
                     push_to_jira = self.push_to_jira and ((not self.findings_groups_enabled or not self.group_by) or not finding_will_be_grouped)
@@ -926,6 +927,8 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         self,
         finding: Finding,
         finding_from_report: Finding,
+        *,
+        is_matched_finding: bool = False,
     ) -> Finding:
         """
         Save all associated objects to the finding after it has been saved
@@ -940,19 +943,22 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             self.endpoint_manager.chunk_endpoints_and_disperse(finding, finding_from_report.unsaved_endpoints)
             if len(self.endpoints_to_add) > 0:
                 self.endpoint_manager.chunk_endpoints_and_disperse(finding, self.endpoints_to_add)
-        # Parsers shouldn't use the tags field, and use unsaved_tags instead.
-        # Merge any tags set by parser into unsaved_tags
-        tags_from_parser = finding_from_report.tags if isinstance(finding_from_report.tags, list) else []
-        unsaved_tags_from_parser = finding_from_report.unsaved_tags if isinstance(finding_from_report.unsaved_tags, list) else []
-        merged_tags = unsaved_tags_from_parser + tags_from_parser
-        if merged_tags:
-            finding_from_report.unsaved_tags = merged_tags
-        if finding_from_report.unsaved_tags:
-            cleaned_tags = clean_tags(finding_from_report.unsaved_tags)
-            if isinstance(cleaned_tags, list):
-                finding.tags.add(*cleaned_tags)
-            elif isinstance(cleaned_tags, str):
-                finding.tags.add(cleaned_tags)
+        # For matched/existing findings, do not update tags from the report,
+        # consistent with how other fields are handled on reimport.
+        if not is_matched_finding:
+            # Parsers shouldn't use the tags field, and use unsaved_tags instead.
+            # Merge any tags set by parser into unsaved_tags
+            tags_from_parser = finding_from_report.tags if isinstance(finding_from_report.tags, list) else []
+            unsaved_tags_from_parser = finding_from_report.unsaved_tags if isinstance(finding_from_report.unsaved_tags, list) else []
+            merged_tags = unsaved_tags_from_parser + tags_from_parser
+            if merged_tags:
+                finding_from_report.unsaved_tags = merged_tags
+            if finding_from_report.unsaved_tags:
+                cleaned_tags = clean_tags(finding_from_report.unsaved_tags)
+                if isinstance(cleaned_tags, list):
+                    finding.tags.add(*cleaned_tags)
+                elif isinstance(cleaned_tags, str):
+                    finding.tags.add(cleaned_tags)
         # Process any files
         if finding_from_report.unsaved_files:
             finding.unsaved_files = finding_from_report.unsaved_files

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -369,12 +369,12 @@ class TagImportMixin:
         findings = response["results"]
         # Make sure we have what we are looking for
         assert_tags_in_findings(findings, 2, ["security", "network"])
-        # Reimport with a different report that has more tags
+        # Reimport with a different report that has more tags — matched findings should retain their original tags
         self.reimport_scan_with_params(test_id, self.generic_sample_with_more_tags_filename, scan_type="Generic Findings Import")
         response = self.get_test_findings_api(test_id)
         findings = response["results"]
-        # Make sure we have what we are looking for
-        assert_tags_in_findings(findings, 2, ["security", "network", "hardened"])
+        # Tags from the report are not applied to matched findings on reimport, consistent with other fields
+        assert_tags_in_findings(findings, 2, ["security", "network"])
 
 
 @versioned_fixtures


### PR DESCRIPTION
## Summary

The behaviour of the Finding Tags in the reimport has been going through a bit of rough patch. At some point it was broken and it was fixed via #14459 . But that PR resulted in tags being added to existing tags, possibly leading to "too many" tags or "obsolete" tags. To avoid any confusion we have now decided to make the tags field behave like all other fields. It's set during import and not updated afterwards. 

We are considering flags on the reimport request to trigger (certain) fields to be updated during reimport, but for now this PR is the desired behaviour.

- On reimport, tags from the report were being appended to matched/existing findings via `tags.add()`, causing tags to accumulate across reimports instead of being left unchanged. This was a regression introduced in #14459 which changed `tags.set()` to `tags.add()`.
- This fix skips tag updates for matched findings during reimport, consistent with how other finding fields (title, severity, description, etc.) are handled — only new findings get tags from the report.
- Updated `test_import_report_with_tags` to reflect the corrected behavior.