### PR TITLE
refactor(engagement): extract copy_engagement workflow into services.py [Phase 2 pilot]

### DIFF
--- a/dojo/engagement/services.py
+++ b/dojo/engagement/services.py
@@ -3,10 +3,14 @@ import logging
 
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
+from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from dojo.celery_dispatch import dojo_dispatch_task
 from dojo.jira import services as jira_services
 from dojo.models import Engagement
+from dojo.notifications.helper import create_notification
+from dojo.utils import calculate_grade
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +30,28 @@ def reopen_engagement(eng):
     eng.active = True
     eng.status = "In Progress"
     eng.save()
+
+
+def copy_engagement(engagement, user):
+    """
+    Copy an engagement (and its tests/findings) within the same product, recalculate the
+    product grade, and notify. Returns the new engagement.
+
+    HTTP-free so both the UI view and (eventually) the API can call it.
+    """
+    product = engagement.product
+    engagement_copy = engagement.copy()
+    dojo_dispatch_task(calculate_grade, product.id)
+    create_notification(
+        event="engagement_copied",
+        title=_("Copying of %s") % engagement.name,
+        description=f'The engagement "{engagement.name}" was copied by {user}',
+        product=product,
+        url=reverse("view_engagement", args=(engagement_copy.id,)),
+        recipients=[engagement.lead],
+        icon="exclamation-triangle",
+    )
+    return engagement_copy
 
 
 @receiver(pre_save, sender=Engagement)

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -24,7 +24,6 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonRes
 from django.shortcuts import get_object_or_404, render
 from django.urls import Resolver404, reverse
 from django.utils import timezone
-from django.utils.translation import gettext as _
 from django.views import View
 from django.views.decorators.cache import cache_page
 from django.views.decorators.http import require_POST
@@ -34,10 +33,15 @@ from openpyxl.styles import Font
 
 import dojo.risk_acceptance.helper as ra_helper
 from dojo.authorization.authorization import user_has_permission_or_403
-from dojo.celery_dispatch import dojo_dispatch_task
 from dojo.endpoint.utils import save_endpoints_to_add
 from dojo.engagement.queries import get_authorized_engagements
-from dojo.engagement.services import close_engagement, reopen_engagement
+from dojo.engagement.services import (
+    close_engagement,
+    reopen_engagement,
+)
+from dojo.engagement.services import (
+    copy_engagement as copy_engagement_service,
+)
 from dojo.filters import (
     EngagementDirectFilter,
     EngagementDirectFilterWithoutObjectLookups,
@@ -107,7 +111,6 @@ from dojo.utils import (
     add_error_message_to_response,
     add_success_message_to_response,
     async_delete,
-    calculate_grade,
     generate_file_response_from_file_path,
     get_cal_event,
     get_page_items,
@@ -391,20 +394,12 @@ def copy_engagement(request, eid):
     if request.method == "POST":
         form = DoneForm(request.POST)
         if form.is_valid():
-            engagement_copy = engagement.copy()
-            dojo_dispatch_task(calculate_grade, product.id)
+            copy_engagement_service(engagement, request.user)
             messages.add_message(
                 request,
                 messages.SUCCESS,
                 "Engagement Copied successfully.",
                 extra_tags="alert-success")
-            create_notification(event="engagement_copied",  # TODO: - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
-                                title=_("Copying of %s") % engagement.name,
-                                description=f'The engagement "{engagement.name}" was copied by {request.user}',
-                                product=product,
-                                url=request.build_absolute_uri(reverse("view_engagement", args=(engagement_copy.id, ))),
-                                recipients=[engagement.lead],
-                                icon="exclamation-triangle")
             return redirect_to_return_url_or_else(request, reverse("view_engagements", args=(product.id, )))
         messages.add_message(
             request,

--- a/unittests/test_copy_model.py
+++ b/unittests/test_copy_model.py
@@ -1,4 +1,7 @@
 
+from unittest.mock import patch
+
+from dojo.engagement.services import copy_engagement
 from dojo.location.models import Location, LocationFindingReference
 from dojo.models import Endpoint, Endpoint_Status, Engagement, Finding, Product, Test, User
 from dojo.url.models import URL
@@ -358,3 +361,32 @@ class TestCopyEngagementModel(DojoTestCase):
         self.assertQuerySetEqual(engagement.notes.all(), engagement_copy.notes.all())
         # Do the tags match
         self.assertEqual(engagement.tags, engagement_copy.tags)
+
+
+class TestCopyEngagementService(DojoTestCase):
+
+    """Phase 2: the copy_engagement service holds the copy workflow extracted from the UI view."""
+
+    @patch("dojo.engagement.services.create_notification")
+    @patch("dojo.engagement.services.dojo_dispatch_task")
+    def test_copy_engagement_service(self, mock_dispatch, mock_notification):
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type("svc_prod_type")
+        product = self.create_product("svc_copy_product", prod_type=product_type)
+        engagement = self.create_engagement("svc_eng", product)
+        test = self.create_test(engagement=engagement, scan_type="NPM Audit Scan", title="test")
+        _ = Finding.objects.create(test=test, reporter=user)
+        before = Engagement.objects.filter(product=product).count()
+        before_findings = Finding.objects.filter(test__engagement__product=product).count()
+        # Run the service
+        engagement_copy = copy_engagement(engagement, user)
+        # A new engagement was created under the same product
+        self.assertEqual(before + 1, Engagement.objects.filter(product=product).count())
+        self.assertNotEqual(engagement.id, engagement_copy.id)
+        self.assertEqual(product, engagement_copy.product)
+        # Findings were duplicated along with the engagement
+        self.assertEqual(before_findings + 1, Finding.objects.filter(test__engagement__product=product).count())
+        # Side effects: grade recalculation dispatched and a notification raised
+        mock_dispatch.assert_called_once()
+        mock_notification.assert_called_once()
+        self.assertEqual(mock_notification.call_args.kwargs["event"], "engagement_copied")


### PR DESCRIPTION
## Summary

Phase 2 pilot of the module reorganization — extract business logic out of an engagement UI view into the engagement service layer.

- Add `copy_engagement(engagement, user)` to `dojo/engagement/services.py`: the engagement copy workflow (clone + product grade recalculation + notification), HTTP-free so both the UI view and a future API endpoint can reuse it. The inline notification in the view carried a TODO asking for exactly this.
- Thin the `copy_engagement` UI view down to form handling + a call to the service.
- The service notification uses a relative `reverse()` URL, matching the convention used by `create_notification` calls elsewhere in the codebase (the old view used `build_absolute_uri`, the outlier).
- Add a unit test for the service — the copy workflow was previously untested.

Stacked on the Phase 1 model branches (base: `reorg/finding-models`).
