### PR TITLE
fix: prevent 500 on org/product delete with deprecated endpoints, and point new-UI banner at 3.3.0

### DIFF
--- a/dojo/api_v2/mixins.py
+++ b/dojo/api_v2/mixins.py
@@ -8,6 +8,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.decorators import action
 
 from dojo.api_v2 import serializers
+from dojo.models import Endpoint
 
 
 class DeletePreviewModelMixin:
@@ -21,9 +22,10 @@ class DeletePreviewModelMixin:
     def delete_preview(self, request, pk=None):
         obj = self.get_object()
 
-        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-        collector.collect([obj])
-        rels = collector.nested()
+        with Endpoint.allow_endpoint_init():  # TODO: Delete this after the move to Locations
+            collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+            collector.collect([obj])
+            rels = collector.nested()
 
         def flatten(elem):
             if isinstance(elem, list):

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1732,7 +1732,8 @@ class ProductViewSet(
             async_del = async_delete()
             async_del.delete(instance)
         else:
-            instance.delete()
+            with Endpoint.allow_endpoint_init():  # TODO: Delete this after the move to Locations
+                instance.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     # def list(self, request):
@@ -1817,7 +1818,8 @@ class ProductTypeViewSet(
             async_del = async_delete()
             async_del.delete(instance)
         else:
-            instance.delete()
+            with Endpoint.allow_endpoint_init():  # TODO: Delete this after the move to Locations
+                instance.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @extend_schema(

--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -47,7 +47,7 @@ def globalize_vars(request):
             profile_url = ""
         additional_banners.append({
             "source": "ui_toggle",
-            "message": "A redesigned UI is available as a beta opt-in. It will become the default on September 8th in the 2.62.0 release.",
+            "message": "A redesigned UI is available as a beta opt-in. It will become the default on September 8th in the 3.3.0 release.",
             "style": "info",
             "url": profile_url,
             "link_text": "Enable it in your profile.",

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -22,7 +22,7 @@ from dojo.forms import (
     Product_TypeForm,
 )
 from dojo.labels import get_labels
-from dojo.models import Dojo_User, Finding, Product, Product_Type
+from dojo.models import Dojo_User, Endpoint, Finding, Product, Product_Type
 from dojo.product.queries import get_authorized_products
 from dojo.product_type.queries import (
     get_authorized_product_types,
@@ -142,7 +142,8 @@ def delete_product_type(request, ptid):
                     message = labels.ORG_DELETE_SUCCESS_ASYNC_MESSAGE
                 else:
                     message = labels.ORG_DELETE_SUCCESS_MESSAGE
-                    product_type.delete()
+                    with Endpoint.allow_endpoint_init():  # TODO: Delete this after the move to Locations
+                        product_type.delete()
                 messages.add_message(request,
                                      messages.SUCCESS,
                                      message,
@@ -152,9 +153,10 @@ def delete_product_type(request, ptid):
     rels = [_("Previewing the relationships has been disabled."), ""]
     display_preview = get_setting("DELETE_PREVIEW")
     if display_preview:
-        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-        collector.collect([product_type])
-        rels = collector.nested()
+        with Endpoint.allow_endpoint_init():  # TODO: Delete this after the move to Locations
+            collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+            collector.collect([product_type])
+            rels = collector.nested()
 
     add_breadcrumb(title=str(labels.ORG_DELETE_LABEL), top_level=False, request=request)
     return render(request, "dojo/delete_product_type.html", {

--- a/unittests/test_delete_with_endpoints_v3.py
+++ b/unittests/test_delete_with_endpoints_v3.py
@@ -1,0 +1,267 @@
+"""
+Regression tests for the V3_FEATURE_LOCATIONS delete-cascade crash.
+
+When ``V3_FEATURE_LOCATIONS`` is enabled the legacy ``Endpoint`` model is deprecated and
+``Endpoint.__init__`` raises ``NotImplementedError``. Django's delete machinery hydrates
+related ``Endpoint`` rows via ``Model.from_db()`` -- both ``NestedObjects.collect()`` (the
+delete preview) and the real cascade delete -- which previously produced a 500 when deleting
+an organization/product that still has endpoints (see Slack #possible-bugs, 2026-06-16).
+
+The fix wraps those delete paths in ``Endpoint.allow_endpoint_init()``. These tests cover
+deletion of every object in the endpoint relation graph (Product_Type, Product, Engagement,
+Test, Finding) via both the UI and the API, plus the delete-preview path for each.
+"""
+import logging
+from types import SimpleNamespace
+
+from django.contrib.auth.models import User
+from django.test import Client, override_settings
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from dojo.models import (
+    Endpoint,
+    Endpoint_Status,
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+    UserContactInfo,
+)
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+@override_settings(
+    V3_FEATURE_LOCATIONS=True,
+    DELETE_PREVIEW=True,
+    ASYNC_OBJECT_DELETE=False,
+)
+class TestDeleteWithEndpointsV3(DojoTestCase):
+
+    """
+    Deleting endpoint-related objects must not 500 when ``V3_FEATURE_LOCATIONS`` is enabled,
+    even though the legacy ``Endpoint`` model is deprecated. ``ASYNC_OBJECT_DELETE=False``
+    forces the synchronous Collector path -- the one that hits the deprecated model.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.admin = User.objects.create(
+            username="test_delete_endpoints_v3_admin",
+            is_staff=True,
+            is_superuser=True,
+        )
+        UserContactInfo.objects.create(user=self.admin, block_execution=True)
+
+        # UI client: session auth (the Django test client does not enforce CSRF).
+        self.ui_client = Client()
+        self.ui_client.force_login(self.admin)
+
+        # API client: token auth, to avoid SessionAuthentication CSRF enforcement on DELETE.
+        token, _ = Token.objects.get_or_create(user=self.admin)
+        self.api_client = APIClient()
+        self.api_client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+
+        # Disable features that add noise/extra work during deletes.
+        self.system_settings(enable_product_grade=False)
+        self.system_settings(enable_github=False)
+        self.system_settings(enable_jira=False)
+
+        self.test_type = Test_Type.objects.get_or_create(name="Manual Test")[0]
+
+    def _build_tree(self, suffix):
+        """Create Product_Type -> Product -> Engagement -> Test -> Finding, plus a legacy
+        Endpoint on the product and an Endpoint_Status linking it to the finding."""
+        product_type = Product_Type.objects.create(name=f"Org with endpoints {suffix}")
+        product = Product.objects.create(
+            name=f"Product with endpoints {suffix}",
+            description="regression fixture",
+            prod_type=product_type,
+        )
+        engagement = Engagement.objects.create(
+            name=f"Engagement {suffix}",
+            product=product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        test = Test.objects.create(
+            engagement=engagement,
+            test_type=self.test_type,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        finding = Finding.objects.create(
+            test=test,
+            title=f"Finding {suffix}",
+            severity="High",
+            description="regression fixture",
+            mitigation="n/a",
+            impact="n/a",
+            reporter=self.admin,
+        )
+        # The Endpoint model is deprecated under V3; constructing/saving it (and walking it
+        # during a cascade delete) requires the escape hatch.
+        with Endpoint.allow_endpoint_init():
+            endpoint = Endpoint(
+                product=product,
+                protocol="https",
+                host=f"host-{suffix}.example.com",
+            )
+            endpoint.save()
+            endpoint_status = Endpoint_Status(endpoint=endpoint, finding=finding)
+            endpoint_status.save()
+
+        return SimpleNamespace(
+            product_type=product_type,
+            product=product,
+            engagement=engagement,
+            test=test,
+            finding=finding,
+            endpoint=endpoint,
+            endpoint_status=endpoint_status,
+        )
+
+    # ------------------------------------------------------------------ delete preview
+
+    def test_ui_delete_pages_render_without_crashing(self):
+        """The UI delete page runs NestedObjects.collect for its preview; it must not crash
+        for any object whose cascade can reach the deprecated Endpoint. (Finding deletion is
+        a POST-only view with no preview page, so it is covered by the API action below.)"""
+        tree = self._build_tree("ui-preview")
+        cases = [
+            ("delete_product_type", "ptid", tree.product_type.id),
+            ("delete_product", "pid", tree.product.id),
+            ("delete_engagement", "eid", tree.engagement.id),
+            ("delete_test", "tid", tree.test.id),
+        ]
+        for ui_name, ui_kwarg, obj_id in cases:
+            with self.subTest(view=ui_name):
+                response = self.ui_client.get(reverse(ui_name, kwargs={ui_kwarg: obj_id}))
+                self.assertEqual(
+                    response.status_code, 200,
+                    f"UI delete page {ui_name} crashed: {response.status_code}",
+                )
+
+    def test_api_delete_preview_without_crashing(self):
+        """The API delete_preview action (shared DeletePreviewModelMixin) runs the same
+        NestedObjects.collect and must not crash for any endpoint-related object."""
+        tree = self._build_tree("api-preview")
+        cases = [
+            ("product_type", tree.product_type.id),
+            ("product", tree.product.id),
+            ("engagement", tree.engagement.id),
+            ("test", tree.test.id),
+            ("finding", tree.finding.id),
+        ]
+        for basename, obj_id in cases:
+            with self.subTest(basename=basename):
+                response = self.api_client.get(
+                    reverse(f"{basename}-delete-preview", kwargs={"pk": obj_id}),
+                )
+                self.assertEqual(
+                    response.status_code, 200,
+                    f"API delete_preview for {basename} crashed: {response.status_code}",
+                )
+
+    # ------------------------------------------------------------------ Product_Type
+
+    def test_delete_product_type_ui(self):
+        tree = self._build_tree("ui-pt")
+        response = self.ui_client.post(
+            reverse("delete_product_type", kwargs={"ptid": tree.product_type.id}),
+            {"id": tree.product_type.id},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Product_Type.objects.filter(pk=tree.product_type.id).exists())
+
+    def test_delete_product_type_api(self):
+        tree = self._build_tree("api-pt")
+        response = self.api_client.delete(
+            reverse("product_type-detail", kwargs={"pk": tree.product_type.id}),
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Product_Type.objects.filter(pk=tree.product_type.id).exists())
+
+    # ------------------------------------------------------------------ Product
+
+    def test_delete_product_ui(self):
+        tree = self._build_tree("ui-prod")
+        response = self.ui_client.post(
+            reverse("delete_product", kwargs={"pid": tree.product.id}),
+            {"id": tree.product.id},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Product.objects.filter(pk=tree.product.id).exists())
+
+    def test_delete_product_api(self):
+        tree = self._build_tree("api-prod")
+        response = self.api_client.delete(
+            reverse("product-detail", kwargs={"pk": tree.product.id}),
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Product.objects.filter(pk=tree.product.id).exists())
+
+    # ------------------------------------------------------------------ Engagement
+
+    def test_delete_engagement_ui(self):
+        tree = self._build_tree("ui-eng")
+        response = self.ui_client.post(
+            reverse("delete_engagement", kwargs={"eid": tree.engagement.id}),
+            {"id": tree.engagement.id},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Engagement.objects.filter(pk=tree.engagement.id).exists())
+
+    def test_delete_engagement_api(self):
+        tree = self._build_tree("api-eng")
+        response = self.api_client.delete(
+            reverse("engagement-detail", kwargs={"pk": tree.engagement.id}),
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Engagement.objects.filter(pk=tree.engagement.id).exists())
+
+    # ------------------------------------------------------------------ Test
+
+    def test_delete_test_ui(self):
+        tree = self._build_tree("ui-test")
+        response = self.ui_client.post(
+            reverse("delete_test", kwargs={"tid": tree.test.id}),
+            {"id": tree.test.id},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Test.objects.filter(pk=tree.test.id).exists())
+
+    def test_delete_test_api(self):
+        tree = self._build_tree("api-test")
+        response = self.api_client.delete(
+            reverse("test-detail", kwargs={"pk": tree.test.id}),
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Test.objects.filter(pk=tree.test.id).exists())
+
+    # ------------------------------------------------------------------ Finding
+
+    def test_delete_finding_ui(self):
+        tree = self._build_tree("ui-find")
+        response = self.ui_client.post(
+            reverse("delete_finding", kwargs={"finding_id": tree.finding.id}),
+            {"id": tree.finding.id},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Finding.objects.filter(pk=tree.finding.id).exists())
+
+    def test_delete_finding_api(self):
+        tree = self._build_tree("api-find")
+        response = self.api_client.delete(
+            reverse("finding-detail", kwargs={"pk": tree.finding.id}),
+        )
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Finding.objects.filter(pk=tree.finding.id).exists())

--- a/unittests/test_delete_with_endpoints_v3.py
+++ b/unittests/test_delete_with_endpoints_v3.py
@@ -78,8 +78,10 @@ class TestDeleteWithEndpointsV3(DojoTestCase):
         self.test_type = Test_Type.objects.get_or_create(name="Manual Test")[0]
 
     def _build_tree(self, suffix):
-        """Create Product_Type -> Product -> Engagement -> Test -> Finding, plus a legacy
-        Endpoint on the product and an Endpoint_Status linking it to the finding."""
+        """
+        Create Product_Type -> Product -> Engagement -> Test -> Finding, plus a legacy
+        Endpoint on the product and an Endpoint_Status linking it to the finding.
+        """
         product_type = Product_Type.objects.create(name=f"Org with endpoints {suffix}")
         product = Product.objects.create(
             name=f"Product with endpoints {suffix}",
@@ -132,9 +134,11 @@ class TestDeleteWithEndpointsV3(DojoTestCase):
     # ------------------------------------------------------------------ delete preview
 
     def test_ui_delete_pages_render_without_crashing(self):
-        """The UI delete page runs NestedObjects.collect for its preview; it must not crash
+        """
+        The UI delete page runs NestedObjects.collect for its preview; it must not crash
         for any object whose cascade can reach the deprecated Endpoint. (Finding deletion is
-        a POST-only view with no preview page, so it is covered by the API action below.)"""
+        a POST-only view with no preview page, so it is covered by the API action below.)
+        """
         tree = self._build_tree("ui-preview")
         cases = [
             ("delete_product_type", "ptid", tree.product_type.id),
@@ -151,8 +155,10 @@ class TestDeleteWithEndpointsV3(DojoTestCase):
                 )
 
     def test_api_delete_preview_without_crashing(self):
-        """The API delete_preview action (shared DeletePreviewModelMixin) runs the same
-        NestedObjects.collect and must not crash for any endpoint-related object."""
+        """
+        The API delete_preview action (shared DeletePreviewModelMixin) runs the same
+        NestedObjects.collect and must not crash for any endpoint-related object.
+        """
         tree = self._build_tree("api-preview")
         cases = [
             ("product_type", tree.product_type.id),


### PR DESCRIPTION
## Summary

This PR contains two related bugfixes targeting the 3.x line.

### 1. Prevent 500 on organization/product delete with deprecated endpoints under `V3_FEATURE_LOCATIONS`

When `V3_FEATURE_LOCATIONS` is enabled, the legacy `Endpoint` model is deprecated and `Endpoint.__init__` raises `NotImplementedError`. Django's delete machinery hydrates cascade-related `Endpoint` rows via `Model.from_db()` (in both the `NestedObjects` delete-preview and the real cascade), so deleting an object that still has legacy Endpoint data raised a 500.

A `Product`/`Product_Type` is what owns `Endpoint` rows, so both are affected by the bug. However:

- **Product (Asset) UI delete was already covered** — `dojo/product/views.py` (`delete_product`) was already wrapped in `Endpoint.allow_endpoint_init()` by an earlier change (commit `50553a3c8c`, "locations: everything else", #14198). It is **not** re-touched here.
- **Product_Type (Organization) UI delete was NOT covered** — this is the reported 500 and the primary fix in this PR (`dojo/product_type/views.py`: both the synchronous delete and the `NestedObjects` preview collect).
- **API delete paths were NOT covered** — this PR also wraps `ProductViewSet.destroy` / `ProductTypeViewSet.destroy` (sync branch) and the shared `DeletePreviewModelMixin.delete_preview`, so the Product/Product_Type **API** delete + delete-preview are fixed here.

Engagement/Test/Finding deletes are intentionally left unwrapped: their cascade only reaches `Endpoint_Status` (whose `__str__` is already self-guarded), never instantiating `Endpoint`.

Test coverage added in `unittests/test_delete_with_endpoints_v3.py` covering UI + API delete and delete-preview for Product_Type, Product, Engagement, Test, and Finding under `V3_FEATURE_LOCATIONS=True`.

### 2. Point the new-UI adoption banner at the 3.3.0 release

The new-UI adoption banner (rendered via `dojo/context_processors.py`) referenced the **2.62.0** release, which no longer exists after the release line was renumbered from 2.x to 3.x. Per the repo's GitHub release milestones, the **September 8th** minor release is now **3.3.0** (due 2026-09-08). The date in the banner is still correct — only the version string was stale — so this updates `2.62.0` → `3.3.0`.

Banner now reads:
> "A redesigned UI is available as a beta opt-in. It will become the default on September 8th in the 3.3.0 release."

## Notes

- The banner is rendered generically from `additional_banners`, so no template changes are needed.
- No tests assert the banner message text (`unittests/test_os_message.py` checks structure/sources only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)