### PR TITLE
Ree/perf indexes

### DIFF
--- a/dojo/db_migrations/0271_finding_perf_indexes.py
+++ b/dojo/db_migrations/0271_finding_perf_indexes.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
             model_name="finding",
             index=models.Index(
                 fields=["severity"],
-                name="idx_finding_open_active_by_severity",
+                name="idx_finding_open_active_sev",
                 condition=models.Q(active=True, is_mitigated=False),
             ),
         ),
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
             model_name="finding",
             index=models.Index(
                 fields=["severity", "-numerical_severity"],
-                name="idx_finding_sev_numsev_open_unverified",
+                name="idx_finding_sev_open_unver",
                 condition=models.Q(active=True, verified=False),
             ),
         ),

--- a/dojo/db_migrations/0271_finding_perf_indexes.py
+++ b/dojo/db_migrations/0271_finding_perf_indexes.py
@@ -1,0 +1,55 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block, and avoids
+    # an ACCESS EXCLUSIVE lock on the (large) dojo_finding table.
+    atomic = False
+
+    dependencies = [
+        ("dojo", "0270_finding_visibility_perf_indexes"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="finding",
+            index=models.Index(
+                fields=["test", "date"],
+                name="idx_finding_testid_date",
+            ),
+        ),
+        AddIndexConcurrently(
+            model_name="finding",
+            index=models.Index(
+                fields=["sla_expiration_date", "test"],
+                name="idx_finding_sla_open_cov",
+                condition=models.Q(is_mitigated=False),
+            ),
+        ),
+        AddIndexConcurrently(
+            model_name="finding",
+            index=models.Index(
+                fields=["severity"],
+                name="idx_finding_open_active_by_severity",
+                condition=models.Q(active=True, is_mitigated=False),
+            ),
+        ),
+        AddIndexConcurrently(
+            model_name="finding",
+            index=models.Index(
+                fields=["severity", "-numerical_severity"],
+                name="idx_finding_sev_numsev_open_unverified",
+                condition=models.Q(active=True, verified=False),
+            ),
+        ),
+        AddIndexConcurrently(
+            model_name="finding",
+            index=models.Index(
+                fields=["test", "sla_expiration_date", "date"],
+                name="idx_finding_sla_breach_cov",
+                include=["id"],
+                condition=models.Q(is_mitigated=False),
+            ),
+        ),
+    ]

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2736,12 +2736,12 @@ class Finding(BaseModel):
             ),
             models.Index(
                 fields=["severity"],
-                name="idx_finding_open_active_by_severity",
+                name="idx_finding_open_active_sev",
                 condition=Q(active=True, is_mitigated=False),
             ),
             models.Index(
                 fields=["severity", "-numerical_severity"],
-                name="idx_finding_sev_numsev_open_unverified",
+                name="idx_finding_sev_open_unver",
                 condition=Q(active=True, verified=False),
             ),
             models.Index(

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2725,6 +2725,31 @@ class Finding(BaseModel):
                 name="idx_finding_riskaccepted_date",
                 condition=Q(risk_accepted=True),
             ),
+            models.Index(
+                fields=["test", "date"],
+                name="idx_finding_testid_date",
+            ),
+            models.Index(
+                fields=["sla_expiration_date", "test"],
+                name="idx_finding_sla_open_cov",
+                condition=Q(is_mitigated=False),
+            ),
+            models.Index(
+                fields=["severity"],
+                name="idx_finding_open_active_by_severity",
+                condition=Q(active=True, is_mitigated=False),
+            ),
+            models.Index(
+                fields=["severity", "-numerical_severity"],
+                name="idx_finding_sev_numsev_open_unverified",
+                condition=Q(active=True, verified=False),
+            ),
+            models.Index(
+                fields=["test", "sla_expiration_date", "date"],
+                name="idx_finding_sla_breach_cov",
+                include=["id"],
+                condition=Q(is_mitigated=False),
+            ),
         ]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Add performance indexes for large finding datasets

Five indexes on dojo_finding backing common finding-list, SLA, and severity queries that were slow for customers with large datasets:

* idx_finding_testid_date (test_id, date) -- per-test finding lists
  ordered/filtered by date.
* idx_finding_sla_open_cov (sla_expiration_date, test_id) WHERE NOT
  is_mitigated -- SLA-expiration scans over open findings only.
* idx_finding_open_active_by_severity (severity) WHERE active AND NOT
  is_mitigated -- severity filters on the open/active working set.
* idx_finding_sev_numsev_open_unverified (severity, numerical_severity
  DESC) WHERE active AND NOT verified -- unverified-triage lists ordered
  by severity.
* idx_finding_sla_breach_cov (test_id, sla_expiration_date, date)
  INCLUDE (id) WHERE NOT is_mitigated -- covering index for SLA-breach
  lookups, served index-only without heap fetches.

The partial WHERE clauses keep these indexes small by excluding mitigated/inactive rows, which dominate row counts on large tenants but are rarely scanned by these queries.

Built CONCURRENTLY (atomic = False) so the migration takes no ACCESS EXCLUSIVE lock on the large dojo_finding table.