### PR TITLE
feat/helm: add basic support for Gateway API HTTPRoute for routing

### DIFF
--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -618,6 +618,9 @@ A Helm chart for Kubernetes to install DefectDojo
 | django.extraInitContainers | list | `[]` | A list of additional initContainers to run before the uwsgi and nginx containers. |
 | django.extraVolumeMounts | list | `[]` | Array of additional volume mount points common to all containers and initContainers. |
 | django.extraVolumes | list | `[]` | A list of extra volumes to mount. |
+| django.httpRoute | object | `{"annotations":{},"enabled":false,"parentRefs":[]}` | Expose the Django service via Gateway API HTTPRoute |
+| django.httpRoute.annotations | object | `{}` | Annotations for the HTTPRoute resource |
+| django.httpRoute.parentRefs | list | `[]` | Parent gateway references for the HTTPRoute parentRefs: - name: my-gateway   namespace: default |
 | django.ingress.activateTLS | bool | `true` |  |
 | django.ingress.annotations | object | `{}` | Restricts the type of ingress controller that can interact with our chart (nginx, traefik, ...) `kubernetes.io/ingress.class: nginx` Depending on the size and complexity of your scans, you might want to increase the default ingress timeouts if you see repeated 504 Gateway Timeouts `nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"` `nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"` |
 | django.ingress.enabled | bool | `true` |  |

--- a/helm/defectdojo/templates/django-httproute.yaml
+++ b/helm/defectdojo/templates/django-httproute.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.django.httpRoute.enabled -}}
+{{- $fullName := include "defectdojo.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  {{- if or .Values.extraAnnotations .Values.django.httpRoute.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.extraAnnotations }}
+    {{ $key }}: {{ quote $value }}
+  {{- end }}
+  {{- range $key, $value := .Values.django.httpRoute.annotations }}
+    {{ $key }}: {{ quote $value }}
+  {{- end }}
+  {{- end }}
+  labels:
+    defectdojo.org/component: django
+    app.kubernetes.io/name: {{ include "defectdojo.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "defectdojo.chart" . }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ quote $value }}
+    {{- end }}
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+  {{- range .Values.django.httpRoute.parentRefs }}
+  - group: {{ .group | default "gateway.networking.k8s.io" }}
+    kind: {{ .kind | default "Gateway" }}
+    name: {{ .name }}
+    {{- if .namespace }}
+    namespace: {{ .namespace }}
+    {{- end }}
+    {{- if .sectionName }}
+    sectionName: {{ .sectionName }}
+    {{- end }}
+  {{- end }}
+  hostnames:
+  - {{ .Values.host | quote }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        {{- if .Values.django.httpRoute.path }}
+        value: {{ .Values.django.httpRoute.path }}
+        {{- else }}
+        value: "/"
+        {{- end }}
+    backendRefs:
+    - name: {{ $fullName }}-django
+      port: {{ .Values.django.nginx.tls.enabled | ternary 443 80 }}
+{{- end }}

--- a/helm/defectdojo/values.schema.json
+++ b/helm/defectdojo/values.schema.json
@@ -532,6 +532,23 @@
                         }
                     }
                 },
+                "httpRoute": {
+                    "description": "Expose the Django service via Gateway API HTTPRoute. For more info follow https://gateway-api.sigs.k8s.io/guides/http-routing/",
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "annotations": {
+                            "description": "Annotations for the HTTPRoute resource",
+                            "type": "object"
+                        },
+                        "parentRefs": {
+                            "description": "Parent gateway references for the HTTPRoute",
+                            "type": "array"
+                        }
+                    }
+                },
                 "mediaPersistentVolume": {
                     "description": "This feature needs more preparation before can be enabled, please visit KUBERNETES.md#media-persistent-volume",
                     "type": "object",

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -372,6 +372,16 @@ django:
     # `nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"`
     # `nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"`
     annotations: {}
+  # -- Expose the Django service via Gateway API HTTPRoute
+  httpRoute:
+    enabled: false
+    # -- Annotations for the HTTPRoute resource
+    annotations: {}
+    # -- Parent gateway references for the HTTPRoute
+    # parentRefs:
+    # - name: my-gateway
+    #   namespace: default
+    parentRefs: []
   nginx:
     # -- If empty, uses values from images.nginx.image
     image:


### PR DESCRIPTION
### Add Gateway API HTTPRoute support for Django service

Adds an optional HTTPRoute resource (Gateway API v1) as an alternative to the existing Ingress for exposing the Django service. This aligns with the Kubernetes ecosystem's move toward the Gateway API as the successor to Ingress.

### Changes

- `templates/django-httproute.yaml` : New template gated by django.httpRoute.enabled. 
- `values.yaml` : Added django.httpRoute section (enabled: false by default) with annotations and parentRefs fields.
- `values.schema.json` : Schema definition for the new django.httpRoute object.

### Usage

```yaml
django:
  httpRoute:
    enabled: true
    annotations: {}
    parentRefs:
    - name: my-gateway
      namespace: default
```

### Notes

- Disabled by default — no impact on existing deployments.
- Can be used alongside or instead of the existing Ingress resource.
- parentRefs entries default group to gateway.networking.k8s.io and kind to Gateway; only name is required.