### PR TITLE
feat(ui): smooth and tidy the filter category accordion in the new UI

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1084,8 +1084,9 @@ span.endpoint_product {
     .filter-form-group > .col-lg-3 { grid-column: span 3; }
 }
 
-/* Filter category grouping (details/summary) */
+/* Filter category grouping (Alpine-toggled accordion) */
 .filter-category {
+    flex: 0 0 100%;
     border-bottom: 1px solid var(--color-border, #DCDCDC);
 }
 
@@ -1097,14 +1098,15 @@ span.endpoint_product {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    width: 100%;
     padding: 0.5rem 0.25rem;
+    background: none;
+    border: none;
+    font: inherit;
+    color: inherit;
+    text-align: left;
     cursor: pointer;
     user-select: none;
-    list-style: none;
-}
-
-.filter-category-header::-webkit-details-marker {
-    display: none;
 }
 
 .filter-category-title {
@@ -1121,8 +1123,25 @@ span.endpoint_product {
     transition: transform 0.2s ease;
 }
 
-.filter-category[open] > .filter-category-header .filter-category-chevron {
+.filter-category-chevron.is-open {
     transform: rotate(180deg);
+}
+
+/* Slide the whole category open/closed via the grid-rows trick so the header
+   stack moves together smoothly instead of snapping. Works in all browsers. */
+.filter-category-content {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.2s ease;
+}
+
+.filter-category-content.is-open {
+    grid-template-rows: 1fr;
+}
+
+.filter-category-content > .filter-category-clip {
+    overflow: hidden;
+    min-height: 0;
 }
 
 .filter-category-body {

--- a/dojo/templates/dojo/filter_snippet.html
+++ b/dojo/templates/dojo/filter_snippet.html
@@ -14,31 +14,35 @@
         {% endfor %}
         {% get_filter_groups form as filter_groups %}
         {% for group in filter_groups %}
-            <details class="filter-category" {% if group.open %}open{% endif %}>
-                <summary class="filter-category-header">
+            <div class="filter-category" x-data="{ open: {% if group.open %}true{% else %}false{% endif %} }">
+                <button type="button" class="filter-category-header" @click="open = !open" :aria-expanded="open">
                     <span class="filter-category-title">{{ group.name }}</span>
-                    <i class="fa-solid fa-chevron-down filter-category-chevron"></i>
-                </summary>
-                <div class="container-fluid filter-form-group filter-category-body">
-                    {% for field in group.fields %}
-                        <div class="col-lg-3 col-md-4 col-sm-6 col-12">
-                            <div class="filter-form-input" style="min-width: 0;">
-                                <label for="{{ field.auto_id }}" class="form-label mb-1" style="display: block;">
-                                    {{ field.label }}
-                                    {% if field.help_text %}
-                                        <i class="fa-solid fa-circle-question has-popover"
-                                        data-content="{{ field.help_text }}">
-                                        </i>
-                                    {% endif %}
-                                </label>
-                                {% with placeholder="placeholder:"|add:field.label %}
-                                  {{ field|addcss:"class: form-control filter-form-control"|addcss:placeholder }}
-                                {% endwith %}
-                            </div>
+                    <i class="fa-solid fa-chevron-down filter-category-chevron{% if group.open %} is-open{% endif %}" :class="{ 'is-open': open }"></i>
+                </button>
+                <div class="filter-category-content{% if group.open %} is-open{% endif %}" :class="{ 'is-open': open }">
+                    <div class="filter-category-clip">
+                        <div class="container-fluid filter-form-group filter-category-body">
+                            {% for field in group.fields %}
+                                <div class="col-lg-3 col-md-4 col-sm-6 col-12">
+                                    <div class="filter-form-input" style="min-width: 0;">
+                                        <label for="{{ field.auto_id }}" class="form-label mb-1" style="display: block;">
+                                            {{ field.label }}
+                                            {% if field.help_text %}
+                                                <i class="fa-solid fa-circle-question has-popover"
+                                                data-content="{{ field.help_text }}">
+                                                </i>
+                                            {% endif %}
+                                        </label>
+                                        {% with placeholder="placeholder:"|add:field.label %}
+                                          {{ field|addcss:"class: form-control filter-form-control"|addcss:placeholder }}
+                                        {% endwith %}
+                                    </div>
+                                </div>
+                            {% endfor %}
                         </div>
-                    {% endfor %}
+                    </div>
                 </div>
-            </details>
+            </div>
         {% endfor %}
         <div class="container-fluid">
             <div class="row mt-3">


### PR DESCRIPTION
**Description**

Addresses maintainer feedback that the new-UI filter panel felt "funky" to expand/collapse and was hard to read.

The filter categories used native `<details>`: the chevron animated but the body snapped open/closed, the header bars jumped to new positions instead of sliding together, and the categories packed inconsistently two-per-row (the filter form is `display: flex; flex-wrap: wrap`).

Changes:
- Convert each category to a small Alpine toggle (a `<button>` with `aria-expanded` and `type="button"`, so it never submits the filter form). The body sits in an overflow-clipped grid that animates `grid-template-rows: 0fr` to `1fr`. Animating the real layout height makes the whole header stack slide together smoothly and collapse fully to 0. This works in all browsers (no `interpolate-size` dependency). Default-open groups server-render the open state, so there is no flash on load.
- Give each category `flex: 0 0 100%` so they stack as full-width rows instead of packing two-per-row, making the panel easy to scan.

No filter behavior changes: same fields, same form submission.

**Test results**

Verified on a local build at the Findings filter panel: categories stack as full-width rows; toggling slides the body and the header stack together (collapses to 0px, expands to content height); clicking a header does not submit the form (`type="button"`); `aria-expanded` reflects state. No Python changed, so no unit tests added.

**Documentation**

N/A.

**Checklist**

- [x] Submitted against `dev`.
- [x] Meaningful PR name.
- [x] Ruff compliant (no Python changed).
- [x] Python 3.13 compliant (no Python changed).