### PR TITLE
docs: Pro set-based deduplication hash code fields for CWE/Vulnerability_Ids

### DIFF
--- a/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.md
@@ -50,6 +50,30 @@ Attempts to use the tool's unique ID first, then falls back to the hash code if 
 #### Global Component
 Matches findings by component name and version across **all Products** in the instance, rather than within a single Product or Engagement. Intended for SCA tools where the same vulnerable dependency appears in many Products. This algorithm is off by default and must be enabled by DefectDojo Support. See [Global Component Deduplication](/triage_findings/finding_deduplication/pro__global_component_deduplication/) for details.
 
+### Set-based Hash Code Fields (Vulnerability IDs and CWEs)
+
+Two finding attributes hold a *set* of values rather than a single value: vulnerability IDs (CVE, GHSA, …) and CWEs. When using the **Hash Code** algorithm (Same Tool or Cross Tool), you can add the following fields to **Hash Code Fields** to control how those sets are compared:
+
+| Field | Findings are duplicates when… |
+|-------|-------------------------------|
+| `vulnerability_ids` | they have the **exact same set** of vulnerability IDs |
+| `vulnerability_ids_partial` | they share **at least one** vulnerability ID |
+| `vulnerability_ids_subset` | one finding's vulnerability IDs are a **subset** of the other's |
+| `cwes_partial` | they share **at least one** CWE |
+| `cwes_subset` | one finding's CWEs are a **subset** of the other's |
+
+The `_partial` and `_subset` fields are compared per finding pair rather than folded into the hash: the remaining Hash Code Fields group the candidate findings, and the set comparison then narrows that group. (Exact matching, `vulnerability_ids`, is folded into the hash directly.)
+
+**Empty values.** If a finding has no vulnerability IDs (or no CWEs) for the configured matcher:
+
+- If Hash Code Fields also include an ordinary field (for example `title`), that field carries the identity — the set matcher is skipped for the pair and the findings can still match on the rest of the hash.
+- If a set matcher is the **only** field, a finding with no values does not match anything: with nothing else to identify it, an empty set is not treated as matching every other finding.
+
+**Configuration rules** (enforced when you save settings):
+
+- A vulnerability IDs field (`vulnerability_ids`, `vulnerability_ids_partial`, or `vulnerability_ids_subset`) may be used on its own — a CVE or GHSA identifies a specific vulnerability instance.
+- CWE fields (`cwes_partial`, `cwes_subset`) may **not** be the only criteria. A CWE is a weakness *class*, not a specific instance, so matching on CWE alone would merge unrelated findings. Pair a CWE matcher with an identifying field such as `title` or `file_path`.
+
 ## Cross Tool Deduplication
 
 Cross Tool Deduplication is disabled by default, as deduplication between different security tools requires careful configuration due to variations in how tools report the same vulnerabilities.

--- a/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.md
@@ -59,10 +59,11 @@ Two finding attributes hold a *set* of values rather than a single value: vulner
 | `vulnerability_ids` | they have the **exact same set** of vulnerability IDs |
 | `vulnerability_ids_partial` | they share **at least one** vulnerability ID |
 | `vulnerability_ids_subset` | one finding's vulnerability IDs are a **subset** of the other's |
+| `cwes` | they have the **exact same set** of CWEs |
 | `cwes_partial` | they share **at least one** CWE |
 | `cwes_subset` | one finding's CWEs are a **subset** of the other's |
 
-The `_partial` and `_subset` fields are compared per finding pair rather than folded into the hash: the remaining Hash Code Fields group the candidate findings, and the set comparison then narrows that group. (Exact matching, `vulnerability_ids`, is folded into the hash directly.)
+The `_partial` and `_subset` fields are compared per finding pair rather than folded into the hash: the remaining Hash Code Fields group the candidate findings, and the set comparison then narrows that group. (Exact matching — `vulnerability_ids` and `cwes` — is folded into the hash directly.)
 
 **Empty values.** If a finding has no vulnerability IDs (or no CWEs) for the configured matcher:
 
@@ -72,7 +73,7 @@ The `_partial` and `_subset` fields are compared per finding pair rather than fo
 **Configuration rules** (enforced when you save settings):
 
 - A vulnerability IDs field (`vulnerability_ids`, `vulnerability_ids_partial`, or `vulnerability_ids_subset`) may be used on its own — a CVE or GHSA identifies a specific vulnerability instance.
-- CWE fields (`cwes_partial`, `cwes_subset`) may **not** be the only criteria. A CWE is a weakness *class*, not a specific instance, so matching on CWE alone would merge unrelated findings. Pair a CWE matcher with an identifying field such as `title` or `file_path`.
+- CWE fields (`cwes`, `cwes_partial`, `cwes_subset`) may **not** be the only criteria. A CWE is a weakness *class*, not a specific instance, so matching on CWE alone would merge unrelated findings. Pair a CWE matcher with an identifying field such as `title` or `file_path`.
 
 ## Cross Tool Deduplication
 


### PR DESCRIPTION
### 🔗 PR stack — CWE / vulnerability-ID consolidation (OSS)

Merge bottom-up:

- [#15145](https://github.com/DefectDojo/django-DefectDojo/pull/15145) — autodetected vulnerability-ID type + uniqueness constraint
    - [#15143](https://github.com/DefectDojo/django-DefectDojo/pull/15143) — multiple CWEs per finding
        - [#15154](https://github.com/DefectDojo/django-DefectDojo/pull/15154) — docs: Pro set-based dedup hash-code fields
        - [#15155](https://github.com/DefectDojo/django-DefectDojo/pull/15155) — pluggable false-positive-history candidate filter

👉 **This PR: [#15154](https://github.com/DefectDojo/django-DefectDojo/pull/15154)**

---

> **Stacked docs PR — do not merge before its base.**

Documentation for the DefectDojo Pro set-match deduplication fields (Pro Tuner). Adds a "Set-based Hash Code Fields" section to the Pro deduplication tuning page covering the vulnerability-ID and CWE set matchers (`vulnerability_ids` exact, `vulnerability_ids_partial`/`_subset`, `cwes_partial`/`_subset`), their empty-set behavior, and the configuration rules.

## Stack (merge bottom-up)

1. #15145 — `feat/vulnerability-id-type` (autodetected vulnerability ID type + uniqueness) → `dev`
2. #15143 — `feat/cwe-vuln-id-consolidation` (multiple CWEs per finding) → stacked on #15145
3. **this PR** — docs → stacked on #15143 (base: `feat/cwe-vuln-id-consolidation`)

The CWE matchers documented here rely on the `Finding_CWE` model from #15143, so this PR is based on that branch. It accompanies the DefectDojo Pro `feat/dedupe-set-match-tokens` PR (dojo-pro #1749), which implements the fields.


