### PR TITLE
fix 500 error on critical product metrics page

### DIFF
--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -147,9 +147,11 @@
                         </h3>
                     </div>
                 </div>
+                {% if form %}
                 <div id="the-filters" class="is-filters panel-body collapse">
                     {% include "dojo/filter_snippet.html" with form=form clear_link="/metrics/product/type" %}
                 </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/dojo/templates_classic/dojo/metrics.html
+++ b/dojo/templates_classic/dojo/metrics.html
@@ -155,9 +155,11 @@
                         </h3>
                     </div>
                 </div>
+                {% if form %}
                 <div id="the-filters" class="is-filters panel-body collapse">
                     {% include "dojo/filter_snippet.html" with form=form clear_link="/metrics/product/type" %}
                 </div>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary

- `critical_product_metrics` view renders `metrics.html` without a `form` context variable
- Django resolves undefined template variables as empty string `""`
- `filter_snippet.html` calls `{% get_filter_groups form %}` unconditionally, which crashes with `AttributeError: 'str' object has no attribute 'visible_fields'`
- Fix: wrap the `filter_snippet.html` include in `{% if form %}` in both `metrics.html` and `metrics_classic/metrics.html`
- The filter UI was already intentionally hidden for this view (filter button guarded by `{% if not critical_prods %}`); the filter content div just wasn't guarded

Fixes #14944
