### PR TITLE
Fix SARIF parser crash on empty extensions

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -384,12 +384,12 @@ class SarifParser:
 
 def get_rules(run):
     rules = {}
-    rules_array = run['tool']['driver'].get('rules', [])
+    rules_array = run["tool"]["driver"].get("rules", [])
     if not rules_array:
-        for extension in run['tool'].get('extensions', []):
-            rules_array.extend(extension.get('rules', []))
+        for extension in run["tool"].get("extensions", []):
+            rules_array.extend(extension.get("rules", []))
     for item in rules_array:
-        rules[item['id']] = item
+        rules[item["id"]] = item
     return rules
 
 

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -384,11 +384,12 @@ class SarifParser:
 
 def get_rules(run):
     rules = {}
-    rules_array = run["tool"]["driver"].get("rules", [])
-    if len(rules_array) == 0 and run["tool"].get("extensions") is not None:
-        rules_array = run["tool"]["extensions"][0].get("rules", [])
+    rules_array = run['tool']['driver'].get('rules', [])
+    if not rules_array:
+        for extension in run['tool'].get('extensions', []):
+            rules_array.extend(extension.get('rules', []))
     for item in rules_array:
-        rules[item["id"]] = item
+        rules[item['id']] = item
     return rules
 
 


### PR DESCRIPTION
Fixes #14897

This PR fixes a SARIF parser crash when importing valid SARIF 2.1.0 reports with empty `results`, empty `driver.rules`, and missing or empty `tool.extensions`.

Previously the parser assumed that `extensions[0]` always exists when `driver.rules` is empty:

`rules_array = run["tool"]["extensions"][0].get("rules", [])`

This could lead to:

`IndexError: list index out of range`

The fix safely iterates through available extensions and collects rules only if they are present, avoiding unsafe indexing and correctly handling spec-compliant SARIF files with no findings.

Tested with the minimal SARIF sample attached in issue #14897.
