### PR TITLE
feat: allow users to request peer review from themselves

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2176,16 +2176,13 @@ class ReviewFindingForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         finding = kwargs.pop("finding", None)
-        user = kwargs.pop("user", None)
+        kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
         # Get the list of users
         if finding is not None:
             users = get_authorized_users_for_product_and_product_type(None, finding.test.engagement.product, "edit")
         else:
             users = get_authorized_users("edit").filter(is_active=True)
-        # Remove the current user
-        if user is not None:
-            users = users.exclude(id=user.id)
         # Save a copy of the original query to be used in the validator
         self.reviewer_queryset = users
         # Set the users in the form


### PR DESCRIPTION
## Summary

Until now it has not been possible for users to request a peer review from themselves. This might have been a valid restriction in the past in older workflows. Right now I think it's not needed to exclude the logged in user. It's quite common I think for users to login to dojo to see the new findings from last night scans and request review from peers on some findings. Or just request review from themselves to make it clear the finding is being looked at.

- Removes the exclusion of the current user from the reviewer dropdown in `ReviewFindingForm`
- Users can now select themselves when requesting a peer review, addressing the request in #14942

Closes #14942