### PR TITLE
Fix Wazuh 4.8 parser to attach endpoints/locations to findings

### DIFF
--- a/dojo/tools/wazuh/v4_8.py
+++ b/dojo/tools/wazuh/v4_8.py
@@ -1,4 +1,7 @@
-from dojo.models import Finding
+from django.conf import settings
+
+from dojo.models import Endpoint, Finding
+from dojo.tools.locations import LocationData
 
 
 class WazuhV4_8:
@@ -17,10 +20,8 @@ class WazuhV4_8:
                 continue  # Skip if this finding has already been processed
 
             description = vuln.get("description")
-            description += "\nAgent id:" + item.get("agent").get("id")
-            description += "\nAgent name:" + item.get("agent").get("name")
             severity = vuln.get("severity")
-            cvssv3_score = vuln.get("score").get("base")
+            cvssv3_score = vuln.get("score").get("base") if vuln.get("score") else None
             publish_date = vuln.get("published_at").split("T")[0]
             detection_time = vuln.get("detected_at").split("T")[0]
             references = vuln.get("reference")
@@ -56,6 +57,15 @@ class WazuhV4_8:
                 unique_id_from_tool=dupe_key,
                 date=detection_time,
             )
+
+            # Create endpoint from agent name
+            agent_name = item.get("agent").get("name")
+            if agent_name is not None:
+                if settings.V3_FEATURE_LOCATIONS:
+                    find.unsaved_locations = [LocationData.url(host=agent_name)]
+                else:
+                    find.unsaved_endpoints = [Endpoint(host=agent_name)]
+
             find.unsaved_vulnerability_ids = [cve]
             dupes[dupe_key] = find
 

--- a/unittests/tools/test_wazuh_parser.py
+++ b/unittests/tools/test_wazuh_parser.py
@@ -65,3 +65,19 @@ class TestWazuhParser(DojoTestCase):
             findings = parser.get_findings(testfile, Test())
             for finding in findings:
                 self.assertEqual("Info", finding.severity)
+
+    def test_parse_v4_8_many_findings_with_location(self):
+        with (get_unit_tests_scans_path("wazuh") / "v4-8_many_findings.json").open(encoding="utf-8") as testfile:
+            parser = WazuhParser()
+            findings = parser.get_findings(testfile, Test())
+            finding = findings[0]
+            self.assertEqual(10, len(findings))
+            self.validate_locations(findings)
+            self.assertEqual("CVE-2025-27558 affects (version: 6.8.0-60.63)", findings[0].title)
+            self.assertEqual("Critical", findings[0].severity)
+            self.assertEqual(9.1, findings[0].cvssv3_score)
+            location = self.get_unsaved_locations(finding)[0]
+            self.assertEqual("myhost0", location.host)
+            self.assertEqual("linux-image-6.8.0-60-generic", finding.component_name)
+            self.assertEqual("6.8.0-60.63", finding.component_version)
+            self.assertEqual("2025-06-30", finding.date)


### PR DESCRIPTION
## Summary

The Wazuh 4.8 parser currently creates findings without associating them with an Endpoint/Location, unlike the 4.7 parser.

This change updates the Wazuh 4.8 parser to attach the agent name to each finding:
- as a `Location` when `V3_FEATURE_LOCATIONS` is enabled
- as an `Endpoint` otherwise

This restores host association for imported Wazuh 4.8 findings and keeps the behavior aligned with the existing feature flag logic.

I also added the missing `cvssv3_score` mapping from the Wazuh score payload.
Tests were added to validate the expected behavior.