### PR TITLE
ci: auto-label release PRs with release-management

### DIFF
--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -111,11 +111,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.pulls.create({
+            const pr = await github.rest.pulls.create({
               owner: '${{ env.GITHUB_ORG }}',
               repo: 'django-DefectDojo',
               title: 'Release: Merge release into master from: ${{ env.NEW_BRANCH }}',
               body: `Release triggered by \`${ process.env.GITHUB_ACTOR }\``,
               head: '${{ env.NEW_BRANCH }}',
               base: 'master'
+            })
+            await github.rest.issues.addLabels({
+              owner: '${{ env.GITHUB_ORG }}',
+              repo: 'django-DefectDojo',
+              issue_number: pr.data.number,
+              labels: ['release-management']
             })

--- a/.github/workflows/release-3-master-into-dev.yml
+++ b/.github/workflows/release-3-master-into-dev.yml
@@ -99,13 +99,19 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.pulls.create({
+            const pr = await github.rest.pulls.create({
               owner: '${{ env.GITHUB_ORG }}',
               repo: 'django-DefectDojo',
               title: 'Release: Merge back ${{ inputs.release_number_new }} into dev from: ${{ env.NEW_BRANCH }}',
               body: `Release triggered by \`${ process.env.GITHUB_ACTOR }\``,
               head: '${{ env.NEW_BRANCH }}',
               base: 'dev'
+            })
+            await github.rest.issues.addLabels({
+              owner: '${{ env.GITHUB_ORG }}',
+              repo: 'django-DefectDojo',
+              issue_number: pr.data.number,
+              labels: ['release-management']
             })
 
   create_pr_for_merge_back_into_bugfix:
@@ -175,11 +181,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.pulls.create({
+            const pr = await github.rest.pulls.create({
               owner: '${{ env.GITHUB_ORG }}',
               repo: 'django-DefectDojo',
               title: 'Release: Merge back ${{ inputs.release_number_new }} into bugfix from: ${{ env.NEW_BRANCH }}',
               body: `Release triggered by \`${ process.env.GITHUB_ACTOR }\``,
               head: '${{ env.NEW_BRANCH }}',
               base: 'bugfix'
+            })
+            await github.rest.issues.addLabels({
+              owner: '${{ env.GITHUB_ORG }}',
+              repo: 'django-DefectDojo',
+              issue_number: pr.data.number,
+              labels: ['release-management']
             })


### PR DESCRIPTION
## Summary
- Extend the three `Create Pull Request` steps in `.github/workflows/release-1-create-pr.yml` and `.github/workflows/release-3-master-into-dev.yml` to `await` `github.rest.pulls.create(...)` and immediately call `github.rest.issues.addLabels(...)` with `['release-management']`.
- Keeps labeling local to the release workflows rather than routing through `.github/labeler.yml`, so the label isn't subject to `sync-labels: true` re-evaluation on later PR events.

## Prerequisite
The `release-management` label must exist in the repo before the next release workflow runs — `issues.addLabels` does not create missing labels. Create it once via the Labels UI or:

```
gh label create release-management --description "Automated release-train PR" --color 0E8A16 --repo DefectDojo/django-DefectDojo
```

## Test plan
- [x] Confirm the `release-management` label exists in the repo.
- [ ] On the next *Release-1* run, verify the resulting PR carries the `release-management` label and the `Create Pull Request` step is green in the Actions log.
- [ ] Same check after *Release-3*: both the `…into dev` and `…into bugfix` PRs should get the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)