### PR TITLE
docs optimization: use defer instead of async

### DIFF
--- a/docs/layouts/_partials/head/script-header.html
+++ b/docs/layouts/_partials/head/script-header.html
@@ -1,7 +1,7 @@
 <!-- Insert scripts NOT needed by stylesheets here -->
 <!-- Start of Reo Javascript -->
 <script type="text/javascript">
-  !function () { var e, t, n; e = "a92cfcfa51eca96", t = function () { Reo.init({ clientID: "a92cfcfa51eca96" }) }, (n = document.createElement("script")).src = "https://static.reo.dev/" + e + "/reo.js", n.async = !0, n.onload = t, document.head.appendChild(n) }();
+  !function(){var e,t,n;e="a92cfcfa51eca96",t=function(){Reo.init({clientID:"a92cfcfa51eca96"})},(n=document.createElement("script")).src="https://static.reo.dev/"+e+"/reo.js",n.defer=!0,n.onload=t,document.head.appendChild(n)}();
 </script>
 <!-- End of Reo Javascript -->
 <script>function initApollo() {


### PR DESCRIPTION
By using `defer` as the argument on our REO.js script we can have it run after the rest of the page is ready, so that we're not competing for load time in our docs.