### PR TITLE
docs: Add Components page and glossary entry

### DIFF
--- a/docs/content/asset_modelling/components/PRO__components.md
+++ b/docs/content/asset_modelling/components/PRO__components.md
@@ -7,9 +7,15 @@ weight: 1
 
 In DefectDojo, Components represent third-party libraries, software components, and modules that potentially have vulnerabilities.
 
-## The Component Table
+* DefectDojo Pro has introduced a beta feature called **Locations**, which will eventually consolidate and  Components and Endpoints.
 
-DefectDojo Pro includes a dedicated table view for Components. Imported Components remain on the table even if all of their associated Findings are Mitigated. When Findings are imported for a specific Component, the Component Table is updated to accurately reflect the new Finding totals.
+## Component Views
+
+DefectDojo Pro includes a dedicated table view for Components, which can be found in the sidebar.  This view shows Active Findings, Duplicate Findings, and Total Findings for each Component.  These figures include all Assets on the DefectDojo instance.
+
+An individual Asset's Components can be seen on the Asset view.
+
+## The Component Table
 
 The Component Table displays the following columns:
 
@@ -19,15 +25,38 @@ The Component Table displays the following columns:
 * **Duplicate Findings** — count of Duplicate Findings associated with the component.
 * **Total Findings** — total count of all Findings associated with the component.
 
-The totals for Active Findings, Duplicate Findings, and Total Findings are calculated from the Findings on the instance.
-
 Clicking on the Component Name or the values for Active Findings, Duplicate Findings, or Total Findings opens a filtered list of Findings for the respective field.
 
 A **None** Component is displayed on the table, which shows all Findings that are not associated with any Component.
 
+Imported Components remain on the table even if all of their associated Findings are Mitigated. When Findings are imported for a specific Component, the Component Table is updated to accurately reflect the new Finding totals.
+
+
+### Example
+
+A Component imported from a Dependency-Check scan against an application with a vulnerable `lodash` dependency might appear on the table as:
+
+| Component | Version | Active Findings | Duplicate Findings | Total Findings |
+| --- | --- | --- | --- | --- |
+| npm:lodash | 4.17.15 | 3 | 1 | 5 |
+
+Clicking `npm:lodash` opens the list of every Finding that references this Component. Clicking `3` opens the same list filtered to Active Findings only.
+
 ## Adding Components
 
-Components can be added from a scan import or by manually editing a Finding. Once a Component Name is associated with a Finding, it is added to the Component Table. If the Component is already associated with other Findings on the instance, the totals for Active Findings, Duplicate Findings, and Total Findings are updated accordingly.
+Components can be parsed from a scan import or by manually editing a Finding. Once a Component Name is associated with a Finding, a corresponding entry will be added to the Component Table automatically. If the Component is already associated with other Findings in DefectDojo, the totals for Active Findings, Duplicate Findings, and Total Findings are updated accordingly.
+
+### How Components are Parsed from Scan Data
+
+When a scan is imported, parsers populate the **Component Name** and **Component Version** fields on each Finding from the scan output. The Component Table is then built from those values. The level of detail and the naming convention depend on the tool that produced the scan:
+
+* **Software Composition Analysis (SCA) tools** typically report a package name and exact version. For example, OWASP Dependency-Check derives the Component from the [Package URL](https://github.com/package-url/purl-spec) in its identifier — a `pkg:npm/lodash@4.17.15` purl becomes `Component Name: npm:lodash`, `Component Version: 4.17.15`.
+* **Container and OS package scanners** such as Trivy, Anchore Grype, and Anchore Engine report the affected OS or language package — for example, `Component Name: curl`, `Component Version: 7.68.0`.
+* **Language-specific dependency scanners** such as npm Audit, pip-audit, bundler-audit, Retire.js, Govulncheck, and OSV-Scanner populate the offending package and version from their respective ecosystem manifests.
+
+Scanners focused on configuration, infrastructure, or source-code logic (such as SAST and IaC tools) generally do not populate the Component fields, and their Findings appear under the **None** Component.
+
+To add or change a Component manually, edit the Finding and set the **Component Name** and **Component Version** fields directly. The Component Table updates as soon as the Finding is saved.
 
 ## Updating Components
 

--- a/docs/content/asset_modelling/components/PRO__components.md
+++ b/docs/content/asset_modelling/components/PRO__components.md
@@ -1,0 +1,40 @@
+---
+title: "Components"
+description: "Tracking third-party libraries and software components in DefectDojo Pro"
+audience: pro
+weight: 1
+---
+
+In DefectDojo, Components represent third-party libraries, software components, and modules that potentially have vulnerabilities.
+
+## The Component Table
+
+DefectDojo Pro includes a dedicated table view for Components. Imported Components remain on the table even if all of their associated Findings are Mitigated. When Findings are imported for a specific Component, the Component Table is updated to accurately reflect the new Finding totals.
+
+The Component Table displays the following columns:
+
+* **Component** — the name of the component, populated from scan data.
+* **Version** — the component version, populated from scan data.
+* **Active Findings** — count of Active Findings associated with the component.
+* **Duplicate Findings** — count of Duplicate Findings associated with the component.
+* **Total Findings** — total count of all Findings associated with the component.
+
+The totals for Active Findings, Duplicate Findings, and Total Findings are calculated from the Findings on the instance.
+
+Clicking on the Component Name or the values for Active Findings, Duplicate Findings, or Total Findings opens a filtered list of Findings for the respective field.
+
+A **None** Component is displayed on the table, which shows all Findings that are not associated with any Component.
+
+## Adding Components
+
+Components can be added from a scan import or by manually editing a Finding. Once a Component Name is associated with a Finding, it is added to the Component Table. If the Component is already associated with other Findings on the instance, the totals for Active Findings, Duplicate Findings, and Total Findings are updated accordingly.
+
+## Updating Components
+
+To update a Component Name or Version, all Findings associated with the Component must have their Component Name or Component Version field updated.
+
+## Removing Components
+
+To remove a Component from the Component Table, all Findings associated with the Component must be updated to remove their Component Name and Component Version fields. Components are also removed if all of their associated Findings are deleted.
+
+If all of a Component's Findings are Mitigated, the Component remains on the table but its Active Findings value is set to 0.

--- a/docs/content/asset_modelling/components/PRO__components.md
+++ b/docs/content/asset_modelling/components/PRO__components.md
@@ -7,7 +7,6 @@ weight: 1
 
 In DefectDojo, Components represent third-party libraries, software components, and modules that potentially have vulnerabilities.
 
-* DefectDojo Pro has introduced a beta feature called **Locations**, which will eventually consolidate and  Components and Endpoints.
 
 ## Component Views
 

--- a/docs/content/asset_modelling/components/_index.md
+++ b/docs/content/asset_modelling/components/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Components"
+title: "Components & Endpoints"
 date: 2021-02-02T20:46:29+01:00
 draft: false
 type: docs

--- a/docs/content/asset_modelling/components/_index.md
+++ b/docs/content/asset_modelling/components/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Components"
+date: 2021-02-02T20:46:29+01:00
+draft: false
+type: docs
+weight: 4
+sidebar:
+  collapsed: false
+exclude_search: true
+---

--- a/docs/content/help/glossary.md
+++ b/docs/content/help/glossary.md
@@ -19,6 +19,8 @@ A scoped security activity representing a testing window, pipeline, or assessmen
 A single execution of a scanner or manual assessment within an Engagement. Tests store execution metadata and act as the ingestion point for Findings.
 ## Service (Both)
 An optional sub-object used to attribute Findings to a specific component or interface within an Asset. Services are most useful in OS DefectDojo, as their functionality is replicated and enhanced by Asset Hierarchy in the Pro version.
+## Components (Both)
+A third-party library, software module, or external dependency that is tracked in DefectDojo Pro. Imported Components are derived from scan data and associated with Findings. In the Pro UI, the Component Table aggregates Active, Duplicate, and Total Finding counts per Component and remains populated even when all associated Findings are Mitigated.
 ## Finding (Both)
 The most granular vulnerability object in DefectDojo's Product Hierarchy that represents a discrete security issue.
 ### Finding Status (Both)


### PR DESCRIPTION
Claude helped me format but **all docs content** was written and validated by me.

[sc-13050]

----

Adds a new Pro-only Components page under Model Your Assets > Components covering the Component Table, and how to add, update, and remove components. Also adds a Component entry to the glossary.