### PR TITLE
fix(dependency_check): fold related dependency paths into description instead of emitting separate findings

### DIFF
--- a/docs/content/releases/os_upgrading/2.59.1.md
+++ b/docs/content/releases/os_upgrading/2.59.1.md
@@ -1,0 +1,32 @@
+---
+title: 'Upgrading to DefectDojo Version 2.59.1'
+toc_hide: true
+weight: -20260603
+description: Dependency Check parser no longer emits separate findings for related dependencies; related file paths are now listed in the main finding's description.
+---
+
+## Dependency Check parser: related dependencies folded into the main finding
+
+The Dependency Check parser previously created one finding per `<relatedDependency>` in the report, in addition to the finding for the main vulnerable dependency. Because OWASP Dependency-Check attaches the vulnerability only to the main dependency in the XML and the related entries are metadata pointing to other files in the same logical component, this produced N findings sharing the same title, CVE, component name and component version — only the file path differed. For projects with Spring Boot, ActiveMQ, or other libraries whose CPE matches many sibling artifacts this produced significant noise.
+
+Starting in 2.59.1, the parser emits exactly one finding per vulnerability per main dependency. The file paths of any related dependencies are surfaced in the finding description under a `**Related Filepaths:**` block.
+
+### Background: what `<relatedDependencies>` actually contains
+
+OWASP Dependency-Check's `DependencyBundlingAnalyzer` merges co-grouped artifacts into a single main dependency and lists the others under `<relatedDependencies>`. It does this under five scenarios:
+
+1. **Identical content (`hashesMatch`)** — the same jar (matching sha1) found at multiple paths, e.g. the same library packaged into multiple ear/war archives.
+2. **Shaded jar (`isShadedJar`)** — a `.jar` and a `pom.xml` extracted from inside it share the same CPE; the pom.xml is recorded as related.
+3. **WebJar (`isWebJar`)** — a `.js` file extracted from a WebJar matches the jar's CPE (mapped via `pkg:maven/org.webjars/<name>@<version>`); the js file is recorded as related to the jar.
+4. **Same CPE + base path + vulnerabilities + filename match** — sibling artifacts in the same project that share a CPE. Example: `spring-boot`, `spring-boot-actuator`, `spring-boot-starter-jdbc`, etc. all map to the `spring_boot` CPE and are grouped under the main `spring-boot` jar.
+5. **NPM same name + version** — the same npm package discovered via different resolution paths (for example `package-lock.json` plus `node_modules`).
+
+Only scenario 1 represents the same vulnerable artifact at multiple deploy locations. Scenarios 2-5 are different files representing one logical component. Both cases were previously inflated into separate findings; both now collapse to one finding with the related paths listed in the description.
+
+### Required actions
+
+- **Users filtering or grouping by the `related` tag**: that tag is no longer applied because related findings are no longer created. Update any saved filters, dashboards, or rules that depend on it. Equivalent information is now available in the finding description (look for `**Related Filepaths:**`).
+- **Reimport behavior**: on the next reimport of an existing Dependency Check report, the previously-created `related` findings will be closed as no longer present in the report. This is expected and matches the new parsing behavior.
+
+
+For more information, check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.59.1).

--- a/docs/content/supported_tools/parsers/file/dependency_check.md
+++ b/docs/content/supported_tools/parsers/file/dependency_check.md
@@ -7,7 +7,21 @@ OWASP Dependency Check output can be imported in Xml format. This parser ingests
 * Suppressed vulnerabilities are tagged with the tag: `suppressed`.
 * Suppressed vulnerabilities are marked as mitigated.
 * If the suppression is missing any `<notes>` tag, it tags them as `no_suppression_document`.
-* Related vulnerable dependencies are tagged with `related` tag.
+
+### Related dependencies
+
+OWASP Dependency-Check's `DependencyBundlingAnalyzer` merges co-grouped artifacts into a single main dependency and lists the others under `<relatedDependencies>` in the report. The vulnerability is attached only to the main dependency; the related entries are metadata pointing to other files in the same logical component.
+
+The parser emits one finding per vulnerability per main dependency and surfaces the related file paths in the finding's description under a `**Related Filepaths:**` block (rather than creating a separate finding per related entry, which produced N findings sharing the same title and CVE differing only in file path).
+
+DC bundles dependencies under five scenarios:
+
+1. **Identical content (`hashesMatch`)** — the same jar (matching sha1) found at multiple paths (e.g. packaged into multiple ear/war archives).
+2. **Shaded jar (`isShadedJar`)** — a `.jar` and a `pom.xml` extracted from inside it share the same CPE.
+3. **WebJar (`isWebJar`)** — a `.js` file extracted from a WebJar maps to the jar's CPE via `pkg:maven/org.webjars/<name>@<version>`.
+4. **Same CPE + base path + vulnerabilities + filename match** — sibling artifacts sharing a CPE (e.g. `spring-boot`, `spring-boot-actuator`, `spring-boot-starter-jdbc` all map to the `spring_boot` CPE).
+5. **NPM same name + version** — the same npm package discovered via different resolution paths (e.g. `package-lock.json` + `node_modules`).
+
 
 ### Sample Scan Data
 Sample Dependency Check scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/dependency_check).

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -86,6 +86,57 @@ class DependencyCheckParser:
         if key not in dupes:
             dupes[key] = finding
 
+    def build_related_dependencies_block(self, dependency, namespace):
+        """
+        Return a markdown block listing related dependencies, or ''.
+
+        Dependency-Check's DependencyBundlingAnalyzer merges co-grouped artifacts
+        into one main dependency and lists the others under <relatedDependencies>.
+        The vulnerability is attached only to the main dependency in the XML; the
+        related entries are metadata pointing to other files in the same logical
+        component. Previously we emitted one finding per related entry, which
+        multiplied a single CVE into N findings sharing the same title and CVE
+        with only the file_path differing — pure noise for the user. Instead we
+        keep one finding for the main dependency and surface the related file
+        paths in its description.
+
+        DC bundles dependencies under five scenarios (see
+        DependencyBundlingAnalyzer.evaluateDependencies):
+
+        1. hashesMatch — identical content (same sha1) found at multiple paths,
+           e.g. the same jar packaged into multiple ear/war archives.
+        2. isShadedJar — a .jar and a pom.xml extracted from inside it share the
+           same CPE; the pom.xml is recorded as related to the jar.
+        3. isWebJar — a .js file extracted from a WebJar matches the jar's CPE
+           (mapped via pkg:maven/org.webjars/<name>@<version>); the js is
+           related to the jar.
+        4. CPE + base path + vulnerabilities + filename match — sibling artifacts
+           in the same project that share a CPE (e.g. spring-boot,
+           spring-boot-actuator, spring-boot-starter all map to the
+           spring_boot CPE).
+        5. NPM same name + version — the same npm package discovered via
+           different resolution paths (e.g. package-lock.json + node_modules).
+
+        Scenario 1 is the only case where the related entries are genuinely
+        separate vulnerable locations; scenarios 2-5 are different files
+        representing one logical component. Listing all related paths in the
+        description preserves the per-location information for scenario 1 while
+        removing the noise from scenarios 2-5.
+        """
+        related = dependency.find(namespace + "relatedDependencies")
+        if related is None:
+            return ""
+        entries = []
+        for rd in related.findall(namespace + "relatedDependency"):
+            file_name = rd.findtext(f"{namespace}fileName")
+            if not file_name:
+                continue
+            file_path = (rd.findtext(f"{namespace}filePath") or "").strip()
+            entries.append(f"- {file_name} ({file_path})" if file_path else f"- {file_name}")
+        if not entries:
+            return ""
+        return "\n**Related Filepaths:**\n" + "\n".join(entries)
+
     def get_filename_and_path_from_dependency(
         self,
         dependency,
@@ -448,6 +499,7 @@ class DependencyCheckParser:
                     namespace + "vulnerabilities",
                 )
                 if vulnerabilities is not None:
+                    related_block = self.build_related_dependencies_block(dependency, namespace)
                     for vulnerability in vulnerabilities.findall(
                         namespace + "vulnerability",
                     ):
@@ -459,28 +511,11 @@ class DependencyCheckParser:
                                 test,
                                 namespace,
                             )
+                            if related_block:
+                                finding.description += related_block
                             if scan_date:
                                 finding.date = scan_date
                             self.add_finding(finding, dupes)
-
-                            relatedDependencies = dependency.find(
-                                namespace + "relatedDependencies",
-                            )
-                            if relatedDependencies is not None:
-                                for relatedDependency in relatedDependencies.findall(
-                                    namespace + "relatedDependency",
-                                ):
-                                    finding = self.get_finding_from_vulnerability(
-                                        dependency,
-                                        relatedDependency,
-                                        vulnerability,
-                                        test,
-                                        namespace,
-                                    )
-                                    if finding:  # could be None
-                                        if scan_date:
-                                            finding.date = scan_date
-                                        self.add_finding(finding, dupes)
 
                     for suppressedVulnerability in vulnerabilities.findall(
                         namespace + "suppressedVulnerability",
@@ -493,6 +528,8 @@ class DependencyCheckParser:
                                 test,
                                 namespace,
                             )
+                            if related_block:
+                                finding.description += related_block
                             if scan_date:
                                 finding.date = scan_date
                             self.add_finding(finding, dupes)

--- a/unittests/tools/test_dependency_check_parser.py
+++ b/unittests/tools/test_dependency_check_parser.py
@@ -58,11 +58,11 @@ class TestDependencyCheckParser(DojoTestCase):
             parser = DependencyCheckParser()
             findings = parser.get_findings(testfile, Test())
             items = findings
-            self.assertEqual(11, len(items))
+            self.assertEqual(9, len(items))
             # test also different component_name formats
 
             with self.subTest(i=0):
-                # identifier -> package url java + 2 relateddependencies
+                # identifier -> package url java + 2 relateddependencies (now folded into description)
                 self.assertEqual(items[0].title, "org.dom4j:dom4j:2.1.1.redhat-00001 | CVE-0000-0001")
                 self.assertEqual(items[0].component_name, "org.dom4j:dom4j")
                 self.assertEqual(items[0].component_version, "2.1.1.redhat-00001")
@@ -72,6 +72,15 @@ class TestDependencyCheckParser(DojoTestCase):
                 )
                 self.assertIn(
                     "/var/lib/adapter-ear1.ear/dom4j-2.1.1.jar",
+                    items[0].description,
+                )
+                self.assertIn("**Related Filepaths:**", items[0].description)
+                self.assertIn(
+                    "adapter-ear8.ear: dom4j-2.1.1.jar (/var/lib/adapter-ear8.ear/dom4j-2.1.1.jar)",
+                    items[0].description,
+                )
+                self.assertIn(
+                    "adapter-ear1.ear: dom4j-extensions-2.1.1.jar (/var/lib/adapter-ear1.ear/dom4j-extensions-2.1.1.jar)",
                     items[0].description,
                 )
                 self.assertEqual(items[0].severity, "High")
@@ -89,192 +98,143 @@ class TestDependencyCheckParser(DojoTestCase):
                 self.assertEqual("CVE-0000-0001", items[0].unsaved_vulnerability_ids[0])
 
             with self.subTest(i=1):
-                self.assertEqual(items[1].title, "org.dom4j:dom4j:2.1.1.redhat-00001 | CVE-0000-0001")
-                self.assertEqual(items[1].component_name, "org.dom4j:dom4j")
-                self.assertEqual(items[1].component_version, "2.1.1.redhat-00001")
-                self.assertIn(
-                    "Description of a bad vulnerability.",
-                    items[1].description,
-                )
-                self.assertIn(
-                    "/var/lib/adapter-ear8.ear/dom4j-2.1.1.jar",
-                    items[1].description,
-                )
-                self.assertEqual(items[1].severity, "High")
-                self.assertEqual(items[1].cvssv3, None)
-                self.assertEqual(items[1].cvssv3_score, None)
-                self.assertEqual(items[1].file_path, "adapter-ear8.ear: dom4j-2.1.1.jar")
-                self.assertEqual(
-                    items[1].mitigation,
-                    "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
-                )
-                self.assertEqual(items[1].unsaved_tags, ["related"])
-                self.assertEqual(1, len(items[1].unsaved_vulnerability_ids))
-                self.assertEqual("CVE-0000-0001", items[1].unsaved_vulnerability_ids[0])
-
-            with self.subTest(i=2):
-                self.assertEqual(items[2].title, "org.dom4j:dom4j:2.1.1.redhat-00001 | CVE-0000-0001")
-                self.assertEqual(items[2].component_name, "org.dom4j:dom4j")
-                self.assertEqual(items[2].component_version, "2.1.1.redhat-00001")
-                self.assertIn(
-                    "Description of a bad vulnerability.",
-                    items[2].description,
-                )
-                self.assertIn(
-                    "/var/lib/adapter-ear1.ear/dom4j-extensions-2.1.1.jar",
-                    items[2].description,
-                )
-                self.assertEqual(items[2].severity, "High")
-                self.assertEqual(items[2].cvssv3, None)
-                self.assertEqual(items[2].cvssv3_score, None)
-                self.assertEqual(items[2].file_path, "adapter-ear1.ear: dom4j-extensions-2.1.1.jar")
-                self.assertEqual(
-                    items[2].mitigation,
-                    "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
-                )
-                self.assertEqual(1, len(items[2].unsaved_vulnerability_ids))
-                self.assertEqual("CVE-0000-0001", items[2].unsaved_vulnerability_ids[0])
-
-            with self.subTest(i=3):
                 # identifier -> package url javascript, no vulnerabilitids, 3 vulnerabilities, relateddependencies without filename (pre v6.0.0)
                 self.assertEqual(
-                    items[3].title, "yargs-parser:5.0.0 | 1500",
+                    items[1].title, "yargs-parser:5.0.0 | 1500",
                 )
-                self.assertEqual(items[3].component_name, "yargs-parser")
-                self.assertEqual(items[3].component_version, "5.0.0")
-                # assert fails due to special characters, not too important
-                # self.assertEqual(items[1].description, "Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz&apos;` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.")
-                self.assertEqual(items[3].severity, "Low")
-                self.assertEqual(items[3].cvssv3, None)
-                self.assertEqual(items[3].cvssv3_score, None)
-                self.assertEqual(items[3].file_path, "yargs-parser:5.0.0")
+                self.assertEqual(items[1].component_name, "yargs-parser")
+                self.assertEqual(items[1].component_version, "5.0.0")
+                self.assertEqual(items[1].severity, "Low")
+                self.assertEqual(items[1].cvssv3, None)
+                self.assertEqual(items[1].cvssv3_score, None)
+                self.assertEqual(items[1].file_path, "yargs-parser:5.0.0")
                 self.assertEqual(
-                    items[3].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description",
+                    items[1].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description",
                 )
                 self.assertIn(
                     "**Source:** NPM",
-                    items[3].description,
+                    items[1].description,
                 )
-                self.assertIsNone(items[3].unsaved_vulnerability_ids)
+                self.assertIsNone(items[1].unsaved_vulnerability_ids)
 
-            with self.subTest(i=4):
+            with self.subTest(i=2):
                 self.assertEqual(
-                    items[4].title,
+                    items[2].title,
                     "yargs-parser:5.0.0 | CVE-2020-7608",
                 )
-                self.assertEqual(items[4].component_name, "yargs-parser")
-                self.assertEqual(items[4].component_version, "5.0.0")
+                self.assertEqual(items[2].component_name, "yargs-parser")
+                self.assertEqual(items[2].component_version, "5.0.0")
                 self.assertIn(
                     'yargs-parser could be tricked into adding or modifying properties\n                        of Object.prototype using a "__proto__" payload.\n**Source:** OSSINDEX\n**Filepath:** \n                /var/lib/jenkins/workspace/nl-selfservice_-_metrics_develop/package-lock.json?yargs-parser',
-                    items[4].description,
+                    items[2].description,
                 )
                 self.assertIn(
                     "/var/lib/jenkins/workspace/nl-selfservice_-_metrics_develop/package-lock.json?yargs-parser",
-                    items[4].description,
+                    items[2].description,
                 )
-                self.assertEqual(items[4].severity, "High")
-                self.assertEqual(items[4].cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N")
-                self.assertEqual(items[4].cvssv3_score, 7.5)
-                self.assertEqual(items[4].file_path, "yargs-parser:5.0.0")
+                self.assertEqual(items[2].severity, "High")
+                self.assertEqual(items[2].cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N")
+                self.assertEqual(items[2].cvssv3_score, 7.5)
+                self.assertEqual(items[2].file_path, "yargs-parser:5.0.0")
                 self.assertEqual(
-                    items[4].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description",
+                    items[2].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description",
                 )
-                self.assertEqual(1, len(items[4].unsaved_vulnerability_ids))
-                self.assertEqual("CVE-2020-7608", items[4].unsaved_vulnerability_ids[0])
+                self.assertEqual(1, len(items[2].unsaved_vulnerability_ids))
+                self.assertEqual("CVE-2020-7608", items[2].unsaved_vulnerability_ids[0])
 
-            with self.subTest(i=5):
+            with self.subTest(i=3):
                 self.assertEqual(
-                    items[5].title,
+                    items[3].title,
                     "yargs-parser:5.0.0 | CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')",
                 )
-                self.assertEqual(items[5].component_name, "yargs-parser")
-                self.assertEqual(items[5].component_version, "5.0.0")
+                self.assertEqual(items[3].component_name, "yargs-parser")
+                self.assertEqual(items[3].component_version, "5.0.0")
                 self.assertIn(
                     "The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.",
-                    items[5].description,
+                    items[3].description,
                 )
                 # check that the filepath is in the description
                 self.assertIn(
                     "/var/lib/jenkins/workspace/nl-selfservice_-_metrics_develop/package-lock.json?yargs-parser",
-                    items[5].description,
+                    items[3].description,
                 )
-                self.assertEqual(items[5].severity, "High")
-                self.assertEqual(items[5].cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H")
-                self.assertEqual(items[5].cvssv3_score, 7.5)
-                self.assertEqual(items[5].file_path, "yargs-parser:5.0.0")
+                self.assertEqual(items[3].severity, "High")
+                self.assertEqual(items[3].cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H")
+                self.assertEqual(items[3].cvssv3_score, 7.5)
+                self.assertEqual(items[3].file_path, "yargs-parser:5.0.0")
                 self.assertEqual(
-                    items[5].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description",
+                    items[3].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description",
                 )
-                self.assertIsNone(items[5].unsaved_vulnerability_ids)
+                self.assertIsNone(items[3].unsaved_vulnerability_ids)
+
+            with self.subTest(i=4):
+                # identifier -> cpe java
+                self.assertEqual(items[4].title, "org.dom4j:dom4j:2.1.1.redhat-00001 | CVE-0000-0001")
+                self.assertEqual(items[4].component_name, "org.dom4j:dom4j")
+                self.assertEqual(items[4].component_version, "2.1.1.redhat-00001")
+                self.assertEqual(items[4].severity, "High")
+                self.assertEqual(items[4].cvssv3, None)
+                self.assertEqual(items[4].cvssv3_score, None)
+                self.assertEqual(items[4].file_path, "adapter-ear2.ear: dom4j-2.1.1.jar")
+                self.assertEqual(
+                    items[4].mitigation,
+                    "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
+                )
+                self.assertEqual(1, len(items[4].unsaved_vulnerability_ids))
+                self.assertEqual("CVE-0000-0001", items[4].unsaved_vulnerability_ids[0])
+
+            with self.subTest(i=5):
+                # identifier -> maven java
+                self.assertEqual(items[5].title, "dom4j:2.1.1 | CVE-0000-0001")
+                self.assertEqual(items[5].component_name, "dom4j")
+                self.assertEqual(items[5].component_version, "2.1.1")
+                self.assertEqual(items[5].severity, "High")
+                self.assertEqual(items[5].cvssv3, None)
+                self.assertEqual(items[5].cvssv3_score, None)
+                self.assertEqual(
+                    items[5].mitigation, "Update dom4j:2.1.1 to at least the version recommended in the description",
+                )
 
             with self.subTest(i=6):
-                # identifier -> cpe java
-                self.assertEqual(items[6].title, "org.dom4j:dom4j:2.1.1.redhat-00001 | CVE-0000-0001")
-                self.assertEqual(items[6].component_name, "org.dom4j:dom4j")
-                self.assertEqual(items[6].component_version, "2.1.1.redhat-00001")
+                # evidencecollected -> single product + single verison javascript
+                self.assertEqual(
+                    items[6].title,
+                    "jquery:3.1.1 | CVE-0000-0001",
+                )
+                self.assertEqual(items[6].component_name, "jquery")
+                self.assertEqual(items[6].component_version, "3.1.1")
                 self.assertEqual(items[6].severity, "High")
                 self.assertEqual(items[6].cvssv3, None)
                 self.assertEqual(items[6].cvssv3_score, None)
-                self.assertEqual(items[6].file_path, "adapter-ear2.ear: dom4j-2.1.1.jar")
                 self.assertEqual(
-                    items[6].mitigation,
-                    "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
+                    items[6].mitigation, "Update jquery:3.1.1 to at least the version recommended in the description",
                 )
-                self.assertEqual(1, len(items[6].unsaved_vulnerability_ids))
-                self.assertEqual("CVE-0000-0001", items[6].unsaved_vulnerability_ids[0])
 
             with self.subTest(i=7):
-                # identifier -> maven java
-                self.assertEqual(items[7].title, "dom4j:2.1.1 | CVE-0000-0001")
-                self.assertEqual(items[7].component_name, "dom4j")
-                self.assertEqual(items[7].component_version, "2.1.1")
-                self.assertEqual(items[7].severity, "High")
-                self.assertEqual(items[7].cvssv3, None)
-                self.assertEqual(items[7].cvssv3_score, None)
-                self.assertEqual(
-                    items[7].mitigation, "Update dom4j:2.1.1 to at least the version recommended in the description",
-                )
-
-            with self.subTest(i=8):
-                # evidencecollected -> single product + single verison javascript
-                self.assertEqual(
-                    items[8].title,
-                    "jquery:3.1.1 | CVE-0000-0001",
-                )
-                self.assertEqual(items[8].component_name, "jquery")
-                self.assertEqual(items[8].component_version, "3.1.1")
-                self.assertEqual(items[8].severity, "High")
-                self.assertEqual(items[8].cvssv3, None)
-                self.assertEqual(items[8].cvssv3_score, None)
-                self.assertEqual(
-                    items[8].mitigation, "Update jquery:3.1.1 to at least the version recommended in the description",
-                )
-
-            with self.subTest(i=9):
                 # Tests for two suppressed vulnerabilities,
                 # One for Suppressed with notes, the other is without.
-                self.assertEqual(items[9].active, False)
+                self.assertEqual(items[7].active, False)
                 self.assertEqual(
-                    items[9].mitigation,
+                    items[7].mitigation,
                     "**This vulnerability is mitigated and/or suppressed:** Document on why we are suppressing this vulnerability is missing!\nUpdate jquery:3.1.1 to at least the version recommended in the description",
                 )
-                self.assertEqual(items[9].unsaved_tags, ["no_suppression_document", "suppressed"])
-                self.assertEqual(items[9].severity, "Critical")
-                self.assertEqual(items[9].cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
-                self.assertEqual(items[9].cvssv3_score, 9.8)
-                self.assertEqual(items[9].is_mitigated, True)
+                self.assertEqual(items[7].unsaved_tags, ["no_suppression_document", "suppressed"])
+                self.assertEqual(items[7].severity, "Critical")
+                self.assertEqual(items[7].cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+                self.assertEqual(items[7].cvssv3_score, 9.8)
+                self.assertEqual(items[7].is_mitigated, True)
 
-            with self.subTest(i=10):
-                self.assertEqual(items[10].active, False)
+            with self.subTest(i=8):
+                self.assertEqual(items[8].active, False)
                 self.assertEqual(
-                    items[10].mitigation,
+                    items[8].mitigation,
                     "**This vulnerability is mitigated and/or suppressed:** This is our reason for not to upgrade it.\nUpdate jquery:3.1.1 to at least the version recommended in the description",
                 )
-                self.assertEqual(items[10].unsaved_tags, ["suppressed"])
-                self.assertEqual(items[10].severity, "Critical")
-                self.assertEqual(items[10].cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
-                self.assertEqual(items[10].cvssv3_score, 9.8)
-                self.assertEqual(items[10].is_mitigated, True)
+                self.assertEqual(items[8].unsaved_tags, ["suppressed"])
+                self.assertEqual(items[8].severity, "Critical")
+                self.assertEqual(items[8].cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+                self.assertEqual(items[8].cvssv3_score, 9.8)
+                self.assertEqual(items[8].is_mitigated, True)
 
     def test_parse_java_6_5_3(self):
         """Test with version 6.5.3"""
@@ -303,7 +263,7 @@ class TestDependencyCheckParser(DojoTestCase):
             parser = DependencyCheckParser()
             findings = parser.get_findings(testfile, Test())
             items = findings
-            self.assertEqual(37, len(items))
+            self.assertEqual(34, len(items))
             # test also different component_name formats
 
             with self.subTest(i=0):


### PR DESCRIPTION
## Summary

- The Dependency Check parser previously emitted one finding per `<relatedDependency>` in the report, in addition to the finding for the main vulnerable dependency. Because OWASP Dependency-Check attaches the vulnerability only to the main dependency in the XML and the related entries are metadata pointing to other files in the same logical component, this produced N findings sharing the same title, CVE, component name and component version — only the file path differed. Issues such as duplicated Spring Boot or ActiveMQ findings stem from this.
- This change folds related dependency file paths into the main finding's description (under a `**Related Filepaths:**` block) and stops emitting one finding per related entry. The `related` tag is no longer applied because no separate related findings are created.
- Adds an explanation of the five `DependencyBundlingAnalyzer` scenarios (`hashesMatch`, `isShadedJar`, `isWebJar`, CPE+base-path+vulns+filename sibling match, NPM same name+version) as a docstring on the new helper in the parser, in the parser documentation page, and in the 2.59.1 upgrade notes.
- Updates the `multiple_vulnerabilities_has_multiple_findings` unit test from 11 findings to 9 and adds assertions for the `**Related Filepaths:**` block on the affected finding.
- Adds `docs/content/releases/os_upgrading/2.59.1.md` with required-actions guidance (saved filters referencing the `related` tag will need updating; on the next reimport the previously created `related` findings will be closed as no longer present).

### Background

Dependency-Check's `DependencyBundlingAnalyzer.evaluateDependencies` merges co-grouped artifacts into a main dependency under five scenarios. Only scenario 1 (`hashesMatch`) represents the same vulnerable artifact at multiple deploy locations; scenarios 2-5 are different files representing one logical component. The XML attaches the vulnerability only to the main dependency in every case, so emitting per-related-dependency findings inflated a single CVE into N near-duplicates regardless of which scenario produced the bundling.

### Files

- `dojo/tools/dependency_check/parser.py` — drop the per-related-dependency loop in `get_findings`; add `build_related_dependencies_block` helper; append the block to the main finding's description.
- `unittests/tools/test_dependency_check_parser.py` — adjust expected count from 11 to 9; add `**Related Filepaths:**` assertions on the affected finding; shift remaining item indices.
- `docs/content/supported_tools/parsers/file/dependency_check.md` — document the new behavior and the five bundling scenarios.
- `docs/content/releases/os_upgrading/2.59.1.md` — upgrade notes for the parser behavior change.
