### PR TITLE
test(perf) on bugfix: re-enable import performance tests with recalibrated query counts

### DIFF
--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -20,7 +20,6 @@ Always verify updated counts by:
 
 import logging
 from contextlib import contextmanager
-from unittest import skip
 from unittest.mock import patch
 
 from crum import impersonate
@@ -275,11 +274,6 @@ class TestDojoImporterPerformanceBase(DojoTestCase):
         self.assertGreater(len_closed_findings4, 0, "Step 4 (empty reimport with close_old_findings=True) should close findings")
 
 
-@skip("Re-baseline pending: Track B legacy authorization reduces auth-layer query "
-      "overhead (no per-action role-permission lookups, simpler permission_to_action "
-      "dispatch). Expected query counts here were calibrated under RBAC and are "
-      "consistently 1-7 queries higher than legacy actual. Re-baseline with a fresh "
-      "calibration run after the upstream merge.")
 @tag("performance")
 @skip_unless_v2
 class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
@@ -349,13 +343,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=171,
+            expected_num_queries1=170,
             expected_num_async_tasks1=2,
-            expected_num_queries2=124,
+            expected_num_queries2=123,
             expected_num_async_tasks2=1,
-            expected_num_queries3=29,
+            expected_num_queries3=28,
             expected_num_async_tasks3=1,
-            expected_num_queries4=100,
+            expected_num_queries4=99,
             expected_num_async_tasks4=0,
         )
 
@@ -373,13 +367,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=187,
+            expected_num_queries1=184,
             expected_num_async_tasks1=2,
-            expected_num_queries2=132,
+            expected_num_queries2=131,
             expected_num_async_tasks2=1,
-            expected_num_queries3=37,
+            expected_num_queries3=36,
             expected_num_async_tasks3=1,
-            expected_num_queries4=100,
+            expected_num_queries4=99,
             expected_num_async_tasks4=0,
         )
 
@@ -398,13 +392,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=197,
+            expected_num_queries1=194,
             expected_num_async_tasks1=4,
-            expected_num_queries2=142,
+            expected_num_queries2=141,
             expected_num_async_tasks2=3,
-            expected_num_queries3=44,
+            expected_num_queries3=43,
             expected_num_async_tasks3=3,
-            expected_num_queries4=109,
+            expected_num_queries4=108,
             expected_num_async_tasks4=2,
         )
 
@@ -530,9 +524,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=110,
+            expected_num_queries1=109,
             expected_num_async_tasks1=2,
-            expected_num_queries2=90,
+            expected_num_queries2=89,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -551,18 +545,15 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=126,
+            expected_num_queries1=123,
             expected_num_async_tasks1=2,
-            expected_num_queries2=107,
+            expected_num_queries2=104,
             expected_num_async_tasks2=2,
         )
 
 
 @tag("performance")
 @override_settings(V3_FEATURE_LOCATIONS=True)
-@skip("Re-baseline pending: same RBAC→legacy query-count drift as "
-      "TestDojoImporterPerformanceSmall. See that class's skip note for the "
-      "rationale.")
 class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase):
 
     r"""
@@ -642,13 +633,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=178,
+            expected_num_queries1=177,
             expected_num_async_tasks1=2,
-            expected_num_queries2=133,
+            expected_num_queries2=132,
             expected_num_async_tasks2=1,
-            expected_num_queries3=37,
+            expected_num_queries3=36,
             expected_num_async_tasks3=1,
-            expected_num_queries4=101,
+            expected_num_queries4=100,
             expected_num_async_tasks4=0,
         )
 
@@ -666,13 +657,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=196,
+            expected_num_queries1=193,
             expected_num_async_tasks1=2,
-            expected_num_queries2=143,
+            expected_num_queries2=142,
             expected_num_async_tasks2=1,
-            expected_num_queries3=47,
+            expected_num_queries3=46,
             expected_num_async_tasks3=1,
-            expected_num_queries4=101,
+            expected_num_queries4=100,
             expected_num_async_tasks4=0,
         )
 
@@ -691,13 +682,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=209,
+            expected_num_queries1=206,
             expected_num_async_tasks1=4,
-            expected_num_queries2=156,
+            expected_num_queries2=155,
             expected_num_async_tasks2=3,
-            expected_num_queries3=54,
+            expected_num_queries3=53,
             expected_num_async_tasks3=3,
-            expected_num_queries4=113,
+            expected_num_queries4=112,
             expected_num_async_tasks4=2,
         )
 
@@ -798,9 +789,9 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=117,
+            expected_num_queries1=116,
             expected_num_async_tasks1=2,
-            expected_num_queries2=93,
+            expected_num_queries2=92,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -818,8 +809,8 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=135,
+            expected_num_queries1=132,
             expected_num_async_tasks1=2,
-            expected_num_queries2=218,
+            expected_num_queries2=215,
             expected_num_async_tasks2=2,
         )


### PR DESCRIPTION
## Summary

- Re-enables `TestDojoImporterPerformanceSmall` and `TestDojoImporterPerformanceSmallLocations` which were skipped pending re-baseline after the RBAC→legacy authorization migration
- Recalibrates expected query counts: legacy auth has lower per-action overhead (no role-permission lookups, simpler dispatch), so all counts decreased by 1–7 queries per step
- Removes the unused `unittest.skip` import