### PR TITLE
fix(ui): add missing "solid" keyword to disclaimer border in new UI

### DIFF
--- a/dojo/templates/dojo/custom_html_report.html
+++ b/dojo/templates/dojo/custom_html_report.html
@@ -5,7 +5,7 @@
     {{ block.super }}
     <div class="container" id="html_report">
         {% if include_disclaimer %}
-            <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+            <div style="background-color:#DADCE2; border:1px solid #003333; padding:.8em; ">
                 <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">Disclaimer</span><br/>
                 <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ disclaimer | bleach_with_a_tags }}</p>
             </div>

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -79,7 +79,7 @@
             </div>
         {% endif %}
         {% if include_disclaimer%}
-            <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+            <div style="background-color:#DADCE2; border:1px solid #003333; padding:.8em; ">
                 <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">Disclaimer</span><br/>
                 <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ disclaimer | bleach_with_a_tags }}</p>
             </div>

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -158,7 +158,7 @@
             </div>
         {% endif %}
         {% if include_disclaimer%}
-            <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+            <div style="background-color:#DADCE2; border:1px solid #003333; padding:.8em; ">
                 <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">Disclaimer</span><br/>
                 <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ disclaimer | bleach_with_a_tags }}</p>
             </div>

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -55,7 +55,7 @@
             </div>
         {% endif %}
         {% if include_disclaimer%}
-            <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+            <div style="background-color:#DADCE2; border:1px solid #003333; padding:.8em; ">
                 <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">Disclaimer</span><br/>
                 <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ disclaimer | bleach_with_a_tags }}</p>
             </div>

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -248,7 +248,7 @@
                                         <label style="display: block">{% trans "Tags" %}</label>
                                         {{ bulk_edit_form.tags }}
                                         {% if bulk_edit_form.disclaimer %}
-                                            <div style="background-color:#DADCE2; border:1px #003333; padding:.3em; margin:.1em; ">
+                                            <div style="background-color:#DADCE2; border:1px solid #003333; padding:.3em; margin:.1em; ">
                                                 <div style="color:#ff0000;">Disclaimer</div>
                                                 <div>{{ bulk_edit_form.disclaimer }}</div>
                                             </div>

--- a/dojo/templates/dojo/form_fields.html
+++ b/dojo/templates/dojo/form_fields.html
@@ -84,7 +84,7 @@
 {% endfor %}
 
 {% if form.disclaimer %}
-    <div class="form-group" style="background-color:#DADCE2; border:1px #003333; padding:.8em; margin:.8em; ">
+    <div class="form-group" style="background-color:#DADCE2; border:1px solid #003333; padding:.8em; margin:.8em; ">
         <div class="col-sm-2" style="color:#ff0000;">Disclaimer</div>
         <div class="col-sm-10">{{ form.disclaimer }}</div>
     </div>

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -117,7 +117,7 @@
             </div>
         {% endif %}
         {% if include_disclaimer%}
-            <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+            <div style="background-color:#DADCE2; border:1px solid #003333; padding:.8em; ">
                 <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">Disclaimer</span><br/>
                 <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ disclaimer | bleach_with_a_tags }}</p>
             </div>

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -140,7 +140,7 @@
             </div>
         {% endif %}
         {% if include_disclaimer%}
-            <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+            <div style="background-color:#DADCE2; border:1px solid #003333; padding:.8em; ">
                 <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">Disclaimer</span><br/>
                 <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ disclaimer | bleach_with_a_tags }}</p>
             </div>

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -112,7 +112,7 @@
             </div>
         {% endif %}
         {% if include_disclaimer%}
-            <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+            <div style="background-color:#DADCE2; border:1px solid #003333; padding:.8em; ">
                 <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">Disclaimer</span><br/>
                 <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ disclaimer | bleach_with_a_tags }}</p>
             </div>

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -144,7 +144,7 @@
             </div>
         {% endif %}
         {% if include_disclaimer%}
-            <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+            <div style="background-color:#DADCE2; border:1px solid #003333; padding:.8em; ">
                 <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">Disclaimer</span><br/>
                 <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ disclaimer | bleach_with_a_tags }}</p>
             </div>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -867,7 +867,7 @@
                                 {{ bulk_edit_form.media.js }}
                                 {{ bulk_edit_form.tags }}
                                 {% if bulk_edit_form.disclaimer %}
-                                    <div style="background-color:#DADCE2; border:1px #003333; padding:.3em; margin:.1em; ">
+                                    <div style="background-color:#DADCE2; border:1px solid #003333; padding:.3em; margin:.1em; ">
                                         <div style="color:#ff0000;">Disclaimer</div>
                                         <div>{{ bulk_edit_form.disclaimer }}</div>
                                     </div>


### PR DESCRIPTION
**Description**

Fixes an invisible border on the disclaimer warning box throughout the new (Tailwind) UI.

The disclaimer box set its border with `border:1px #003333` — width and color, but no
border-style keyword. Per the CSS spec, `border-style` defaults to `none`, so the border
never renders regardless of width/color. The box was clearly meant to have a border (it
sets both), but none displayed. Adding `solid` makes it render — this applies equally to
the on-screen views and the report/PDF output.

Fixed across `dojo/templates/`:
- Interactive views: `view_test.html`, `form_fields.html`, `findings_list_snippet.html`
- Report templates: `custom_html_report.html` and the `*_pdf_report.html` set (endpoint,
  engagement, finding, product, product_endpoint, product_type, test)

Out of scope (same bug, deliberately separate): the classic UI (`dojo/templates_classic/`,
being deprecated) and the email notification `.tpl` templates (different rendering engine).

**Test results**

One-property CSS correction, no logic change. Confirmed the shorthand was the cause:
`border:1px <color>` computes `border-style:none` / `border-width:0` (no border); adding
`solid` renders a 1px border. Verified the computed values in-browser. No Python changed,
so no unit tests added.

**Documentation**

N/A.

**Checklist**

- [x] Bugfix — submitted against the `bugfix` branch.
- [x] Meaningful PR name.
- [x] Ruff compliant (no Python changed).
- [x] Python 3.13 compliant (no Python changed).