### PR TITLE
perf(jira,product): fix finding-group push N+1 and add case-insensitive product-name index

### DIFF
--- a/dojo/db_migrations/0273_product_upper_name_index.py
+++ b/dojo/db_migrations/0273_product_upper_name_index.py
@@ -1,0 +1,20 @@
+from django.contrib.postgres.operations import AddIndexConcurrently
+from django.db import migrations, models
+from django.db.models.functions import Upper
+
+
+class Migration(migrations.Migration):
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block, and avoids
+    # an ACCESS EXCLUSIVE lock on the dojo_product table.
+    atomic = False
+
+    dependencies = [
+        ("dojo", "0272_reencrypt_tool_config_credentials_aes_gcm"),
+    ]
+
+    operations = [
+        AddIndexConcurrently(
+            model_name="product",
+            index=models.Index(Upper("name"), name="dojo_product_upper_name_idx"),
+        ),
+    ]

--- a/dojo/jira/helper.py
+++ b/dojo/jira/helper.py
@@ -789,7 +789,11 @@ def push_finding_to_jira(finding_id, *args, **kwargs) -> tuple[str, bool]:
 
 @app.task
 def push_finding_group_to_jira(finding_group_id, *args, **kwargs) -> tuple[str, bool]:
-    finding_group = get_object_or_none(Finding_Group, id=finding_group_id)
+    # Prefetch the group's findings: the JIRA helpers below (jira_description,
+    # jira_priority, get_sla_deadline, get_labels, ...) each call
+    # finding_group.findings.all(), which would otherwise re-query per call and
+    # N+1 on dojo_finding_group_findings (Sentry DJANGO-42P8).
+    finding_group = get_object_or_none(Finding_Group.objects.prefetch_related("findings"), id=finding_group_id)
     if not finding_group:
         message = f"Finding_Group with id {finding_group_id} does not exist, skipping push_finding_group_to_jira"
         logger.warning(message)

--- a/dojo/product/models.py
+++ b/dojo/product/models.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 
 from django.core.validators import MinValueValidator
 from django.db import models
+from django.db.models.functions import Upper
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -124,6 +125,12 @@ class Product(BaseModel):
 
     class Meta:
         ordering = ("name",)
+        indexes = [
+            # Serves the case-insensitive product-name lookup
+            # (WHERE UPPER(name) = UPPER(%s)) used when filtering findings by
+            # product name; the plain unique btree on name can't (Sentry DJANGO-D2M).
+            models.Index(Upper("name"), name="dojo_product_upper_name_idx"),
+        ]
 
     def __str__(self):
         return self.name

--- a/unittests/test_jira_finding_group_perf.py
+++ b/unittests/test_jira_finding_group_perf.py
@@ -1,14 +1,16 @@
-"""Query-count regression test for pushing a finding group to JIRA.
+"""
+Query-count regression test for pushing a finding group to JIRA.
 
 Regression: DJANGO-42P8 — push_finding_group_to_jira loaded the group without
-prefetching its findings, so the downstream JIRA helpers (jira_description,
+prefetching its findings, so the JIRA helpers it fans out to (jira_description,
 jira_priority, get_sla_deadline, get_labels, get_tags, ...) each re-ran
-``finding_group.findings.all()``, producing an N+1 on dojo_finding_group_findings.
+finding_group.findings.all(), producing an N+1 on dojo_finding_group_findings.
 """
 from unittest.mock import patch
 
 from django.test import TestCase
 
+from dojo.jira.helper import push_finding_group_to_jira
 from dojo.models import Dojo_User, Finding, Finding_Group, Test
 
 
@@ -24,18 +26,17 @@ class JiraFindingGroupPushQueryCountTest(TestCase):
 
     @patch("dojo.jira.helper.add_jira_issue")
     @patch("dojo.jira.helper.update_jira_issue")
-    def test_group_findings_prefetched_before_jira_helpers(self, mock_update, mock_add):  # noqa: ARG002
-        """The group handed to the JIRA helpers must have its findings prefetched.
-
-        The real helpers read ``finding_group.findings.all()`` several times; if the
-        group is prefetched those reads hit the cache (0 queries). Without the fix
-        each read is a fresh dojo_finding_group_findings query (N+1).
+    def test_group_findings_prefetched_before_jira_helpers(self, mock_update, mock_add):
         """
-        from dojo.jira.helper import push_finding_group_to_jira
+        The group handed to the JIRA helpers must have its findings prefetched.
 
+        The real helpers read finding_group.findings.all() several times; if the
+        group is prefetched those reads hit the prefetch (0 queries). Without the
+        fix each read is a fresh dojo_finding_group_findings query (N+1).
+        """
         group = self._make_group(5)
 
-        def _simulate_jira_helpers(obj, *args, **kwargs):  # noqa: ARG001
+        def _simulate_jira_helpers(obj, *args, **kwargs):
             with self.assertNumQueries(0):
                 for _ in range(5):
                     list(obj.findings.all())

--- a/unittests/test_jira_finding_group_perf.py
+++ b/unittests/test_jira_finding_group_perf.py
@@ -1,0 +1,46 @@
+"""Query-count regression test for pushing a finding group to JIRA.
+
+Regression: DJANGO-42P8 — push_finding_group_to_jira loaded the group without
+prefetching its findings, so the downstream JIRA helpers (jira_description,
+jira_priority, get_sla_deadline, get_labels, get_tags, ...) each re-ran
+``finding_group.findings.all()``, producing an N+1 on dojo_finding_group_findings.
+"""
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from dojo.models import Dojo_User, Finding, Finding_Group, Test
+
+
+class JiraFindingGroupPushQueryCountTest(TestCase):
+    fixtures = ["dojo_testdata.json"]
+
+    def _make_group(self, num_findings: int) -> Finding_Group:
+        test = Test.objects.first()
+        admin = Dojo_User.objects.get(username="admin")
+        group = Finding_Group.objects.create(test=test, name="perf group", creator=admin)
+        group.findings.add(*list(Finding.objects.all()[:num_findings]))
+        return group
+
+    @patch("dojo.jira.helper.add_jira_issue")
+    @patch("dojo.jira.helper.update_jira_issue")
+    def test_group_findings_prefetched_before_jira_helpers(self, mock_update, mock_add):  # noqa: ARG002
+        """The group handed to the JIRA helpers must have its findings prefetched.
+
+        The real helpers read ``finding_group.findings.all()`` several times; if the
+        group is prefetched those reads hit the cache (0 queries). Without the fix
+        each read is a fresh dojo_finding_group_findings query (N+1).
+        """
+        from dojo.jira.helper import push_finding_group_to_jira
+
+        group = self._make_group(5)
+
+        def _simulate_jira_helpers(obj, *args, **kwargs):  # noqa: ARG001
+            with self.assertNumQueries(0):
+                for _ in range(5):
+                    list(obj.findings.all())
+            return "ok", True
+
+        mock_add.side_effect = _simulate_jira_helpers
+        push_finding_group_to_jira(group.id)
+        mock_add.assert_called_once()

--- a/unittests/test_jira_finding_group_perf.py
+++ b/unittests/test_jira_finding_group_perf.py
@@ -12,8 +12,10 @@ from django.test import TestCase
 
 from dojo.jira.helper import push_finding_group_to_jira
 from dojo.models import Dojo_User, Finding, Finding_Group, Test
+from unittests.dojo_test_case import versioned_fixtures
 
 
+@versioned_fixtures
 class JiraFindingGroupPushQueryCountTest(TestCase):
     fixtures = ["dojo_testdata.json"]
 

--- a/unittests/test_product_name_index.py
+++ b/unittests/test_product_name_index.py
@@ -1,0 +1,23 @@
+"""Schema regression test for the case-insensitive product-name index.
+
+Regression: DJANGO-D2M — filtering findings by product name issues
+``WHERE UPPER(dojo_product.name) = UPPER(%s)``. The plain unique btree on
+dojo_product.name can't serve that predicate, so a functional Upper(name) index
+is required to keep the lookup fast.
+"""
+from django.db import connection
+from django.test import TestCase
+
+INDEX_NAME = "dojo_product_upper_name_idx"
+
+
+class ProductUpperNameIndexTest(TestCase):
+    def test_upper_name_functional_index_exists(self):
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT indexdef FROM pg_indexes WHERE tablename = 'dojo_product' AND indexname = %s",
+                [INDEX_NAME],
+            )
+            row = cursor.fetchone()
+        self.assertIsNotNone(row, f"expected functional index {INDEX_NAME} on dojo_product")
+        self.assertIn("upper", row[0].lower(), f"index {INDEX_NAME} is not on UPPER(name): {row[0]}")

--- a/unittests/test_product_name_index.py
+++ b/unittests/test_product_name_index.py
@@ -1,4 +1,5 @@
-"""Schema regression test for the case-insensitive product-name index.
+"""
+Schema regression test for the case-insensitive product-name index.
 
 Regression: DJANGO-D2M — filtering findings by product name issues
 ``WHERE UPPER(dojo_product.name) = UPPER(%s)``. The plain unique btree on


### PR DESCRIPTION
Shortcut: [sc-13412](https://app.shortcut.com/defectdojo/story/13412)

Two focused fixes for Sentry \`db_query\` issues.

## Fixes
- **DJANGO-42P8** — \`push_finding_group_to_jira\` loaded the group without prefetching its findings, so the JIRA helpers it fans out to (jira_description, jira_priority, get_sla_deadline, get_labels, get_tags, ...) each re-ran \`finding_group.findings.all()\`, producing an N+1 on \`dojo_finding_group_findings\`. Load the group with \`prefetch_related('findings')\`.
- **DJANGO-D2M** — filtering findings by product name issues \`WHERE UPPER(dojo_product.name) = UPPER(%s)\`, which the plain unique btree can't serve (slow scan). Add a functional \`Upper(name)\` index (created CONCURRENTLY, migration 0273).

## Testing
- jira: query-count regression test (5 → 0 \`dojo_finding_group_findings\` reads); existing jira push behavior unchanged.
- index: schema regression test asserting the index exists; \`makemigrations --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)