### PR TITLE
Use a dedicated permission class for BurpRawRequestResponseViewSet

### DIFF
--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -455,6 +455,23 @@ class UserHasFindingNotePermission(BaseRelatedObjectPermission):
     }
 
 
+class UserHasBurpRawRequestResponsePermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return check_post_permission(
+            request, Finding, "finding", Permissions.Finding_Edit,
+        )
+
+    def has_object_permission(self, request, view, obj):
+        return check_object_permission(
+            request,
+            obj.finding,
+            Permissions.Finding_View,
+            Permissions.Finding_Edit,
+            Permissions.Finding_Edit,
+            Permissions.Finding_Edit,
+        )
+
+
 class UserHasImportPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         # permission check takes place before validation, so we don't have access to serializer.validated_data()

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -3011,7 +3011,7 @@ class BurpRawRequestResponseViewSet(
     filterset_fields = ["finding"]
     permission_classes = (
         IsAuthenticated,
-        permissions.UserHasFindingRelatedObjectPermission,
+        permissions.UserHasBurpRawRequestResponsePermission,
     )
 
     def get_queryset(self):

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1788,6 +1788,7 @@ class FindingRequestResponseTest(DojoAPITestCase):
         self.assertEqual(200, response.status_code, response.content[:1000])
 
 
+@versioned_fixtures
 class RequestResponsePairsAuthzTest(DojoAPITestCase):
 
     fixtures = ["dojo_testdata.json"]

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1788,6 +1788,66 @@ class FindingRequestResponseTest(DojoAPITestCase):
         self.assertEqual(200, response.status_code, response.content[:1000])
 
 
+class RequestResponsePairsAuthzTest(DojoAPITestCase):
+
+    fixtures = ["dojo_testdata.json"]
+
+    def _client_for(self, username):
+        user = User.objects.get(username=username)
+        token = Token.objects.get(user=user)
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+        return client
+
+    def test_admin_can_create_request_response_pair_positive_control(self):
+        client = self._client_for("admin")
+        before = BurpRawRequestResponse.objects.filter(finding_id=7).count()
+        response = client.post(
+            "/api/v2/request_response_pairs/",
+            dumps({
+                "finding": 7,
+                "burpRequestBase64": "cmVxdWVzdAo=",
+                "burpResponseBase64": "cmVzcG9uc2UK",
+            }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201, response.content[:1000])
+        self.assertEqual(BurpRawRequestResponse.objects.filter(finding_id=7).count(), before + 1)
+
+    def test_unrelated_user_cannot_create_request_response_pair_on_hidden_finding(self):
+        client = self._client_for("user2")
+        # Sanity: the victim finding is genuinely hidden from this user.
+        get_response = client.get("/api/v2/findings/7/")
+        self.assertEqual(get_response.status_code, 404)
+
+        before = BurpRawRequestResponse.objects.filter(finding_id=7).count()
+        response = client.post(
+            "/api/v2/request_response_pairs/",
+            dumps({
+                "finding": 7,
+                "burpRequestBase64": "cmVxdWVzdAo=",
+                "burpResponseBase64": "cmVzcG9uc2UK",
+            }),
+            content_type="application/json",
+        )
+        self.assertIn(response.status_code, (403, 404), response.content[:1000])
+        self.assertEqual(BurpRawRequestResponse.objects.filter(finding_id=7).count(), before)
+
+    def test_post_without_finding_returns_4xx(self):
+        client = self._client_for("user2")
+        response = client.post(
+            "/api/v2/request_response_pairs/",
+            dumps({
+                "burpRequestBase64": "cmVxdWVzdAo=",
+                "burpResponseBase64": "cmVzcG9uc2UK",
+            }),
+            content_type="application/json",
+        )
+        # check_post_permission raises ParseError (400) when "finding" is omitted.
+        self.assertGreaterEqual(response.status_code, 400)
+        self.assertLess(response.status_code, 500)
+
+
 @versioned_fixtures
 class FilesTest(DojoAPITestCase):
     fixtures = ["dojo_testdata.json"]


### PR DESCRIPTION
## What

The top-level `/api/v2/request_response_pairs/` viewset previously reused `UserHasFindingRelatedObjectPermission`, a `BaseRelatedObjectPermission` subclass whose `has_permission` returns `True`. That class is shaped for `@action(detail=True, …)` endpoints where DRF resolves the parent `Finding` from the URL and `has_object_permission` runs against it. On a top-level `POST` there is no parent object resolved yet, so the create flow only ran `has_object_permission` against the not-yet-saved row and skipped any check on the client-supplied `finding` foreign key.

This PR introduces `UserHasBurpRawRequestResponsePermission`, mirroring the pattern already used by `UserHasFindingPermission`, `UserHasProductPermission`, and the other parent-keyed viewsets:

- `has_permission` calls `check_post_permission(request, Finding, "finding", Permissions.Finding_Edit)` on `POST`, which fetches the referenced finding and rejects with `403`/`404` unless the user has `Finding_Edit`. Missing `finding` is rejected with `ParseError`.
- `has_object_permission` dereferences `obj.finding` for retrieve/update/delete so list/detail/PUT/PATCH/DELETE behavior is unchanged.

The other 11 callers of `UserHasFindingRelatedObjectPermission` are all `@action(detail=True, …)` decorators where the URL-resolved finding makes the existing class behave correctly, so the base class is left as-is.

## Test plan

Added `unittests.test_rest_framework.RequestResponsePairsAuthzTest` covering:

1. Positive control — admin POST returns `201` and the row count increases.
2. A user with no product/product_type/global membership receives `404` for `GET /api/v2/findings/7/` and a 4xx for `POST /api/v2/request_response_pairs/` with that finding ID; the row count is unchanged.
3. POST without `finding` returns 4xx (the `ParseError` path in `check_post_permission`).

```bash
docker compose -f docker-compose.yml -f docker-compose.override.unit_tests.yml run --rm \
  -e DJANGO_SETTINGS_MODULE=dojo.settings.settings \
  --entrypoint '' uwsgi \
  python3 manage.py test \
  unittests.test_rest_framework.RequestResponsePairsAuthzTest -v2 --keepdb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)