### PR TITLE
fix(mass_model_updater): never skip a deferred tracked field as "unchanged" [sc-13375]

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1647,7 +1647,11 @@ def mass_model_updater(model_type, models, function, fields, page_size=1000, ord
     When ``fields`` is given:
       - skip_unchanged (default True): rows whose tracked ``fields`` were not changed by
         ``function`` are not written (compared against the values loaded from the page
-        query; deferred fields are read from ``__dict__`` so no extra query is issued).
+        query, read from ``__dict__`` so no extra query is issued). If any tracked field
+        is deferred (e.g. the queryset used ``.only()``/``.defer()`` and omitted it) the
+        no-op check is skipped for that row and it is always written, because ``__dict__``
+        has no loaded value to compare against and would otherwise read as ``None`` --
+        silently dropping a real change to ``None``.
       - writer (optional): a callable ``writer(model_type, batch, fields)`` used to persist
         each batch instead of Django's ``bulk_update`` (e.g. a backend-specific fast path).
         Defaults to ``bulk_update``.
@@ -1690,9 +1694,12 @@ def mass_model_updater(model_type, models, function, fields, page_size=1000, ord
             last_id = model.id
 
             # snapshot tracked fields before mutation (read from __dict__ to avoid
-            # triggering a deferred-field load); used to skip no-op writes
+            # triggering a deferred-field load); used to skip no-op writes.
+            # If any tracked field is deferred it is absent from __dict__ and would
+            # read as None -- making a real change to None look unchanged and dropping
+            # the write -- so leave before=None to force a write for that row.
             before = None
-            if fields and skip_unchanged:
+            if fields and skip_unchanged and not model.get_deferred_fields().intersection(fields):
                 before = [model.__dict__.get(f) for f in fields]
 
             function(model)

--- a/unittests/test_mass_model_updater.py
+++ b/unittests/test_mass_model_updater.py
@@ -130,6 +130,48 @@ class TestMassModelUpdater(DojoTestCase):
             msg="skip_unchanged=False must still write unchanged rows",
         )
 
+    def test_writes_deferred_field_recomputed_to_none(self):
+        # Regression (dojo-pro risk-mode SLA recalc): when the tracked field is
+        # deferred (queryset used .only() and omitted it), the before-snapshot must
+        # not be read as None from __dict__ and mistaken for "unchanged". Recomputing
+        # a populated field to None must still persist.
+        ids = self._finding_ids()
+        # Seed a non-None value via a normally-loaded queryset.
+        mass_model_updater(
+            Finding, Finding.objects.filter(id__in=ids),
+            lambda f: setattr(f, "hash_code", f"seed-{f.id}"), fields=["hash_code"], order="asc",
+        )
+        # Reload deferring hash_code, then recompute it to None.
+        deferred_qs = Finding.objects.filter(id__in=ids).only("id")
+        with CaptureQueriesContext(connection) as ctx:
+            mass_model_updater(
+                Finding, deferred_qs,
+                lambda f: setattr(f, "hash_code", None), fields=["hash_code"], order="asc",
+            )
+        self.assertGreater(
+            len(_updates(ctx.captured_queries)), 0,
+            msg="deferred tracked field must not be treated as unchanged",
+        )
+        for fid in ids:
+            self.assertIsNone(
+                Finding.objects.get(id=fid).hash_code,
+                msg=f"finding {fid}: deferred field recomputed to None was not persisted",
+            )
+
+    def test_writes_deferred_field_recomputed_to_value(self):
+        # Same guard, non-None target: a deferred field updated to a value persists.
+        ids = self._finding_ids()
+        deferred_qs = Finding.objects.filter(id__in=ids).only("id")
+        mass_model_updater(
+            Finding, deferred_qs,
+            lambda f: setattr(f, "hash_code", f"deferred-{f.id}"), fields=["hash_code"], order="asc",
+        )
+        for fid in ids:
+            self.assertEqual(
+                Finding.objects.get(id=fid).hash_code, f"deferred-{fid}",
+                msg=f"finding {fid}: deferred field update not persisted",
+            )
+
     def test_hashcode_values_writer_uses_values_sql_on_postgres(self):
         if connection.vendor != "postgresql":
             self.skipTest("VALUES fast path is postgres-only")


### PR DESCRIPTION
## Problem

`mass_model_updater(..., skip_unchanged=True)` (added in #15046) decides whether to write each row by snapshotting its tracked `fields` **before** calling `function`, reading `model.__dict__.get(field)` to avoid triggering a deferred-field query.

But when a tracked field is **deferred** — the caller's queryset used `.only()`/`.defer()` and omitted it — `__dict__` has no entry, so the snapshot reads `None`. If `function` then recomputes that field to `None`, the comparison `None == None` marks the row "unchanged" and the **write is silently dropped**, leaving the stale persisted value in the DB.

This bit DefectDojo Pro's risk-mode SLA recalculation: its queryset deferred `sla_expiration_date` while updating it, so clearing a finding's SLA to `None` (enforcement disabled) never persisted — the finding kept its old SLA. (Companion fix in dojo-pro adds the field to its `.only(...)`; this PR removes the footgun at the source.)

## Fix

Guard the no-op check with `model.get_deferred_fields()`: if any tracked field is deferred, skip the comparison and always write that row. No extra query; non-deferred rows keep the fast skip-unchanged path.

## Tests

Adds two regression tests to `unittests/test_mass_model_updater.py`:
- `test_writes_deferred_field_recomputed_to_none` — a deferred field recomputed to `None` must issue an UPDATE and persist (fails without this fix: 0 UPDATEs).
- `test_writes_deferred_field_recomputed_to_value` — deferred field updated to a value persists.

Full `TestMassModelUpdater` suite (11 tests) passes; reverting the guard makes the None test fail with `0 not greater than 0`.

## Scope

`skip_unchanged` exists only on `dev` (not in 3.0.200 / `bugfix` / `master`), so released versions are unaffected.