### PR TITLE
fix(ui): stop client/server sort flash on asset & finding-group lists

### DIFF
--- a/dojo/templates/dojo/finding_groups_list_snippet.html
+++ b/dojo/templates/dojo/finding_groups_list_snippet.html
@@ -172,6 +172,14 @@
         };
 
         $(document).ready(function() {
+            // Disable DataTables' client-side ordering on columns that sort server-side via dojo_sort
+            // (?o=), so a header click does ONE sort (server reload) instead of an instant client
+            // re-sort that "flashes" before the reload. (upstream issue #1811)
+            var serverSortDataKeys = new Set(['name', 'findings_count', 'creator', 'sla_deadline']);
+            var serverSortTargets = [];
+            for (var i = 0; i < datatables_columns.length; i++) {
+                if (serverSortDataKeys.has(datatables_columns[i]["data"])) { serverSortTargets.push(i); }
+            }
             $('#open_finding_groups').DataTable({
                 drawCallback: function(){
                     $('#open_finding_groups .has-popover').hover(
@@ -183,6 +191,10 @@
                 columns: datatables_columns,
                 order: [],
                 columnDefs: [
+                    {
+                        orderable: false,
+                        targets: serverSortTargets
+                    },
                     {
                         targets: 'severity-sort',
                         orderDataType: 'severity-asc'

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -343,9 +343,12 @@
                   },
                   colReorder: true,
 				  autoWidth: false,
+                  // Columns whose headers render server-side sort links (dojo_sort -> ?o=) must NOT
+                  // also be client-sortable by DataTables, or a header click triggers an instant client
+                  // re-sort that "flashes" right before the server reload redraws. (upstream issue #1811)
                   "columns": [
                       { "data": "action", "searchable": false },
-                      { "data": "product" },
+                      { "data": "product", "orderable": false },
                       { "data": "tags" },
                       { "data": "criticality" , render: function (data, type, row) {
                         const criticals = {
@@ -381,10 +384,10 @@
                               return type === 'export' ? getDojoExportValueFromTag(data, 'i', 'data-content') :  data;
                       }},
                       {% endif %}
-                      { "data": "findings" },
+                      { "data": "findings", "orderable": false },
                       { "data": "locations" },
                       { "data": "contacts" },
-                      { "data": "product_type" },
+                      { "data": "product_type", "orderable": false },
                   ],
                   order: [],
                   columnDefs: [

--- a/dojo/templates_classic/dojo/finding_groups_list_snippet.html
+++ b/dojo/templates_classic/dojo/finding_groups_list_snippet.html
@@ -172,6 +172,14 @@
         };
 
         $(document).ready(function() {
+            // Disable DataTables' client-side ordering on columns that sort server-side via dojo_sort
+            // (?o=), so a header click does ONE sort (server reload) instead of an instant client
+            // re-sort that "flashes" before the reload. (upstream issue #1811)
+            var serverSortDataKeys = new Set(['name', 'findings_count', 'creator', 'sla_deadline']);
+            var serverSortTargets = [];
+            for (var i = 0; i < datatables_columns.length; i++) {
+                if (serverSortDataKeys.has(datatables_columns[i]["data"])) { serverSortTargets.push(i); }
+            }
             $('#open_finding_groups').DataTable({
                 drawCallback: function(){
                     $('#open_finding_groups .has-popover').hover(
@@ -183,6 +191,10 @@
                 columns: datatables_columns,
                 order: [],
                 columnDefs: [
+                    {
+                        orderable: false,
+                        targets: serverSortTargets
+                    },
                     {
                         targets: 'severity-sort',
                         orderDataType: 'severity-asc'

--- a/dojo/templates_classic/dojo/product.html
+++ b/dojo/templates_classic/dojo/product.html
@@ -343,9 +343,12 @@
                   },
                   colReorder: true,
 				  autoWidth: false,
+                  // Columns whose headers render server-side sort links (dojo_sort -> ?o=) must NOT
+                  // also be client-sortable by DataTables, or a header click triggers an instant client
+                  // re-sort that "flashes" right before the server reload redraws. (upstream issue #1811)
                   "columns": [
                       { "data": "action", "searchable": false },
-                      { "data": "product" },
+                      { "data": "product", "orderable": false },
                       { "data": "tags" },
                       { "data": "criticality" , render: function (data, type, row) {
                         const criticals = {
@@ -381,10 +384,10 @@
                               return type === 'export' ? getDojoExportValueFromTag(data, 'i', 'data-content') :  data;
                       }},
                       {% endif %}
-                      { "data": "findings" },
+                      { "data": "findings", "orderable": false },
                       { "data": "locations" },
                       { "data": "contacts" },
-                      { "data": "product_type" },
+                      { "data": "product_type", "orderable": false },
                   ],
                   order: [],
                   columnDefs: [


### PR DESCRIPTION
## Description

Sortable column headers on the **Asset list** (`/asset`) and the open **Finding Groups list** (`/finding_group/open`) each rendered BOTH:

- a server-side `dojo_sort` link (`?o=…`, full page reload), and
- a client-side DataTables sort handler.

A single header click fired both: DataTables instantly re-sorted the currently displayed rows, then the server reload redrew them with the server-sorted set — a visible "flash". This is the long-standing client-vs-server sort conflict from #1811.

## Fix

Disable DataTables' client-side ordering on the columns that already sort server-side via `dojo_sort`, so a header click triggers only the server reload. Columns *without* a `dojo_sort` link stay client-sortable (e.g. Tags, Criticality, Severity), and the custom Severity sort is untouched.

This mirrors the fix already merged in `findings_list_snippet.html`.

Both UI trees:

- `product.html` (new + classic): `orderable: false` on the `product` / `findings` / `product_type` columns.
- `finding_groups_list_snippet.html` (new + classic): a `serverSortTargets` `columnDef` (same pattern as `findings_list_snippet.html`), keyed by column `data` so it is immune to the conditional Jira/GitHub column shifting.

## Scope / completeness

The conflict requires a table to have **both** a `.DataTable()` init **and** `dojo_sort` headers. That intersection is exactly six templates: `findings_list_snippet.html` (already fixed), and `product.html` + `finding_groups_list_snippet.html` (fixed here) — across both UI trees. Other DataTables pages use plain (client-only) headers, and other `dojo_sort` pages have no DataTables, so neither flashes.

## Testing

Verified in-browser on both UIs (Tailwind + classic), on `/asset` and `/finding_group/open`:

- the `dojo_sort` columns are no longer client-orderable (no double-sort);
- clicking a `dojo_sort` header produces no client-side reorder — only the server `?o=` reload;
- all non-`dojo_sort` columns remain client-sortable, including the custom Severity sort.
