### PR TITLE
fix(filters): don't auto-open the filter panel when only sorting a column

### DIFF
--- a/dojo/templates/dojo/components.html
+++ b/dojo/templates/dojo/components.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load humanize %}
 {% load display_tags %}
 {% load static %}
@@ -16,7 +17,7 @@
                     </div>
                 </h3>
             </div>
-            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form|has_active_filters %}in{% endif %}">
                 {% include "dojo/filter_snippet.html" with form=filter.form %}
             </div>
         </div>

--- a/dojo/templates/dojo/dev_env.html
+++ b/dojo/templates/dojo/dev_env.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -28,7 +29,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if dts.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if dts.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=dts.form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -34,7 +35,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filter_form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filter_form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filter_form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -15,7 +16,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filter_form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filter_form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filter_form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/engineer_metrics.html
+++ b/dojo/templates/dojo/engineer_metrics.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -15,7 +16,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filtered.form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/note_type.html
+++ b/dojo/templates/dojo/note_type.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -29,7 +30,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if ntl.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if ntl.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=ntl.form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -36,7 +37,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if prod_filter.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if prod_filter.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=prod_filter.form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/product_components.html
+++ b/dojo/templates/dojo/product_components.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% block content %}
     {{ block.super }}
 
@@ -14,7 +15,7 @@
                         </div>
                     </h3>
             </div>
-            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form|has_active_filters %}in{% endif %}">
                 {% include "dojo/filter_snippet.html" with form=filter.form %}
             </div>
         </div>

--- a/dojo/templates/dojo/product_type.html
+++ b/dojo/templates/dojo/product_type.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% load display_tags %}
@@ -33,7 +34,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if ptl.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if ptl.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=ptl.form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/request_endpoint_report.html
+++ b/dojo/templates/dojo/request_endpoint_report.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load humanize %}
 {% block content %}
     {{ block.super }}
@@ -13,7 +14,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form|has_active_filters %}in{% endif %}">
                     <div class="dojo-filter-heading">Filters</div>
                     <div class="filter-set">
 

--- a/dojo/templates/dojo/request_report.html
+++ b/dojo/templates/dojo/request_report.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load humanize %}
 {% load display_tags %}
 {% block content %}
@@ -26,7 +27,7 @@
                     </h3>
                 </div>
 
-                <div id="the-filters" class="is-filters panel-body {% if findings.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body {% if findings.form|has_active_filters %}in{% endif %}">
                     <div class="dojo-filter-heading">Filters</div>
                     <div class="filter-set">
 

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -1,3 +1,4 @@
+{% load filter_tags %}
 {% load humanize %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -27,7 +28,7 @@
                 </div>
               </h4>
         </div>
-        <div id="the-filters-{{status}}" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+        <div id="the-filters-{{status}}" class="is-filters panel-body collapse {% if filter.form|has_active_filters %}in{% endif %}">
             {% include "dojo/filter_snippet.html" with form=filter.form %}
         </div>
 

--- a/dojo/templates/dojo/templates.html
+++ b/dojo/templates/dojo/templates.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -42,7 +43,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filtered.form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/test_type.html
+++ b/dojo/templates/dojo/test_type.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -28,7 +29,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if test_types.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if test_types.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=test_types.form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/users.html
+++ b/dojo/templates/dojo/users.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load i18n %}
 {% load navigation_tags %}
 {% load authorization_tags %}
@@ -38,7 +39,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filtered.form %}
                 </div>
             </div>

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load display_tags %}
 {% load humanize %}
 {% load survey_tags %}
@@ -231,7 +232,7 @@
                                 </h4>
                             </div>
                         </div>
-                        <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+                        <div id="the-filters" class="is-filters panel-body collapse {% if filter.form|has_active_filters %}in{% endif %}">
                             {% include "dojo/filter_snippet.html" with form=filter.form %}
                         </div>
                     {% if tests %}

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load i18n %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -73,7 +74,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if prod_filter.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if prod_filter.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=prod_filter.form %}
                 </div>
                 {% if products %}

--- a/dojo/templates_classic/dojo/action_history.html
+++ b/dojo/templates_classic/dojo/action_history.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load display_tags %}
 {% block content %}
     {{ block.super }}
@@ -14,7 +15,7 @@
                             </div>
                         </h4>
                     </div>
-                    <div id="pghistory-filters" class="is-filters panel-body collapse {% if pghistory_filter.form.has_changed %}in{% endif %}">
+                    <div id="pghistory-filters" class="is-filters panel-body collapse {% if pghistory_filter.form|has_active_filters %}in{% endif %}">
                         {% include "dojo/filter_snippet.html" with form=pghistory_filter.form %}
                     </div>
                     <div class="clearfix">
@@ -135,7 +136,7 @@
                             </div>
                         </h4>
                     </div>
-                    <div id="the-filters" class="is-filters panel-body collapse {% if log_entry_filter.form.has_changed %}in{% endif %}">
+                    <div id="the-filters" class="is-filters panel-body collapse {% if log_entry_filter.form|has_active_filters %}in{% endif %}">
                         {% include "dojo/filter_snippet.html" with form=log_entry_filter.form %}
                     </div>
                     <div class="clearfix">

--- a/dojo/templates_classic/dojo/components.html
+++ b/dojo/templates_classic/dojo/components.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load humanize %}
 {% load display_tags %}
 {% load static %}
@@ -16,7 +17,7 @@
                     </div>
                 </h3>
             </div>
-            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form|has_active_filters %}in{% endif %}">
                 {% include "dojo/filter_snippet.html" with form=filter.form %}
             </div>
         </div>

--- a/dojo/templates_classic/dojo/dev_env.html
+++ b/dojo/templates_classic/dojo/dev_env.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -28,7 +29,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if dts.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if dts.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=dts.form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/engagement.html
+++ b/dojo/templates_classic/dojo/engagement.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -34,7 +35,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filter_form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filter_form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filter_form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/engagements_all.html
+++ b/dojo/templates_classic/dojo/engagements_all.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -15,7 +16,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filter_form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filter_form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filter_form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/engineer_metrics.html
+++ b/dojo/templates_classic/dojo/engineer_metrics.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -15,7 +16,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filtered.form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/note_type.html
+++ b/dojo/templates_classic/dojo/note_type.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -29,7 +30,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if ntl.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if ntl.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=ntl.form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/product.html
+++ b/dojo/templates_classic/dojo/product.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -36,7 +37,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if prod_filter.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if prod_filter.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=prod_filter.form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/product_components.html
+++ b/dojo/templates_classic/dojo/product_components.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% block content %}
     {{ block.super }}
 
@@ -14,7 +15,7 @@
                         </div>
                     </h3>
             </div>
-            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form|has_active_filters %}in{% endif %}">
                 {% include "dojo/filter_snippet.html" with form=filter.form %}
             </div>
         </div>

--- a/dojo/templates_classic/dojo/product_type.html
+++ b/dojo/templates_classic/dojo/product_type.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% load display_tags %}
@@ -33,7 +34,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if ptl.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if ptl.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=ptl.form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/request_endpoint_report.html
+++ b/dojo/templates_classic/dojo/request_endpoint_report.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load humanize %}
 {% block content %}
     {{ block.super }}
@@ -13,7 +14,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form|has_active_filters %}in{% endif %}">
                     <div class="dojo-filter-heading">Filters</div>
                     <div class="filter-set">
 

--- a/dojo/templates_classic/dojo/request_report.html
+++ b/dojo/templates_classic/dojo/request_report.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load humanize %}
 {% load display_tags %}
 {% block content %}
@@ -26,7 +27,7 @@
                     </h3>
                 </div>
 
-                <div id="the-filters" class="is-filters panel-body {% if findings.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body {% if findings.form|has_active_filters %}in{% endif %}">
                     <div class="dojo-filter-heading">Filters</div>
                     <div class="filter-set">
 

--- a/dojo/templates_classic/dojo/snippets/engagement_list.html
+++ b/dojo/templates_classic/dojo/snippets/engagement_list.html
@@ -1,3 +1,4 @@
+{% load filter_tags %}
 {% load humanize %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -27,7 +28,7 @@
                 </div>
               </h4>
         </div>
-        <div id="the-filters-{{status}}" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+        <div id="the-filters-{{status}}" class="is-filters panel-body collapse {% if filter.form|has_active_filters %}in{% endif %}">
             {% include "dojo/filter_snippet.html" with form=filter.form %}
         </div>
 

--- a/dojo/templates_classic/dojo/templates.html
+++ b/dojo/templates_classic/dojo/templates.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -42,7 +43,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filtered.form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/test_type.html
+++ b/dojo/templates_classic/dojo/test_type.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
@@ -28,7 +29,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if test_types.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if test_types.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=test_types.form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/users.html
+++ b/dojo/templates_classic/dojo/users.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load i18n %}
 {% load navigation_tags %}
 {% load authorization_tags %}
@@ -38,7 +39,7 @@
                         </div>
                     </h3>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if filtered.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=filtered.form %}
                 </div>
             </div>

--- a/dojo/templates_classic/dojo/view_eng.html
+++ b/dojo/templates_classic/dojo/view_eng.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load display_tags %}
 {% load humanize %}
 {% load survey_tags %}
@@ -231,7 +232,7 @@
                                 </h4>
                             </div>
                         </div>
-                        <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+                        <div id="the-filters" class="is-filters panel-body collapse {% if filter.form|has_active_filters %}in{% endif %}">
                             {% include "dojo/filter_snippet.html" with form=filter.form %}
                         </div>
                     {% if tests %}

--- a/dojo/templates_classic/dojo/view_product_type.html
+++ b/dojo/templates_classic/dojo/view_product_type.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load filter_tags %}
 {% load i18n %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -73,7 +74,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="the-filters" class="is-filters panel-body collapse {% if prod_filter.form.has_changed %}in{% endif %}">
+                <div id="the-filters" class="is-filters panel-body collapse {% if prod_filter.form|has_active_filters %}in{% endif %}">
                     {% include "dojo/filter_snippet.html" with form=prod_filter.form %}
                 </div>
                 {% if products %}

--- a/dojo/templatetags/filter_tags.py
+++ b/dojo/templatetags/filter_tags.py
@@ -59,6 +59,26 @@ FINDING_FIELD_GROUPS = OrderedDict([
 # Categories that should be expanded by default
 DEFAULT_OPEN_GROUPS = {"Search", "Severity & Risk", "Status"}
 
+# Query param that django_filters' OrderingFilter uses for column sorting.
+# Sorting is not filtering, so it must not auto-expand the filter panel.
+ORDERING_PARAM = "o"
+
+
+@register.filter
+def has_active_filters(form):
+    """
+    Return True only if a real *filter* is applied to a bound filter form.
+
+    Like Django's ``form.has_changed()`` but ignores the ordering field (``o``).
+    Column-header sort links write ``?o=...`` into the same filter form, so
+    plain ``has_changed`` treats sorting as filtering and auto-opens the filter
+    panel even though the user only sorted a column. Ignoring ``o`` keeps the
+    panel closed unless an actual filter value changed.
+    """
+    if form is None:
+        return False
+    return bool(set(form.changed_data) - {ORDERING_PARAM})
+
 
 def _is_finding_filter(form):
     """Check if a form is a Finding-related filter."""

--- a/unittests/test_filter_tags.py
+++ b/unittests/test_filter_tags.py
@@ -1,0 +1,40 @@
+from django.http import QueryDict
+
+from dojo.filters import ProductFilter
+from dojo.models import Product
+from dojo.templatetags.filter_tags import has_active_filters
+from unittests.dojo_test_case import DojoTestCase
+
+
+class HasActiveFiltersTests(DojoTestCase):
+
+    """
+    Regression tests for the list-page filter panel auto-opening.
+
+    The panel must auto-expand only when a real filter is applied, not when the
+    user merely sorts a column. Column-header sort links write ?o=... into the
+    same filter form, so plain form.has_changed() would treat sorting as
+    filtering and pop the panel open. has_active_filters() ignores the ordering
+    field so sorting alone leaves the panel closed.
+    """
+
+    def _form(self, query):
+        return ProductFilter(QueryDict(query), queryset=Product.objects.none()).form
+
+    def test_no_params_has_no_active_filters(self):
+        self.assertFalse(has_active_filters(self._form("")))
+
+    def test_ascending_sort_only_is_not_an_active_filter(self):
+        self.assertFalse(has_active_filters(self._form("o=prod_type__name")))
+
+    def test_descending_sort_only_is_not_an_active_filter(self):
+        self.assertFalse(has_active_filters(self._form("o=-name")))
+
+    def test_real_filter_is_active(self):
+        self.assertTrue(has_active_filters(self._form("name=anything")))
+
+    def test_filter_combined_with_sort_is_active(self):
+        self.assertTrue(has_active_filters(self._form("name=anything&o=prod_type__name")))
+
+    def test_none_form_is_not_active(self):
+        self.assertFalse(has_active_filters(None))


### PR DESCRIPTION
**Description**

List pages share a single `django-filter` form for both filtering **and** column sorting (the `OrderingFilter` `o` parameter). The filter panel's initial expanded state is driven by `{% if ...form.has_changed %}`, so sorting a column — which only adds `?o=...` to the URL — flips `has_changed()` to `True` and auto-opens the filter panel even though no filter was applied.

This is most visible on the **Asset (Product) list**: clicking the *Organization* or *Active (Verified) Findings* column header reloads the page and the filter panel springs open. (Originally reported in #1811 and since regressed.)

**Fix:** add a small `has_active_filters` template filter that mirrors `form.has_changed()` but ignores the ordering field (`o`), and use it for the panel-expand condition on all list pages, in **both UI trees**:
- `dojo/templates/` — new (Tailwind) UI — 17 templates.
- `dojo/templates_classic/` — classic (default) UI — 18 templates (the same list pages, plus both filter panels on `action_history.html`).

Sorting is no longer treated as filtering, so the panel stays closed unless a real filter value is set.

This is intentionally narrow and low-risk:
- `form.has_changed()` itself is **not** modified, so nothing relying on Django's `has_changed()` semantics is affected.
- `django-filter` does not use `has_changed()` for filtering (it uses `cleaned_data`), so query/sort results are unchanged.
- The only observable effect is the filter panel's initial open/closed state.

`view_finding.html` uses a separate, hand-managed `has_changed` flag for similar-findings, and the condition in `view_notification_webhooks.html` is commented out — both intentionally left unchanged in both trees.

**Test results**

Added `unittests/test_filter_tags.py` covering `has_active_filters`:
- no params / sort-only (`o=prod_type__name`, `o=-name`) → not active (panel stays closed)
- a real filter (`name=…`) / filter + sort → active (panel opens)

```
Ran 6 tests in 0.017s
OK
```

- Verified end-to-end through the template engine that `{% if form|has_active_filters %}` renders the panel CLOSED for sort-only requests and OPEN when a filter value is present.
- Verified live on the new (Tailwind) UI: sorting the Asset list by Organization no longer opens the panel.
- Compile-checked all 18 modified classic templates parse correctly with the new `{% load filter_tags %}` + `|has_active_filters`.

**Documentation**

No documentation changes needed — UI behavior fix, no settings or model changes.

**Known related issue (out of scope here):** on tables enhanced by DataTables, clicking a sortable header briefly client-sorts the visible rows before the server-side `?o=` reload replaces them (a momentary "flash"). That is the long-standing client-vs-server sort conflict also noted in #1811 and is intentionally **not** addressed in this PR.

**Checklist**

- [x] Bugfix submitted against the `bugfix` branch.
- [x] Meaningful PR name (may be used in release notes).
- [x] Code is Ruff compliant (see `ruff.toml`).
- [x] Code is Python 3.13 compliant.
- [x] No model changes / migrations required.
- [x] Added applicable unit tests.
- [x] Fix applied to both the new and classic UI template trees.
- [ ] Add the `bugfix` label.