### PR TITLE
feat(ui): animate collapse panels in the new UI

### DIFF
--- a/dojo/static/dojo/js/index.js
+++ b/dojo/static/dojo/js/index.js
@@ -69,6 +69,67 @@
    Handles [data-toggle="collapse"] by toggling .in on the target element.
    CSS in tailwind.css:  .collapse { display:none }  .collapse.in { display:block }
 */
+/* Animate a collapse target open/closed by sliding its height between 0 and
+   its natural size, then settling to auto (open) or display:none via .in
+   (closed). Falls back to an instant toggle when reduced motion is requested. */
+function animateCollapse(target, toggle) {
+    if (target._ddCollapsing) return;  // ignore clicks while mid-animation
+    var willOpen = !target.classList.contains('in');
+    if (toggle) toggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+
+    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        target.classList.toggle('in', willOpen);
+        return;
+    }
+
+    var DURATION = 250;
+    var finished = false;
+    target._ddCollapsing = true;
+
+    if (willOpen) target.classList.add('in');     // make it measurable / visible
+
+    // Animate height AND vertical padding together, so the panel collapses all
+    // the way to 0 instead of stalling at the panel-body's padding "floor".
+    var cs = getComputedStyle(target);
+    var padTop = cs.paddingTop, padBottom = cs.paddingBottom;
+    // In border-box (Tailwind's default) the height property already includes
+    // padding, so animate to the full scrollHeight; only subtract in content-box.
+    var fullH = cs.boxSizing === 'border-box'
+        ? target.scrollHeight
+        : target.scrollHeight - parseFloat(padTop) - parseFloat(padBottom);
+    var contentH = fullH + 'px';
+    var collapsed = { height: '0px', paddingTop: '0px', paddingBottom: '0px' };
+    var expanded = { height: contentH, paddingTop: padTop, paddingBottom: padBottom };
+    var from = willOpen ? collapsed : expanded;
+    var to = willOpen ? expanded : collapsed;
+
+    target.style.overflow = 'hidden';
+    target.style.height = from.height;
+    target.style.paddingTop = from.paddingTop;
+    target.style.paddingBottom = from.paddingBottom;
+    void target.offsetHeight;                     // force reflow so the transition runs
+    target.style.transition = 'height ' + DURATION + 'ms ease, padding ' + DURATION + 'ms ease';
+    target.style.height = to.height;
+    target.style.paddingTop = to.paddingTop;
+    target.style.paddingBottom = to.paddingBottom;
+
+    function done() {
+        if (finished) return;
+        finished = true;
+        if (!willOpen) target.classList.remove('in');  // hide before clearing styles
+        target.style.transition = '';
+        target.style.height = '';
+        target.style.paddingTop = '';
+        target.style.paddingBottom = '';
+        target.style.overflow = '';
+        target._ddCollapsing = false;
+        target.removeEventListener('transitionend', onEnd);
+    }
+    function onEnd(ev) { if (ev.target === target && ev.propertyName === 'height') done(); }
+    target.addEventListener('transitionend', onEnd);
+    setTimeout(done, DURATION + 80);          // fallback if transitionend doesn't fire
+}
+
 document.addEventListener('click', function (e) {
     var toggle = e.target.closest('[data-toggle="collapse"]');
     if (!toggle) return;
@@ -86,10 +147,7 @@ document.addEventListener('click', function (e) {
         if (!sel) return;
         var target = document.querySelector(sel);
         if (target) {
-            target.classList.toggle('in');
-            // Toggle aria-expanded on the trigger
-            var isOpen = target.classList.contains('in');
-            toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+            animateCollapse(target, toggle);
         }
     });
 });

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -949,7 +949,7 @@
         <!-- end #wrapper -->
 
         <!-- our JS -->
-        <script src="{% static "dojo/js/index.js" %}"></script>
+        <script src="{% static "dojo/js/index.js" %}?v={% static_v "dojo/js/index.js" %}"></script>
 
         <!-- CVSS -->
         <script src="{% static "dojo/js/cvsscalc31_helptext.js" %}"></script>


### PR DESCRIPTION
**Description**

Collapse panels in the new UI (finding-detail sections like Description / Mitigation / Impact, and other `data-toggle="collapse"` panels) toggled open and closed instantly with no animation, which felt abrupt. This adds a smooth height slide, consistent with the filter accordion.

Changes:
- `index.js`: the shared collapse shim now animates the target's height and vertical padding between 0 and its natural size over 250ms, then settles to `auto` (open) or `display:none` via `.in` (closed). It respects `prefers-reduced-motion` (instant toggle), preserves `aria-expanded`, guards against re-clicks mid-animation, and handles both `border-box` and `content-box`. One change covers every collapse panel in the new UI, with no per-panel template changes.
- `base.html`: cache-bust `index.js` with `?v={% static_v %}` (matching how the CSS is loaded) so this JS change actually reaches users' browsers. First-party JS was not versioned before.

No Bootstrap is reintroduced. This enhances the new UI's own vanilla-JS shim that already replaced Bootstrap's collapse.

**Test results**

Verified on a local build (finding detail page): clicking a section animates its height smoothly from 0 to full and back (sampled per frame: steady 0 to 56px on open, 56 to 0px on close, no stall or jump), `aria-expanded` toggles correctly, and the form is not submitted. No Python changed, so no unit tests added.

**Documentation**

N/A.

**Checklist**

- [x] Submitted against `dev`.
- [x] Meaningful PR name.
- [x] Ruff compliant (no Python changed).
- [x] Python 3.13 compliant (no Python changed).