### PR TITLE
Fixing gha for new versioning scheme

### DIFF
--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Validate proper bugfix branch release_number format is being used
         if: ${{ inputs.from_branch == 'bugfix' }}
         run: |
-          # Expect the last octet in release_number to not be 0
-          echo "${{ inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.[1-9]$"
+          # Expect a valid x.y.z release_number with a 1-3 digit last octet
+          echo "${{ inputs.release_number }}" | grep "^[0-9]*\.[0-9]*\.[0-9]\{1,3\}$"
 
       - name: Validate proper dev branch release_number format is being used
         if: ${{ inputs.from_branch == 'dev' }}


### PR DESCRIPTION
Validation regex only matched a single-digit patch ([1-9]), so 3.0.100 (and even 3.0.10) failed. Fixed so we can use 1-3 digits in the last octet. 