### PR TITLE
docs: SSO user local-login fallback for open source

### DIFF
--- a/docs/content/admin/user_management/OS__creating_new_users.md
+++ b/docs/content/admin/user_management/OS__creating_new_users.md
@@ -36,6 +36,8 @@ The admin who creates the account is responsible for delivering the initial cred
 
 If your instance is configured with [SSO](../configure_sso/), the workflow is different — users are typically created on first login from the Identity Provider, and you only need to grant them group membership or roles afterwards.
 
+If you have moved to open-source DefectDojo (where SSO is Pro-only) and existing SSO users can no longer log in, see [Re-enabling login for SSO users](../os__sso_user_local_login_fallback/).
+
 ## Recovering from a lost MFA token
 
 If a user loses access to their MFA device, see the [MFA recovery section](/get_started/pro/cloud/connectivity-troubleshooting/#ive-lost-access-to-my-mfa-codes) of the connectivity troubleshooting guide. There is currently no way to remove MFA from an account without an MFA code — the workaround is to create a new account for the user and re-grant the same permissions.

--- a/docs/content/admin/user_management/OS__sso_user_local_login_fallback.md
+++ b/docs/content/admin/user_management/OS__sso_user_local_login_fallback.md
@@ -1,0 +1,73 @@
+---
+title: "Re-enabling login for SSO users (Open Source)"
+description: "Give SSO-provisioned users a local password after moving to Open Source, where SSO is a Pro-only feature"
+audience: opensource
+weight: 2
+---
+
+## When this applies
+
+SSO (SAML, OIDC, OAuth) is a [DefectDojo Pro](https://defectdojo.com) feature. If you upgrade to open-source DefectDojo 3.x (or otherwise move off Pro), the SSO login options are removed, and users who were provisioned through SSO can no longer log in. Their accounts were never given a local password, and the UI and API will not let you set one for them: DefectDojo detects them as SSO accounts and blocks the change.
+
+You do **not** need to delete and recreate these users (which would lose their history, permissions, and object ownership). Instead, give each account a local password on the backend and force a password reset on next login.
+
+See the [SSO section](/admin/sso/) and the [3.0 upgrade notes](/releases/os_upgrading/3.0/#sso-providers-are-available-in-defectdojo-pro-only) for background on SSO being Pro-only.
+
+## Why it happens
+
+Open-source DefectDojo authenticates against Django's local user database only. It decides whether an account is an "SSO user" purely by whether the account has a usable password. SSO-provisioned accounts were created with an *unusable* password, so:
+
+* local login fails (there is no password to check), and
+* the **Force password reset** control in the UI and API is blocked, with a message that the user is authorized through SSO.
+
+Setting a real password clears both conditions at once: the account can log in locally, and the forced-reset flag becomes settable.
+
+## The workaround
+
+Run these steps from the Django shell inside the `uwsgi` container:
+
+```bash
+docker compose exec uwsgi ./manage.py shell
+```
+
+### A single user
+
+```python
+from dojo.user.models import Dojo_User, UserContactInfo
+
+u = Dojo_User.objects.get(username="alice@example.com")
+u.set_password("<temporary-strong-password>")   # makes the account a local login account
+u.save()
+
+uci, _ = UserContactInfo.objects.get_or_create(user=u)
+uci.force_password_reset = True                  # force a change on next login
+uci.save()
+```
+
+### All users without a usable password (bulk)
+
+```python
+from dojo.user.models import Dojo_User, UserContactInfo
+
+for u in Dojo_User.objects.all():
+    if not u.has_usable_password():
+        u.set_password("<temporary-strong-password>")
+        u.save()
+        uci, _ = UserContactInfo.objects.get_or_create(user=u)
+        uci.force_password_reset = True
+        uci.save()
+        print("reset:", u.username)
+```
+
+## What the user does next
+
+Deliver the temporary password to each user out-of-band (email, your team chat, however you normally share secrets). On their next login, DefectDojo redirects them to the **Change Password** page and will not let them go anywhere else until they set their own password. The forced-reset flag clears automatically once they do.
+
+If your instance has the "I forgot my password" flow enabled (`DD_FORGOT_PASSWORD`, on by default) and email configured, users can instead use the **I forgot my password** link on the login page after their account has a usable password, and set a password without needing the temporary one.
+
+## Notes
+
+* **Kubernetes:** run the shell in the Django pod instead, e.g. `kubectl exec -it deploy/defectdojo-django -c uwsgi -- ./manage.py shell` (adjust the deployment and container names to your release).
+* Choose a strong throwaway password. With `force_password_reset = True` the user cannot keep it, so it only needs to survive one login.
+* Keep at least one working local admin account so you are never locked out.
+* Once users have local passwords, we strongly recommend requiring MFA. See [Creating a new user](../os__creating_new_users/).

--- a/docs/content/admin/user_management/OS__sso_user_local_login_fallback.md
+++ b/docs/content/admin/user_management/OS__sso_user_local_login_fallback.md
@@ -30,7 +30,7 @@ Run these steps from the Django shell inside the `uwsgi` container:
 docker compose exec -it uwsgi ./manage.py shell
 ```
 
-### A single user
+### Exmaple for a single user
 
 ```python
 from dojo.user.models import Dojo_User, UserContactInfo
@@ -42,21 +42,6 @@ u.save()
 uci, _ = UserContactInfo.objects.get_or_create(user=u)
 uci.force_password_reset = True                  # force a change on next login
 uci.save()
-```
-
-### All users without a usable password (bulk)
-
-```python
-from dojo.user.models import Dojo_User, UserContactInfo
-
-for u in Dojo_User.objects.all():
-    if not u.has_usable_password():
-        u.set_password("<temporary-strong-password>")
-        u.save()
-        uci, _ = UserContactInfo.objects.get_or_create(user=u)
-        uci.force_password_reset = True
-        uci.save()
-        print("reset:", u.username)
 ```
 
 ## What the user does next

--- a/docs/content/admin/user_management/OS__sso_user_local_login_fallback.md
+++ b/docs/content/admin/user_management/OS__sso_user_local_login_fallback.md
@@ -27,7 +27,7 @@ Setting a real password clears both conditions at once: the account can log in l
 Run these steps from the Django shell inside the `uwsgi` container:
 
 ```bash
-docker compose exec uwsgi ./manage.py shell
+docker compose exec -it uwsgi ./manage.py shell
 ```
 
 ### A single user
@@ -70,4 +70,3 @@ If your instance has the "I forgot my password" flow enabled (`DD_FORGOT_PASSWOR
 * **Kubernetes:** run the shell in the Django pod instead, e.g. `kubectl exec -it deploy/defectdojo-django -c uwsgi -- ./manage.py shell` (adjust the deployment and container names to your release).
 * Choose a strong throwaway password. With `force_password_reset = True` the user cannot keep it, so it only needs to survive one login.
 * Keep at least one working local admin account so you are never locked out.
-* Once users have local passwords, we strongly recommend requiring MFA. See [Creating a new user](../os__creating_new_users/).


### PR DESCRIPTION
**Shortcut:** [sc-13517](https://app.shortcut.com/defectdojo/story/13517)

## Problem

After migrating to open-source DefectDojo 3.x, SSO (SAML/OIDC/OAuth) is a Pro-only feature and the SSO login options are removed. Users that were provisioned through SSO can no longer log in: they were never given a local password, and the UI and API refuse to set one because DefectDojo detects any account with no usable password as an SSO account and blocks the change. Deleting and recreating those users loses their history, permissions, and object ownership.

## Change

Adds an Open Source documentation page, **Re-enabling login for SSO users (Open Source)**, under Admin → User Management. It explains why the lockout happens (`has_usable_password()` is the sole SSO signal in OSS) and documents the backend workaround:

- Set a local password with `user.set_password("<temp>")` from the Django shell (`docker compose exec uwsgi ./manage.py shell`), which flips `has_usable_password()` to `True` and lifts the SSO guards.
- Set `UserContactInfo.force_password_reset = True` so the middleware forces the user to choose their own password on next login.

Includes a single-user snippet, a Kubernetes variant, and the forgot-password alternative. Cross-links the new page from the existing "SSO Users" section of the creating-new-users page.

> Note: the correct call is `set_password(...)`, not `set_usable_password()` — the latter is not a Django model method (5.1 only added a `usable_password` form field; this repo runs Django 5.2.14).

## Verification

Built the docs with Hugo (`hugo --environment development`): builds cleanly with no errors or warnings. Confirmed the new page renders at `/admin/user_management/os__sso_user_local_login_fallback/`, the cross-link resolves both directions, and the linked 3.0 upgrade-notes anchor exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)