### PR TITLE
fix(tags): keep user-set tags when creating a finding under product tag inheritance

### DIFF
--- a/dojo/tags/signals.py
+++ b/dojo/tags/signals.py
@@ -3,6 +3,7 @@ import logging
 
 from django.db.models import signals
 from django.dispatch import receiver
+from tagulous.models.fields import SingleTagField, TagField
 
 from dojo.celery_dispatch import dojo_dispatch_task
 from dojo.location.models import Location, LocationFindingReference, LocationProductReference
@@ -15,6 +16,31 @@ from dojo.tags.inheritance import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _flush_pending_tag_fields(instance):
+    """
+    Persist any tags assigned to ``instance`` *before* it was first saved.
+
+    Tagulous holds tags set on an unsaved instance (``finding.tags = [...]``
+    followed by ``finding.save()``) in an in-memory manager and only writes
+    them to the through table from its own ``post_save`` handler. That handler
+    is registered by ``tagulous``' AppConfig.ready(), which runs *after*
+    ``dojo``'s (``dojo`` precedes ``tagulous`` in ``INSTALLED_APPS``), so the
+    inheritance ``post_save`` handler below fires first. When it reads
+    ``instance.tags`` on the freshly-saved row it loads an empty, DB-backed
+    manager and the pending pre-save tags are lost — the user's tags silently
+    disappear on finding creation when product tag inheritance is enabled
+    (#15092).
+
+    Flushing here makes the inheritance path independent of signal-handler
+    ordering: the instance's own tags are committed first, then inheritance
+    merges the product tags on top.
+    """
+    for field in instance._meta.get_fields():
+        if isinstance(field, SingleTagField | TagField):
+            descriptor = getattr(type(instance), field.name)
+            descriptor.get_manager(instance).post_save_handler()
 
 
 def auto_inherit_product_tags(instance):
@@ -32,6 +58,9 @@ def auto_inherit_product_tags(instance):
     products = get_products_to_inherit_tags_from(instance)
     if not products:
         return
+    # Commit the instance's own (possibly pre-save assigned) tags before we
+    # read/merge them, so inheritance never clobbers them — see #15092.
+    _flush_pending_tag_fields(instance)
     incoming_inherited_tags = [tag.name for product in products for tag in product.tags.all()]
     _sync_inherited_tags(instance, incoming_inherited_tags)
 

--- a/unittests/test_tag_inheritance.py
+++ b/unittests/test_tag_inheritance.py
@@ -307,6 +307,45 @@ class TestPerProductTagInheritance(DojoTestCase):
         self.assertEqual(sorted(t.name for t in eng_with.tags.all()), ["inherit-me"])
         self.assertEqual(list(eng_without.tags.all()), [])
 
+    def test_finding_created_with_own_tag_keeps_it_and_inherits(self):
+        """
+        Regression test for #15092.
+
+        Assigning tags to an unsaved finding and then saving it (the UI
+        "add finding" flow: ``finding.tags = [...]; finding.save()``) must keep
+        the user's own tags *and* merge the inherited product tags. Previously
+        the inheritance post_save handler ran before tagulous persisted the
+        pre-save tags and silently dropped them.
+        """
+        product = self.create_product("Inherit On Create", tags=["product-tag"])
+        product.enable_product_tag_inheritance = True
+        product.save()
+        engagement = self.create_engagement("Eng", product)
+        test = self.create_test(engagement=engagement, scan_type="ZAP Scan")
+
+        finding = Finding(test=test, title="With own tag", severity="Medium", reporter=self.get_test_admin())
+        finding.tags = ["my-own-tag"]
+        finding.save()
+        finding.refresh_from_db()
+
+        self.assertEqual(sorted(t.name for t in finding.tags.all()), ["my-own-tag", "product-tag"])
+        self.assertEqual([t.name for t in finding.inherited_tags.all()], ["product-tag"])
+
+    def test_finding_created_without_own_tag_still_inherits(self):
+        """A finding created with no tags must still receive the product's inherited tags (#15092 guard)."""
+        product = self.create_product("Inherit No Own Tag", tags=["product-tag"])
+        product.enable_product_tag_inheritance = True
+        product.save()
+        engagement = self.create_engagement("Eng", product)
+        test = self.create_test(engagement=engagement, scan_type="ZAP Scan")
+
+        finding = Finding(test=test, title="No own tag", severity="Medium", reporter=self.get_test_admin())
+        finding.save()
+        finding.refresh_from_db()
+
+        self.assertEqual([t.name for t in finding.tags.all()], ["product-tag"])
+        self.assertEqual([t.name for t in finding.inherited_tags.all()], ["product-tag"])
+
 
 # ---------------------------------------------------------------------------
 # Integration tests — endpoint inheritance (v2 only)


### PR DESCRIPTION
Fixes #15092

## Problem

When a product has **tag inheritance enabled**, creating a finding with its own tag via the UI ("add finding" flow) silently drops the user's tag — only the inherited product tags survive. Editing the finding afterwards and adding a tag works, which is what made the loss look specific to creation.

Reproduced exactly:

| flow | result |
|---|---|
| create with pre-save tag (`finding.tags = [...]; finding.save()`) | ❌ `['producttag']` — user tag gone |
| add tag after save (edit flow) | ✅ `['myrandomtag', 'producttag']` |
| inheritance **off** | ✅ user tag survives |

## Root cause — signal-handler ordering

The `post_save` dispatch order for `Finding` is:

1. imagekit → 2. watson → 3. **`dojo.tags.signals.inherit_tags_on_instance`** → 4. **tagulous's flush** (`PostSaveHandler`)

Tagulous holds tags assigned to an *unsaved* instance in an in-memory manager and only writes them to the through table from its own `post_save` handler, which is registered in **tagulous'** `AppConfig.ready()`. Because `"dojo"` precedes `"tagulous"` in `INSTALLED_APPS`, dojo's inheritance handler runs **first**: reading `instance.tags` on the freshly-saved row loads an empty, DB-backed manager and discards the pending pre-save tags before tagulous can persist them.

## Fix

Before computing/merging inherited tags, flush the instance's own tag fields (tagulous `manager.post_save_handler()`) so the user's tags are committed first. This makes inheritance independent of signal-handler ordering — findings created with *or* without their own tags now end up correct. 

- `dojo/tags/signals.py` — new `_flush_pending_tag_fields()` helper, called at the top of `auto_inherit_product_tags()`.
- `unittests/test_tag_inheritance.py` — two regression tests (create-with-own-tag, create-without-tag). The first fails without the fix and passes with it.

## Testing

- Reproduced the bug and validated the fix in a running stack (both cases correct).
- `test_tag_inheritance` (39), `test_tags` (26), `test_tag_inheritance_perf` (24) — all green.
