### PR TITLE
Improve SLA breach notification format and display

### DIFF
--- a/dojo/templates/notifications/mail/sla_breach.tpl
+++ b/dojo/templates/notifications/mail/sla_breach.tpl
@@ -14,14 +14,14 @@
                 {% if sla_age < 0 %}
                   {% blocktranslate trimmed %}
                     This security finding has breached its SLA.
-                    
-                    - Day(s) overdue: {{sla}}
+                    <br/>
+                    - Day(s) overdue: {{sla_age}}
                   {% endblocktranslate %}
                 {% else %}
                   {% blocktranslate trimmed %}
                     A security finding is about to breach its SLA.
-                    
-                    - Day(s) remaining: {{sla}}
+                    <br/>   
+                    - Day(s) remaining: {{sla_age}}
                   {% endblocktranslate %}
                 {% endif %}
             </p>

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1576,12 +1576,13 @@ def sla_compute_and_notify(*args, **kwargs):
                     findings_list = []
 
                     for n in comb_notif_kind:
-                        title = _notification_title_for_finding(n.finding, kind, n.finding.sla_days_remaining())
-
+                        sla_age = n.finding.sla_days_remaining()
+                        title = _notification_title_for_finding(n.finding, kind, sla_age)
                         create_notification(
                             event="sla_breach",
                             title=title,
                             finding=n.finding,
+                            sla_age=sla_age,
                             url=reverse("view_finding", args=(n.finding.id,)),
                         )
 


### PR DESCRIPTION
Enhance the format of SLA breach notifications by updating the overdue and remaining days display. This change improves clarity for users receiving notifications about SLA breaches.

