### PR TITLE
Add mitigation filters and complete mitigation filter test coverage

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1625,6 +1625,7 @@ class ApiFindingFilter(DojoFilter):
     verified = BooleanFilter(field_name="verified")
     has_jira = BooleanFilter(field_name="jira_issue", lookup_expr="isnull", exclude=True)
     fix_available = BooleanFilter(field_name="fix_available")
+    mitigation_available = BooleanFilter(method="filter_mitigation_available", label="Mitigation Available")
     # CharFilter
     component_version = CharFilter(lookup_expr="icontains")
     component_name = CharFilter(lookup_expr="icontains")
@@ -1797,6 +1798,11 @@ class ApiFindingFilter(DojoFilter):
 
         return queryset.filter(mitigated=value)
 
+    def filter_mitigation_available(self, queryset, name, value):
+        if value:
+            return queryset.exclude(mitigation__isnull=True).exclude(mitigation__exact="")
+        return queryset.filter(Q(mitigation__isnull=True) | Q(mitigation__exact=""))
+
 
 class PercentageFilter(NumberFilter):
     def __init__(self, *args, **kwargs):
@@ -1831,6 +1837,8 @@ class FindingFilterHelper(FilterSet):
     duplicate = ReportBooleanFilter()
     is_mitigated = ReportBooleanFilter()
     fix_available = ReportBooleanFilter()
+    mitigation = CharFilter(lookup_expr="icontains")
+    mitigation_available = BooleanFilter(method="filter_mitigation_available", label="Mitigation Available")
     mitigated = DateRangeFilter(field_name="mitigated", label="Mitigated Date")
     mitigated_on = DateTimeFilter(field_name="mitigated", lookup_expr="exact", label="Mitigated On", method="filter_mitigated_on")
     mitigated_before = DateTimeFilter(field_name="mitigated", lookup_expr="lt", label="Mitigated Before")
@@ -2019,6 +2027,11 @@ class FindingFilterHelper(FilterSet):
             return queryset.filter(mitigated__gte=value, mitigated__lt=nextday)
 
         return queryset.filter(mitigated=value)
+
+    def filter_mitigation_available(self, queryset, name, value):
+        if value:
+            return queryset.exclude(mitigation__isnull=True).exclude(mitigation__exact="")
+        return queryset.filter(Q(mitigation__isnull=True) | Q(mitigation__exact=""))
 
 
 def get_finding_group_queryset_for_context(pid=None, eid=None, tid=None):
@@ -3399,6 +3412,7 @@ class ReportFindingFilterHelper(FilterSet):
     out_of_scope = ReportBooleanFilter()
     outside_of_sla = FindingSLAFilter(label="Outside of SLA")
     file_path = CharFilter(lookup_expr="icontains")
+    mitigation_available = BooleanFilter(method="filter_mitigation_available", label="Mitigation Available")
 
     o = OrderingFilter(
         fields=(
@@ -3420,6 +3434,11 @@ class ReportFindingFilterHelper(FilterSet):
                    "thread_id", "notes", "inherited_tags", "endpoints",
                    "numerical_severity", "reporter", "last_reviewed",
                    "jira_creation", "jira_change", "files"]
+
+    def filter_mitigation_available(self, queryset, name, value):
+        if value:
+            return queryset.exclude(mitigation__isnull=True).exclude(mitigation__exact="")
+        return queryset.filter(Q(mitigation__isnull=True) | Q(mitigation__exact=""))
 
     def manage_kwargs(self, kwargs):
         self.prod_type = None

--- a/unittests/test_filter_finding_mitigation.py
+++ b/unittests/test_filter_finding_mitigation.py
@@ -1,0 +1,102 @@
+import datetime
+
+from django.test import TestCase
+from django.utils import timezone
+
+from dojo.filters import ApiFindingFilter, FindingFilterHelper
+from dojo.models import (
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+)
+
+
+def _make_finding(title, mitigation, product):
+    test_type, _ = Test_Type.objects.get_or_create(name="Unit Test")
+    engagement = Engagement.objects.create(
+        name="Test Engagement",
+        product=product,
+        target_start=timezone.now().date(),
+        target_end=(timezone.now() + datetime.timedelta(days=1)).date(),
+    )
+    test = Test.objects.create(
+        engagement=engagement,
+        test_type=test_type,
+        target_start=timezone.now(),
+        target_end=timezone.now() + datetime.timedelta(hours=1),
+    )
+    return Finding.objects.create(
+        title=title,
+        test=test,
+        severity="Medium",
+        mitigation=mitigation,
+        verified=True,
+        active=True,
+    )
+
+
+class MitigationFilterTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        prod_type = Product_Type.objects.create(name="Test Type")
+        product = Product.objects.create(
+            name="Test Product",
+            prod_type=prod_type,
+        )
+        cls.finding_with_mitigation = _make_finding("Finding A", "apply patch", product)
+        cls.finding_null_mitigation = _make_finding("Finding B", None, product)
+        cls.finding_empty_mitigation = _make_finding("Finding C", "", product)
+
+    def _api_filter(self, params):
+        qs = Finding.objects.all()
+        f = ApiFindingFilter(params, queryset=qs)
+        return set(f.qs.values_list("id", flat=True))
+
+    def test_mitigation_icontains(self):
+        # Filtering by mitigation text returns only findings whose mitigation contains that substring
+        pass
+
+    def test_mitigation_available_true(self):
+        # mitigation_available=true returns only findings with a non-null, non-empty mitigation
+        pass
+
+    def test_mitigation_available_false(self):
+        # mitigation_available=false returns only findings with a null or empty mitigation
+        pass
+
+    def test_mitigation_available_false_handles_null(self):
+        # mitigation_available=false includes findings where mitigation is NULL
+        pass
+
+    def test_mitigation_available_false_handles_empty_string(self):
+        # mitigation_available=false includes findings where mitigation is an empty string
+        pass
+
+
+class MitigationUIFilterTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        prod_type = Product_Type.objects.create(name="UI Test Type")
+        product = Product.objects.create(
+            name="UI Test Product",
+            prod_type=prod_type,
+        )
+        cls.finding_with_mitigation = _make_finding("UI Finding A", "upgrade to v2", product)
+        cls.finding_null_mitigation = _make_finding("UI Finding B", None, product)
+        cls.finding_empty_mitigation = _make_finding("UI Finding C", "", product)
+
+    def _ui_filter(self, params):
+        qs = Finding.objects.all()
+        f = FindingFilterHelper(params, queryset=qs)
+        return set(f.qs.values_list("id", flat=True))
+
+    def test_mitigation_available_true(self):
+        # mitigation_available=true returns only findings with a non-null, non-empty mitigation
+        pass
+
+    def test_mitigation_available_false(self):
+        # mitigation_available=false returns only findings with a null or empty mitigation
+        pass

--- a/unittests/test_filter_finding_mitigation.py
+++ b/unittests/test_filter_finding_mitigation.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from dojo.filters import ApiFindingFilter, FindingFilterHelper
 from dojo.models import (
+    Dojo_User,
     Engagement,
     Finding,
     Product,
@@ -14,7 +15,7 @@ from dojo.models import (
 )
 
 
-def _make_finding(title, mitigation, product):
+def _make_finding(title, mitigation, product, reporter):
     test_type, _ = Test_Type.objects.get_or_create(name="Unit Test")
     engagement = Engagement.objects.create(
         name="Test Engagement",
@@ -33,6 +34,7 @@ def _make_finding(title, mitigation, product):
         test=test,
         severity="Medium",
         mitigation=mitigation,
+        reporter=reporter,
         verified=True,
         active=True,
     )
@@ -41,62 +43,174 @@ def _make_finding(title, mitigation, product):
 class MitigationFilterTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.reporter = Dojo_User.objects.create_user(
+            username="mitigation-filter-api",
+            email="mitigation-filter-api@example.com",
+            password="password123",  # noqa: S106
+        )
         prod_type = Product_Type.objects.create(name="Test Type")
         product = Product.objects.create(
             name="Test Product",
             prod_type=prod_type,
         )
-        cls.finding_with_mitigation = _make_finding("Finding A", "apply patch", product)
-        cls.finding_null_mitigation = _make_finding("Finding B", None, product)
-        cls.finding_empty_mitigation = _make_finding("Finding C", "", product)
+        cls.finding_with_mitigation = _make_finding("Finding A", "apply patch", product, cls.reporter)
+        cls.finding_upper_mitigation = _make_finding("Finding D", "APPLY PATCH", product, cls.reporter)
+        cls.finding_whitespace_mitigation = _make_finding("Finding E", "   ", product, cls.reporter)
+        cls.finding_null_mitigation = _make_finding("Finding B", None, product, cls.reporter)
+        cls.finding_empty_mitigation = _make_finding("Finding C", "", product, cls.reporter)
 
     def _api_filter(self, params):
-        qs = Finding.objects.all()
+        qs = Finding.objects.filter(
+            title__in=["Finding A", "Finding B", "Finding C", "Finding D", "Finding E"]
+        )
         f = ApiFindingFilter(params, queryset=qs)
         return set(f.qs.values_list("id", flat=True))
 
-    def test_mitigation_icontains(self):
-        # Filtering by mitigation text returns only findings whose mitigation contains that substring
-        pass
+    # --- mitigation icontains ---
+
+    def test_mitigation_icontains_lowercase(self):
+        # Substring match: "patch" should hit "apply patch" and "APPLY PATCH"
+        result = self._api_filter({"mitigation": "patch"})
+        self.assertIn(self.finding_with_mitigation.id, result)
+        self.assertIn(self.finding_upper_mitigation.id, result)
+        self.assertNotIn(self.finding_null_mitigation.id, result)
+        self.assertNotIn(self.finding_empty_mitigation.id, result)
+
+    def test_mitigation_icontains_uppercase(self):
+        # Case-insensitive: uppercase query also matches lowercase stored value
+        result = self._api_filter({"mitigation": "PATCH"})
+        self.assertIn(self.finding_with_mitigation.id, result)
+        self.assertIn(self.finding_upper_mitigation.id, result)
+
+    def test_mitigation_icontains_no_match(self):
+        result = self._api_filter({"mitigation": "ZZZNOMATCH"})
+        self.assertEqual(result, set())
+
+    def test_mitigation_icontains_partial(self):
+        # Partial substring match
+        result = self._api_filter({"mitigation": "apply"})
+        self.assertIn(self.finding_with_mitigation.id, result)
+        self.assertIn(self.finding_upper_mitigation.id, result)
+        self.assertNotIn(self.finding_null_mitigation.id, result)
+        self.assertNotIn(self.finding_empty_mitigation.id, result)
+
+    # --- mitigation_available=true ---
 
     def test_mitigation_available_true(self):
-        # mitigation_available=true returns only findings with a non-null, non-empty mitigation
-        pass
+        # Returns only findings with non-null, non-empty mitigation
+        result = self._api_filter({"mitigation_available": "true"})
+        self.assertIn(self.finding_with_mitigation.id, result)
+        self.assertIn(self.finding_upper_mitigation.id, result)
+        # Whitespace-only is NOT null and NOT empty string — current impl includes it
+        self.assertIn(self.finding_whitespace_mitigation.id, result)
+        self.assertNotIn(self.finding_null_mitigation.id, result)
+        self.assertNotIn(self.finding_empty_mitigation.id, result)
+
+    # --- mitigation_available=false ---
 
     def test_mitigation_available_false(self):
-        # mitigation_available=false returns only findings with a null or empty mitigation
-        pass
+        # Returns findings where mitigation is null OR empty string
+        result = self._api_filter({"mitigation_available": "false"})
+        self.assertIn(self.finding_null_mitigation.id, result)
+        self.assertIn(self.finding_empty_mitigation.id, result)
+        self.assertNotIn(self.finding_with_mitigation.id, result)
+        self.assertNotIn(self.finding_upper_mitigation.id, result)
 
     def test_mitigation_available_false_handles_null(self):
-        # mitigation_available=false includes findings where mitigation is NULL
-        pass
+        # NULL mitigation is explicitly captured by the false branch
+        result = self._api_filter({"mitigation_available": "false"})
+        self.assertIn(self.finding_null_mitigation.id, result)
 
     def test_mitigation_available_false_handles_empty_string(self):
-        # mitigation_available=false includes findings where mitigation is an empty string
-        pass
+        # Empty-string mitigation is explicitly captured by the false branch
+        result = self._api_filter({"mitigation_available": "false"})
+        self.assertIn(self.finding_empty_mitigation.id, result)
+
+    def test_mitigation_available_false_excludes_whitespace(self):
+        # Whitespace-only mitigation ("   ") is NOT null and NOT empty-string,
+        # so the false branch does NOT include it — document current behavior.
+        result = self._api_filter({"mitigation_available": "false"})
+        self.assertNotIn(self.finding_whitespace_mitigation.id, result)
+
+    # --- no filter parameter ---
+
+    def test_no_filter_returns_full_set(self):
+        # Baseline: no params → all five findings returned
+        result = self._api_filter({})
+        expected = {
+            self.finding_with_mitigation.id,
+            self.finding_upper_mitigation.id,
+            self.finding_whitespace_mitigation.id,
+            self.finding_null_mitigation.id,
+            self.finding_empty_mitigation.id,
+        }
+        self.assertEqual(result, expected)
+
+    # --- combined filters (intersection) ---
+
+    def test_combined_mitigation_text_and_available_true(self):
+        # "patch" icontains AND mitigation_available=true → only the two "patch" findings
+        result = self._api_filter({"mitigation": "patch", "mitigation_available": "true"})
+        self.assertEqual(
+            result,
+            {self.finding_with_mitigation.id, self.finding_upper_mitigation.id},
+        )
+
+    def test_combined_mitigation_text_and_available_false(self):
+        # text filter AND mitigation_available=false → empty: false branch returns null/empty,
+        # icontains on null/empty returns nothing matching "patch"
+        result = self._api_filter({"mitigation": "patch", "mitigation_available": "false"})
+        self.assertEqual(result, set())
 
 
 class MitigationUIFilterTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
+        cls.reporter = Dojo_User.objects.create_user(
+            username="mitigation-filter-ui",
+            email="mitigation-filter-ui@example.com",
+            password="password123",  # noqa: S106
+        )
         prod_type = Product_Type.objects.create(name="UI Test Type")
         product = Product.objects.create(
             name="UI Test Product",
             prod_type=prod_type,
         )
-        cls.finding_with_mitigation = _make_finding("UI Finding A", "upgrade to v2", product)
-        cls.finding_null_mitigation = _make_finding("UI Finding B", None, product)
-        cls.finding_empty_mitigation = _make_finding("UI Finding C", "", product)
+        cls.finding_with_mitigation = _make_finding("UI Finding A", "upgrade to v2", product, cls.reporter)
+        cls.finding_whitespace_mitigation = _make_finding("UI Finding D", "  ", product, cls.reporter)
+        cls.finding_null_mitigation = _make_finding("UI Finding B", None, product, cls.reporter)
+        cls.finding_empty_mitigation = _make_finding("UI Finding C", "", product, cls.reporter)
 
     def _ui_filter(self, params):
-        qs = Finding.objects.all()
+        qs = Finding.objects.filter(
+            title__in=["UI Finding A", "UI Finding B", "UI Finding C", "UI Finding D"]
+        )
         f = FindingFilterHelper(params, queryset=qs)
         return set(f.qs.values_list("id", flat=True))
 
     def test_mitigation_available_true(self):
-        # mitigation_available=true returns only findings with a non-null, non-empty mitigation
-        pass
+        # True branch: excludes null and empty string; whitespace-only is included
+        result = self._ui_filter({"mitigation_available": "true"})
+        self.assertIn(self.finding_with_mitigation.id, result)
+        self.assertIn(self.finding_whitespace_mitigation.id, result)
+        self.assertNotIn(self.finding_null_mitigation.id, result)
+        self.assertNotIn(self.finding_empty_mitigation.id, result)
 
     def test_mitigation_available_false(self):
-        # mitigation_available=false returns only findings with a null or empty mitigation
-        pass
+        # False branch: returns null and empty string, excludes non-empty
+        result = self._ui_filter({"mitigation_available": "false"})
+        self.assertIn(self.finding_null_mitigation.id, result)
+        self.assertIn(self.finding_empty_mitigation.id, result)
+        self.assertNotIn(self.finding_with_mitigation.id, result)
+        # Whitespace-only is not null/empty → not in false branch
+        self.assertNotIn(self.finding_whitespace_mitigation.id, result)
+
+    def test_no_filter_returns_full_set(self):
+        result = self._ui_filter({})
+        expected = {
+            self.finding_with_mitigation.id,
+            self.finding_whitespace_mitigation.id,
+            self.finding_null_mitigation.id,
+            self.finding_empty_mitigation.id,
+        }
+        self.assertEqual(result, expected)


### PR DESCRIPTION
## :warning: Pre-Approval check :warning:

This PR covers and addresses the existing issue #14558, and is within acceptable contribution scope as a bugfix/enhancement to existing filtering behavior and added/improved tests.

**Description**

This PR adds mitigation filtering support for Findings and validates that behavior with comprehensive unit tests.

Implementation:
- Adds `mitigation_available` boolean filtering to finding filters.
- Adds/uses `mitigation` text filtering (`icontains`) for mitigation content search.
- Supports filtering semantics:
  - `mitigation_available=true` → findings with mitigation set (non-null, non-empty string)
  - `mitigation_available=false` → findings with mitigation unset (null or empty string)
  - `mitigation=<text>` → case-insensitive partial text matching in mitigation

Coverage is applied across API/UI/report finding filter paths through existing filter classes.
This PR also completes mitigation filter test coverage and ensures test data setup is valid for finding creation and FK constraints, tests can be found in `dojo/unittests/test_filter_finding_mitigation.py`

Related to #14556 

**Test results**

Executed and passing:
- `docker compose run --rm --entrypoint "" uwsgi python manage.py test unittests.test_filter_finding_mitigation -v 2`
  - Result: `Ran 15 tests ... OK`
- `docker compose -f docker-compose.yml -f docker-compose.override.unit_tests.yml run --rm --entrypoint "" uwsgi python3 manage.py test unittests.test_finding_group_filter_context -v 2`
  - Result: `Ran 7 tests ... OK`
Mitigation test coverage includes:
- text matching
- case-insensitive search behavior
- `mitigation_available=true/false`
- null and empty-string handling
- whitespace behavior
- combined filters
- no-filter baseline behavior

**Documentation**

No documentation updates required:
- No new parser
- No new model/schema changes
- No new setting introduced

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.