### PR TITLE
test(perf): always run both v2 and v3 importer perf cases

### DIFF
--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -49,7 +49,7 @@ from dojo.models import (
 )
 from dojo.tools.stackhawk.parser import StackHawkParser
 
-from .dojo_test_case import DojoTestCase, get_unit_tests_scans_path, skip_unless_v2
+from .dojo_test_case import DojoTestCase, get_unit_tests_scans_path
 
 logger = logging.getLogger(__name__)
 
@@ -275,7 +275,7 @@ class TestDojoImporterPerformanceBase(DojoTestCase):
 
 
 @tag("performance")
-@skip_unless_v2
+@override_settings(V3_FEATURE_LOCATIONS=False)
 class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
 
     """Performance tests using small sample files (StackHawk, ~6 findings)."""


### PR DESCRIPTION
## Summary

The v2 importer performance class `TestDojoImporterPerformanceSmall` was gated behind `@skip_unless_v2`, so it was **skipped whenever the environment had `V3_FEATURE_LOCATIONS` enabled**. That meant a given CI run only ever exercised one mode (v2 *or* v3), never both.

This replaces the skip with `@override_settings(V3_FEATURE_LOCATIONS=False)` on the v2 class, mirroring how the v3 class already uses `@override_settings(V3_FEATURE_LOCATIONS=True)`. Now **both** classes always run regardless of the ambient setting.

## Verification

`unittests.test_importers_performance` — **10 tests, 0 skipped** (previously `skipped=5`), green in both ambient modes:
- ambient `DD_V3_FEATURE_LOCATIONS=True`: Ran 10, OK
- ambient `DD_V3_FEATURE_LOCATIONS=False`: Ran 10, OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)