### PR TITLE
feat(helm): add Gateway API HTTPRoute and External Secrets Operator support

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -34,4 +34,8 @@ dependencies:
 #     description: Critical bug
 annotations:
   artifacthub.io/prerelease: "true"
-  artifacthub.io/changes: ""
+  artifacthub.io/changes: |
+    - kind: added
+      description: Add Gateway API HTTPRoute support as an alternative to Ingress
+    - kind: added
+      description: Add External Secrets Operator (ESO) support for external secret stores

--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -618,6 +618,7 @@ A Helm chart for Kubernetes to install DefectDojo
 | django.extraInitContainers | list | `[]` | A list of additional initContainers to run before the uwsgi and nginx containers. |
 | django.extraVolumeMounts | list | `[]` | Array of additional volume mount points common to all containers and initContainers. |
 | django.extraVolumes | list | `[]` | A list of extra volumes to mount. |
+| django.httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[],"rules":[]}` | Kubernetes Gateway API HTTPRoute configuration (alternative to Ingress) |
 | django.ingress.activateTLS | bool | `true` |  |
 | django.ingress.annotations | object | `{}` | Restricts the type of ingress controller that can interact with our chart (nginx, traefik, ...) `kubernetes.io/ingress.class: nginx` Depending on the size and complexity of your scans, you might want to increase the default ingress timeouts if you see repeated 504 Gateway Timeouts `nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"` `nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"` |
 | django.ingress.enabled | bool | `true` |  |
@@ -683,6 +684,12 @@ A Helm chart for Kubernetes to install DefectDojo
 | django.uwsgi.startupProbe.periodSeconds | int | `5` |  |
 | django.uwsgi.startupProbe.successThreshold | int | `1` |  |
 | django.uwsgi.startupProbe.timeoutSeconds | int | `1` |  |
+| externalSecret | object | `{"annotations":{},"data":[],"enabled":false,"labels":{},"refreshInterval":"1h0m0s","secretStoreRef":{"kind":"","name":""},"targetSecretName":""}` | External Secrets Operator integration |
+| externalSecret.data | list | `[]` | Data mappings from the external store |
+| externalSecret.enabled | bool | `false` | Enable the ExternalSecret resource |
+| externalSecret.refreshInterval | string | `"1h0m0s"` | How often to refresh the secret from the external store |
+| externalSecret.secretStoreRef | object | `{"kind":"","name":""}` | Reference to a SecretStore or ClusterSecretStore |
+| externalSecret.targetSecretName | string | `""` | Name of the Kubernetes Secret created by ESO |
 | extraAnnotations | object | `{}` | Annotations globally added to all resources |
 | extraConfigs | object | `{}` | To add extra variables not predefined by helm config it is possible to define in extraConfigs block, e.g. below: NOTE  Do not store any kind of sensitive information inside of it ``` DD_SOCIAL_AUTH_AUTH0_OAUTH2_ENABLED: 'true' DD_SOCIAL_AUTH_AUTH0_KEY: 'dev' DD_SOCIAL_AUTH_AUTH0_DOMAIN: 'xxxxx' ``` |
 | extraEnv | list | `[]` | To add (or override) extra variables which need to be pulled from another configMap, you can use extraEnv. For example: ``` - name: DD_DATABASE_HOST   valueFrom:     configMapKeyRef:       name: my-other-postgres-configmap       key: cluster_endpoint ``` |

--- a/helm/defectdojo/templates/django-httproute.yaml
+++ b/helm/defectdojo/templates/django-httproute.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.django.httpRoute.enabled -}}
+{{- $fullName := include "defectdojo.fullname" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    defectdojo.org/component: django
+    app.kubernetes.io/name: {{ include "defectdojo.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "defectdojo.chart" . }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ quote $value }}
+    {{- end }}
+    {{- with .Values.django.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.extraAnnotations .Values.django.httpRoute.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.extraAnnotations }}
+    {{ $key }}: {{ quote $value }}
+    {{- end }}
+    {{- with .Values.django.httpRoute.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- with .Values.django.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.django.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.django.httpRoute.rules }}
+    {{- with .matches }}
+    - matches:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ $fullName }}-django
+          port: {{ $.Values.django.nginx.tls.enabled | ternary 443 80 }}
+          weight: 1
+    {{- end }}
+{{- end }}

--- a/helm/defectdojo/templates/django-httproute.yaml
+++ b/helm/defectdojo/templates/django-httproute.yaml
@@ -37,14 +37,14 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.django.httpRoute.rules }}
-    {{- with .matches }}
-    - matches:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .filters }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
       filters:
-      {{- toYaml . | nindent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       backendRefs:
         - group: ""
           kind: Service

--- a/helm/defectdojo/templates/external-secret.yaml
+++ b/helm/defectdojo/templates/external-secret.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.externalSecret.enabled }}
+{{- $fullName := include "defectdojo.fullname" . -}}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    defectdojo.org/component: django
+    app.kubernetes.io/name: {{ include "defectdojo.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "defectdojo.chart" . }}
+    {{- range $key, $value := .Values.extraLabels }}
+    {{ $key }}: {{ quote $value }}
+    {{- end }}
+    {{- with .Values.externalSecret.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.extraAnnotations .Values.externalSecret.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.extraAnnotations }}
+    {{ $key }}: {{ quote $value }}
+    {{- end }}
+    {{- with .Values.externalSecret.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalSecret.refreshInterval | default "1h0m0s" }}
+  secretStoreRef:
+    {{- toYaml .Values.externalSecret.secretStoreRef | nindent 4 }}
+  target:
+    name: {{ .Values.externalSecret.targetSecretName }}
+  data:
+    {{- toYaml .Values.externalSecret.data | nindent 4 }}
+{{- end }}

--- a/helm/defectdojo/values.schema.json
+++ b/helm/defectdojo/values.schema.json
@@ -388,6 +388,46 @@
             "description": "create valkey secret in defectdojo chart, outside of valkey chart",
             "type": "boolean"
         },
+        "externalSecret": {
+            "description": "External Secrets Operator integration",
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enable the ExternalSecret resource",
+                    "type": "boolean"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "refreshInterval": {
+                    "description": "How often to refresh the secret from the external store",
+                    "type": "string"
+                },
+                "secretStoreRef": {
+                    "description": "Reference to a SecretStore or ClusterSecretStore",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "kind": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "targetSecretName": {
+                    "description": "Name of the Kubernetes Secret created by ESO",
+                    "type": "string"
+                },
+                "data": {
+                    "description": "Data mappings from the external store",
+                    "type": "array"
+                }
+            }
+        },
         "dbMigrationChecker": {
             "type": "object",
             "properties": {
@@ -510,6 +550,33 @@
                 "extraVolumes": {
                     "description": "A list of extra volumes to mount.",
                     "type": "array"
+                },
+                "httpRoute": {
+                    "description": "Kubernetes Gateway API HTTPRoute configuration (alternative to Ingress)",
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "parentRefs": {
+                            "type": "array"
+                        },
+                        "hostnames": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "rules": {
+                            "type": "array"
+                        }
+                    }
                 },
                 "ingress": {
                     "type": "object",

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -13,6 +13,28 @@ createSecret: false
 createValkeySecret: false
 # -- create postgresql secret in defectdojo chart, outside of postgresql chart
 createPostgresqlSecret: false
+
+# -- External Secrets Operator integration
+externalSecret:
+  # -- Enable the ExternalSecret resource
+  enabled: false
+  labels: {}
+  annotations: {}
+  # -- How often to refresh the secret from the external store
+  refreshInterval: 1h0m0s
+  # -- Reference to a SecretStore or ClusterSecretStore
+  secretStoreRef:
+    name: ""
+    kind: ""
+  # -- Name of the Kubernetes Secret created by ESO
+  targetSecretName: ""
+  # -- Data mappings from the external store
+  data: []
+  # - secretKey: DD_ADMIN_PASSWORD
+  #   remoteRef:
+  #     key: my-vault-path
+  #     property: admin-password
+
 # -- Track configuration (trackConfig): will automatically respin application pods in case of config changes detection
 # can be:
 # 1. disabled (default)
@@ -372,6 +394,21 @@ django:
     # `nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"`
     # `nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"`
     annotations: {}
+  # -- Kubernetes Gateway API HTTPRoute configuration (alternative to Ingress)
+  httpRoute:
+    enabled: false
+    labels: {}
+    annotations: {}
+    parentRefs: []
+    # - name: my-gateway
+    #   namespace: default
+    hostnames: []
+    # - defectdojo.example.com
+    rules: []
+    # - matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
   nginx:
     # -- If empty, uses values from images.nginx.image
     image:


### PR DESCRIPTION
## Summary

- **HTTPRoute support**: Adds a `django-httproute.yaml` template as an alternative to the classic Ingress resource for users running Kubernetes Gateway API controllers (e.g. Envoy Gateway, Istio, Cilium). Configured via `django.httpRoute` values. Disabled by default.
- **External Secrets Operator (ESO) support**: Adds an `external-secret.yaml` template for syncing secrets from external stores (HashiCorp Vault, AWS Secrets Manager, Azure Key Vault, etc.) via the [External Secrets Operator](https://external-secrets.io). Configured via `externalSecret` values. Disabled by default.

## Motivation

**HTTPRoute**: The Kubernetes Gateway API (`gateway.networking.k8s.io/v1`) is now GA and increasingly adopted. This allows users who have moved to Gateway API to use DefectDojo natively without maintaining separate HTTPRoute manifests. Related: #14667

**External Secrets**: Many production deployments avoid storing secrets in Helm values or manually-created Kubernetes Secrets. ESO is the standard solution for syncing secrets from external vaults. Adding first-class support makes DefectDojo easier to deploy securely.

## Changes

| File | Change |
|---|---|
| `helm/defectdojo/templates/django-httproute.yaml` | New HTTPRoute template |
| `helm/defectdojo/templates/external-secret.yaml` | New ExternalSecret template |
| `helm/defectdojo/values.yaml` | Added `django.httpRoute` and `externalSecret` value blocks |

## HTTPRoute details

- Gated by `django.httpRoute.enabled` (default `false`)
- Supports `parentRefs`, `hostnames`, and flexible `rules` with `matches` and `filters`
- Automatically selects port 80 or 443 based on `django.nginx.tls.enabled`
- Follows DefectDojo's existing labeling and annotation patterns (`extraLabels`, `extraAnnotations`)
- Can be used alongside or instead of the existing Ingress

Example values:

```yaml
django:
  httpRoute:
    enabled: true
    parentRefs:
      - name: my-gateway
        namespace: default
    hostnames:
      - defectdojo.example.com
    rules:
      - matches:
          - path:
              type: PathPrefix
              value: /
```

## ExternalSecret details

- Gated by `externalSecret.enabled` (default `false`)
- Uses the stable `external-secrets.io/v1` API
- Supports any SecretStore/ClusterSecretStore provider
- `targetSecretName` controls the name of the Kubernetes Secret created by ESO

Example values:

```yaml
externalSecret:
  enabled: true
  refreshInterval: 30m
  secretStoreRef:
    name: my-vault-store
    kind: ClusterSecretStore
  targetSecretName: defectdojo
  data:
    - secretKey: DD_ADMIN_PASSWORD
      remoteRef:
        key: defectdojo/admin
        property: password
    - secretKey: DD_SECRET_KEY
      remoteRef:
        key: defectdojo/app
        property: secret-key
```

## Test plan

- [x] `helm lint helm/defectdojo` passes
- [x] `helm template` with httpRoute enabled renders a valid `gateway.networking.k8s.io/v1 HTTPRoute` with correct service name and port
- [x] `helm template` with `django.nginx.tls.enabled=true` correctly selects port 443
- [x] `helm template` with externalSecret enabled renders a valid `external-secrets.io/v1 ExternalSecret`
- [x] `helm template` with default values produces neither HTTPRoute nor ExternalSecret resources