### PR TITLE
fix(checkmarx_one): handle explicit null scanner sections in filtered reports

### DIFF
--- a/dojo/tools/checkmarx_one/parser.py
+++ b/dojo/tools/checkmarx_one/parser.py
@@ -41,15 +41,17 @@ class CheckmarxOneParser:
         data: dict,
     ) -> list[Finding]:
         findings = []
-        cwe_store = data.get("vulnerabilityDetails", [])
+        # Reports filtered to a subset of scanners may contain the other
+        # sections as explicit nulls, so fall back to empty containers
+        cwe_store = data.get("vulnerabilityDetails") or []
         # SAST
-        if (results := data.get("scanResults", {}).get("resultsList")) is not None:
+        if (results := (data.get("scanResults") or {}).get("resultsList")) is not None:
             findings += self.parse_sast_vulnerabilities(test, results, cwe_store)
         # IaC
-        if (results := data.get("iacScanResults", {}).get("technology")) is not None:
+        if (results := (data.get("iacScanResults") or {}).get("technology")) is not None:
             findings += self.parse_iac_vulnerabilities(test, results, cwe_store)
         # SCA
-        if (results := data.get("scaScanResults", {}).get("packages")) is not None:
+        if (results := (data.get("scaScanResults") or {}).get("packages")) is not None:
             findings += self.parse_sca_vulnerabilities(test, results, cwe_store)
         return findings
 

--- a/unittests/scans/checkmarx_one/vulnerabilities_from_scan_results_null_details.json
+++ b/unittests/scans/checkmarx_one/vulnerabilities_from_scan_results_null_details.json
@@ -1,0 +1,95 @@
+{
+    "reportCreationDate": "2026-06-30T10:15:00.000000Z",
+    "reportType": "scan",
+    "reportHeader": {
+        "reportName": "improved-scan-report",
+        "projectName": "sast-only-project",
+        "branchName": "main"
+    },
+    "scanResults": {
+        "totalResults": 2,
+        "resultsList": [
+            {
+                "queryName": "Reflected_XSS",
+                "queryId": 9349880549689768000,
+                "description": "The method embeds untrusted data in generated output, enabling an attacker to inject malicious code into the generated web-page.",
+                "vulnerabilitiesTotal": 1,
+                "queryPath": "Kotlin/Kotlin_High_Risk/Reflected_XSS",
+                "cweId": 79,
+                "categories": [
+                    {
+                        "name": "OWASP Top 10 2021",
+                        "subCategories": [
+                            "A3-Injection"
+                        ]
+                    }
+                ],
+                "vulnerabilities": [
+                    {
+                        "similarityId": 134962663,
+                        "status": "Recurrent",
+                        "state": "To Verify",
+                        "severity": "High",
+                        "foundDate": "2026-06-16T14:39:59Z",
+                        "firstFoundDate": "2026-03-18T20:51:25Z",
+                        "sourceFileName": "/src/main/kotlin/api/CustomerController.kt",
+                        "destinationFileName": "/src/main/kotlin/domain/entity/Customer.kt",
+                        "sourceLine": 69,
+                        "destinationLine": 484,
+                        "nodes": [
+                            {
+                                "fileName": "/src/main/kotlin/api/CustomerController.kt",
+                                "method": "putCustomer",
+                                "line": 69,
+                                "code": "@RequestBody s: S"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "queryName": "Deprecated_API",
+                "queryId": 9349880549689768001,
+                "description": "The application references code elements that have been declared as deprecated.",
+                "vulnerabilitiesTotal": 1,
+                "queryPath": "Go/Go_Low_Visibility/Deprecated_API",
+                "cweId": 477,
+                "categories": [
+                    {
+                        "name": "OWASP ASVS",
+                        "subCategories": [
+                            "V01 Architecture, Design and Threat Modeling"
+                        ]
+                    }
+                ],
+                "vulnerabilities": [
+                    {
+                        "similarityId": 872206556,
+                        "status": "New",
+                        "state": "To Verify",
+                        "severity": "Low",
+                        "foundDate": "2026-06-16T14:39:59Z",
+                        "firstFoundDate": "2026-06-16T14:39:59Z",
+                        "sourceFileName": "/scripts/export/e.go",
+                        "destinationFileName": "/scripts/export/e.go",
+                        "sourceLine": 9,
+                        "destinationLine": 9,
+                        "nodes": [
+                            {
+                                "fileName": "/scripts/export/e.go",
+                                "method": "main",
+                                "line": 9,
+                                "code": "ioutil.ReadFile(path)"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "iacScanResults": null,
+    "scaScanResults": null,
+    "containerScanResults": null,
+    "apiSecScanResults": null,
+    "vulnerabilityDetails": null
+}

--- a/unittests/scans/checkmarx_one/vulnerabilities_from_scan_results_sast_only.json
+++ b/unittests/scans/checkmarx_one/vulnerabilities_from_scan_results_sast_only.json
@@ -1,0 +1,110 @@
+{
+    "reportCreationDate": "2026-06-30T10:15:00.000000Z",
+    "reportType": "scan",
+    "reportHeader": {
+        "reportName": "improved-scan-report",
+        "projectName": "sast-only-project",
+        "branchName": "main"
+    },
+    "scanResults": {
+        "totalResults": 2,
+        "resultsList": [
+            {
+                "queryName": "Reflected_XSS",
+                "queryId": 9349880549689768000,
+                "description": "The method embeds untrusted data in generated output, enabling an attacker to inject malicious code into the generated web-page.",
+                "vulnerabilitiesTotal": 1,
+                "queryPath": "Kotlin/Kotlin_High_Risk/Reflected_XSS",
+                "cweId": 79,
+                "categories": [
+                    {
+                        "name": "OWASP Top 10 2021",
+                        "subCategories": [
+                            "A3-Injection"
+                        ]
+                    }
+                ],
+                "vulnerabilities": [
+                    {
+                        "similarityId": 134962663,
+                        "status": "Recurrent",
+                        "state": "To Verify",
+                        "severity": "High",
+                        "foundDate": "2026-06-16T14:39:59Z",
+                        "firstFoundDate": "2026-03-18T20:51:25Z",
+                        "sourceFileName": "/src/main/kotlin/api/CustomerController.kt",
+                        "destinationFileName": "/src/main/kotlin/domain/entity/Customer.kt",
+                        "sourceLine": 69,
+                        "destinationLine": 484,
+                        "nodes": [
+                            {
+                                "fileName": "/src/main/kotlin/api/CustomerController.kt",
+                                "method": "putCustomer",
+                                "line": 69,
+                                "code": "@RequestBody s: S"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "queryName": "Deprecated_API",
+                "queryId": 9349880549689768001,
+                "description": "The application references code elements that have been declared as deprecated.",
+                "vulnerabilitiesTotal": 1,
+                "queryPath": "Go/Go_Low_Visibility/Deprecated_API",
+                "cweId": 477,
+                "categories": [
+                    {
+                        "name": "OWASP ASVS",
+                        "subCategories": [
+                            "V01 Architecture, Design and Threat Modeling"
+                        ]
+                    }
+                ],
+                "vulnerabilities": [
+                    {
+                        "similarityId": 872206556,
+                        "status": "New",
+                        "state": "To Verify",
+                        "severity": "Low",
+                        "foundDate": "2026-06-16T14:39:59Z",
+                        "firstFoundDate": "2026-06-16T14:39:59Z",
+                        "sourceFileName": "/scripts/export/e.go",
+                        "destinationFileName": "/scripts/export/e.go",
+                        "sourceLine": 9,
+                        "destinationLine": 9,
+                        "nodes": [
+                            {
+                                "fileName": "/scripts/export/e.go",
+                                "method": "main",
+                                "line": 9,
+                                "code": "ioutil.ReadFile(path)"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    "iacScanResults": null,
+    "scaScanResults": null,
+    "containerScanResults": null,
+    "apiSecScanResults": null,
+    "vulnerabilityDetails": [
+        {
+            "vulnerabilityName": "Reflected_XSS",
+            "risk": "A successful XSS exploit would allow an attacker to rewrite web pages and insert malicious scripts.",
+            "cause": "The application creates web pages that include untrusted data without proper encoding.",
+            "generalRecommendations": "Fully encode all dynamic data before embedding it in output.",
+            "cweId": 79
+        },
+        {
+            "vulnerabilityName": "Deprecated_API",
+            "risk": "Referencing deprecated modules can expose the application to known vulnerabilities.",
+            "cause": "The application references code elements that have been declared as deprecated.",
+            "generalRecommendations": "Always prefer to use the most updated versions of libraries and packages.",
+            "cweId": 477
+        }
+    ]
+}

--- a/unittests/tools/test_checkmarx_one_parser.py
+++ b/unittests/tools/test_checkmarx_one_parser.py
@@ -154,6 +154,40 @@ class TestCheckmarxOneParser(DojoTestCase):
             self.maxDiff = None
             test_sast_finding(sast_finding)
 
+    def test_checkmarx_vulnerabilities_from_scan_results_sast_only(self):
+        """Reports filtered to SAST contain the other scanner sections as explicit nulls."""
+        with (get_unit_tests_scans_path("checkmarx_one") / "vulnerabilities_from_scan_results_sast_only.json").open(encoding="utf-8") as testfile:
+            parser = CheckmarxOneParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(2, len(findings))
+            with self.subTest(i=0):
+                for finding in findings:
+                    self.assertIsNotNone(finding.title)
+                    self.assertIsNotNone(finding.test)
+                    self.assertIsNotNone(finding.date)
+                    self.assertIsNotNone(finding.severity)
+                    self.assertIsNotNone(finding.description)
+                    self.assertEqual(["sast"], finding.unsaved_tags)
+            finding_test = findings[0]
+            self.assertEqual("High", finding_test.severity)
+            self.assertEqual("Kotlin/Kotlin High Risk/Reflected XSS", finding_test.title)
+            self.assertEqual("/src/main/kotlin/domain/entity/Customer.kt", finding_test.file_path)
+            # CWE details come from the populated vulnerabilityDetails store
+            self.assertEqual(79, finding_test.cwe)
+            self.assertEqual("Fully encode all dynamic data before embedding it in output.", finding_test.mitigation)
+
+    def test_checkmarx_vulnerabilities_from_scan_results_null_vulnerability_details(self):
+        """A null vulnerabilityDetails section must not break parsing of SAST results."""
+        with (get_unit_tests_scans_path("checkmarx_one") / "vulnerabilities_from_scan_results_null_details.json").open(encoding="utf-8") as testfile:
+            parser = CheckmarxOneParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(2, len(findings))
+            finding_test = findings[0]
+            self.assertEqual("High", finding_test.severity)
+            self.assertEqual("Kotlin/Kotlin High Risk/Reflected XSS", finding_test.title)
+            # No CWE store available, so store-derived fields fall back to empty
+            self.assertEqual("", finding_test.mitigation)
+
     def test_checkmarx_one_false_positive_status(self):
         with (get_unit_tests_scans_path("checkmarx_one") / "one-open-one-false-positive.json").open(encoding="utf-8") as testfile:
             parser = CheckmarxOneParser()


### PR DESCRIPTION
**Description**

The Checkmarx One parser crashes when importing a report filtered to a subset of scanners (e.g. SAST-only). Such reports contain the other scanner sections as explicit nulls rather than omitting them:

```json
"iacScanResults": null,
"scaScanResults": null,
"containerScanResults": null
```

`dict.get(key, {})` only falls back to the default when the key is *absent* — for a present-but-null key it returns `None`, so in `parse_vulnerabilities_from_scan_list`:

```python
data.get("iacScanResults", {}).get("technology")
# AttributeError: 'NoneType' object has no attribute 'get'
```

The same pattern breaks a null `vulnerabilityDetails` section one line earlier: the `None` is passed into `parse_sast_vulnerabilities` as the CWE store and crashes with `TypeError: 'NoneType' object is not iterable` in `get_cwe_store_entry`.

This PR falls back to empty containers using the same idiom already used elsewhere in the codebase (e.g. `dojo/tools/xygeni/secrets.py`, `dojo/tools/twistlock/parser.py`):

- `(data.get("scanResults") or {}).get("resultsList")` — same for `iacScanResults` / `scaScanResults`
- `cwe_store = data.get("vulnerabilityDetails") or []`

Null sections are now skipped and the available results import normally. Reported by a user importing a SAST-only report into DefectDojo (37 findings imported successfully after the fix).

**Test results**

Two regression fixtures added under `unittests/scans/checkmarx_one/`, each verified to reproduce its distinct crash against the unfixed parser:

- `vulnerabilities_from_scan_results_sast_only.json` — scanner sections null, `vulnerabilityDetails` populated → reproduces the `AttributeError` on `iacScanResults`; the test also asserts CWE-store-derived fields (cwe, mitigation) are populated.
- `vulnerabilities_from_scan_results_null_details.json` — `vulnerabilityDetails` also null → reproduces the `TypeError` in the CWE store lookup; the test asserts store-derived fields fall back to empty.

All 9 tests in `unittests.tools.test_checkmarx_one_parser` pass. Ruff clean on the changed files.

**Documentation**

No documentation changes needed (bug fix, no behavior change for valid reports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)