### PR TITLE
fix: pass username strings instead of Dojo_User objects to create_not…

### DIFF
--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -894,7 +894,7 @@ def process_tag_notifications(request, note, parent_url, parent_title):
     usernames_to_check = set(un.lower() for un in regex.findall(note.entry))  # noqa: C401
 
     users_to_notify = [
-        Dojo_User.objects.filter(username=username).get()
+        username
         for username in usernames_to_check
         if Dojo_User.objects.filter(is_active=True, username=username).exists()
     ]


### PR DESCRIPTION
## Description

Fix `user_mentioned` notifications silently failing when a user is 
@mentioned in a Finding or Test note.

Closes #14923

## Root Cause

`process_tag_notifications()` passed `Dojo_User` objects as `recipients` 
to `create_notification()`, but `_process_recipients()` filters using 
`user__username__in=kwargs["recipients"]` which expects username strings. 
The type mismatch caused the queryset to return zero results → zero 
notifications delivered.

## Change

One-line fix in `process_tag_notifications()`: return username strings 
from the list comprehension instead of `Dojo_User` objects.

## Testing

Verified manually via Django shell:
- Before fix: `create_notification(recipients=[Dojo_User object])` → 0 alerts
- After fix: `create_notification(recipients=["username"])` → 1 alert created

Tested on DefectDojo 2.58.4, Docker Compose deployment.

## Checklist
- [x] Fix is minimal and focused (single function, one file)
- [x] No new dependencies introduced
- [x] Manually verified working