### PR TITLE
Fix Xygeni SAST/Secrets deduplication: key on uniqueHash, not issueId

### DIFF
--- a/docs/content/releases/os_upgrading/3.0.200.md
+++ b/docs/content/releases/os_upgrading/3.0.200.md
@@ -1,0 +1,35 @@
+---
+title: 'Upgrading to DefectDojo Version 3.0.200'
+toc_hide: true
+weight: -20260629
+description: Xygeni parser keys SAST/Secrets deduplication on uniqueHash; repeated secrets are aggregated into one finding.
+---
+
+## Xygeni parser: deduplication keys corrected to `uniqueHash`
+
+This corrects the Xygeni deduplication keys introduced in 3.0.100. That release keyed SAST and Secrets findings on Xygeni's `issueId`, which encodes the file path and line but not the code. As a result two distinct findings on the same line (same detector, different code) collapsed into one, because they share an `issueId` even though their `uniqueHash` differs.
+
+`uniqueHash` is Xygeni's location-independent identity for a finding: for SAST it hashes the detector and the normalized code (the line is deliberately excluded), and for Secrets it hashes the secret value, type, detector, file and key. Keying on it keeps genuinely distinct findings apart and keeps a finding's identity stable when code shifts to a different line.
+
+The deduplication keys are now:
+
+| Scan type | `unique_id_from_tool` (dedup key) | `vuln_id_from_tool` (grouping only) |
+|-----------|-----------------------------------|-------------------------------------|
+| SAST | `uniqueHash` | `detector` |
+| SCA | `uniqueHash` | `userId` (CVE / GHSA / OSV) |
+| Secrets | `uniqueHash` | `detector` |
+
+All three scan types now use the `unique_id_from_tool` deduplication algorithm. SCA was switched from `unique_id_from_tool_or_hash_code`; its `unique_id_from_tool` value is unchanged, so SCA findings are not affected.
+
+### Repeated secrets in the same file
+
+The same secret value can be leaked on several lines of one file. Because `uniqueHash` excludes the line, all those occurrences share one identity, so the parser now aggregates them into a single finding and lists every line where the secret appears in the description. This is more stable than emitting one finding per line, which would reopen findings whenever the lines shifted.
+
+### Required actions
+
+- **No action required for new imports.**
+- **Reimport behavior:** on the first reimport of an existing Xygeni SAST or Secrets test after upgrading, the previously-imported findings carry the old `issueId`-based `unique_id_from_tool` and will not match the new `uniqueHash`-based ids. Those findings are closed as no longer present and a fresh set is created with the corrected ids. This is a one-time effect; subsequent reimports match normally. SCA tests are not affected.
+
+This is intentionally a one-time hit rather than a versioned (V2) parser. The Xygeni `unique_id_from_tool` mapping is now considered final; any future change to finding identity will be delivered as a new parser version.
+
+For more information, check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.0.200).

--- a/docs/content/supported_tools/parsers/file/xygeni.md
+++ b/docs/content/supported_tools/parsers/file/xygeni.md
@@ -64,24 +64,28 @@ Sample Xygeni JSON reports can be found
 
 ### Deduplication
 
-Every finding carries both `unique_id_from_tool` and `vuln_id_from_tool`, and
-the deduplication algorithm is configured per scan type:
+Every finding carries both `unique_id_from_tool` and `vuln_id_from_tool`. All
+scan types deduplicate on `unique_id_from_tool`, keyed on Xygeni's `uniqueHash`:
 
-| Scan type            | Algorithm                          | `unique_id_from_tool` | `vuln_id_from_tool` | Hash-code fields (fallback)                               |
-| -------------------- | ---------------------------------- | --------------------- | ------------------- | --------------------------------------------------------- |
-| Xygeni SAST Scan     | `unique_id_from_tool`              | `issueId`             | `uniqueHash`        | n/a                                                       |
-| Xygeni SCA Scan      | `unique_id_from_tool_or_hash_code` | `uniqueHash`          | `issueId`           | `vulnerability_ids`, `component_name`, `component_version` |
-| Xygeni Secrets Scan  | `unique_id_from_tool`              | `issueId`             | `uniqueHash`        | n/a                                                       |
+| Scan type            | Algorithm             | `unique_id_from_tool` | `vuln_id_from_tool`        |
+| -------------------- | --------------------- | --------------------- | ------------------------- |
+| Xygeni SAST Scan     | `unique_id_from_tool` | `uniqueHash`          | `detector`                |
+| Xygeni SCA Scan      | `unique_id_from_tool` | `uniqueHash`          | `userId` (CVE / GHSA / OSV) |
+| Xygeni Secrets Scan  | `unique_id_from_tool` | `uniqueHash`          | `detector`                |
 
-For SAST and Secrets the dedup key is the per-occurrence `issueId` (which
-encodes the file path and line). The same secret value or code pattern can
-appear several times in one file; Xygeni reuses a single `uniqueHash` across
-those occurrences, so keying dedup on `uniqueHash` would collapse them into one
-Finding and underreport the occurrences. Keying on `issueId` keeps each
-occurrence as its own Finding, while `uniqueHash` is retained as the
-`vuln_id_from_tool` that groups occurrences of the same value.
+`uniqueHash` is Xygeni's location-independent identity for a finding. For SAST
+it hashes the detector and the normalized code with the line deliberately
+excluded, so two findings on the same line with different code stay distinct,
+while the same code that shifts lines keeps its identity across scans. For SCA
+it encodes CVE + package + version, and for Secrets it hashes the secret value,
+type, detector, file and key.
 
-For SCA the dedup key stays `uniqueHash` (it encodes CVE + package + version,
-unique per finding) and the hash-code fallback enables cross-tool
-deduplication: the same CVE on the same package@version reported by Xygeni and
-another SCA scanner (Snyk, Trivy, etc.) collapse into a single Finding.
+`vuln_id_from_tool` is a non-unique grouping label only — never a dedup key. It
+is the `detector` (the rule that fired or the kind of secret) for SAST and
+Secrets, and the user-friendly vulnerability id (`userId`: CVE / GHSA / OSV) for
+SCA.
+
+The same secret value can be leaked on several lines of one file. Because
+`uniqueHash` excludes the line, those occurrences share one identity, so the
+Secrets parser aggregates them into a single Finding and lists every line where
+the secret appears in the description.

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1105,7 +1105,6 @@ HASHCODE_FIELDS_PER_SCANNER = {
     "n0s1 Scanner": ["description"],
     "IriusRisk Threats Scan": ["title", "component_name"],
     "Orca Security Alerts": ["title", "component_name"],
-    "Xygeni SCA Scan": ["vulnerability_ids", "component_name", "component_version"],
     "Qualys VMDR": ["title", "component_name", "vuln_id_from_tool"],
     "Alert Logic Scan": ["title", "component_name", "vuln_id_from_tool"],
     "PICUS Scan": ["vuln_id_from_tool"],
@@ -1183,7 +1182,6 @@ HASHCODE_ALLOWS_NULL_CWE = {
     "Cyberwatch scan (Galeax)": True,
     "OpenVAS Parser v2": True,
     "OpenReports": True,
-    "Xygeni SCA Scan": True,
 }
 
 # List of fields that are known to be usable in hash_code computation)
@@ -1381,7 +1379,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     "IriusRisk Threats Scan": DEDUPE_ALGO_HASH_CODE,
     "Orca Security Alerts": DEDUPE_ALGO_HASH_CODE,
     "Xygeni SAST Scan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
-    "Xygeni SCA Scan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
+    "Xygeni SCA Scan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     "Xygeni Secrets Scan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     "Qualys VMDR": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
     "Alert Logic Scan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,

--- a/dojo/tools/xygeni/sast.py
+++ b/dojo/tools/xygeni/sast.py
@@ -35,13 +35,13 @@ def _build_finding(vuln, test):
         cwe=parse_cwe(cwes=vuln.get("cwes"), cwe=vuln.get("cwe"), tags=vuln.get("tags")),
         static_finding=True,
         dynamic_finding=False,
-        # One detector can flag the same code pattern at several locations. Xygeni reuses a
-        # single ``uniqueHash`` across those occurrences but gives each a distinct ``issueId``
-        # (which encodes filepath + line). Dedup is keyed on ``unique_id_from_tool``, so use
-        # the per-occurrence ``issueId`` to keep each occurrence as its own Finding;
-        # ``uniqueHash`` groups them as the vuln id.
-        unique_id_from_tool=vuln.get("issueId") or vuln.get("uniqueHash"),
-        vuln_id_from_tool=vuln.get("uniqueHash"),
+        # ``uniqueHash`` is Xygeni's identity for a finding across scans. For SAST it is
+        # MD5(kind + detector + filepath + normalized code), with the line deliberately excluded:
+        # two findings on the same line with different code get different hashes (kept distinct),
+        # while the same code that shifts lines keeps its identity (no churn). ``detector`` is the
+        # rule that fired, used as the non-unique grouping id.
+        unique_id_from_tool=vuln.get("uniqueHash"),
+        vuln_id_from_tool=vuln.get("detector"),
     )
 
     _apply_code_flow_fields(finding, vuln.get("codeFlows") or [])

--- a/dojo/tools/xygeni/sca.py
+++ b/dojo/tools/xygeni/sca.py
@@ -52,8 +52,11 @@ def _build_finding(dep, vuln, test):
         component_version=component_version,
         static_finding=True,
         dynamic_finding=False,
+        # ``uniqueHash`` (``CVE#component:version``) is Xygeni's identity for the finding across
+        # scans. ``userId`` is the user-friendly vulnerability id (CVE / GHSA / OSV), used as the
+        # non-unique grouping id.
         unique_id_from_tool=vuln.get("uniqueHash"),
-        vuln_id_from_tool=vuln.get("issueId"),
+        vuln_id_from_tool=vuln.get("userId"),
     )
 
     if vuln.get("cve"):

--- a/dojo/tools/xygeni/secrets.py
+++ b/dojo/tools/xygeni/secrets.py
@@ -15,21 +15,46 @@ DEFAULT_CWE = 798  # CWE-798: Use of Hard-coded Credentials
 
 
 def parse_secrets(data, test):
-    """Convert a Xygeni Secrets JSON report into a list of Findings."""
-    return [_build_finding(secret, test) for secret in data.get("secrets") or []]
+    """
+    Convert a Xygeni Secrets JSON report into a list of Findings.
+
+    The same secret value can be leaked on several lines of one file. Xygeni gives every such
+    occurrence the same ``uniqueHash`` (it is location-independent by design), so the occurrences
+    are aggregated into a single Finding whose description lists every line where the secret
+    appears. This keeps the finding identity stable across scans: a synthetic per-line id would
+    reopen findings whenever the lines shift.
+    """
+    groups = {}
+    for secret in data.get("secrets") or []:
+        key = secret.get("uniqueHash") or secret.get("issueId")
+        groups.setdefault(key, []).append(secret)
+    return [_build_finding(occurrences, test) for occurrences in groups.values()]
 
 
-def _build_finding(secret, test):
+def _build_finding(occurrences, test):
+    secret = occurrences[0]
     location = secret.get("location") or {}
     filepath = location.get("filepath") or ""
     filename = PurePosixPath(filepath).name or filepath or "unknown file"
     secret_type = secret.get("type") or secret.get("detector") or "secret"
+
+    lines = []
+    for occ in occurrences:
+        begin_line = (occ.get("location") or {}).get("beginLine")
+        if begin_line is not None and begin_line not in lines:
+            lines.append(begin_line)
+    lines.sort()
 
     description_parts = []
     if secret.get("description"):
         description_parts.append(str(secret["description"]))
     if location.get("code"):
         description_parts.append(f"```\n{location['code']}\n```")
+    if len(lines) > 1:
+        joined = ", ".join(str(line) for line in lines)
+        description_parts.append(
+            f"This secret is leaked {len(lines)} times in `{filename}`, on lines: {joined}.",
+        )
 
     cwe = parse_cwe(tags=secret.get("tags")) or DEFAULT_CWE
 
@@ -39,16 +64,17 @@ def _build_finding(secret, test):
         description="\n\n".join(description_parts) if description_parts else "",
         severity=map_severity(secret.get("severity")),
         file_path=filepath or None,
-        line=location.get("beginLine"),
+        line=lines[0] if lines else location.get("beginLine"),
         cwe=cwe,
         mitigation=f"Rotate this {secret_type} secret immediately and remove it from version-control history.",
         static_finding=True,
         dynamic_finding=False,
-        # The same secret value can appear several times in one file. Xygeni assigns every
-        # occurrence the same ``uniqueHash`` (it hashes the secret value, not the location)
-        # but a distinct ``issueId`` (which encodes filepath + line). Dedup is keyed on
-        # ``unique_id_from_tool``, so use the per-occurrence ``issueId`` to keep each
-        # occurrence as its own Finding; ``uniqueHash`` groups them as the vuln id.
-        unique_id_from_tool=secret.get("issueId") or secret.get("uniqueHash"),
-        vuln_id_from_tool=secret.get("uniqueHash"),
+        # ``uniqueHash`` is Xygeni's identity for the secret across scans: it hashes the secret
+        # value + type + detector + file + key, with the line deliberately excluded. The same
+        # secret leaked on several lines of one file shares it, so the occurrences are aggregated
+        # into this single Finding (the lines are listed in the description above) instead of being
+        # split with a synthetic per-line id that would churn across scans. ``detector`` is the
+        # secret type, used as the non-unique grouping id.
+        unique_id_from_tool=secret.get("uniqueHash"),
+        vuln_id_from_tool=secret.get("detector"),
     )

--- a/unittests/tools/test_xygeni_parser.py
+++ b/unittests/tools/test_xygeni_parser.py
@@ -101,11 +101,13 @@ class TestXygeniParser(DojoTestCase):
                 f for f in findings
                 if f.component_name == "cookie"
                 and f.component_version == "0.5.0"
-                and f.vuln_id_from_tool == "SCA.CVE-2024-47764"
+                and f.vuln_id_from_tool == "CVE-2024-47764"
             ),
             None,
         )
         self.assertIsNotNone(match, "expected the cookie@0.5.0 / CVE-2024-47764 SCA finding")
+        # uniqueHash is the dedup identity; userId is the user-friendly vuln id grouping label
+        self.assertEqual("CVE-2024-47764#:cookie:0.5.0:javascript", match.unique_id_from_tool)
         self.assertEqual("CVE-2024-47764", match.title)
         self.assertEqual("CVE-2024-47764", match.cve)
         self.assertIn("CVE-2024-47764", match.unsaved_vulnerability_ids)

--- a/unittests/tools/test_xygeni_parser.py
+++ b/unittests/tools/test_xygeni_parser.py
@@ -44,13 +44,13 @@ class TestXygeniParser(DojoTestCase):
         match = next(
             (
                 f for f in findings
-                if f.unique_id_from_tool == "SAS.injection.python.code_injection_deserialization.dockerized_labs/insec_des_lab/main.py.36"
+                if f.unique_id_from_tool == "nsXRi+PTLom/sG8m6weOXw"
             ),
             None,
         )
-        self.assertIsNotNone(match, "expected the deserialization SAST finding by issueId")
-        # uniqueHash is kept as the vuln id; the per-occurrence issueId drives dedup
-        self.assertEqual("nsXRi+PTLom/sG8m6weOXw", match.vuln_id_from_tool)
+        self.assertIsNotNone(match, "expected the deserialization SAST finding by uniqueHash")
+        # uniqueHash is the dedup identity; the detector is the non-unique grouping id
+        self.assertEqual("python.code_injection_deserialization", match.vuln_id_from_tool)
         self.assertEqual("python.code_injection_deserialization", match.title)
         self.assertEqual("Critical", match.severity)
         self.assertEqual(502, match.cwe)
@@ -62,19 +62,28 @@ class TestXygeniParser(DojoTestCase):
         self.assertEqual("serialized_data", match.sast_source_object)
         self.assertIn("Data flow", match.description)
 
-    def test_sast_repeated_detector_in_same_file_stays_distinct(self):
-        # One detector flagging the same pattern at several lines shares a uniqueHash but
-        # carries a distinct issueId per line. Each occurrence must remain its own Finding.
+    def test_sast_same_code_repeated_in_same_file_shares_unique_id(self):
+        # The same detector flagging identical code on several lines shares one uniqueHash (the
+        # line is excluded from the hash), so every occurrence carries the same unique_id_from_tool
+        # and DefectDojo folds them into a single finding on import. The detector is the grouping id.
         with self._load("sast_many_findings.json") as testfile:
             findings = XygeniParser().get_findings(testfile, Test())
 
         occurrences = [
             f for f in findings
-            if f.vuln_id_from_tool == "VsqoC9U6q8EYG0QZ5UqxXw"  # forms_without_csrf_protection, 4 lines
+            if f.unique_id_from_tool == "VsqoC9U6q8EYG0QZ5UqxXw"  # html.forms_without_csrf_protection, 4 lines
         ]
-        self.assertEqual(4, len(occurrences), "all occurrences of the repeated detector must be kept")
-        unique_ids = {f.unique_id_from_tool for f in occurrences}
-        self.assertEqual(4, len(unique_ids), "each occurrence needs a distinct unique_id_from_tool")
+        self.assertEqual(4, len(occurrences), "the parser still emits one finding per report entry")
+        self.assertEqual(
+            {"VsqoC9U6q8EYG0QZ5UqxXw"},
+            {f.unique_id_from_tool for f in occurrences},
+            "identical code shares one unique_id so dedup folds the occurrences into one finding",
+        )
+        self.assertEqual(
+            {"html.forms_without_csrf_protection"},
+            {f.vuln_id_from_tool for f in occurrences},
+            "the detector is the shared, non-unique grouping id",
+        )
 
     def test_sca_many_findings(self):
         with self._load("sca_many_findings.json") as testfile:
@@ -116,33 +125,34 @@ class TestXygeniParser(DojoTestCase):
             self.assertIsNotNone(finding.cwe)
 
         match = next(
-            (f for f in findings if f.unique_id_from_tool == "SEC.private_key.private_key..ssh/id_rsa.1"),
+            (f for f in findings if f.unique_id_from_tool == "LVAjuA4Z40VxktixjtztXg"),
             None,
         )
-        self.assertIsNotNone(match, "expected the .ssh/id_rsa private-key secret finding")
-        # uniqueHash is kept as the vuln id; the per-occurrence issueId drives dedup
-        self.assertEqual("LVAjuA4Z40VxktixjtztXg", match.vuln_id_from_tool)
+        self.assertIsNotNone(match, "expected the .ssh/id_rsa private-key secret finding by uniqueHash")
+        # uniqueHash is the dedup identity; the detector is the non-unique grouping id
+        self.assertEqual("private_key", match.vuln_id_from_tool)
         self.assertEqual("Critical", match.severity)
         self.assertEqual(".ssh/id_rsa", match.file_path)
         self.assertEqual(1, match.line)
         self.assertIn("private_key", match.title)
         self.assertIn("Rotate", match.mitigation)
 
-    def test_secrets_repeated_in_same_file_stay_distinct(self):
-        # A secret value repeated in one file shares a uniqueHash across occurrences but
-        # carries a distinct issueId per line. The parser must surface each occurrence as
-        # its own Finding (distinct unique_id_from_tool) so dedup does not collapse them.
+    def test_secrets_repeated_in_same_file_aggregate_into_one_finding(self):
+        # A secret value repeated in one file shares a single uniqueHash across occurrences (the
+        # line is excluded from the hash). The parser aggregates them into one Finding with a
+        # stable identity and lists every line where the secret appears in the description.
         with self._load("secrets_many_findings.json") as testfile:
             findings = XygeniParser().get_findings(testfile, Test())
 
         occurrences = [
             f for f in findings
-            if f.vuln_id_from_tool == "1yvAV2ndtW4yYG+TJQhhXg"  # .docker/.dockercfg, lines 9 and 29
+            if f.unique_id_from_tool == "1yvAV2ndtW4yYG+TJQhhXg"  # .docker/.dockercfg, lines 9 and 29
         ]
-        self.assertEqual(2, len(occurrences), "both occurrences of the repeated secret must be kept")
-        unique_ids = {f.unique_id_from_tool for f in occurrences}
-        self.assertEqual(2, len(unique_ids), "each occurrence needs a distinct unique_id_from_tool")
-        self.assertEqual({9, 29}, {f.line for f in occurrences})
+        self.assertEqual(1, len(occurrences), "the repeated secret must collapse into a single finding")
+        finding = occurrences[0]
+        self.assertEqual("dockercfg", finding.vuln_id_from_tool)
+        self.assertEqual(9, finding.line, "the finding's line is the first occurrence")
+        self.assertIn("lines: 9, 29", finding.description, "every leaked line must be listed in the description")
 
     # ----- dispatch + error cases -----
 
@@ -164,8 +174,8 @@ class TestXygeniParser(DojoTestCase):
         }
         findings = XygeniParser().get_findings(io.StringIO(json.dumps(report)), Test())
         self.assertEqual(1, len(findings))
-        self.assertEqual("SECRETS.aws-access-key.config.ini:12", findings[0].unique_id_from_tool)
-        self.assertEqual("abc123", findings[0].vuln_id_from_tool)
+        self.assertEqual("abc123", findings[0].unique_id_from_tool)
+        self.assertEqual("aws-access-key", findings[0].vuln_id_from_tool)
         self.assertEqual(798, findings[0].cwe)
 
     def test_raises_on_missing_scan_type(self):


### PR DESCRIPTION
## :warning: Pre-Approval check :warning:

This is a bug fix for an existing parser (the Xygeni parser added in #14769, refined in #15003), which falls under the "Acceptable examples" in CONTRIBUTING (bug fix for an existing parser), so no separate pre-approval issue is filed.

**Description**

A user reported a corner case in the dedup keys introduced in #15003: two SAST findings for the **same detector on the very same line**, differing only in their `code`, were incorrectly deduplicated into one. #15003 keyed `unique_id_from_tool` on Xygeni's `issueId`, which encodes the file path and line but **not** the code, so the two findings share an `issueId` even though their `uniqueHash` differs.

`uniqueHash` is Xygeni's location-independent identity for a finding:
- **SAST**: `MD5(kind + detector + filepath + normalized code)` — the line is deliberately excluded.
- **SCA**: `CVE#component:version`.
- **Secrets**: hashes the secret value + type + detector + file + key.

Keying `unique_id_from_tool` on `uniqueHash` keeps genuinely distinct findings apart (different code on the same line) and keeps a finding's identity stable when code shifts to a different line (no reopen churn).

This also improves `vuln_id_from_tool`, which is a non-unique grouping label only (never a dedup key in our configuration): it now uses the `detector` for SAST/Secrets and the user-friendly vulnerability id (`userId`: CVE / GHSA / OSV) for SCA, matching how comparable parsers populate the field (Semgrep `check_id`, SARIF `ruleId`; Grype/Snyk vulnerability id).

| Scan type | `unique_id_from_tool` (prev → new) | `vuln_id_from_tool` (prev → new) | Algorithm |
|-----------|------------------------------------|----------------------------------|-----------|
| SAST | `issueId` → **`uniqueHash`** | `uniqueHash` → **`detector`** | `unique_id_from_tool` |
| SCA | `uniqueHash` (unchanged) | `issueId` → **`userId`** | `unique_id_from_tool_or_hash_code` → **`unique_id_from_tool`** |
| Secrets | `issueId` → **`uniqueHash`** | `uniqueHash` → **`detector`** | `unique_id_from_tool` |

All three scan types now deduplicate on `unique_id_from_tool` keyed on `uniqueHash`. SCA's `unique_id_from_tool` value is unchanged, so SCA findings are not affected by the algorithm switch; its now-unused hash-code settings entries are removed.

**Repeated secrets in one file**

The same secret value can be leaked on several lines of one file. Because `uniqueHash` excludes the line, those occurrences share one identity. Rather than splitting them with a synthetic per-line/sequence id (which would reopen findings whenever the lines shift), the Secrets parser aggregates them into a single finding and lists every line where the secret appears in the description.

**Test results**

Updated `unittests/tools/test_xygeni_parser.py`:
- SAST/Secrets/SCA assertions updated to the new `unique_id_from_tool` (`uniqueHash`) and `vuln_id_from_tool` (`detector` / `userId`) values.
- `test_sast_same_code_repeated_in_same_file_shares_unique_id` — identical code on 4 lines now shares one `unique_id_from_tool`, so dedup folds the occurrences into one finding.
- `test_secrets_repeated_in_same_file_aggregate_into_one_finding` — a secret repeated on lines 9 and 29 now yields one finding whose description lists both lines.

Ruff (0.15.15) passes on all changed files.

**Documentation**

- `docs/content/supported_tools/parsers/file/xygeni.md` — Deduplication section rewritten for the `uniqueHash` mapping.
- `docs/content/releases/os_upgrading/3.0.200.md` — upgrade note describing the one-time reimport effect (existing SAST/Secrets findings re-key from `issueId` to `uniqueHash`), superseding the 3.0.100 note. This is intentionally a one-time hit rather than a versioned (V2) parser; the `unique_id_from_tool` mapping is now considered final.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`. (Branched off the latest `bugfix`, the correct base for a bug fix.)
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] If this is a new feature and not a bug fix, you've included the proper documentation. (Not a new feature; docs updated anyway.)
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder. (No model changes.)
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR. (`bugfix`)
