### PR TITLE
Remove 'safe' filter from description output

### DIFF
--- a/dojo/templates/notifications/alert/other.tpl
+++ b/dojo/templates/notifications/alert/other.tpl
@@ -1,1 +1,1 @@
-{% load i18n %}{{ description|safe }}
+{% load i18n %}{{ description }}


### PR DESCRIPTION
This pull request makes a minor change to the `dojo/templates/notifications/alert/other.tpl` template by removing the `safe` filter from the `description` variable, which will prevent HTML in the description from being rendered as markup.