### PR TITLE
fix(rbac): resolve product-scoped users for the engagement Testing Lead selector

### DIFF
--- a/dojo/authorization/query_registrations.py
+++ b/dojo/authorization/query_registrations.py
@@ -427,7 +427,10 @@ def _get_authorized_users_for_product_type(users, product_type, permission):
         return users.none()
     if _is_unrestricted(user, permission_to_action(permission)) or user.is_staff:
         return users
-    return users.none()
+    if product_type is None:
+        return users.none()
+    # OS: users authorized on this product type via authorized_users.
+    return users.filter(id__in=product_type.authorized_users.values("id"))
 
 
 register_auth_filter("user.get_authorized_users_for_product_type", _get_authorized_users_for_product_type)
@@ -441,7 +444,14 @@ def _get_authorized_users_for_product_and_product_type(users, product, permissio
         return users.none()
     if _is_unrestricted(user, permission_to_action(permission)) or user.is_staff:
         return users
-    return users.none()
+    if product is None:
+        return users.none()
+    # OS: users authorized on this product via authorized_users, either
+    # directly on the product or via its product type.
+    return users.filter(
+        Q(id__in=product.authorized_users.values("id"))
+        | Q(id__in=product.prod_type.authorized_users.values("id")),
+    )
 
 
 register_auth_filter("user.get_authorized_users_for_product_and_product_type", _get_authorized_users_for_product_and_product_type)

--- a/dojo/authorization/query_registrations.py
+++ b/dojo/authorization/query_registrations.py
@@ -429,8 +429,12 @@ def _get_authorized_users_for_product_type(users, product_type, permission):
         return users
     if product_type is None:
         return users.none()
-    # OS: users authorized on this product type via authorized_users.
-    return users.filter(id__in=product_type.authorized_users.values("id"))
+    # OS: users authorized on this product type via authorized_users, plus
+    # superusers (2.58.4 always surfaced is_superuser users as candidates).
+    return users.filter(
+        Q(id__in=product_type.authorized_users.values("id"))
+        | Q(is_superuser=True),
+    )
 
 
 register_auth_filter("user.get_authorized_users_for_product_type", _get_authorized_users_for_product_type)
@@ -446,11 +450,13 @@ def _get_authorized_users_for_product_and_product_type(users, product, permissio
         return users
     if product is None:
         return users.none()
-    # OS: users authorized on this product via authorized_users, either
-    # directly on the product or via its product type.
+    # OS: users authorized on this product via authorized_users (directly on
+    # the product or via its product type), plus superusers (2.58.4 always
+    # surfaced is_superuser users as candidates).
     return users.filter(
         Q(id__in=product.authorized_users.values("id"))
-        | Q(id__in=product.prod_type.authorized_users.values("id")),
+        | Q(id__in=product.prod_type.authorized_users.values("id"))
+        | Q(is_superuser=True),
     )
 
 

--- a/dojo/authorization/query_registrations.py
+++ b/dojo/authorization/query_registrations.py
@@ -413,7 +413,14 @@ def _get_authorized_users(permission, user=None):
         return Dojo_User.objects.none()
     if _is_unrestricted(user, permission_to_action(permission)) or user.is_staff:
         return Dojo_User.objects.all().order_by("first_name", "last_name")
-    return Dojo_User.objects.filter(pk=user.pk)
+    # OS: collaborators — users sharing the caller's authorized products /
+    # product types (via authorized_users), plus superusers. Mirrors 2.58.4,
+    # which returned co-members of the caller's authorized products/types.
+    return Dojo_User.objects.filter(
+        Q(authorized_products__id__in=_authorized_product_ids(user))
+        | Q(authorized_product_types__id__in=_authorized_product_type_ids(user))
+        | Q(is_superuser=True),
+    ).distinct().order_by("first_name", "last_name")
 
 
 register_auth_filter("user.get_authorized_users", _get_authorized_users)

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -343,13 +343,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=170,
+            expected_num_queries1=171,
             expected_num_async_tasks1=2,
-            expected_num_queries2=123,
+            expected_num_queries2=124,
             expected_num_async_tasks2=1,
-            expected_num_queries3=28,
+            expected_num_queries3=29,
             expected_num_async_tasks3=1,
-            expected_num_queries4=99,
+            expected_num_queries4=100,
             expected_num_async_tasks4=0,
         )
 
@@ -367,13 +367,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=184,
+            expected_num_queries1=187,
             expected_num_async_tasks1=2,
-            expected_num_queries2=131,
+            expected_num_queries2=132,
             expected_num_async_tasks2=1,
-            expected_num_queries3=36,
+            expected_num_queries3=37,
             expected_num_async_tasks3=1,
-            expected_num_queries4=99,
+            expected_num_queries4=100,
             expected_num_async_tasks4=0,
         )
 
@@ -392,13 +392,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=194,
+            expected_num_queries1=197,
             expected_num_async_tasks1=4,
-            expected_num_queries2=141,
+            expected_num_queries2=142,
             expected_num_async_tasks2=3,
-            expected_num_queries3=43,
+            expected_num_queries3=44,
             expected_num_async_tasks3=3,
-            expected_num_queries4=108,
+            expected_num_queries4=109,
             expected_num_async_tasks4=2,
         )
 
@@ -524,9 +524,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=109,
+            expected_num_queries1=110,
             expected_num_async_tasks1=2,
-            expected_num_queries2=89,
+            expected_num_queries2=90,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -545,9 +545,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=123,
+            expected_num_queries1=126,
             expected_num_async_tasks1=2,
-            expected_num_queries2=104,
+            expected_num_queries2=107,
             expected_num_async_tasks2=2,
         )
 
@@ -633,13 +633,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=177,
+            expected_num_queries1=178,
             expected_num_async_tasks1=2,
-            expected_num_queries2=132,
+            expected_num_queries2=133,
             expected_num_async_tasks2=1,
-            expected_num_queries3=36,
+            expected_num_queries3=37,
             expected_num_async_tasks3=1,
-            expected_num_queries4=100,
+            expected_num_queries4=101,
             expected_num_async_tasks4=0,
         )
 
@@ -657,13 +657,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=193,
+            expected_num_queries1=196,
             expected_num_async_tasks1=2,
-            expected_num_queries2=142,
+            expected_num_queries2=143,
             expected_num_async_tasks2=1,
-            expected_num_queries3=46,
+            expected_num_queries3=47,
             expected_num_async_tasks3=1,
-            expected_num_queries4=100,
+            expected_num_queries4=101,
             expected_num_async_tasks4=0,
         )
 
@@ -682,13 +682,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=206,
+            expected_num_queries1=209,
             expected_num_async_tasks1=4,
-            expected_num_queries2=155,
+            expected_num_queries2=156,
             expected_num_async_tasks2=3,
-            expected_num_queries3=53,
+            expected_num_queries3=54,
             expected_num_async_tasks3=3,
-            expected_num_queries4=112,
+            expected_num_queries4=113,
             expected_num_async_tasks4=2,
         )
 
@@ -789,9 +789,9 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=116,
+            expected_num_queries1=117,
             expected_num_async_tasks1=2,
-            expected_num_queries2=92,
+            expected_num_queries2=93,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -809,8 +809,8 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=132,
+            expected_num_queries1=135,
             expected_num_async_tasks1=2,
-            expected_num_queries2=215,
+            expected_num_queries2=218,
             expected_num_async_tasks2=2,
         )

--- a/unittests/test_user_queries.py
+++ b/unittests/test_user_queries.py
@@ -344,3 +344,49 @@ class TestGetAuthorizedUsersForProductAndProductType(DojoTestCase):
         )
         for user in users:
             self.assertTrue(user.is_active)
+
+
+class TestGetAuthorizedUsersViaAuthorizedUsers(DojoTestCase):
+
+    """
+    OS authorized_users-based resolution for the product / product-type user
+    queries (regression test for issue #15062 — empty Testing Lead selector).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.product_type = Product_Type.objects.create(name="AU Test PT")
+        cls.product = Product.objects.create(
+            name="AU Test Product", description="t", prod_type=cls.product_type,
+        )
+
+        cls.product_member = Dojo_User.objects.create(username="au_product_member", is_active=True)
+        cls.product_type_member = Dojo_User.objects.create(username="au_pt_member", is_active=True)
+        cls.unrelated = Dojo_User.objects.create(username="au_unrelated", is_active=True)
+
+        # The "authorized users" sections the reporter used in the UI.
+        cls.product.authorized_users.add(cls.product_member)
+        cls.product_type.authorized_users.add(cls.product_type_member)
+
+    @patch("dojo.authorization.query_registrations.get_current_user")
+    def test_product_and_product_type_returns_authorized_users(self, mock_get_current_user):
+        # #15062: a non-staff user authorized on the product (via authorized_users)
+        # must get a non-empty list so they can pick a Testing Lead. The list
+        # contains users authorized directly on the product and via its type.
+        mock_get_current_user.return_value = self.product_member
+        users = get_authorized_users_for_product_and_product_type(
+            None, self.product, Permissions.Product_View,
+        )
+        self.assertIn(self.product_member, users)
+        self.assertIn(self.product_type_member, users)
+        self.assertNotIn(self.unrelated, users)
+
+    @patch("dojo.authorization.query_registrations.get_current_user")
+    def test_product_type_returns_authorized_users(self, mock_get_current_user):
+        mock_get_current_user.return_value = self.product_type_member
+        users = get_authorized_users_for_product_type(
+            None, self.product_type, Permissions.Product_Type_View,
+        )
+        self.assertIn(self.product_type_member, users)
+        self.assertNotIn(self.product_member, users)
+        self.assertNotIn(self.unrelated, users)

--- a/unittests/test_user_queries.py
+++ b/unittests/test_user_queries.py
@@ -89,25 +89,40 @@ class TestUserQueries(DojoTestCase):
 
     @patch("dojo.authorization.query_registrations.get_current_user")
     def test_user_global_permission_legacy(self, mock_current_user):
-        # Legacy: Global_Role(role=Reader) is inert. The user has no
-        # is_staff / is_superuser flag, so only their own row is returned.
+        # Carrier Global_Role(role=Reader) is inert in OS. Without any
+        # authorized_users membership the user sees only superusers (always
+        # surfaced, matching 2.58.4).
         mock_current_user.return_value = self.global_permission_user
 
         self.assertQuerySetEqual(
-            Dojo_User.objects.filter(pk=self.global_permission_user.pk),
+            Dojo_User.objects.filter(is_superuser=True).order_by("first_name", "last_name"),
             get_authorized_users(Permissions.Product_View),
         )
 
     @patch("dojo.authorization.query_registrations.get_current_user")
     def test_user_regular_legacy(self, mock_current_user):
-        # Legacy: per-product RBAC role is inert. A non-staff non-superuser
-        # only sees themselves.
+        # Carrier Product_Member / Product_Type_Member are inert in OS. Without
+        # any authorized_users membership the user sees only superusers.
         mock_current_user.return_value = self.regular_user
 
         self.assertQuerySetEqual(
-            Dojo_User.objects.filter(pk=self.regular_user.pk),
+            Dojo_User.objects.filter(is_superuser=True).order_by("first_name", "last_name"),
             get_authorized_users(Permissions.Product_View),
         )
+
+    @patch("dojo.authorization.query_registrations.get_current_user")
+    def test_user_collaborators_via_authorized_users(self, mock_current_user):
+        # v2 parity: a non-staff user sees co-members of the products/types
+        # they are authorized on (via authorized_users), plus superusers.
+        self.product_1.authorized_users.add(self.regular_user)
+        self.product_1.authorized_users.add(self.product_user)
+        mock_current_user.return_value = self.regular_user
+
+        users = get_authorized_users(Permissions.Product_View)
+        self.assertIn(self.regular_user, users)
+        self.assertIn(self.product_user, users)
+        self.assertIn(self.admin_user, users)
+        self.assertNotIn(self.invisible_user, users)
 
 
 class TestGetAuthorizedUsersForProductType(DojoTestCase):
@@ -185,16 +200,18 @@ class TestGetAuthorizedUsersForProductType(DojoTestCase):
         self.assertIn(self.user_global_reader, users)
 
     @patch("dojo.authorization.query_registrations.get_current_user")
-    def test_non_staff_caller_sees_none(self, mock_get_current_user):
-        # Legacy: a non-staff non-superuser caller can't enumerate users
-        # for a product_type — including users with explicit memberships.
+    def test_non_staff_caller_sees_only_superusers(self, mock_get_current_user):
+        # OS: carrier Product_Type_Member is inert. A non-staff caller without
+        # authorized_users membership sees only superusers (2.58.4 parity).
         mock_get_current_user.return_value = self.user_product_type_member
         users = get_authorized_users_for_product_type(
             Dojo_User.objects.all(),
             self.product_type,
             Permissions.Product_Type_View,
         )
-        self.assertEqual(users.count(), 0)
+        self.assertIn(self.superuser, users)
+        self.assertNotIn(self.user_product_type_member, users)
+        self.assertNotIn(self.user_no_perms, users)
 
     @patch("dojo.authorization.query_registrations.get_current_user")
     def test_anonymous_caller_sees_none(self, mock_get_current_user):
@@ -311,14 +328,18 @@ class TestGetAuthorizedUsersForProductAndProductType(DojoTestCase):
         self.assertIn(self.user_global_reader, users)
 
     @patch("dojo.authorization.query_registrations.get_current_user")
-    def test_non_staff_caller_sees_none(self, mock_get_current_user):
+    def test_non_staff_caller_sees_only_superusers(self, mock_get_current_user):
+        # OS: carrier Product_Member is inert. A non-staff caller without
+        # authorized_users membership sees only superusers (2.58.4 parity).
         mock_get_current_user.return_value = self.user_product_member
         users = get_authorized_users_for_product_and_product_type(
             None,
             self.product,
             Permissions.Product_View,
         )
-        self.assertEqual(users.count(), 0)
+        self.assertIn(self.superuser, users)
+        self.assertNotIn(self.user_product_member, users)
+        self.assertNotIn(self.user_no_perms, users)
 
     @patch("dojo.authorization.query_registrations.get_current_user")
     def test_anonymous_caller_sees_none(self, mock_get_current_user):

--- a/unittests/test_user_queries.py
+++ b/unittests/test_user_queries.py
@@ -363,6 +363,8 @@ class TestGetAuthorizedUsersViaAuthorizedUsers(DojoTestCase):
         cls.product_member = Dojo_User.objects.create(username="au_product_member", is_active=True)
         cls.product_type_member = Dojo_User.objects.create(username="au_pt_member", is_active=True)
         cls.unrelated = Dojo_User.objects.create(username="au_unrelated", is_active=True)
+        # Superuser not in any authorized_users — must still surface (2.58.4 parity).
+        cls.superuser = Dojo_User.objects.create(username="au_superuser", is_active=True, is_superuser=True)
 
         # The "authorized users" sections the reporter used in the UI.
         cls.product.authorized_users.add(cls.product_member)
@@ -372,13 +374,15 @@ class TestGetAuthorizedUsersViaAuthorizedUsers(DojoTestCase):
     def test_product_and_product_type_returns_authorized_users(self, mock_get_current_user):
         # #15062: a non-staff user authorized on the product (via authorized_users)
         # must get a non-empty list so they can pick a Testing Lead. The list
-        # contains users authorized directly on the product and via its type.
+        # contains users authorized directly on the product and via its type,
+        # plus superusers (2.58.4 parity).
         mock_get_current_user.return_value = self.product_member
         users = get_authorized_users_for_product_and_product_type(
             None, self.product, Permissions.Product_View,
         )
         self.assertIn(self.product_member, users)
         self.assertIn(self.product_type_member, users)
+        self.assertIn(self.superuser, users)
         self.assertNotIn(self.unrelated, users)
 
     @patch("dojo.authorization.query_registrations.get_current_user")
@@ -388,5 +392,6 @@ class TestGetAuthorizedUsersViaAuthorizedUsers(DojoTestCase):
             None, self.product_type, Permissions.Product_Type_View,
         )
         self.assertIn(self.product_type_member, users)
+        self.assertIn(self.superuser, users)
         self.assertNotIn(self.product_member, users)
         self.assertNotIn(self.unrelated, users)


### PR DESCRIPTION
## Fixes #15062

The engagement **Testing Lead** selector (a required field) is empty for any user who was granted access to a product via the product's *authorized users* section, which blocks them from creating an engagement.

### Root cause
`dojo/forms.py` populates the lead field from `get_authorized_users_for_product_and_product_type(None, product, "view")`. In the v3 OS authorization layer (`dojo/authorization/query_registrations.py`) the two impls are incomplete:

```python
def _get_authorized_users_for_product_and_product_type(users, product, permission):
    ...
    if _is_unrestricted(...) or user.is_staff:
        return users
    return users.none()      # <-- product argument ignored; non-staff caller gets nothing
```

They **ignore the `product`/`product_type` argument** and return `users.none()` for every non-staff/non-superuser caller, so a product-scoped user gets an empty lead list. (Granting full/global access "fixes" it only because that flips the user into the `_is_unrestricted` branch — which is why an admin never sees the bug.)

### Behaviour in 2.58.4 (what this restores)
In 2.58.4 the same function was a real query and was **not gated on the calling user** — any caller, including a non-staff product member, received the users authorized on that product/type:

```python
def get_authorized_users_for_product_and_product_type(users, product, permission):
    if users is None:
        users = Dojo_User.objects.filter(is_active=True)
    roles = get_roles_for_permission(permission)
    return users.filter(
        Q(id__in=Subquery(product_member_users))        # Product_Member of product
        | Q(id__in=Subquery(product_type_member_users)) # Product_Type_Member of product.prod_type
        | Q(id__in=Subquery(group_member_users))        # via Product_Group / Product_Type_Group / Global_Role groups
        | Q(global_role__role__in=roles)                # users with a matching Global_Role
        | Q(is_superuser=True),                         # superusers
    )
```

The v3 rewrite introduced two behaviours that weren't in 2.58.4: it now branches on the **calling** user, and for any non-staff caller it returns nothing — ignoring `product` entirely. That is the regression.

### Fix
Resolve the users authorized on the given product / product type via the `authorized_users` M2M — the inverse of the existing `_authorized_product_ids` helper, consistent with the rest of the OS layer. Superuser/staff still bypass; anonymous and `None` object still return none.

- `_get_authorized_users_for_product_type` → users in `product_type.authorized_users` **plus superusers**
- `_get_authorized_users_for_product_and_product_type` → users in `product.authorized_users` **or** `product.prod_type.authorized_users` **plus superusers**

This is the OS-layer equivalent of the 2.58.4 query: v3 split the model so that the RBAC carrier tables (`Product_Member`, `Product_Type_Group`, `Global_Role`, …) moved to Pro, while OS membership is the `authorized_users` M2M. The `is_superuser` clause is carried over from 2.58.4 (which always surfaced superusers as candidates). Pro layers the member/group/global-role resolution back on via its own registration; global-role is Pro-only in v3 (roles are inert in OS), so it is intentionally not resolved here.

It also fixes the same empty-selector symptom in the Test form lead, finding bulk-edit reviewer/assignee, and notification recipient resolution, which call the same functions.

### Also in this PR — `get_authorized_users` (same regression, sibling function)
`_get_authorized_users` had the identical v2→v3 regression: for any non-staff/non-superuser caller it returned only the caller themselves (`pk=user.pk`), whereas 2.58.4 returned the caller's **collaborators** — users sharing the caller's authorized products/types — plus global-role users and superusers. This collapsed several user dropdowns to self-only for scoped users:

- `dojo/engagement/views.py` and `dojo/test/views.py` — the engagement/test "users" lists
- `dojo/auditlog/filters.py` — the audit-log *actor* / *user* filter dropdowns
- `dojo/api_v2/serializers.py` — `get_authorized_users("edit", ...)`

Fix: resolve collaborators via the `authorized_users` M2M (users sharing the caller's authorized products / product types) plus superusers — the OS-applicable part of 2.58.4. Carrier roles (`Product_Member`, `Global_Role`, …) remain inert in OS; global-role resolution stays a Pro concern.

### Tests
`unittests/test_user_queries.py`:
- new `TestGetAuthorizedUsersViaAuthorizedUsers` — a product-authorized user gets a non-empty list containing the product + product-type authorized users and superusers (and excludes unrelated users); product-type-authorized user resolution
- new `test_user_collaborators_via_authorized_users` — `get_authorized_users` returns co-members of the caller's authorized product plus superusers
- the carrier-table tests were updated for the new behaviour: carrier roles remain inert in OS, but a non-staff caller now correctly sees superusers (previously asserted self-only / none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
