### PR TITLE
Fix SARIF parser: unwrap BlackDuck nested fingerprint dict values

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -632,6 +632,9 @@ def get_fingerprints_hashes(values):
             key_method = key
             key_method_version = 0
         value = values[key]
+        # some tools (e.g. BlackDuck) wrap the hash as {"value": "<hash>"} instead of a plain string
+        if isinstance(value, dict):
+            value = value.get("value", "")
         if fingerprints.get(key_method):
             if fingerprints[key_method]["version"] < key_method_version:
                 fingerprints[key_method] = {

--- a/unittests/scans/sarif/blackduck_nested_fingerprints.sarif
+++ b/unittests/scans/sarif/blackduck_nested_fingerprints.sarif
@@ -1,0 +1,292 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Example-Application",
+          "rules": [
+            {
+              "id": "BDSA-2020-1001 (CVE-2020-11022)",
+              "name": "BDSA-2020-1001 (CVE-2020-11022)",
+              "shortDescription": {
+                "text": "BDSA-2020-1001 (CVE-2020-11022)"
+              },
+              "fullDescription": {
+                "text": "jQuery is vulnerable to XSS via the HTML passed to certain jQuery methods."
+              },
+              "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2020-11022",
+              "properties": {
+                "tags": ["BDSA", "CWE-79", "SBOM"],
+                "cwe": ["CWE-79"]
+              }
+            },
+            {
+              "id": "BDSA-2021-1002 (CVE-2021-23337)",
+              "name": "BDSA-2021-1002 (CVE-2021-23337)",
+              "shortDescription": {
+                "text": "BDSA-2021-1002 (CVE-2021-23337)"
+              },
+              "fullDescription": {
+                "text": "Lodash is vulnerable to command injection via the template function."
+              },
+              "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+              "properties": {
+                "tags": ["BDSA", "CWE-78", "SBOM"],
+                "cwe": ["CWE-78"]
+              }
+            },
+            {
+              "id": "BDSA-2019-1003 (CVE-2019-10744)",
+              "name": "BDSA-2019-1003 (CVE-2019-10744)",
+              "shortDescription": {
+                "text": "BDSA-2019-1003 (CVE-2019-10744)"
+              },
+              "fullDescription": {
+                "text": "Lodash is vulnerable to prototype pollution via the defaultsDeep function."
+              },
+              "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2019-10744",
+              "properties": {
+                "tags": ["BDSA", "CWE-1321", "SBOM"],
+                "cwe": ["CWE-1321"]
+              }
+            },
+            {
+              "id": "BDSA-2022-1004",
+              "name": "BDSA-2022-1004",
+              "shortDescription": {
+                "text": "BDSA-2022-1004"
+              },
+              "fullDescription": {
+                "text": "Example-lib is affected by a denial of service vulnerability."
+              },
+              "helpUri": "https://nvd.nist.gov/vuln/search",
+              "properties": {
+                "tags": ["BDSA", "CWE-400", "SBOM"],
+                "cwe": ["CWE-400"]
+              }
+            },
+            {
+              "id": "BDSA-2023-1005 (CVE-2023-26115)",
+              "name": "BDSA-2023-1005 (CVE-2023-26115)",
+              "shortDescription": {
+                "text": "BDSA-2023-1005 (CVE-2023-26115)"
+              },
+              "fullDescription": {
+                "text": "word-wrap is vulnerable to ReDoS via the wrap function."
+              },
+              "helpUri": "https://nvd.nist.gov/vuln/detail/CVE-2023-26115",
+              "properties": {
+                "tags": ["BDSA", "CWE-1333", "SBOM"],
+                "cwe": ["CWE-1333"]
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "BDSA-2020-1001 (CVE-2020-11022)",
+          "level": "warning",
+          "message": {
+            "text": "BDSA-2020-1001 (CVE-2020-11022) in example-frontend-lib 1.0.0"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "npm/example-frontend-lib@1.0.0"
+                }
+              }
+            }
+          ],
+          "fixes": [
+            {
+              "description": {
+                "text": "Upgrade/patch dependency: example-frontend-lib 1.0.0."
+              }
+            }
+          ],
+          "properties": {
+            "securityRisk": "MEDIUM",
+            "component": "example-frontend-lib",
+            "componentVersion": "1.0.0",
+            "componentOrigin": "npm",
+            "matchType": "exact",
+            "exploitAvailable": false,
+            "solutionAvailable": true,
+            "workaroundAvailable": false,
+            "remediationStatus": "New",
+            "reachable": "unknown"
+          },
+          "fingerprints": {
+            "csvRowSha256": {
+              "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          }
+        },
+        {
+          "ruleId": "BDSA-2021-1002 (CVE-2021-23337)",
+          "level": "error",
+          "message": {
+            "text": "BDSA-2021-1002 (CVE-2021-23337) in example-util-lib 4.17.20"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "npm/example-util-lib@4.17.20"
+                }
+              }
+            }
+          ],
+          "fixes": [
+            {
+              "description": {
+                "text": "Upgrade/patch dependency: example-util-lib 4.17.20."
+              }
+            }
+          ],
+          "properties": {
+            "securityRisk": "HIGH",
+            "component": "example-util-lib",
+            "componentVersion": "4.17.20",
+            "componentOrigin": "npm",
+            "matchType": "exact",
+            "exploitAvailable": true,
+            "solutionAvailable": true,
+            "workaroundAvailable": false,
+            "remediationStatus": "New",
+            "reachable": "unknown"
+          },
+          "fingerprints": {
+            "csvRowSha256": {
+              "value": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            }
+          }
+        },
+        {
+          "ruleId": "BDSA-2019-1003 (CVE-2019-10744)",
+          "level": "error",
+          "message": {
+            "text": "BDSA-2019-1003 (CVE-2019-10744) in example-util-lib 4.17.20"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "npm/example-util-lib@4.17.20"
+                }
+              }
+            }
+          ],
+          "fixes": [
+            {
+              "description": {
+                "text": "Upgrade/patch dependency: example-util-lib 4.17.20."
+              }
+            }
+          ],
+          "properties": {
+            "securityRisk": "HIGH",
+            "component": "example-util-lib",
+            "componentVersion": "4.17.20",
+            "componentOrigin": "npm",
+            "matchType": "exact",
+            "exploitAvailable": false,
+            "solutionAvailable": true,
+            "workaroundAvailable": false,
+            "remediationStatus": "New",
+            "reachable": "unknown"
+          },
+          "fingerprints": {
+            "csvRowSha256": {
+              "value": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            }
+          }
+        },
+        {
+          "ruleId": "BDSA-2022-1004",
+          "level": "note",
+          "message": {
+            "text": "BDSA-2022-1004 in example-common-lib 2.3.1"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "maven/example-common-lib@2.3.1"
+                }
+              }
+            }
+          ],
+          "fixes": [
+            {
+              "description": {
+                "text": "Upgrade/patch dependency: example-common-lib 2.3.1."
+              }
+            }
+          ],
+          "properties": {
+            "securityRisk": "LOW",
+            "component": "example-common-lib",
+            "componentVersion": "2.3.1",
+            "componentOrigin": "maven",
+            "matchType": "exact",
+            "exploitAvailable": false,
+            "solutionAvailable": false,
+            "workaroundAvailable": true,
+            "remediationStatus": "Ignored",
+            "reachable": "unknown"
+          },
+          "fingerprints": {
+            "csvRowSha256": {
+              "value": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+            }
+          }
+        },
+        {
+          "ruleId": "BDSA-2023-1005 (CVE-2023-26115)",
+          "level": "error",
+          "message": {
+            "text": "BDSA-2023-1005 (CVE-2023-26115) in example-text-lib 1.2.5"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "npm/example-text-lib@1.2.5"
+                }
+              }
+            }
+          ],
+          "fixes": [
+            {
+              "description": {
+                "text": "Upgrade/patch dependency: example-text-lib 1.2.5."
+              }
+            }
+          ],
+          "properties": {
+            "securityRisk": "CRITICAL",
+            "component": "example-text-lib",
+            "componentVersion": "1.2.5",
+            "componentOrigin": "npm",
+            "matchType": "exact",
+            "exploitAvailable": true,
+            "solutionAvailable": true,
+            "workaroundAvailable": false,
+            "remediationStatus": "New",
+            "reachable": "unknown"
+          },
+          "fingerprints": {
+            "csvRowSha256": {
+              "value": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/tools/test_sarif_parser.py
+++ b/unittests/tools/test_sarif_parser.py
@@ -595,8 +595,10 @@ add_core(ptr, offset, val);
         )
 
     def test_blackduck_nested_fingerprints(self):
-        """BlackDuck wraps fingerprint values as {"value": "<hash>"} instead of a plain string.
-        Verify unique_id_from_tool is extracted as a string, not left as a dict."""
+        """
+        BlackDuck wraps fingerprint values as {"value": "<hash>"} instead of a plain string.
+        Verify unique_id_from_tool is extracted as a string, not left as a dict.
+        """
         with (get_unit_tests_scans_path("sarif") / "blackduck_nested_fingerprints.sarif").open(encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())

--- a/unittests/tools/test_sarif_parser.py
+++ b/unittests/tools/test_sarif_parser.py
@@ -580,6 +580,44 @@ add_core(ptr, offset, val);
             get_fingerprints_hashes(data2["fingerprints"]),
         )
 
+        # some tools (e.g. BlackDuck) wrap the hash as {"value": "<hash>"} instead of a plain string
+        data3 = {"fingerprints": {"csvRowSha256": {"value": "abc123"}}}
+        self.assertEqual(
+            {"csvRowSha256": {"version": 0, "value": "abc123"}},
+            get_fingerprints_hashes(data3["fingerprints"]),
+        )
+
+        # nested dict with no "value" key falls back to empty string rather than raising KeyError
+        data4 = {"fingerprints": {"csvRowSha256": {"other": "data"}}}
+        self.assertEqual(
+            {"csvRowSha256": {"version": 0, "value": ""}},
+            get_fingerprints_hashes(data4["fingerprints"]),
+        )
+
+    def test_blackduck_nested_fingerprints(self):
+        """BlackDuck wraps fingerprint values as {"value": "<hash>"} instead of a plain string.
+        Verify unique_id_from_tool is extracted as a string, not left as a dict."""
+        with (get_unit_tests_scans_path("sarif") / "blackduck_nested_fingerprints.sarif").open(encoding="utf-8") as testfile:
+            parser = SarifParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(5, len(findings))
+            for finding in findings:
+                self.common_checks(finding)
+                self.assertIsInstance(finding.unique_id_from_tool, str)
+                self.assertFalse(finding.unique_id_from_tool.startswith("{"))
+            with self.subTest(i=0):
+                finding = findings[0]
+                self.assertEqual("Medium", finding.severity)
+                self.assertEqual("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", finding.unique_id_from_tool)
+            with self.subTest(i=1):
+                finding = findings[1]
+                self.assertEqual("High", finding.severity)
+                self.assertEqual("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", finding.unique_id_from_tool)
+            with self.subTest(i=3):
+                finding = findings[3]
+                self.assertEqual("Info", finding.severity)
+                self.assertEqual("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", finding.unique_id_from_tool)
+
     def test_tags_from_result_properties(self):
         with (get_unit_tests_scans_path("sarif") / "taint-python-report.sarif").open(encoding="utf-8") as testfile:
             parser = SarifParser()


### PR DESCRIPTION
## Summary

- BlackDuck SARIF output wraps fingerprint values as `{"value": "<hash>"}` objects instead of the plain strings the SARIF 2.1.0 spec requires
- `get_fingerprints_hashes()` stored these dicts directly into `unique_id_from_tool`, which Django's CharField silently coerced to `str(dict)` on save — but the objects arrive as actual dicts in memory
- On second reimport, `update_candidates_with_saved_finding()` uses `unique_id_from_tool` as a Python dict key (`candidates_by_uid.setdefault(finding.unique_id_from_tool, [])`) — dicts are not hashable, raising `TypeError: cannot use 'dict' as a set element (unhashable type: 'dict')`
- This crash happens for **all** reimport deduplication algorithms (the update runs unconditionally), so there is no algorithm-based workaround

## Fix

Unwrap the nested dict at parse time in `get_fingerprints_hashes()`:
```python
if isinstance(value, dict):
    value = value.get("value", "")
```

## Test plan

- [x] Ran `manage.py test unittests.tools.test_sarif_parser` — all 25 tests pass
- [x] Added 2 new cases to `test_get_fingerprints_hashes` covering nested dict with `value` key and nested dict with missing `value` key (empty-string fallback)
- [x] Added `test_blackduck_nested_fingerprints` integration test with a sanitized 5-finding SARIF fixture covering Medium/High/Info/Critical severity levels — verifies `unique_id_from_tool` is a plain string and not a dict representation
- [x] Sanitized fixture uses fictional tool name, component names, and synthetic fingerprint hashes; real public CVE IDs are retained for authenticity

## Note on existing findings in affected customer databases

Findings created before this fix will have `unique_id_from_tool` stored as `"{'value': 'abc123...'}"` (the `str()` repr of the dict). After deploying the fix, new reimports will produce the correct hash string — these will not match the old str-repr values, causing the old findings to be closed and new ones opened on the next reimport. Customers should be warned if they care about finding continuity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)