### PR TITLE
feat(jira): support multiple components in project settings (SC-13173)

### DIFF
--- a/docs/content/issue_tracking/jira/OS__jira_guide.md
+++ b/docs/content/issue_tracking/jira/OS__jira_guide.md
@@ -159,7 +159,7 @@ Here is an example of a **jira\_full** Issue:
 
 #### Component
 
-If you manage your Jira Space using Components, you can assign the appropriate Component for DefectDojo here.
+If you manage your Jira Space using Components, you can assign the appropriate Component for DefectDojo here. To assign more than one Component, enter a comma-separated list (for example, `Security, DevSecOps`); each value is sent to Jira as a separate component.
 
 **Custom fields**
 

--- a/docs/content/issue_tracking/jira/PRO__jira_guide.md
+++ b/docs/content/issue_tracking/jira/PRO__jira_guide.md
@@ -126,7 +126,7 @@ Here is an example of a **jira\_full** Issue:
 
 #### Component
 
-If you manage your Jira Space using Components, you can assign the appropriate Component for DefectDojo here.
+If you manage your Jira Space using Components, you can assign the appropriate Component for DefectDojo here. To assign more than one Component, enter a comma-separated list (for example, `Security, DevSecOps`); each value is sent to Jira as a separate component.
 
 #### Custom fields
 

--- a/docs/content/releases/os_upgrading/3.1.md
+++ b/docs/content/releases/os_upgrading/3.1.md
@@ -2,7 +2,7 @@
 title: 'Upgrading to DefectDojo Version 3.1.x'
 toc_hide: true
 weight: -20260617
-description: Blank Finding components are now normalized to NULL so component-less findings group together.
+description: Blank Finding components are now normalized to NULL so component-less findings group together; JIRA project configurations now support multiple comma-separated components.
 ---
 
 ## Blank Finding components normalized to NULL
@@ -14,3 +14,11 @@ Findings without a component now consistently store `NULL`. Blank values are nor
 ### What you need to do
 
 Nothing — the change is applied automatically by the database migration included in this release. After upgrading, component-less findings will group together under a single "None" entry.
+
+## Multiple JIRA components per project
+
+The `Component` field on a JIRA project configuration now supports assigning more than one Jira component. Separate multiple component names with a comma (for example, `Security,DevSecOps`), and each name is sent to Jira as a distinct component. A single value without commas continues to behave as before.
+
+### What you need to do
+
+Nothing is required. Note that a component name that legitimately contains a comma will be split into separate components — component names rarely contain commas, so this is an accepted limitation.

--- a/dojo/jira/forms.py
+++ b/dojo/jira/forms.py
@@ -135,6 +135,11 @@ class JIRAProjectForm(forms.ModelForm):
         self.engagement = kwargs.pop("engagement", None)
         super().__init__(*args, **kwargs)
 
+        self.fields["component"].help_text = (
+            "Comma-separate multiple components to assign more than one to the JIRA issue, "
+            "e.g. 'Security, DevSecOps'."
+        )
+
         logger.debug("self.target: %s, self.product: %s, self.instance: %s", self.target, self.product, self.instance)
         logger.debug("data: %s", self.data)
         if self.target == "engagement":

--- a/dojo/jira/helper.py
+++ b/dojo/jira/helper.py
@@ -867,7 +867,12 @@ def prepare_jira_issue_fields(
     }
 
     if component_name:
-        fields["components"] = [{"name": component_name}]
+        # The component field holds a comma-separated list of component names, so split it
+        # into the list of components Jira expects ([{"name": "A"}, {"name": "B"}]). A single
+        # value without commas yields a single component. (SC-13173)
+        components = [{"name": name.strip()} for name in component_name.split(",") if name.strip()]
+        if components:
+            fields["components"] = components
 
     if custom_fields:
         fields.update(custom_fields)

--- a/unittests/test_jira_helper.py
+++ b/unittests/test_jira_helper.py
@@ -29,3 +29,49 @@ class JIRAHelperTest(TestCase):
     def test_issue_from_jira_is_active_defaults_to_active_on_missing_attribute(self):
         """AttributeError anywhere in the fields.status.statusCategory.key chain defaults to active."""
         self.assertTrue(jira_helper.issue_from_jira_is_active(Mock(spec=[])))
+
+
+class JIRAComponentFieldTest(TestCase):
+
+    """
+    SC-13173: the JIRA project `component` field holds a comma-separated list of
+    component names. prepare_jira_issue_fields must split it into multiple Jira
+    components so Jira receives [{"name": "A"}, {"name": "B"}] instead of a single
+    component named "A,B".
+    """
+
+    def _fields(self, component_name):
+        return jira_helper.prepare_jira_issue_fields(
+            project_key="PROJ",
+            issuetype_name="Bug",
+            summary="summary",
+            description="description",
+            component_name=component_name,
+        )
+
+    def test_single_component(self):
+        fields = self._fields("Security")
+        self.assertEqual([{"name": "Security"}], fields["components"])
+
+    def test_multiple_components_split_on_comma(self):
+        fields = self._fields("Security,DevSecOps")
+        self.assertEqual([{"name": "Security"}, {"name": "DevSecOps"}], fields["components"])
+
+    def test_multiple_components_whitespace_trimmed(self):
+        fields = self._fields("Security, DevSecOps ,  Platform")
+        self.assertEqual(
+            [{"name": "Security"}, {"name": "DevSecOps"}, {"name": "Platform"}],
+            fields["components"],
+        )
+
+    def test_empty_entries_dropped(self):
+        fields = self._fields("Security,,DevSecOps,")
+        self.assertEqual([{"name": "Security"}, {"name": "DevSecOps"}], fields["components"])
+
+    def test_no_component_omits_field(self):
+        fields = self._fields("")
+        self.assertNotIn("components", fields)
+
+    def test_only_separators_omits_field(self):
+        fields = self._fields(" , , ")
+        self.assertNotIn("components", fields)


### PR DESCRIPTION
## Summary
Implements [SC-13173](https://app.shortcut.com/defectdojo/story/13173) — allow assigning more than one Jira component from a project's settings.

The JIRA project `component` field is a single text value that was sent to Jira as one component named after the entire string (e.g. `Security,DevSecOps`) instead of separate components. Jira's REST API expects a list: `[{"name": "Security"}, {"name": "DevSecOps"}]`.

## Changes
- `prepare_jira_issue_fields` now splits the component value on commas, trims whitespace, and drops empty entries, producing one Jira component per name. A single value without commas still yields one component.
- `JIRAProjectForm` documents that commas separate multiple components (form-level help text; no migration).
- Updated the Component section in the OS and PRO Jira guides.

### Known limitation
A component whose name legitimately contains a comma would be split. This is an accepted trade-off given component names rarely contain commas.

## Testing
- `unittests.test_jira_helper.JIRAComponentFieldTest` — new (verified red→green): single value, comma split, whitespace trimming, empty-entry dropping, and field omission when no component is set.
- `test_jira_helper` → 11 OK, `test_jira_config_product` → 15 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)