### PR TITLE
FIX: correct #toggleBox positioning in Chrome on login page

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1859,8 +1859,7 @@ small {
     background-color: transparent!important;
     border: none!important;
     font-weight: bold!important;
-    position: absolute!important;
-    left: 0!important;
+    position: relative!important;
 }
 
 .EasyMDEContainer .table {


### PR DESCRIPTION
Fixes #15134

Replaced position:absolute and left:0 with position:relative on #toggleBox to fix the Show Password toggle appearing at the far left of the viewport in Chrome. Safari and Firefox were unaffected due to different containing block handling.

Manually verified the CSS change. No automated tests needed for a single CSS property fix. Login page layout and Show Password functionality are unaffected.

No documentation changes needed.
