### PR TITLE
fix(mass_model_updater): read tracked fields via attribute access for skip_unchanged

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1646,8 +1646,10 @@ def mass_model_updater(model_type, models, function, fields, page_size=1000, ord
 
     When ``fields`` is given:
       - skip_unchanged (default True): rows whose tracked ``fields`` were not changed by
-        ``function`` are not written (compared against the values loaded from the page
-        query; deferred fields are read from ``__dict__`` so no extra query is issued).
+        ``function`` are not written. The pre-``function`` value of each tracked field is
+        read with normal attribute access, so callers must ensure the tracked ``fields``
+        are loaded by the queryset (i.e. not excluded via ``.only()``/``.defer()``);
+        otherwise accessing a deferred tracked field issues a per-row query.
       - writer (optional): a callable ``writer(model_type, batch, fields)`` used to persist
         each batch instead of Django's ``bulk_update`` (e.g. a backend-specific fast path).
         Defaults to ``bulk_update``.
@@ -1689,16 +1691,17 @@ def mass_model_updater(model_type, models, function, fields, page_size=1000, ord
             i += 1
             last_id = model.id
 
-            # snapshot tracked fields before mutation (read from __dict__ to avoid
-            # triggering a deferred-field load); used to skip no-op writes
+            # snapshot tracked fields before mutation; used to skip no-op writes.
+            # Read via normal attribute access so the real persisted value is compared
+            # (callers must load the tracked fields; see docstring).
             before = None
             if fields and skip_unchanged:
-                before = [model.__dict__.get(f) for f in fields]
+                before = [getattr(model, f) for f in fields]
 
             function(model)
 
             if fields and skip_unchanged and before is not None and all(
-                model.__dict__.get(f) == old for f, old in zip(fields, before, strict=True)
+                getattr(model, f) == old for f, old in zip(fields, before, strict=True)
             ):
                 # nothing changed for this row -> no write needed
                 pass

--- a/unittests/test_mass_model_updater.py
+++ b/unittests/test_mass_model_updater.py
@@ -130,6 +130,54 @@ class TestMassModelUpdater(DojoTestCase):
             msg="skip_unchanged=False must still write unchanged rows",
         )
 
+    def test_writes_deferred_tracked_field_recomputed_to_none(self):
+        # Regression (dojo-pro risk-mode SLA recalc): the before-snapshot reads each
+        # tracked field with normal attribute access, so a deferred tracked field is
+        # loaded and its real persisted value is compared -- never mistaken for an
+        # absent/None value. Recomputing a populated field to None must still persist.
+        ids = self._finding_ids()
+        # Seed a non-None value via a normally-loaded queryset.
+        mass_model_updater(
+            Finding, Finding.objects.filter(id__in=ids),
+            lambda f: setattr(f, "hash_code", f"seed-{f.id}"), fields=["hash_code"], order="asc",
+        )
+        # Reload deferring hash_code (the tracked field), then recompute it to None.
+        deferred_qs = Finding.objects.filter(id__in=ids).only("id")
+        with CaptureQueriesContext(connection) as ctx:
+            mass_model_updater(
+                Finding, deferred_qs,
+                lambda f: setattr(f, "hash_code", None), fields=["hash_code"], order="asc",
+            )
+        self.assertGreater(
+            len(_updates(ctx.captured_queries)), 0,
+            msg="deferred tracked field recomputed to None must still issue an UPDATE",
+        )
+        for fid in ids:
+            self.assertIsNone(
+                Finding.objects.get(id=fid).hash_code,
+                msg=f"finding {fid}: deferred field recomputed to None was not persisted",
+            )
+
+    def test_skips_deferred_tracked_field_left_unchanged(self):
+        # The flip side: a deferred tracked field that function() does NOT change must
+        # still be recognised as unchanged (real value loaded and compared equal) and
+        # issue no UPDATE -- the skip-unchanged optimization keeps working with .only().
+        ids = self._finding_ids()
+        mass_model_updater(
+            Finding, Finding.objects.filter(id__in=ids),
+            lambda f: setattr(f, "hash_code", f"keep-{f.id}"), fields=["hash_code"], order="asc",
+        )
+        deferred_qs = Finding.objects.filter(id__in=ids).only("id")
+        with CaptureQueriesContext(connection) as ctx:
+            mass_model_updater(
+                Finding, deferred_qs,
+                lambda f: setattr(f, "hash_code", f"keep-{f.id}"), fields=["hash_code"], order="asc",
+            )
+        self.assertEqual(
+            len(_updates(ctx.captured_queries)), 0,
+            msg="deferred tracked field left unchanged must not issue an UPDATE",
+        )
+
     def test_hashcode_values_writer_uses_values_sql_on_postgres(self):
         if connection.vendor != "postgresql":
             self.skipTest("VALUES fast path is postgres-only")


### PR DESCRIPTION
## Summary

- `mass_model_updater(..., skip_unchanged=True)` (added in #15046) snapshotted each tracked field with `model.__dict__.get(f)` before calling `function`, to avoid triggering a deferred-field load when deciding whether a row changed.
- When a tracked field is **deferred** — the caller's queryset used `.only()`/`.defer()` and omitted it — `__dict__` has no entry, so the snapshot reads `None`. If `function` recomputes that field to `None`, the comparison `None == None` marks the row "unchanged" and the **write is silently dropped**, leaving a stale persisted value.
- Root cause is a caller that defers a field it then updates (e.g. a `.only(...)` that omits the very field passed in `fields=`). The previous `__dict__` approach turned that caller mistake into silent data loss instead of a visible cost.
- Fix: read the pre-`function` value of each tracked field with normal attribute access (`getattr`) instead of `__dict__`. A deferred tracked field is loaded and compared against its real persisted value, so a real change can never be mistaken for a no-op. The skip-unchanged optimization keeps working for correctly-loaded querysets; a deferred tracked field now degrades to a visible per-row load rather than silent incorrectness. Documented that callers needing the fast path must load the tracked fields.
- Adds two regression tests to `unittests/test_mass_model_updater.py`: a deferred tracked field recomputed to `None` must issue an UPDATE and persist; a deferred tracked field left unchanged must still skip the write.
- `skip_unchanged` exists only on `dev` (not in released versions), so released versions are unaffected.

Alternative to #15112, which guards the no-op check with `get_deferred_fields()` and always writes deferred rows. This PR instead removes the `__dict__` indirection that caused the bug, so the no-op check stays correct (and the optimization keeps working) for deferred-but-loaded rows.
