### PR TITLE
fix(api): add created/updated date filters to risk_acceptance endpoint

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -3126,10 +3126,16 @@ class ApiEndpointFilter(DojoFilter):
 
 
 class ApiRiskAcceptanceFilter(DojoFilter):
+    # DateRangeFilter
+    created = DateRangeFilter()
+    updated = DateRangeFilter()
+
     o = OrderingFilter(
         # tuple-mapping retains order
         fields=(
             ("name", "name"),
+            ("created", "created"),
+            ("updated", "updated"),
         ),
     )
 


### PR DESCRIPTION
## Summary

Closes #14623.

The `risk_acceptance` API returns `created` and `updated` timestamps in its responses but `ApiRiskAcceptanceFilter` did not expose either as a query parameter, while the matching `findings`, `products`, and `assets` filters all do (see `ApiProductFilter`, `ApiFindingFilter` for the same pattern). Clients had no way to scope listings by acceptance date.

## Change

Add `DateRangeFilter(created)` and `DateRangeFilter(updated)` to `ApiRiskAcceptanceFilter` and expose both fields in the existing `OrderingFilter`, matching the convention used by the sibling resources.

```python
class ApiRiskAcceptanceFilter(DojoFilter):
    created = DateRangeFilter()
    updated = DateRangeFilter()

    o = OrderingFilter(
        fields=(
            ("name", "name"),
            ("created", "created"),
            ("updated", "updated"),
        ),
    )
    ...
```

`Risk_Acceptance.created` (auto_now_add) and `Risk_Acceptance.updated` (auto_now) already exist on the model (`dojo/models.py` L3976–3977) so no migration is needed.

## Test plan

- [x] `python -c 'import ast; ast.parse(open("dojo/filters.py").read())'` — file parses
- [ ] Confirm OpenAPI schema for `/api/v2/risk_acceptance/` lists `created`, `updated`, and `o` query parameters
- [ ] Manual: `GET /api/v2/risk_acceptance/?created=week` returns last week's acceptances; `GET /api/v2/risk_acceptance/?o=-updated` sorts by most-recently-updated first