### PR TITLE
refactor(ui): use design tokens instead of hardcoded colors on new lo…

### DIFF
--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -11,12 +11,12 @@
         align-items: center;
         justify-content: center;
         padding: 2rem 1rem;
-        background: linear-gradient(135deg, #e8f3fb 0%, #f7f8f9 50%, #fff 100%);
+        background: linear-gradient(135deg, var(--color-dd-primary-50) 0%, var(--color-surface-2) 50%, var(--color-surface) 100%);
     }
     .login-card {
         width: 100%;
         max-width: 26rem;
-        background: white;
+        background: var(--color-surface);
         border-radius: 0.75rem;
         box-shadow: 0 4px 6px -1px rgba(0,0,0,0.07), 0 10px 15px -3px rgba(0,0,0,0.05), 0 0 0 1px rgba(0,0,0,0.03);
         padding: 2.5rem 2rem;
@@ -33,14 +33,14 @@
         text-align: center;
         font-size: 1.375rem;
         font-weight: 600;
-        color: #191919;
+        color: var(--color-text);
         margin-bottom: 0.25rem;
         letter-spacing: -0.01em;
     }
     .login-card .login-subtitle {
         text-align: center;
         font-size: 0.875rem;
-        color: #666666;
+        color: var(--color-text-muted);
         margin-bottom: 1.75rem;
     }
     .login-card .form-group {
@@ -55,12 +55,12 @@
     .login-card .form-control {
         height: 2.75rem;
         font-size: 0.9375rem;
-        border-color: #DCDCDC;
+        border-color: var(--color-border);
         border-radius: 0.5rem;
         transition: border-color 150ms, box-shadow 150ms;
     }
     .login-card .form-control:focus {
-        border-color: #1779C5;
+        border-color: var(--color-dd-primary-500);
         box-shadow: 0 0 0 3px rgba(23, 121, 197, 0.12);
     }
     .login-btn {
@@ -69,13 +69,13 @@
         font-size: 0.9375rem;
         font-weight: 600;
         border-radius: 0.5rem;
-        background: #1779C5;
+        background: var(--color-dd-primary-500);
         color: white;
         border: none;
         transition: background-color 150ms, transform 100ms, box-shadow 150ms;
     }
     .login-btn:hover {
-        background: #204D87;
+        background: var(--color-dd-primary-700);
         box-shadow: 0 2px 8px rgba(0, 56, 100, 0.2);
     }
     .login-btn:active {
@@ -89,11 +89,11 @@
         font-size: 0.8125rem;
     }
     .login-links a {
-        color: #1779C5;
+        color: var(--color-dd-primary-500);
         font-weight: 500;
     }
     .login-links a:hover {
-        color: #204D87;
+        color: var(--color-dd-primary-700);
         text-decoration: underline;
     }
 {% endblock %}


### PR DESCRIPTION
**Description**

The new Tailwind login page (`dojo/templates/dojo/login.html`) hardcoded hex
color values that exactly duplicate the design tokens defined in
`components/tailwind.css` (`@theme`). This swaps them for the corresponding
`var(--color-*)` tokens so the login page stays in sync with the design system
if the palette ever changes, instead of silently drifting.

The compiled token values are byte-identical to the hex they replace, so there
is **no visual change**:

| Was | Now |
| --- | --- |
| `#e8f3fb`, `#f7f8f9`, `#fff` (gradient) | `--color-dd-primary-50`, `--color-surface-2`, `--color-surface` |
| `#191919` / `#666666` | `--color-text` / `--color-text-muted` |
| `#DCDCDC` | `--color-border` |
| `#1779C5` / `#204D87` | `--color-dd-primary-500` / `--color-dd-primary-700` |

`#333333` (control label) and the alpha-channel `rgba()` shadows are left as-is
since they have no exact token equivalent.

**Test results**

Ran the new UI locally (docker dev stack) and loaded `/login`. Verified the
page renders identically and that each token resolves to the exact RGB of the
hex it replaced (e.g. Login button computes `rgb(23,121,197)` = `#1779C5`,
title `rgb(25,25,25)` = `#191919`, input border `rgb(220,220,220)` = `#DCDCDC`).
No functional/Python changes, so no unit tests added.

**Documentation**

N/A — no behavior or documented feature changes.

**Checklist**

- [x] Submitted against `dev` (this is a change, not a bugfix).
- [x] Meaningful PR name.
- [x] Ruff compliant (no Python changed).
- [x] Python 3.13 compliant (no Python changed).
- [ ] New feature docs — N/A.
- [ ] Model migrations — N/A.
- [ ] Unit tests — N/A (template-only, no behavior change).