### PR TITLE
Rename title to 'Open-Source Permissions'

### DIFF
--- a/docs/content/admin/user_management/OS__authorized_users.md
+++ b/docs/content/admin/user_management/OS__authorized_users.md
@@ -1,5 +1,5 @@
 ---
-title: "Authorized Users"
+title: "Open-Source Permissions"
 description: "How access to Products and Product Types is granted in open-source DefectDojo"
 weight: 1
 audience: opensource


### PR DESCRIPTION
To avoid confusion, and to make it easier to compare / contrast features I'm going to suggest that we rename the "Authorized Users" doc to "Open-Source Permissions"