### PR TITLE
fix(risk_acceptance): reinstate findings when expiration date updated via API

### DIFF
--- a/dojo/risk_acceptance/api/serializer.py
+++ b/dojo/risk_acceptance/api/serializer.py
@@ -50,6 +50,7 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
         findings_to_remove = set(existing_findings) - set(new_findings)
         findings_to_add = Finding.objects.filter(id__in=[x.id for x in findings_to_add])
         findings_to_remove = Finding.objects.filter(id__in=[x.id for x in findings_to_remove])
+        old_expiration_date = self.instance.expiration_date
         # Make the update in the database
         instance = super().update(instance, validated_data)
         user = getattr(self.context.get("request", None), "user", None)
@@ -58,6 +59,9 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
         # Remove the ones that were not present in the payload
         for finding in findings_to_remove:
             ra_helper.remove_finding_from_risk_acceptance(user, instance, finding)
+
+        if instance.expiration_date != old_expiration_date:
+            ra_helper.reinstate(instance, old_expiration_date)
 
         # Handle orphaned risk acceptances: link to engagement if it now has findings
         # This is fine as Pro has its own model + relationshop to track links with engagements.


### PR DESCRIPTION
## Summary

- `RiskAcceptanceSerializer.update()` never called `ra_helper.reinstate()` when `expiration_date` changed, unlike the legacy Django view (`engagement/views.py:1308-1310`) which does so correctly.
- This caused two related bugs reported by a customer:
  1. **Findings stay Active after extending an expired RA** — when a user edits the expiration date from a past date to a future date via the API (Edit Risk Acceptance form in the UI), `reinstate()` is never called, so findings remain `active=True / risk_accepted=False` instead of being set back to inactive/risk-accepted.
  2. **Findings stay Inactive on subsequent expiry cycles** — because `reinstate()` was never called, `expiration_date_handled` was never cleared. The Celery expiration task queries with `expiration_date_handled__isnull=True`, so the RA is permanently excluded from every future expiry run and findings are never reactivated when the RA expires again.

## Fix

Capture `old_expiration_date` before `super().update()`, then call `ra_helper.reinstate()` when the date changes — matching the logic that already exists in the legacy Django view.

```python
old_expiration_date = self.instance.expiration_date
instance = super().update(instance, validated_data)
...
if instance.expiration_date != old_expiration_date:
    ra_helper.reinstate(instance, old_expiration_date)
```

`reinstate()` already handles the two outcomes internally: it reinstates findings (only when `expiration_date_handled` is set, i.e. the RA previously expired) and unconditionally clears `expiration_date_handled` and `expiration_date_warned`, making the RA eligible for the next Celery expiry cycle.

## Test plan

- [ ] Edit a Risk Acceptance with an expired date to a future date via the API — verify findings become `active=False / risk_accepted=True`
- [ ] Confirm `expiration_date_handled` is `None` after the update — verify the Celery task will pick it up on the next expiry cycle
- [ ] Edit a fresh (never-expired) RA's date — verify findings are unchanged and `expiration_date_handled` stays `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)