### PR TITLE
PDF Report: Show vulnerability IDs

### DIFF
--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -104,6 +104,9 @@
                                     {% if finding.cwe > 0 %}
                                         <th>CWE</th>
                                     {% endif %}
+                                    {% if finding.vulnerability_ids %}
+                                        <th>Vulnerability IDs</th>
+                                    {% endif %}
                                     {% endblock finding_header %}
                                 </tr>
                                 <tr>
@@ -146,6 +149,9 @@
                                                 <i class="fa-solid fa-arrow-up-right-from-square"></i> {{ finding.cwe }}
                                             </a>
                                         </td>
+                                    {% endif %}
+                                    {% if finding.vulnerability_ids %}
+                                        <td>{{ finding.vulnerability_ids }}</td>
                                     {% endif %}
                                     {% endblock finding_data %}
                                 </tr>

--- a/unittests/test_pdf_report_rendering.py
+++ b/unittests/test_pdf_report_rendering.py
@@ -9,6 +9,7 @@ from dojo.models import (
     Test,
     Test_Type,
     User,
+    Vulnerability_Id,
 )
 from unittests.dojo_test_case import DojoTestCase, versioned_fixtures
 
@@ -171,6 +172,16 @@ class TestPdfReportTextWrapping(DojoTestCase):
 
         # Mitigation content should appear
         self.assertIn("Remove Debug Files From Public Directories", html)
+
+    def test_report_finding_table_includes_vulnerability_ids(self):
+        """Finding PDF reports should show vulnerability IDs in the finding table."""
+        finding = self._create_finding()
+        Vulnerability_Id.objects.create(finding=finding, vulnerability_id="CVE-2026-12345")
+
+        html = self._render_finding_report(Finding.objects.filter(pk=finding.pk))
+
+        self.assertIn("Vulnerability IDs", html)
+        self.assertIn("CVE-2026-12345", html)
 
     def test_long_unbroken_string_in_report_field(self):
         """


### PR DESCRIPTION


**Description**

Fixes https://github.com/DefectDojo/django-DefectDojo/issues/10620.

The finding PDF report table did not show vulnerability IDs, even though other report outputs already include them. This PR adds the missing conditional `Vulnerability IDs` column to the PDF finding report template and renders the finding's saved vulnerability IDs when present.

The PDF report header now includes:

```django
{% if finding.vulnerability_ids %}
    <th>Vulnerability IDs</th>
{% endif %}
```

The PDF report data row now includes:

```django
{% if finding.vulnerability_ids %}
    <td>{{ finding.vulnerability_ids }}</td>
{% endif %}
```

I also added coverage to the existing PDF report rendering tests:

```python
def test_report_finding_table_includes_vulnerability_ids(self):
    """Finding PDF reports should show vulnerability IDs in the finding table."""
    finding = self._create_finding()
    Vulnerability_Id.objects.create(finding=finding, vulnerability_id="CVE-2026-12345")

    html = self._render_finding_report(Finding.objects.filter(pk=finding.pk))

    self.assertIn("Vulnerability IDs", html)
    self.assertIn("CVE-2026-12345", html)
```

**Test results**

Ideally you extend the test suite in `tests/` and `dojo/unittests` to cover the changed in this PR.
Alternatively, describe what you have and haven't tested.

**Documentation**

Passed:

```bash
python -m compileall unittests\test_pdf_report_rendering.py
```

Passed with the existing staticfiles warning for `/app/components/node_modules`:

```bash
docker compose -f docker-compose.yml -f docker-compose.override.unit_tests.yml run --rm --entrypoint "python manage.py check" uwsgi
```

Passed, 7 tests OK:

```bash
docker compose -f docker-compose.yml -f docker-compose.override.unit_tests.yml run --rm --entrypoint "python manage.py test unittests.test_pdf_report_rendering.TestPdfReportTextWrapping -v2 --keepdb" uwsgi
```

Passed:

```bash
ruff check --isolated unittests/test_pdf_report_rendering.py
```

Full local `ruff check` could not run because local `ruff 0.15.2` does not recognize the repo config selector `PLW0717`.
**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

