### PR TITLE
Update changelog for May 2026 release (v2.58.0)

### DIFF
--- a/docs/content/releases/pro/changelog.md
+++ b/docs/content/releases/pro/changelog.md
@@ -12,6 +12,14 @@ For Open Source release notes, please see the [Releases page on GitHub](https://
 
 ## May 2026: v2.58
 
+### May 6, 2026: v2.58.1
+
+* **(Pro UI)** You can now activate or deactivate Test Types and Users directly from their list menus, so retiring or restoring entries no longer requires opening the edit form.
+* **(Pro UI)** Anchor links now open in a new tab as expected, so following a reference no longer pulls you away from the page you were working on.
+* **(Pro UI)** Adding findings to an existing Risk Acceptance works reliably again. A recent performance improvement caused the form to fail for some users; you can now resume managing accepted findings without errors.
+* **(Pro UI)** Your customized table column order is now preserved across page refreshes. Previously only column visibility carried over, so any rearranging you did would silently revert to the default — forcing you to reorder columns every session.
+* **(API)** Fixed a 500 error when fetching vulnerable endpoints (`GET /api/vue/endpoints/{id}/vulnerable/`), restoring reliable access to vulnerability data for an endpoint.
+
 ### May 4, 2026: v2.58.0
 
 * **(Pro UI)** Added shared table preferences so saved column/filter configurations on list views can be shared across users.
@@ -40,7 +48,7 @@ For Open Source release notes, please see the [Releases page on GitHub](https://
 * **(Pro UI)** Corrected the Product column label on the Group page under the V3 relabeling.
 * **(Pro UI)** Removed the duplicate greeting message shown after login.
 * **(Performance)** Create-path notifications are now dispatched asynchronously, removing a source of slow POST latency.
-* **(Deployment)** On premise deployments now include the Orchestrator services.
+* **(Deployment)** On premise deployments now include the Orchestrator services. Please see [additional instructions](/releases/pro/ddorch-database) for more details
 * **(Notifications)** Improved the format and display of SLA breach notifications.
 * **(Engineer Metrics)** Fixed a KeyError that could be raised when loading the Engineer Metrics page.
 * **(Tools)** Contrast parser no longer collapses distinct findings that share a rule name.

--- a/docs/content/releases/pro/changelog.md
+++ b/docs/content/releases/pro/changelog.md
@@ -10,6 +10,25 @@ Here are the release notes for **DefectDojo Pro (Cloud Version)**. These release
 
 For Open Source release notes, please see the [Releases page on GitHub](https://github.com/DefectDojo/django-DefectDojo/releases), or alternatively consult the Open Source [upgrade notes](/releases/os_upgrading/upgrading_guide/).
 
+## May 2026: v2.58
+
+### May 4, 2026: v2.58.0
+
+* **(Pro UI)** Added shared table preferences so saved column/filter configurations on list views can be shared across users.
+* **(Pro UI)** Markdown content now wraps text correctly, preventing horizontal overflow on long lines.
+* **(Performance)** Pro UI List Virtualization
+* **(Performance)** Improved import performance by optimizing import queries and bulk-applying parser-supplied per-finding tags.
+* **(Performance)** Locations endpoints optimized for faster retrieval on large datasets.
+* **(SBOM)** SBOM imports now support replace mode for re-importing the full inventory of a component set.
+* **(Reports)** Beat Reporting feature is now available for Cloud subscribers
+* **(API)** Added `created` and `updated` date filters to the Risk Acceptance API.
+* **(Jira)** Webhook handler no longer mis-mitigates findings on non-"done" Jira issue transitions.
+* **(Deployment)** Default Celery task serializer is now JSON, removing pickle from the task dispatch path.
+* **(Tools)** Added Qualys VMDR CSV parser.
+* **(Tools)** Coverity API parser now supports `RESOURCE_LEAK` quality findings.
+* **(Tools)** SonarQube parser now falls back to `mdDesc` when populating finding descriptions.
+* **(Settings)** `MAX_ZIP_*` limits are now configurable via settings.
+
 ## Apr 2026: v2.57
 
 ### Apr 27, 2026: v2.57.3


### PR DESCRIPTION
Document new features and improvements introduced in the May 2026 release of DefectDojo Pro, including enhancements to the UI, performance optimizations, and new tools and settings.

