### PR TITLE
refactor: rename dispatch kwarg sync= to force_sync=

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1474,7 +1474,7 @@ class FindingSerializer(serializers.ModelSerializer):
 
         if push_to_jira or jira_services.is_keep_in_sync(instance):
             # Push synchronously so that we can see jira errors in real time
-            success, message = jira_services.push(instance, sync=True)
+            success, message = jira_services.push(instance, force_sync=True)
             if not success:
                 raise serializers.ValidationError(message)
 

--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -67,7 +67,7 @@ class DojoAsyncTask(Task):
             kwargs["async_user_id"] = user.id if user else None
 
         # Control flag used for sync/async decision; never pass into the task itself
-        kwargs.pop("sync", None)
+        kwargs.pop("force_sync", None)
 
         # Track dispatch
         dojo_async_task_counter.incr(

--- a/dojo/celery_dispatch.py
+++ b/dojo/celery_dispatch.py
@@ -61,7 +61,7 @@ def dojo_dispatch_task(task_or_sig: _SupportsSi | _SupportsApplyAsync | Signatur
 
     - Inject `async_user_id` if missing.
     - Capture and inject pghistory context if available.
-    - Respect `sync=True` (foreground execution) and user `block_execution`.
+    - Respect `force_sync=True` (foreground execution) and user `block_execution`.
     - Support `countdown=<seconds>` for async dispatch.
 
     Returns:

--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -58,9 +58,9 @@ dojo_async_task_counter = ThreadLocalTaskCounter()
 def we_want_async(*args, func=None, **kwargs):
     from dojo.utils import get_current_user  # noqa: PLC0415 circular import
 
-    sync = kwargs.get("sync", False)
-    if sync:
-        logger.debug("dojo_async_task %s: running task in the foreground as sync=True has been found as kwarg", func)
+    force_sync = kwargs.get("force_sync", False)
+    if force_sync:
+        logger.debug("dojo_async_task %s: running task in the foreground as force_sync=True has been found as kwarg", func)
         return False
 
     user = get_current_user()

--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -467,7 +467,7 @@ def post_process_findings_batch(
     push_to_jira=False,
     jira_instance_id=None,
     user=None,
-    sync=False,
+    force_sync=False,
     **kwargs,
 ):
 
@@ -510,7 +510,7 @@ def post_process_findings_batch(
     if product_grading_option and system_settings.enable_product_grade:
         from dojo.celery_dispatch import dojo_dispatch_task  # noqa: PLC0415 circular import
 
-        dojo_dispatch_task(calculate_grade, findings[0].test.engagement.product.id, sync=sync)
+        dojo_dispatch_task(calculate_grade, findings[0].test.engagement.product.id, force_sync=force_sync)
 
     # If we received the ID of a jira instance, then we need to determine the keep in sync behavior
     jira_instance = None

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -97,7 +97,7 @@ def view_finding_group(request, fgid):
                 elif not finding_group.has_jira_issue:
                     jira_services.link_finding_group(request, finding_group, jira_issue)
             elif push_to_jira:
-                jira_services.push(finding_group, sync=True)
+                jira_services.push(finding_group, force_sync=True)
 
             finding_group.save()
             return HttpResponseRedirect(reverse("view_test", args=(finding_group.test.id,)))
@@ -194,7 +194,7 @@ def push_to_jira(request, fgid):
 
         # it may look like success here, but the push_to_jira are swallowing exceptions
         # but cant't change too much now without having a test suite, so leave as is for now with the addition warning message to check alerts for background errors.
-        if jira_services.push(group, sync=True):
+        if jira_services.push(group, force_sync=True):
             messages.add_message(
                 request,
                 messages.SUCCESS,

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -279,7 +279,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
                     product_grading_option=True,
                     issue_updater_option=True,
                     push_to_jira=push_to_jira,
-                    sync=kwargs.get("sync", False),
+                    force_sync=kwargs.get("force_sync", False),
                 )
 
             # No chord: tasks are dispatched immediately above per batch

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -434,7 +434,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                             issue_updater_option=True,
                             push_to_jira=push_to_jira,
                             jira_instance_id=getattr(self.jira_instance, "id", None),
-                            sync=kwargs.get("sync", False),
+                            force_sync=kwargs.get("force_sync", False),
                         )
 
         # No chord: tasks are dispatched immediately above per batch

--- a/unittests/test_async_delete.py
+++ b/unittests/test_async_delete.py
@@ -252,11 +252,11 @@ class TestAsyncDelete(DojoTestCase):
         )
 
     @override_settings(ASYNC_OBJECT_DELETE=True)
-    def test_async_delete_accepts_sync_kwarg(self):
+    def test_async_delete_accepts_force_sync_kwarg(self):
         """
-        Test that async_delete passes through the sync kwarg properly.
+        Test that async_delete passes through the force_sync kwarg properly.
 
-        The sync=True kwarg forces synchronous execution for the top-level task.
+        The force_sync=True kwarg forces synchronous execution for the top-level task.
         However, nested task dispatches still need user context to run synchronously,
         so we use impersonate here as well.
         """
@@ -265,14 +265,14 @@ class TestAsyncDelete(DojoTestCase):
 
         # Use impersonate to ensure nested tasks also run synchronously
         with impersonate(self.testuser):
-            # Explicitly pass sync=True
+            # Explicitly pass force_sync=True
             async_del = async_delete()
-            async_del.delete(product, sync=True)
+            async_del.delete(product, force_sync=True)
 
         # Verify the product was deleted
         self.assertFalse(
             Product.objects.filter(pk=product_pk).exists(),
-            "Product should be deleted with sync=True",
+            "Product should be deleted with force_sync=True",
         )
 
     def test_async_delete_helper_methods(self):

--- a/unittests/test_reimport_prefetch.py
+++ b/unittests/test_reimport_prefetch.py
@@ -118,7 +118,7 @@ class ReimportDuplicateFindingsTestBase(DojoTestCase):
                 minimum_severity="Info",
                 active=True,
                 verified=True,
-                sync=True,
+                force_sync=True,
                 scan_type=SCAN_TYPE,
             )
             return reimporter.process_scan(scan)

--- a/unittests/test_update_import_history.py
+++ b/unittests/test_update_import_history.py
@@ -72,7 +72,7 @@ class UpdateImportHistoryTests(TransactionTestCase):
             minimum_severity="Info",
             active=True,
             verified=True,
-            sync=True,
+            force_sync=True,
             scan_type="StackHawk HawkScan",
         )
         # Explicitly create the Test similar to Engagement creation


### PR DESCRIPTION
## Summary

- in #14881 we introduce `force_async` which made me realize we should use `force_sync=True` instead of `sync=True`. IS more explicit and clear what it does.
- Rename the dispatch control kwarg `sync=` → `force_sync=` on `dojo_dispatch_task` / `dojo_async_task` / `we_want_async`.
- Hard rename — no alias period.

## Why

- The bare name `sync` collides with unrelated parameters elsewhere in the codebase (e.g. `JIRA_Instance.finding_jira_sync`, `is_keep_in_sync`, scan types named \"HawkScan\"), making code search and review confusing.
- A recently-introduced `force_async=True` kwarg solves the inverse problem (always run in background). `force_sync` is the symmetric, intention-revealing name for the existing flag — readers instantly know what \"force\" means relative to the default async-when-possible behavior.

## Changes

Caller / dispatch chain:
- [dojo/decorators.py](dojo/decorators.py) — `we_want_async` reads `force_sync` from kwargs.
- [dojo/celery_dispatch.py](dojo/celery_dispatch.py) — docstring.
- [dojo/celery.py](dojo/celery.py) — `DojoAsyncTask.apply_async` pops `force_sync` (control flag, never reaches the task body).
- [dojo/importers/default_importer.py](dojo/importers/default_importer.py), [default_reimporter.py](dojo/importers/default_reimporter.py) — propagate `force_sync` from importer kwargs to `post_process_findings_batch`.
- [dojo/finding/helper.py](dojo/finding/helper.py) — `post_process_findings_batch` signature + nested `dojo_dispatch_task(calculate_grade, ..., force_sync=force_sync)`.
- [dojo/api_v2/serializers.py](dojo/api_v2/serializers.py), [dojo/finding_group/views.py](dojo/finding_group/views.py) — JIRA push call sites that want foreground execution.

Tests:
- [unittests/test_async_delete.py](unittests/test_async_delete.py), [test_reimport_prefetch.py](unittests/test_reimport_prefetch.py), [test_update_import_history.py](unittests/test_update_import_history.py) — updated kwargs + docstrings.

## Test plan

- [x] `ruff check` clean on all changed files.
- [x] `pytest unittests/test_async_delete.py::TestAsyncDelete::test_async_delete_accepts_force_sync_kwarg` — passes.
- [x] Pre-existing failures in `test_reimport_prefetch.py` reproduce on `dev` baseline → not caused by this change (verified by stashing the diff and re-running).

## Notes

- This PR may conflict with the watson prefetch PR (#14881) in `dojo/decorators.py` since both touch `we_want_async`. Whichever merges second rebases.