### PR TITLE
feat(ui): fold Finding Groups under Findings in the sidebar

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -196,7 +196,7 @@
                         </div>
                     </div>
 
-                    <!-- Findings -->
+                    <!-- Findings (Finding Groups folded in) -->
                     <div x-data="{ open: false }">
                         <a href="{% url 'open_findings' %}" @click.prevent="open = !open"
                            class="flex items-center gap-3 px-4 py-2 text-gray-300 hover:text-white hover:bg-white/10 transition-colors cursor-pointer">
@@ -212,18 +212,7 @@
                             {% if "view"|has_global_permission %}
                                 <a href="{% url 'templates' %}" class="block py-1.5 pl-12 pr-4 text-sm text-gray-400 hover:text-white hover:bg-white/10">{% trans "Finding Templates" %}</a>
                             {% endif %}
-                        </div>
-                    </div>
-
-                    <!-- Finding Groups -->
-                    <div x-data="{ open: false }">
-                        <a href="{% url 'all_finding_groups' %}" @click.prevent="open = !open"
-                           class="flex items-center gap-3 px-4 py-2 text-gray-300 hover:text-white hover:bg-white/10 transition-colors cursor-pointer">
-                            <i class="fa-solid fa-triangle-exclamation w-5 text-center flex-shrink-0"></i>
-                            <span class="flex-1 truncate">{% trans "Finding Groups" %}</span>
-                            <i :class="open && 'rotate-90'" class="fa-solid fa-chevron-right text-xs transition-transform duration-200"></i>
-                        </a>
-                        <div x-show="open" x-transition.duration.200ms x-cloak class="overflow-hidden bg-black/10">
+                            <div style="margin:.25rem 1rem; border-top:1px solid rgba(255,255,255,0.1);"></div>
                             <a href="{% url 'open_finding_groups' %}" class="block py-1.5 pl-12 pr-4 text-sm text-gray-400 hover:text-white hover:bg-white/10">{% trans "Open Findings Groups" %}</a>
                             <a href="{% url 'all_finding_groups' %}" class="block py-1.5 pl-12 pr-4 text-sm text-gray-400 hover:text-white hover:bg-white/10">{% trans "All Findings Groups" %}</a>
                             <a href="{% url 'closed_finding_groups' %}" class="block py-1.5 pl-12 pr-4 text-sm text-gray-400 hover:text-white hover:bg-white/10">{% trans "Closed Findings Groups" %}</a>


### PR DESCRIPTION
**Description**

Folds the "Finding Groups" navigation into the "Findings" section of the new-UI
sidebar, per maintainer feedback. The three Finding Groups links (Open / All /
Closed Findings Groups) now live inside the Findings dropdown, separated by a
subtle divider, and the standalone top-level "Finding Groups" item is removed.

This declutters the top-level navigation and keeps related finding views grouped.
No links or destinations change, only their placement in the sidebar.

**Test results**

Verified against a local build: the dashboard's sidebar renders the three group
links inside the Findings dropdown (after Finding Templates, below a divider), and
the standalone "Finding Groups" item no longer appears. All links resolve to the
same views as before. No Python changed, so no unit tests added.

**Documentation**

N/A.

**Checklist**

- [x] Submitted against `dev`.
- [x] Meaningful PR name.
- [x] Ruff compliant (no Python changed).
- [x] Python 3.13 compliant (no Python changed).