### PR TITLE
store more parameters in import settings

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -460,6 +460,13 @@ class BaseImporter(ImporterOptions):
         import_settings["push_to_jira"] = self.push_to_jira
         import_settings["tags"] = self.tags
         import_settings["scan_date"] = self.scan_date.isoformat() if self.scan_date_override else None
+        import_settings["service"] = self.service
+        import_settings["close_old_findings_product_scope"] = self.close_old_findings_product_scope
+        import_settings["do_not_reactivate"] = self.do_not_reactivate
+        import_settings["apply_tags_to_findings"] = self.apply_tags_to_findings
+        import_settings["apply_tags_to_endpoints"] = self.apply_tags_to_endpoints
+        import_settings["group_by"] = self.group_by
+        import_settings["create_finding_groups_for_all_findings"] = self.create_finding_groups_for_all_findings
         if settings.V3_FEATURE_LOCATIONS:
             # Add the list of locations that were added exclusively at import time
             if len(self.endpoints_to_add) > 0:

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -1083,6 +1083,13 @@ def import_settings_tag(test_import, *, autoescape=True):
             <b>Push to jira:</b> %s<br/>
             <b>Tags:</b> %s<br/>
             <b>Endpoints:</b> %s<br/>
+            <b>Service:</b> %s<br/>
+            <b>Close Old Findings (Product Scope):</b> %s<br/>
+            <b>Do Not Reactivate:</b> %s<br/>
+            <b>Apply Tags to Findings:</b> %s<br/>
+            <b>Apply Tags to Endpoints:</b> %s<br/>
+            <b>Group By:</b> %s<br/>
+            <b>Create Finding Groups for All Findings:</b> %s<br/>
         "
     </i>
     """
@@ -1090,26 +1097,31 @@ def import_settings_tag(test_import, *, autoescape=True):
     icon = "fa-info-circle"
     color = ""
 
+    s = test_import.import_settings
+    common_fields = (
+        esc(test_import.id),
+        esc(s.get("active", None)),
+        esc(s.get("verified", None)),
+        esc(s.get("minimum_severity", None)),
+        esc(s.get("close_old_findings", None)),
+        esc(s.get("push_to_jira", None)),
+        esc(s.get("tags", None)),
+    )
+    extra_fields = (
+        esc(s.get("service", None)),
+        esc(s.get("close_old_findings_product_scope", None)),
+        esc(s.get("do_not_reactivate", None)),
+        esc(s.get("apply_tags_to_findings", None)),
+        esc(s.get("apply_tags_to_endpoints", None)),
+        esc(s.get("group_by", None)),
+        esc(s.get("create_finding_groups_for_all_findings", None)),
+    )
+
     if not settings.V3_FEATURE_LOCATIONS:
         # TODO: Delete this after the move to Locations
-        return mark_safe(html % (icon, color, icon,
-                                    esc(test_import.id),
-                                    esc(test_import.import_settings.get("active", None)),
-                                    esc(test_import.import_settings.get("verified", None)),
-                                    esc(test_import.import_settings.get("minimum_severity", None)),
-                                    esc(test_import.import_settings.get("close_old_findings", None)),
-                                    esc(test_import.import_settings.get("push_to_jira", None)),
-                                    esc(test_import.import_settings.get("tags", None)),
-                                    esc(test_import.import_settings.get("endpoints", test_import.import_settings.get("endpoint", None)))))
-    return mark_safe(html % (icon, color, icon,
-                             esc(test_import.id),
-                             esc(test_import.import_settings.get("active", None)),
-                             esc(test_import.import_settings.get("verified", None)),
-                             esc(test_import.import_settings.get("minimum_severity", None)),
-                             esc(test_import.import_settings.get("close_old_findings", None)),
-                             esc(test_import.import_settings.get("push_to_jira", None)),
-                             esc(test_import.import_settings.get("tags", None)),
-                             esc(test_import.import_settings.get("locations", None))))
+        endpoints = esc(s.get("endpoints", s.get("endpoint", None)))
+        return mark_safe(html % (icon, color, icon, *common_fields, endpoints, *extra_fields))
+    return mark_safe(html % (icon, color, icon, *common_fields, esc(s.get("locations", None)), *extra_fields))
 
 
 @register.filter(needs_autoescape=True)

--- a/unittests/test_update_import_history.py
+++ b/unittests/test_update_import_history.py
@@ -177,3 +177,26 @@ class UpdateImportHistoryTests(TransactionTestCase):
         # Verify import_settings is JSON-serializable
         json.dumps(settings)
         self.assertIsNone(settings["scan_date"])
+
+    def test_import_settings_contains_scope_and_group_fields(self):
+        """import_settings should persist the seven scope/tag/group-by importer options."""
+        self.importer.service = "my-service"
+        self.importer.close_old_findings_product_scope = True
+        self.importer.do_not_reactivate = True
+        self.importer.apply_tags_to_findings = True
+        self.importer.apply_tags_to_endpoints = True
+        self.importer.group_by = "component_name"
+        self.importer.create_finding_groups_for_all_findings = True
+
+        new_findings = self._create_findings(1)
+        test_import = self.importer.update_import_history(new_findings=new_findings)
+
+        s = test_import.import_settings
+        json.dumps(s)
+        self.assertEqual(s["service"], "my-service")
+        self.assertTrue(s["close_old_findings_product_scope"])
+        self.assertTrue(s["do_not_reactivate"])
+        self.assertTrue(s["apply_tags_to_findings"])
+        self.assertTrue(s["apply_tags_to_endpoints"])
+        self.assertEqual(s["group_by"], "component_name")
+        self.assertTrue(s["create_finding_groups_for_all_findings"])


### PR DESCRIPTION
There are some more useful fields to store for context/reference, i.e. the `service` field.

<img width="1008" height="1102" alt="image" src="https://github.com/user-attachments/assets/676d3240-4607-4381-ab87-a67e924f2d2b" />
