### PR TITLE
Add centralized banner system with OS messaging support

### DIFF
--- a/dojo/announcement/os_message.py
+++ b/dojo/announcement/os_message.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 
 logger = logging.getLogger(__name__)
 
-BUCKET_URL = "https://storage.googleapis.com/defectdojo-os-messages-dev/open_source_message.md"
+BUCKET_URL = "https://storage.googleapis.com/defectdojo-os-messages-prod/open_source_message.md"
 CACHE_SECONDS = 3600
 HTTP_TIMEOUT_SECONDS = 2
 CACHE_KEY = "os_message:v1"

--- a/dojo/announcement/os_message.py
+++ b/dojo/announcement/os_message.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 
 logger = logging.getLogger(__name__)
 
-BUCKET_URL = "https://storage.googleapis.com/defectdojo-os-messages-prod/open_source_message.md"
+BUCKET_URL = "https://storage.googleapis.com/defectdojo-os-messages-dev/open_source_message.md"
 CACHE_SECONDS = 3600
 HTTP_TIMEOUT_SECONDS = 2
 CACHE_KEY = "os_message:v1"
@@ -96,7 +96,7 @@ def parse_os_message(text):
         if expanded_source:
             expanded_rendered = markdown.markdown(
                 expanded_source,
-                extensions=["extra", "fenced_code"],
+                extensions=["extra", "fenced_code", "nl2br"],
             )
             expanded_html = bleach.clean(
                 expanded_rendered,

--- a/dojo/announcement/signals.py
+++ b/dojo/announcement/signals.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -7,22 +6,11 @@ from dojo.models import Announcement, Dojo_User, UserAnnouncement
 
 @receiver(post_save, sender=Dojo_User)
 def add_announcement_to_new_user(sender, instance, **kwargs):
-    announcements = Announcement.objects.all()
-    if announcements.count() > 0:
-        dojo_user = Dojo_User.objects.get(id=instance.id)
-        announcement = announcements.first()
-        cloud_announcement = (
-            "DefectDojo Pro Cloud and On-Premise Subscriptions Now Available!"
-            in announcement.message
+    announcement = Announcement.objects.first()
+    if announcement is not None:
+        UserAnnouncement.objects.get_or_create(
+            user=instance, announcement=announcement,
         )
-        if not cloud_announcement or settings.CREATE_CLOUD_BANNER:
-            user_announcements = UserAnnouncement.objects.filter(
-                user=dojo_user, announcement=announcement,
-            )
-            if user_announcements.count() == 0:
-                UserAnnouncement.objects.get_or_create(
-                    user=dojo_user, announcement=announcement,
-                )
 
 
 @receiver(post_save, sender=Announcement)

--- a/dojo/announcements/os_message.py
+++ b/dojo/announcements/os_message.py
@@ -1,0 +1,119 @@
+import logging
+
+import bleach
+import markdown
+import requests
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+BUCKET_URL = "https://storage.googleapis.com/defectdojo-os-messages-prod/open_source_message.md"
+CACHE_SECONDS = 3600
+HTTP_TIMEOUT_SECONDS = 2
+CACHE_KEY = "os_message:v1"
+
+INLINE_TAGS = ["strong", "em", "a"]
+INLINE_ATTRS = {"a": ["href", "title"]}
+
+# Keep BLOCK_TAGS / BLOCK_ATTRS in sync with the DaaS publisher's
+# MARKDOWNIFY["default"]["WHITELIST_TAGS"] / WHITELIST_ATTRS so previews
+# on DaaS and rendering in OSS stay byte-identical.
+BLOCK_TAGS = [
+    "p", "ul", "ol", "li", "a", "strong", "em", "code", "pre",
+    "blockquote", "h2", "h3", "h4", "hr", "br", "b", "i",
+    "abbr", "acronym",
+]
+BLOCK_ATTRS = {
+    "a": ["href", "title"],
+    "abbr": ["title"],
+    "acronym": ["title"],
+}
+
+_MISS = object()
+
+
+def fetch_os_message():
+    cached = cache.get(CACHE_KEY, default=_MISS)
+    if cached is not _MISS:
+        return cached
+
+    try:
+        response = requests.get(BUCKET_URL, timeout=HTTP_TIMEOUT_SECONDS)
+    except Exception:
+        logger.debug("os_message: fetch failed", exc_info=True)
+        cache.set(CACHE_KEY, None, CACHE_SECONDS)
+        return None
+
+    if response.status_code != 200 or not response.text.strip():
+        cache.set(CACHE_KEY, None, CACHE_SECONDS)
+        return None
+
+    cache.set(CACHE_KEY, response.text, CACHE_SECONDS)
+    return response.text
+
+
+def _strip_outer_p(html):
+    stripped = html.strip()
+    if stripped.startswith("<p>") and stripped.endswith("</p>"):
+        return stripped[3:-4]
+    return stripped
+
+
+def parse_os_message(text):
+    lines = text.splitlines()
+
+    headline_source = None
+    body_start = None
+    for index, line in enumerate(lines):
+        if line.startswith("# "):
+            headline_source = line[2:].strip()
+            body_start = index + 1
+            break
+
+    if not headline_source:
+        return None
+
+    headline_source = headline_source[:100]
+    headline_rendered = markdown.markdown(headline_source)
+    headline_cleaned = bleach.clean(
+        headline_rendered,
+        tags=INLINE_TAGS,
+        attributes=INLINE_ATTRS,
+        strip=True,
+    )
+    headline_html = _strip_outer_p(headline_cleaned)
+
+    expanded_html = None
+    expanded_marker = "## Expanded Message"
+    expanded_body_lines = None
+    for offset, line in enumerate(lines[body_start:], start=body_start):
+        if line.strip() == expanded_marker:
+            expanded_body_lines = lines[offset + 1:]
+            break
+
+    if expanded_body_lines is not None:
+        expanded_source = "\n".join(expanded_body_lines).strip()
+        if expanded_source:
+            expanded_rendered = markdown.markdown(
+                expanded_source,
+                extensions=["extra", "fenced_code"],
+            )
+            expanded_html = bleach.clean(
+                expanded_rendered,
+                tags=BLOCK_TAGS,
+                attributes=BLOCK_ATTRS,
+                strip=True,
+            )
+
+    return {"message": headline_html, "expanded_html": expanded_html}
+
+
+def get_os_banner():
+    try:
+        text = fetch_os_message()
+        if not text:
+            return None
+        return parse_os_message(text)
+    except Exception:
+        logger.debug("os_message: get_os_banner failed", exc_info=True)
+        return None

--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -36,19 +36,30 @@ def globalize_vars(request):
         "DOCUMENTATION_URL": settings.DOCUMENTATION_URL,
         "API_TOKENS_ENABLED": settings.API_TOKENS_ENABLED,
         "API_TOKEN_AUTH_ENDPOINT_ENABLED": settings.API_TOKEN_AUTH_ENDPOINT_ENABLED,
-        "CREATE_CLOUD_BANNER": settings.CREATE_CLOUD_BANNER,
+        "SHOW_PLG_LINK": True,
         # V3 Feature Flags
         "V3_FEATURE_LOCATIONS": settings.V3_FEATURE_LOCATIONS,
     }
 
+    additional_banners = []
+
     if (os_banner := get_os_banner()) is not None:
-        context["additional_banners"] = [{
+        additional_banners.append({
+            "source": "os",
             "message": os_banner["message"],
             "style": "info",
             "url": "",
             "link_text": "",
             "expanded_html": os_banner["expanded_html"],
-        }]
+        })
+
+    if hasattr(request, "session"):
+        for banner in request.session.pop("_product_banners", []):
+            additional_banners.append(banner)
+
+    if additional_banners:
+        context["additional_banners"] = additional_banners
+
     return context
 
 

--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -5,7 +5,7 @@ import time
 from django.conf import settings
 from django.contrib import messages
 
-from dojo.announcements.os_message import get_os_banner
+from dojo.announcement.os_message import get_os_banner
 from dojo.labels import get_labels
 from dojo.models import Alerts, System_Settings, UserAnnouncement
 
@@ -40,8 +40,8 @@ def globalize_vars(request):
         # V3 Feature Flags
         "V3_FEATURE_LOCATIONS": settings.V3_FEATURE_LOCATIONS,
     }
-    os_banner = get_os_banner()
-    if os_banner is not None:
+
+    if (os_banner := get_os_banner()) is not None:
         context["additional_banners"] = [{
             "message": os_banner["message"],
             "style": "info",

--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -5,13 +5,14 @@ import time
 from django.conf import settings
 from django.contrib import messages
 
+from dojo.announcements.os_message import get_os_banner
 from dojo.labels import get_labels
 from dojo.models import Alerts, System_Settings, UserAnnouncement
 
 
 def globalize_vars(request):
     # return the value you want as a dictionnary. you may add multiple values in there.
-    return {
+    context = {
         "SHOW_LOGIN_FORM": settings.SHOW_LOGIN_FORM,
         "FORGOT_PASSWORD": settings.FORGOT_PASSWORD,
         "FORGOT_USERNAME": settings.FORGOT_USERNAME,
@@ -39,6 +40,16 @@ def globalize_vars(request):
         # V3 Feature Flags
         "V3_FEATURE_LOCATIONS": settings.V3_FEATURE_LOCATIONS,
     }
+    os_banner = get_os_banner()
+    if os_banner is not None:
+        context["additional_banners"] = [{
+            "message": os_banner["message"],
+            "style": "info",
+            "url": "",
+            "link_text": "",
+            "expanded_html": os_banner["expanded_html"],
+        }]
+    return context
 
 
 def bind_system_settings(request):

--- a/dojo/management/commands/complete_initialization.py
+++ b/dojo/management/commands/complete_initialization.py
@@ -14,7 +14,6 @@ from django.db import connection, connections
 from django.db.utils import ProgrammingError
 
 from dojo.auditlog import configure_pghistory_triggers
-from dojo.models import Announcement, Dojo_User, UserAnnouncement
 
 
 class Command(BaseCommand):
@@ -38,13 +37,11 @@ class Command(BaseCommand):
 
         if self.admin_user_exists():
             self.stdout.write("Admin user already exists; skipping first-boot setup")
-            self.create_announcement_banner()
             self.initialize_data()
             return
 
         self.ensure_admin_secrets()
         self.first_boot_setup()
-        self.create_announcement_banner()
         self.initialize_data()
 
     # ------------------------------------------------------------------
@@ -57,29 +54,6 @@ class Command(BaseCommand):
 
         self.stdout.write("Initializing non-standard permissions")
         call_command("initialize_permissions")
-
-    def create_announcement_banner(self) -> None:
-        if os.getenv("DD_CREATE_CLOUD_BANNER"):
-            return
-
-        self.stdout.write("Creating announcement banner")
-
-        announcement, _ = Announcement.objects.get_or_create(id=1)
-        announcement.message = (
-            '<a href="https://cloud.defectdojo.com/accounts/onboarding/plg_step_1" '
-            'target="_blank">'
-            "DefectDojo Pro Cloud and On-Premise Subscriptions Now Available! "
-            "Create an account to try Pro for free!"
-            "</a>"
-        )
-        announcement.dismissable = True
-        announcement.save()
-
-        for user in Dojo_User.objects.all():
-            UserAnnouncement.objects.get_or_create(
-                user=user,
-                announcement=announcement,
-            )
 
     # ------------------------------------------------------------------
     # Auditlog consistency

--- a/dojo/product_announcements.py
+++ b/dojo/product_announcements.py
@@ -1,8 +1,6 @@
 
 import logging
 
-from django.conf import settings
-from django.contrib import messages
 from django.http import HttpRequest, HttpResponse
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -30,12 +28,8 @@ class ProductAnnouncementManager:
         response_data: dict | None = None,
         **kwargs: dict,
     ):
-        """Skip all this if the CREATE_CLOUD_BANNER is not set"""
-        if not settings.CREATE_CLOUD_BANNER:
-            return
-        # Fill in the vars if the were supplied correctly
         if request is not None and isinstance(request, HttpRequest):
-            self._add_django_message(
+            self._add_session_banner(
                 request=request,
                 message=mark_safe(f"{self.base_message} {self.ui_outreach}"),
             )
@@ -51,18 +45,21 @@ class ProductAnnouncementManager:
             msg = "At least one of request, response, or response_data must be supplied"
             raise ValueError(msg)
 
-    def _add_django_message(self, request: HttpRequest, message: str):
-        """Add a message to the UI"""
+    def _add_session_banner(self, request: HttpRequest, message: str):
+        """Store a banner in the session for rendering via additional_banners."""
         try:
-            messages.add_message(
-                request=request,
-                level=messages.INFO,
-                message=_(message),
-                extra_tags="alert-info",
-            )
+            banners = request.session.get("_product_banners", [])
+            banners.append({
+                "source": "product_announcement",
+                "message": str(_(message)),
+                "style": "info",
+                "url": "",
+                "link_text": "",
+                "expanded_html": None,
+            })
+            request.session["_product_banners"] = banners
         except Exception:
-            # make sure we catch any exceptions that might happen: https://github.com/DefectDojo/django-DefectDojo/issues/14041
-            logger.exception(f"Error adding message to Django: {message}")
+            logger.exception(f"Error storing product announcement banner: {message}")
 
     def _add_api_response_key(self, message: str, data: dict) -> dict:
         """Update the response data in place"""

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -356,8 +356,6 @@ env = environ.FileAwareEnv(
     DD_HASHCODE_FIELDS_PER_SCANNER=(str, ""),
     # Set deduplication algorithms per parser, via en env variable that contains a JSON string
     DD_DEDUPLICATION_ALGORITHM_PER_PARSER=(str, ""),
-    # Dictates whether cloud banner is created or not
-    DD_CREATE_CLOUD_BANNER=(bool, True),
     # With this setting turned on, Dojo maintains an audit log of changes made to entities (Findings, Tests, Engagements, Products, ...)
     # If you run big import you may want to disable this because there's a performance hit during (re-)imports.
     DD_ENABLE_AUDITLOG=(bool, True),
@@ -1339,13 +1337,6 @@ CELERY_BEAT_SCHEDULE = {
             "expires": int(60 * 1 * 1.2),  # If a task is not executed within 72 seconds, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
         },
     },
-    "trigger_evaluate_pro_proposition": {
-        "task": "dojo.tasks.evaluate_pro_proposition",
-        "schedule": timedelta(hours=8),
-        "options": {
-            "expires": int(60 * 60 * 8 * 1.2),  # If a task is not executed within 9.6 hours, it should be dropped from the queue. Two more tasks should be scheduled in the meantime.
-        },
-    },
     "clear_sessions": {
         "task": "dojo.tasks.clear_sessions",
         "schedule": crontab(hour=0, minute=0, day_of_week=0),
@@ -2082,9 +2073,6 @@ FILE_IMPORT_TYPES = env("DD_FILE_IMPORT_TYPES")
 AUDITLOG_DISABLE_ON_RAW_SAVE = False
 #  You can set extra Jira headers by suppling a dictionary in header: value format (pass as env var like "headr_name=value,another_header=anohter_value")
 ADDITIONAL_HEADERS = env("DD_ADDITIONAL_HEADERS")
-# Dictates whether cloud banner is created or not
-CREATE_CLOUD_BANNER = env("DD_CREATE_CLOUD_BANNER")
-
 # ------------------------------------------------------------------------------
 # Auditlog
 # ------------------------------------------------------------------------------

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1127,14 +1127,19 @@ div.custom-search-form {
 }
 
 .os-banner-toggle {
+    background: transparent;
+    border: 0;
+    padding: 0;
     margin-left: 6px;
-    cursor: pointer;
     color: inherit;
-    text-decoration: none;
+    cursor: pointer;
+    line-height: 1;
 }
 
-.os-banner-toggle .fa-caret-down {
-    transition: transform 0.15s ease-in-out;
+.os-banner-toggle:focus,
+.os-banner-toggle:active {
+    outline: none;
+    box-shadow: none;
 }
 
 .os-banner-toggle:not(.collapsed) .fa-caret-down {

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1126,6 +1126,25 @@ div.custom-search-form {
     border-radius: 0px 0px 4px 4px;
 }
 
+.os-banner-toggle {
+    margin-left: 6px;
+    cursor: pointer;
+    color: inherit;
+    text-decoration: none;
+}
+
+.os-banner-toggle .fa-caret-down {
+    transition: transform 0.15s ease-in-out;
+}
+
+.os-banner-toggle:not(.collapsed) .fa-caret-down {
+    transform: rotate(180deg);
+}
+
+.os-banner-expanded {
+    margin-top: 8px;
+}
+
 @media (min-width: 795px) {
     div.custom-search-form {
         height: 21px;

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1124,9 +1124,20 @@ div.custom-search-form {
 .announcement-banner {
     margin: 0px -15px;
     border-radius: 0px 0px 4px 4px;
+    color: #000;
 }
 
-.os-banner-toggle {
+.announcement-banner a {
+    color: #0645ad;
+    text-decoration: underline;
+}
+
+.announcement-banner strong,
+.announcement-banner b {
+    color: #222;
+}
+
+.banner-toggle {
     background: transparent;
     border: 0;
     padding: 0;
@@ -1136,17 +1147,17 @@ div.custom-search-form {
     line-height: 1;
 }
 
-.os-banner-toggle:focus,
-.os-banner-toggle:active {
+.banner-toggle:focus,
+.banner-toggle:active {
     outline: none;
     box-shadow: none;
 }
 
-.os-banner-toggle:not(.collapsed) .fa-caret-down {
+.banner-toggle:not(.collapsed) .fa-caret-down {
     transform: rotate(180deg);
 }
 
-.os-banner-expanded {
+.banner-expanded {
     margin-top: 8px;
 }
 

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -16,9 +16,8 @@ from dojo.auditlog import run_flush_auditlog
 from dojo.celery import app
 from dojo.celery_dispatch import dojo_dispatch_task
 from dojo.finding.helper import fix_loop_duplicates
-from dojo.location.models import Location
 from dojo.management.commands.jira_status_reconciliation import jira_status_reconciliation
-from dojo.models import Alerts, Announcement, Endpoint, Engagement, Finding, Product, System_Settings, User
+from dojo.models import Alerts, Engagement, Finding, Product, System_Settings, User
 from dojo.notifications.helper import create_notification
 from dojo.utils import calculate_grade, sla_compute_and_notify
 
@@ -216,37 +215,6 @@ def fix_loop_duplicates_task(*args, **kwargs):
     # Wrap with pghistory context for audit trail
     with pghistory.context(source="fix_loop_duplicates"):
         return fix_loop_duplicates()
-
-
-@app.task
-def evaluate_pro_proposition(*args, **kwargs):
-    # Ensure we should be doing this
-    if not settings.CREATE_CLOUD_BANNER:
-        return
-    # Get the announcement object
-    announcement = Announcement.objects.get_or_create(id=1)[0]
-    # Quick check for a user has modified the current banner - if not, exit early as we dont want to stomp
-    if not any(
-        entry in announcement.message
-        for entry in [
-            "",
-            "DefectDojo Pro Cloud and On-Premise Subscriptions Now Available!",
-            "Findings/Endpoints in their systems",
-        ]
-    ):
-        return
-    # Count the objects the determine if the banner should be updated
-    if settings.V3_FEATURE_LOCATIONS:
-        object_count = Finding.objects.count() + Location.objects.count()
-    else:
-        # TODO: Delete this after the move to Locations
-        object_count = Finding.objects.count() + Endpoint.objects.count()
-    # Unless the count is greater than 100k, exit early
-    if object_count < 100000:
-        return
-    # Update the announcement
-    announcement.message = f'Only professionals have {object_count:,} Findings and Endpoints in their systems... <a href="https://www.defectdojo.com/pricing" target="_blank">Get DefectDojo Pro</a> today!'
-    announcement.save()
 
 
 @app.task

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -199,7 +199,7 @@
                                             </a>
                                         </li>
                                     {% endif %}
-                                    {% if CREATE_CLOUD_BANNER %}
+                                    {% if SHOW_PLG_LINK %}
                                         <li>
                                             <a href="https://cloud.defectdojo.com/accounts/onboarding/plg_step_1">
                                                 <i class="fa-solid fa-level-up fa-fw"></i>
@@ -671,17 +671,18 @@
                     </div>
                 {% endif %}
                 {% for banner in additional_banners %}
-                    <div role="alert" class="announcement-banner alert alert-{{ banner.style }} show">
+                    <div role="alert" class="announcement-banner alert alert-{{ banner.style }} show"
+                         data-source="{{ banner.source }}">
                         {{ banner.message|safe }}{% if banner.url %} <a href="{{ banner.url }}">{{ banner.link_text }}</a>{% endif %}
                         {% if banner.expanded_html %}
-                            <button type="button" class="os-banner-toggle collapsed"
+                            <button type="button" class="banner-toggle collapsed"
                                     data-toggle="collapse"
-                                    data-target="#os-banner-expanded-{{ forloop.counter }}"
+                                    data-target="#banner-expanded-{{ forloop.counter }}"
                                     aria-expanded="false"
-                                    aria-controls="os-banner-expanded-{{ forloop.counter }}">
+                                    aria-controls="banner-expanded-{{ forloop.counter }}">
                                 <i class="fa-solid fa-caret-down"></i>
                             </button>
-                            <div id="os-banner-expanded-{{ forloop.counter }}" class="collapse os-banner-expanded">
+                            <div id="banner-expanded-{{ forloop.counter }}" class="collapse banner-expanded">
                                 {{ banner.expanded_html|safe }}
                             </div>
                         {% endif %}

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -674,11 +674,13 @@
                     <div role="alert" class="announcement-banner alert alert-{{ banner.style }} show">
                         {{ banner.message|safe }}{% if banner.url %} <a href="{{ banner.url }}">{{ banner.link_text }}</a>{% endif %}
                         {% if banner.expanded_html %}
-                            <a role="button" data-toggle="collapse" href="#os-banner-expanded-{{ forloop.counter }}"
-                               aria-expanded="false" aria-controls="os-banner-expanded-{{ forloop.counter }}"
-                               class="os-banner-toggle collapsed">
+                            <button type="button" class="os-banner-toggle collapsed"
+                                    data-toggle="collapse"
+                                    data-target="#os-banner-expanded-{{ forloop.counter }}"
+                                    aria-expanded="false"
+                                    aria-controls="os-banner-expanded-{{ forloop.counter }}">
                                 <i class="fa-solid fa-caret-down"></i>
-                            </a>
+                            </button>
                             <div id="os-banner-expanded-{{ forloop.counter }}" class="collapse os-banner-expanded">
                                 {{ banner.expanded_html|safe }}
                             </div>

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -672,7 +672,17 @@
                 {% endif %}
                 {% for banner in additional_banners %}
                     <div role="alert" class="announcement-banner alert alert-{{ banner.style }} show">
-                        {{ banner.message }} <a href="{{ banner.url }}">{{ banner.link_text }}</a>
+                        {{ banner.message|safe }}{% if banner.url %} <a href="{{ banner.url }}">{{ banner.link_text }}</a>{% endif %}
+                        {% if banner.expanded_html %}
+                            <a role="button" data-toggle="collapse" href="#os-banner-expanded-{{ forloop.counter }}"
+                               aria-expanded="false" aria-controls="os-banner-expanded-{{ forloop.counter }}"
+                               class="os-banner-toggle collapsed">
+                                <i class="fa-solid fa-caret-down"></i>
+                            </a>
+                            <div id="os-banner-expanded-{{ forloop.counter }}" class="collapse os-banner-expanded">
+                                {{ banner.expanded_html|safe }}
+                            </div>
+                        {% endif %}
                     </div>
                 {% endfor %}
                 <div class="container-fluid">

--- a/unittests/test_os_message.py
+++ b/unittests/test_os_message.py
@@ -177,6 +177,7 @@ class TestGlobalizeVarsOsBanner(SimpleTestCase):
             result = context_processors.globalize_vars(self.request)
         self.assertIn("additional_banners", result)
         entry = result["additional_banners"][0]
+        self.assertEqual(entry["source"], "os")
         self.assertEqual(entry["message"], "<strong>Hi</strong>")
         self.assertEqual(entry["expanded_html"], "<p>body</p>")
         self.assertEqual(entry["style"], "info")
@@ -188,6 +189,16 @@ class TestGlobalizeVarsOsBanner(SimpleTestCase):
             result = context_processors.globalize_vars(self.request)
         self.assertNotIn("additional_banners", result)
 
+    def test_show_plg_link_is_true_by_default(self):
+        with patch.object(context_processors, "get_os_banner", return_value=None):
+            result = context_processors.globalize_vars(self.request)
+        self.assertTrue(result["SHOW_PLG_LINK"])
+
+    def test_create_cloud_banner_not_in_context(self):
+        with patch.object(context_processors, "get_os_banner", return_value=None):
+            result = context_processors.globalize_vars(self.request)
+        self.assertNotIn("CREATE_CLOUD_BANNER", result)
+
     def test_template_renders_bleached_message(self):
         banner = {"message": "<strong>Hi</strong>", "expanded_html": None}
         with patch.object(context_processors, "get_os_banner", return_value=banner):
@@ -196,3 +207,37 @@ class TestGlobalizeVarsOsBanner(SimpleTestCase):
             "{% for b in additional_banners %}{{ b.message|safe }}{% endfor %}",
         ).render(Context(ctx))
         self.assertIn("<strong>Hi</strong>", rendered)
+
+    def test_session_product_banners_merged_into_additional_banners(self):
+        session_banner = {
+            "source": "product_announcement",
+            "message": "Pro has async imports!",
+            "style": "info",
+            "url": "",
+            "link_text": "",
+            "expanded_html": None,
+        }
+        self.request.session = {"_product_banners": [session_banner]}
+        with patch.object(context_processors, "get_os_banner", return_value=None):
+            result = context_processors.globalize_vars(self.request)
+        self.assertIn("additional_banners", result)
+        self.assertEqual(len(result["additional_banners"]), 1)
+        self.assertEqual(result["additional_banners"][0]["source"], "product_announcement")
+        self.assertEqual(self.request.session.get("_product_banners"), None)
+
+    def test_os_and_session_banners_combined(self):
+        os_banner = {"message": "<strong>OS msg</strong>", "expanded_html": None}
+        session_banner = {
+            "source": "product_announcement",
+            "message": "Pro msg",
+            "style": "info",
+            "url": "",
+            "link_text": "",
+            "expanded_html": None,
+        }
+        self.request.session = {"_product_banners": [session_banner]}
+        with patch.object(context_processors, "get_os_banner", return_value=os_banner):
+            result = context_processors.globalize_vars(self.request)
+        self.assertEqual(len(result["additional_banners"]), 2)
+        self.assertEqual(result["additional_banners"][0]["source"], "os")
+        self.assertEqual(result["additional_banners"][1]["source"], "product_announcement")

--- a/unittests/test_os_message.py
+++ b/unittests/test_os_message.py
@@ -6,7 +6,7 @@ from django.template import Context, Template
 from django.test import RequestFactory, SimpleTestCase, override_settings
 
 from dojo import context_processors
-from dojo.announcements import os_message
+from dojo.announcement import os_message
 
 
 class _Resp:
@@ -105,44 +105,44 @@ class TestFetchOsMessage(SimpleTestCase):
 
     def test_200_with_body_caches_body(self):
         body = "# headline\n"
-        with patch("dojo.announcements.os_message.requests.get", return_value=_Resp(200, body)) as mock_get:
+        with patch("dojo.announcement.os_message.requests.get", return_value=_Resp(200, body)) as mock_get:
             result = os_message.fetch_os_message()
         self.assertEqual(result, body)
         self.assertEqual(cache.get(os_message.CACHE_KEY), body)
         mock_get.assert_called_once()
 
     def test_404_caches_none(self):
-        with patch("dojo.announcements.os_message.requests.get", return_value=_Resp(404, "not found")):
+        with patch("dojo.announcement.os_message.requests.get", return_value=_Resp(404, "not found")):
             result = os_message.fetch_os_message()
         self.assertIsNone(result)
         self.assertIsNone(cache.get(os_message.CACHE_KEY, default="sentinel"))
 
     def test_timeout_caches_none(self):
-        with patch("dojo.announcements.os_message.requests.get", side_effect=requests.exceptions.Timeout):
+        with patch("dojo.announcement.os_message.requests.get", side_effect=requests.exceptions.Timeout):
             result = os_message.fetch_os_message()
         self.assertIsNone(result)
         self.assertIsNone(cache.get(os_message.CACHE_KEY, default="sentinel"))
 
     def test_connection_error_caches_none(self):
-        with patch("dojo.announcements.os_message.requests.get", side_effect=requests.exceptions.ConnectionError):
+        with patch("dojo.announcement.os_message.requests.get", side_effect=requests.exceptions.ConnectionError):
             result = os_message.fetch_os_message()
         self.assertIsNone(result)
         self.assertIsNone(cache.get(os_message.CACHE_KEY, default="sentinel"))
 
     def test_empty_body_caches_none(self):
-        with patch("dojo.announcements.os_message.requests.get", return_value=_Resp(200, "   \n\n")):
+        with patch("dojo.announcement.os_message.requests.get", return_value=_Resp(200, "   \n\n")):
             result = os_message.fetch_os_message()
         self.assertIsNone(result)
         self.assertIsNone(cache.get(os_message.CACHE_KEY, default="sentinel"))
 
     def test_second_call_hits_cache(self):
-        with patch("dojo.announcements.os_message.requests.get", return_value=_Resp(200, "# h\n")) as mock_get:
+        with patch("dojo.announcement.os_message.requests.get", return_value=_Resp(200, "# h\n")) as mock_get:
             os_message.fetch_os_message()
             os_message.fetch_os_message()
         self.assertEqual(mock_get.call_count, 1)
 
     def test_second_call_after_failure_also_hits_cache(self):
-        with patch("dojo.announcements.os_message.requests.get", side_effect=requests.exceptions.Timeout) as mock_get:
+        with patch("dojo.announcement.os_message.requests.get", side_effect=requests.exceptions.Timeout) as mock_get:
             os_message.fetch_os_message()
             os_message.fetch_os_message()
         self.assertEqual(mock_get.call_count, 1)
@@ -155,12 +155,12 @@ class TestGetOsBanner(SimpleTestCase):
         cache.clear()
 
     def test_returns_none_when_fetch_returns_none(self):
-        with patch("dojo.announcements.os_message.fetch_os_message", return_value=None):
+        with patch("dojo.announcement.os_message.fetch_os_message", return_value=None):
             self.assertIsNone(os_message.get_os_banner())
 
     def test_swallows_parse_exception(self):
-        with patch("dojo.announcements.os_message.fetch_os_message", return_value="# ok\n"), \
-             patch("dojo.announcements.os_message.parse_os_message", side_effect=RuntimeError("boom")):
+        with patch("dojo.announcement.os_message.fetch_os_message", return_value="# ok\n"), \
+             patch("dojo.announcement.os_message.parse_os_message", side_effect=RuntimeError("boom")):
             self.assertIsNone(os_message.get_os_banner())
 
 

--- a/unittests/test_os_message.py
+++ b/unittests/test_os_message.py
@@ -1,0 +1,198 @@
+from unittest.mock import patch
+
+import requests
+from django.core.cache import cache
+from django.template import Context, Template
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from dojo import context_processors
+from dojo.announcements import os_message
+
+
+class _Resp:
+    def __init__(self, status_code=200, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+class TestParseOsMessage(SimpleTestCase):
+
+    def setUp(self):
+        cache.clear()
+
+    def test_valid_doc_with_expanded(self):
+        text = (
+            "# DefectDojo v3.0 is available\n"
+            "\n"
+            "## Expanded Message\n"
+            "\n"
+            "- Major feature A\n"
+            "- Major feature B\n"
+        )
+        result = os_message.parse_os_message(text)
+        self.assertEqual(result["message"], "DefectDojo v3.0 is available")
+        self.assertIn("<li>Major feature A</li>", result["expanded_html"])
+        self.assertIn("<li>Major feature B</li>", result["expanded_html"])
+
+    def test_missing_headline_returns_none(self):
+        text = "No headline here\n## Expanded Message\nbody\n"
+        self.assertIsNone(os_message.parse_os_message(text))
+
+    def test_headline_inline_markdown(self):
+        text = "# Read the **release notes** at [link](https://example.com)\n"
+        result = os_message.parse_os_message(text)
+        self.assertIn("<strong>release notes</strong>", result["message"])
+        self.assertIn('<a href="https://example.com">link</a>', result["message"])
+        self.assertIsNone(result["expanded_html"])
+
+    def test_headline_strips_disallowed_html(self):
+        text = "# Headline <script>alert(1)</script> tail\n"
+        result = os_message.parse_os_message(text)
+        self.assertNotIn("<script", result["message"])
+        self.assertNotIn("</script>", result["message"])
+        self.assertIn("Headline", result["message"])
+
+    def test_missing_expanded_section(self):
+        text = "# Just a headline\n"
+        result = os_message.parse_os_message(text)
+        self.assertEqual(result["message"], "Just a headline")
+        self.assertIsNone(result["expanded_html"])
+
+    def test_expanded_with_fenced_code(self):
+        text = (
+            "# Headline\n"
+            "## Expanded Message\n"
+            "```python\n"
+            "print('hi')\n"
+            "```\n"
+        )
+        result = os_message.parse_os_message(text)
+        self.assertIn("<pre>", result["expanded_html"])
+        self.assertIn("<code>", result["expanded_html"])
+        self.assertIn("print('hi')", result["expanded_html"])
+
+    def test_expanded_strips_script_tag(self):
+        text = (
+            "# Headline\n"
+            "## Expanded Message\n"
+            "<script>alert(1)</script>\n"
+            "Body paragraph\n"
+        )
+        result = os_message.parse_os_message(text)
+        self.assertNotIn("<script", result["expanded_html"])
+        self.assertNotIn("</script>", result["expanded_html"])
+        self.assertIn("Body paragraph", result["expanded_html"])
+
+    def test_headline_outer_p_is_stripped(self):
+        text = "# Plain headline\n"
+        result = os_message.parse_os_message(text)
+        self.assertFalse(result["message"].startswith("<p>"))
+        self.assertFalse(result["message"].endswith("</p>"))
+
+    def test_headline_truncated_to_100_chars(self):
+        long_headline = "x" * 200
+        text = f"# {long_headline}\n"
+        result = os_message.parse_os_message(text)
+        self.assertLessEqual(len(result["message"]), 100)
+
+
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+class TestFetchOsMessage(SimpleTestCase):
+
+    def setUp(self):
+        cache.clear()
+
+    def test_200_with_body_caches_body(self):
+        body = "# headline\n"
+        with patch("dojo.announcements.os_message.requests.get", return_value=_Resp(200, body)) as mock_get:
+            result = os_message.fetch_os_message()
+        self.assertEqual(result, body)
+        self.assertEqual(cache.get(os_message.CACHE_KEY), body)
+        mock_get.assert_called_once()
+
+    def test_404_caches_none(self):
+        with patch("dojo.announcements.os_message.requests.get", return_value=_Resp(404, "not found")):
+            result = os_message.fetch_os_message()
+        self.assertIsNone(result)
+        self.assertIsNone(cache.get(os_message.CACHE_KEY, default="sentinel"))
+
+    def test_timeout_caches_none(self):
+        with patch("dojo.announcements.os_message.requests.get", side_effect=requests.exceptions.Timeout):
+            result = os_message.fetch_os_message()
+        self.assertIsNone(result)
+        self.assertIsNone(cache.get(os_message.CACHE_KEY, default="sentinel"))
+
+    def test_connection_error_caches_none(self):
+        with patch("dojo.announcements.os_message.requests.get", side_effect=requests.exceptions.ConnectionError):
+            result = os_message.fetch_os_message()
+        self.assertIsNone(result)
+        self.assertIsNone(cache.get(os_message.CACHE_KEY, default="sentinel"))
+
+    def test_empty_body_caches_none(self):
+        with patch("dojo.announcements.os_message.requests.get", return_value=_Resp(200, "   \n\n")):
+            result = os_message.fetch_os_message()
+        self.assertIsNone(result)
+        self.assertIsNone(cache.get(os_message.CACHE_KEY, default="sentinel"))
+
+    def test_second_call_hits_cache(self):
+        with patch("dojo.announcements.os_message.requests.get", return_value=_Resp(200, "# h\n")) as mock_get:
+            os_message.fetch_os_message()
+            os_message.fetch_os_message()
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_second_call_after_failure_also_hits_cache(self):
+        with patch("dojo.announcements.os_message.requests.get", side_effect=requests.exceptions.Timeout) as mock_get:
+            os_message.fetch_os_message()
+            os_message.fetch_os_message()
+        self.assertEqual(mock_get.call_count, 1)
+
+
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+class TestGetOsBanner(SimpleTestCase):
+
+    def setUp(self):
+        cache.clear()
+
+    def test_returns_none_when_fetch_returns_none(self):
+        with patch("dojo.announcements.os_message.fetch_os_message", return_value=None):
+            self.assertIsNone(os_message.get_os_banner())
+
+    def test_swallows_parse_exception(self):
+        with patch("dojo.announcements.os_message.fetch_os_message", return_value="# ok\n"), \
+             patch("dojo.announcements.os_message.parse_os_message", side_effect=RuntimeError("boom")):
+            self.assertIsNone(os_message.get_os_banner())
+
+
+@override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}})
+class TestGlobalizeVarsOsBanner(SimpleTestCase):
+
+    def setUp(self):
+        cache.clear()
+        self.request = RequestFactory().get("/")
+
+    def test_additional_banners_populated_when_banner_present(self):
+        banner = {"message": "<strong>Hi</strong>", "expanded_html": "<p>body</p>"}
+        with patch.object(context_processors, "get_os_banner", return_value=banner):
+            result = context_processors.globalize_vars(self.request)
+        self.assertIn("additional_banners", result)
+        entry = result["additional_banners"][0]
+        self.assertEqual(entry["message"], "<strong>Hi</strong>")
+        self.assertEqual(entry["expanded_html"], "<p>body</p>")
+        self.assertEqual(entry["style"], "info")
+        self.assertEqual(entry["url"], "")
+        self.assertEqual(entry["link_text"], "")
+
+    def test_additional_banners_absent_when_no_banner(self):
+        with patch.object(context_processors, "get_os_banner", return_value=None):
+            result = context_processors.globalize_vars(self.request)
+        self.assertNotIn("additional_banners", result)
+
+    def test_template_renders_bleached_message(self):
+        banner = {"message": "<strong>Hi</strong>", "expanded_html": None}
+        with patch.object(context_processors, "get_os_banner", return_value=banner):
+            ctx = context_processors.globalize_vars(self.request)
+        rendered = Template(
+            "{% for b in additional_banners %}{{ b.message|safe }}{% endfor %}",
+        ).render(Context(ctx))
+        self.assertIn("<strong>Hi</strong>", rendered)

--- a/unittests/test_product_announcements.py
+++ b/unittests/test_product_announcements.py
@@ -1,3 +1,4 @@
+from collections import UserDict
 
 from django.http import HttpRequest, HttpResponse
 from django.test import SimpleTestCase
@@ -10,7 +11,7 @@ from dojo.product_announcements import (
 )
 
 
-class _SessionDict(dict):
+class _SessionDict(UserDict):
 
     """Minimal session stand-in that supports .get/.pop/[] like Django sessions."""
 

--- a/unittests/test_product_announcements.py
+++ b/unittests/test_product_announcements.py
@@ -1,0 +1,213 @@
+from unittest.mock import MagicMock
+
+from django.http import HttpRequest, HttpResponse
+from django.test import SimpleTestCase
+
+from dojo.product_announcements import (
+    ErrorPageProductAnnouncement,
+    LargeScanSizeProductAnnouncement,
+    LongRunningRequestProductAnnouncement,
+    ProductAnnouncementManager,
+    ScanTypeProductAnnouncement,
+)
+
+
+class _SessionDict(dict):
+    """Minimal session stand-in that supports .get/.pop/[] like Django sessions."""
+
+
+def _make_request():
+    request = HttpRequest()
+    request.session = _SessionDict()
+    return request
+
+
+def _make_response(data=None):
+    response = HttpResponse()
+    response.data = data if data is not None else {}
+    return response
+
+
+class TestProductAnnouncementSessionBanner(SimpleTestCase):
+
+    def test_stores_banner_in_session(self):
+        request = _make_request()
+        ErrorPageProductAnnouncement(request=request)
+        banners = request.session["_product_banners"]
+        self.assertEqual(len(banners), 1)
+        self.assertEqual(banners[0]["source"], "product_announcement")
+        self.assertEqual(banners[0]["style"], "info")
+        self.assertIn("Pro comes with support.", banners[0]["message"])
+        self.assertIsNone(banners[0]["expanded_html"])
+
+    def test_multiple_announcements_accumulate_in_session(self):
+        request = _make_request()
+        ErrorPageProductAnnouncement(request=request)
+        ErrorPageProductAnnouncement(request=request)
+        banners = request.session["_product_banners"]
+        self.assertEqual(len(banners), 2)
+
+    def test_banner_message_contains_outreach_link(self):
+        request = _make_request()
+        ErrorPageProductAnnouncement(request=request)
+        message = request.session["_product_banners"][0]["message"]
+        self.assertIn("cloud.defectdojo.com", message)
+        self.assertIn("Try today for free", message)
+
+    def test_session_error_is_swallowed(self):
+        request = HttpRequest()
+        request.session = None
+        ErrorPageProductAnnouncement(request=request)
+
+    def test_no_settings_guard(self):
+        """Product announcements fire without any settings check."""
+        request = _make_request()
+        ErrorPageProductAnnouncement(request=request)
+        self.assertEqual(len(request.session["_product_banners"]), 1)
+
+
+class TestProductAnnouncementApiPath(SimpleTestCase):
+
+    def test_api_response_gets_pro_key(self):
+        response = _make_response(data={})
+        ErrorPageProductAnnouncement(response=response)
+        self.assertIn("pro", response.data)
+        self.assertEqual(len(response.data["pro"]), 1)
+        self.assertIn("Pro comes with support.", str(response.data["pro"][0]))
+
+    def test_api_response_appends_to_existing_pro_list(self):
+        response = _make_response(data={"pro": ["existing"]})
+        ErrorPageProductAnnouncement(response=response)
+        self.assertEqual(len(response.data["pro"]), 2)
+        self.assertEqual(response.data["pro"][0], "existing")
+
+    def test_api_response_data_dict_gets_pro_key(self):
+        data = {}
+        LargeScanSizeProductAnnouncement(response_data=data, duration=120.0)
+        self.assertIn("pro", data)
+
+    def test_requires_at_least_one_target(self):
+        with self.assertRaises(ValueError):
+            ErrorPageProductAnnouncement()
+
+
+class TestErrorPageProductAnnouncement(SimpleTestCase):
+
+    def test_message_content(self):
+        request = _make_request()
+        ErrorPageProductAnnouncement(request=request)
+        message = request.session["_product_banners"][0]["message"]
+        self.assertIn("Pro comes with support.", message)
+
+    def test_api_path(self):
+        response = _make_response()
+        ErrorPageProductAnnouncement(response=response)
+        self.assertIn("Pro comes with support.", str(response.data["pro"][0]))
+
+
+class TestLargeScanSizeProductAnnouncement(SimpleTestCase):
+
+    def test_fires_when_duration_exceeds_threshold(self):
+        request = _make_request()
+        LargeScanSizeProductAnnouncement(request=request, duration=120.0)
+        banners = request.session["_product_banners"]
+        self.assertEqual(len(banners), 1)
+        self.assertIn("import took about 2 minute(s)", banners[0]["message"])
+        self.assertIn("async imports", banners[0]["message"])
+
+    def test_does_not_fire_when_duration_below_threshold(self):
+        request = _make_request()
+        LargeScanSizeProductAnnouncement(request=request, duration=30.0)
+        self.assertEqual(len(request.session.get("_product_banners", [])), 0)
+
+    def test_fires_at_boundary(self):
+        request = _make_request()
+        LargeScanSizeProductAnnouncement(request=request, duration=60.1)
+        self.assertEqual(len(request.session["_product_banners"]), 1)
+
+    def test_does_not_fire_at_exact_threshold(self):
+        request = _make_request()
+        LargeScanSizeProductAnnouncement(request=request, duration=60.0)
+        self.assertEqual(len(request.session.get("_product_banners", [])), 0)
+
+
+class TestLongRunningRequestProductAnnouncement(SimpleTestCase):
+
+    def test_fires_when_duration_exceeds_threshold(self):
+        request = _make_request()
+        LongRunningRequestProductAnnouncement(request=request, duration=20.0)
+        banners = request.session["_product_banners"]
+        self.assertEqual(len(banners), 1)
+        self.assertIn("performance tested", banners[0]["message"])
+
+    def test_does_not_fire_when_duration_below_threshold(self):
+        request = _make_request()
+        LongRunningRequestProductAnnouncement(request=request, duration=10.0)
+        self.assertEqual(len(request.session.get("_product_banners", [])), 0)
+
+    def test_does_not_fire_at_exact_threshold(self):
+        request = _make_request()
+        LongRunningRequestProductAnnouncement(request=request, duration=15.0)
+        self.assertEqual(len(request.session.get("_product_banners", [])), 0)
+
+
+class TestScanTypeProductAnnouncement(SimpleTestCase):
+
+    def test_fires_for_supported_scan_type(self):
+        request = _make_request()
+        ScanTypeProductAnnouncement(request=request, scan_type="Snyk Scan")
+        banners = request.session["_product_banners"]
+        self.assertEqual(len(banners), 1)
+        self.assertIn("Snyk Scan", banners[0]["message"])
+        self.assertIn("no-code connector", banners[0]["message"])
+
+    def test_does_not_fire_for_unsupported_scan_type(self):
+        request = _make_request()
+        ScanTypeProductAnnouncement(request=request, scan_type="Unknown Scanner")
+        self.assertEqual(len(request.session.get("_product_banners", [])), 0)
+
+    def test_does_not_fire_for_none_scan_type(self):
+        request = _make_request()
+        ScanTypeProductAnnouncement(request=request, scan_type=None)
+        self.assertEqual(len(request.session.get("_product_banners", [])), 0)
+
+    def test_all_supported_scan_types_fire(self):
+        for scan_type in ScanTypeProductAnnouncement.supported_scan_types:
+            request = _make_request()
+            ScanTypeProductAnnouncement(request=request, scan_type=scan_type)
+            self.assertEqual(
+                len(request.session["_product_banners"]), 1,
+                f"Expected banner for {scan_type}",
+            )
+
+    def test_api_path_for_supported_scan_type(self):
+        data = {}
+        ScanTypeProductAnnouncement(response_data=data, scan_type="Wiz Scan")
+        self.assertIn("pro", data)
+        self.assertIn("Wiz Scan", str(data["pro"][0]))
+
+
+class TestBannerDictSchema(SimpleTestCase):
+    """Verify every banner stored in the session has the expected keys."""
+
+    EXPECTED_KEYS = {"source", "message", "style", "url", "link_text", "expanded_html"}
+
+    def test_error_page_banner_has_all_keys(self):
+        request = _make_request()
+        ErrorPageProductAnnouncement(request=request)
+        self.assertEqual(set(request.session["_product_banners"][0].keys()), self.EXPECTED_KEYS)
+
+    def test_large_scan_banner_has_all_keys(self):
+        request = _make_request()
+        LargeScanSizeProductAnnouncement(request=request, duration=120.0)
+        self.assertEqual(set(request.session["_product_banners"][0].keys()), self.EXPECTED_KEYS)
+
+    def test_long_running_banner_has_all_keys(self):
+        request = _make_request()
+        LongRunningRequestProductAnnouncement(request=request, duration=20.0)
+        self.assertEqual(set(request.session["_product_banners"][0].keys()), self.EXPECTED_KEYS)
+
+    def test_scan_type_banner_has_all_keys(self):
+        request = _make_request()
+        ScanTypeProductAnnouncement(request=request, scan_type="Snyk Scan")
+        self.assertEqual(set(request.session["_product_banners"][0].keys()), self.EXPECTED_KEYS)

--- a/unittests/test_product_announcements.py
+++ b/unittests/test_product_announcements.py
@@ -1,4 +1,3 @@
-from unittest.mock import MagicMock
 
 from django.http import HttpRequest, HttpResponse
 from django.test import SimpleTestCase
@@ -7,12 +6,12 @@ from dojo.product_announcements import (
     ErrorPageProductAnnouncement,
     LargeScanSizeProductAnnouncement,
     LongRunningRequestProductAnnouncement,
-    ProductAnnouncementManager,
     ScanTypeProductAnnouncement,
 )
 
 
 class _SessionDict(dict):
+
     """Minimal session stand-in that supports .get/.pop/[] like Django sessions."""
 
 
@@ -188,6 +187,7 @@ class TestScanTypeProductAnnouncement(SimpleTestCase):
 
 
 class TestBannerDictSchema(SimpleTestCase):
+
     """Verify every banner stored in the session has the expected keys."""
 
     EXPECTED_KEYS = {"source", "message", "style", "url", "link_text", "expanded_html"}


### PR DESCRIPTION
- Introduces a new Open Source Messaging banner that fetches markdown content from a GCS bucket, renders it with bleach-sanitized HTML, and        
  displays it via the existing additional_banners template loop. Cached for 1 hour; fetch failures silently yield no banner.
- Replaces the DD_CREATE_CLOUD_BANNER / CREATE_CLOUD_BANNER setting and all cloud-banner-specific logic with a centralized additional_banners      
  context processor pattern. Both OS messages and product announcements now flow through the same rendering pipeline, each tagged with a source field
   (os, product_announcement).              
- Migrates ProductAnnouncementManager from django.contrib.messages to session-based banners (_product_banners), which are popped by the context    
  processor and rendered in the unified template loop.                                                                                               
- Removes the evaluate_pro_proposition Celery task/beat schedule and the create_announcement_banner initialization command logic.
- Simplifies the add_announcement_to_new_user signal by removing cloud-banner conditional checks.                                                  
- Adds 52 unit tests covering the OS message fetcher/parser and product announcement manager.