### PR TITLE
Fix planned remediation version appearing under Reviewers in findings list

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1959,6 +1959,7 @@ class FindingFilterHelper(FilterSet):
              "risk_acceptance__created__date"),
             ("last_reviewed", "last_reviewed"),
             ("planned_remediation_date", "planned_remediation_date"),
+            ("planned_remediation_version", "planned_remediation_version"),
             ("title", "title"),
             ("test__engagement__product__name",
              "test__engagement__product__name"),
@@ -1985,6 +1986,7 @@ class FindingFilterHelper(FilterSet):
             "kev_date": "Date added to KEV",
             "sla_age_days": "SLA age (days)",
             "planned_remediation_date": "Planned Remediation",
+            "planned_remediation_version": "Planned remediation version",
         },
     )
 

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -393,6 +393,9 @@
                                     <th scope="col">
                                         {% dojo_sort request 'Planned Remediation' 'planned_remediation_date' %}
                                     </th>
+                                    <th scope="col">
+                                        {% dojo_sort request 'Planned remediation version' 'planned_remediation_version' %}
+                                    </th>
                                     {% if filter_name != 'Closed' %}
                                         <th scope="col">
                                             {% trans "Reviewers" %}


### PR DESCRIPTION
## Summary

The open findings table rendered a `planned_remediation_version` cell without a matching header column, so the version value aligned under the **Reviewers** header and shifted the rest of the row.

This adds the missing header (with sort link) and registers `planned_remediation_version` on `FindingFilterHelper` ordering so server-side sort matches the UI.

Fixes #14757.