### PR TITLE
refactor(locations): consistent object lookups in endpoint views

### DIFF
--- a/dojo/url/ui/views.py
+++ b/dojo/url/ui/views.py
@@ -43,6 +43,20 @@ from dojo.utils import (
 logger = logging.getLogger(__name__)
 
 
+def _get_location_or_404(request, location_id, permission):
+    """
+    Resolve a Location for the endpoint views via the shared authorized queryset.
+
+    Keeps object retrieval in these views consistent with the list/host views, which
+    already scope Location lookups through ``get_authorized_locations``. A lookup that
+    falls outside the queryset returns 404, matching object retrieval elsewhere.
+    """
+    return get_object_or_404(
+        get_authorized_locations(permission, Location.objects.all(), request.user),
+        id=location_id,
+    )
+
+
 def view_endpoint(request: HttpRequest, location_id: int):
     return process_endpoint_view(request, location_id, host_view=False)
 
@@ -95,7 +109,7 @@ def process_endpoint_view(request: HttpRequest, location_id: int, *, host_view=F
         - host_view: Boolean indicating if host view is enabled.
 
     """
-    location = get_object_or_404(Location, id=location_id)
+    location = _get_location_or_404(request, location_id, "view")
     if location.location_type != URL.get_location_type():
         messages.add_message(
             request,
@@ -288,7 +302,7 @@ def process_endpoints_view(request, *, host_view=False, vulnerable=False):
 
 def edit_endpoint(request, location_id):
     # Retrieve the Location object by ID and add breadcrumb for editing
-    location = get_object_or_404(Location, id=location_id)
+    location = _get_location_or_404(request, location_id, "edit")
     add_breadcrumb(parent=location, title="Edit", top_level=False, request=request)
     # Initialize the URLForm with the current URL instance for editing
     form = URLForm(instance=location.url)
@@ -366,7 +380,7 @@ def add_endpoint_to_finding(request, finding_id):
 
 def delete_endpoint(request, location_id):
     # Retrieve the Location object by primary key and initialize the delete form
-    location = get_object_or_404(Location, pk=location_id)
+    location = _get_location_or_404(request, location_id, "delete")
     form = DeleteEndpointForm(instance=location)
     # Handle POST request for deleting an endpoint and its relationships
     if request.method == "POST":
@@ -399,7 +413,7 @@ def delete_endpoint(request, location_id):
 
 def manage_meta_data(request, location_id):
     # Retrieve the Location object by ID and filter its associated metadata
-    location = Location.objects.get(id=location_id)
+    location = _get_location_or_404(request, location_id, "edit")
     meta_data_query = DojoMeta.objects.filter(location=location)
     # Map the foreign key for the formset to the location
     form_mapping = {"location": location}
@@ -624,10 +638,10 @@ def migrate_endpoints_view(request):
 
 
 def endpoint_report(request, location_id):
-    location = get_object_or_404(Location, id=location_id)
+    location = _get_location_or_404(request, location_id, "view")
     return generate_report(request, location, host_view=False)
 
 
 def endpoint_host_report(request, location_id):
-    location = get_object_or_404(Location, id=location_id)
+    location = _get_location_or_404(request, location_id, "view")
     return generate_report(request, location, host_view=True)

--- a/unittests/test_location_cross_product_authz.py
+++ b/unittests/test_location_cross_product_authz.py
@@ -57,9 +57,16 @@ class LocationEndpointViewCrossProductAuthzTest(DojoTestCase):
         super().setUp()
         self.client.force_login(self.alice)
 
+    # A cross-product request is denied by the AuthorizationMiddleware object check
+    # (URL_PERMISSIONS maps these views to ("object", Location, ...)). DefectDojo renders
+    # PermissionDenied via dojo.views.custom_unauthorized_view, which returns HTTP 400
+    # app-wide, so the denied status here is 400. The view-level get_authorized_locations
+    # lookup is defense-in-depth behind that middleware check.
+    DENIED_STATUS = 400
+
     def test_view_endpoint_cross_product_is_denied(self):
         response = self.client.get(reverse("view_endpoint", kwargs={"location_id": self.location_b.id}))
-        self.assertEqual(404, response.status_code)
+        self.assertEqual(self.DENIED_STATUS, response.status_code)
 
     def test_view_endpoint_own_product_is_allowed(self):
         response = self.client.get(reverse("view_endpoint", kwargs={"location_id": self.location_a.id}))
@@ -71,7 +78,7 @@ class LocationEndpointViewCrossProductAuthzTest(DojoTestCase):
             reverse("edit_endpoint", kwargs={"location_id": self.location_b.id}),
             {"protocol": "https", "host": "changed.example.test"},
         )
-        self.assertEqual(404, response.status_code)
+        self.assertEqual(self.DENIED_STATUS, response.status_code)
         self.location_b.url.refresh_from_db()
         self.assertEqual(original_host, self.location_b.url.host)
 
@@ -80,5 +87,5 @@ class LocationEndpointViewCrossProductAuthzTest(DojoTestCase):
             reverse("delete_endpoint", kwargs={"location_id": self.location_b.id}),
             {"id": self.location_b.id},
         )
-        self.assertEqual(404, response.status_code)
+        self.assertEqual(self.DENIED_STATUS, response.status_code)
         self.assertTrue(Location.objects.filter(pk=self.location_b.id).exists())

--- a/unittests/test_location_cross_product_authz.py
+++ b/unittests/test_location_cross_product_authz.py
@@ -1,0 +1,84 @@
+from django.urls import reverse
+
+from dojo.authorization.roles_permissions import Roles
+from dojo.location.models import Location, LocationProductReference
+from dojo.location.status import ProductLocationStatus
+from dojo.models import (
+    Dojo_User,
+    Product,
+    Product_Member,
+    Product_Type,
+    Role,
+    User,
+)
+from dojo.url.models import URL
+from unittests.dojo_test_case import DojoTestCase, skip_unless_v3
+
+
+@skip_unless_v3
+class LocationEndpointViewCrossProductAuthzTest(DojoTestCase):
+
+    """
+    The endpoint (Location) UI views resolve objects by location_id.
+
+    A user authorized for one product must not be able to read, edit, or delete a
+    Location that belongs only to a different product.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        prod_type, _ = Product_Type.objects.get_or_create(name="LOC-XProd PT")
+        writer_role = Role.objects.get(id=Roles.Writer)
+
+        cls.product_a = Product.objects.create(name="LOC-XProd Product A", description="A", prod_type=prod_type)
+        cls.product_b = Product.objects.create(name="LOC-XProd Product B", description="B", prod_type=prod_type)
+
+        # Alice is authorized only for Product A. Legacy authorization is membership-based
+        # via authorized_users, so mirror the Product_Member row onto that M2M.
+        cls.alice = User.objects.create_user(
+            username="loc_xprod_alice",
+            password="not-a-real-secret",  # noqa: S106 - test fixture user
+        )
+        Product_Member.objects.create(user=cls.alice, product=cls.product_a, role=writer_role)
+        cls.product_a.authorized_users.add(Dojo_User.objects.get(pk=cls.alice.pk))
+
+        # A URL location that belongs only to Product B (Alice must not reach it).
+        cls.location_b = URL.create_location_from_value("https://private.example.test/secret").location
+        LocationProductReference.objects.create(
+            location=cls.location_b, product=cls.product_b, status=ProductLocationStatus.Active,
+        )
+        # A URL location that belongs to Product A (Alice may reach it).
+        cls.location_a = URL.create_location_from_value("https://a.example.test/ok").location
+        LocationProductReference.objects.create(
+            location=cls.location_a, product=cls.product_a, status=ProductLocationStatus.Active,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(self.alice)
+
+    def test_view_endpoint_cross_product_is_denied(self):
+        response = self.client.get(reverse("view_endpoint", kwargs={"location_id": self.location_b.id}))
+        self.assertEqual(404, response.status_code)
+
+    def test_view_endpoint_own_product_is_allowed(self):
+        response = self.client.get(reverse("view_endpoint", kwargs={"location_id": self.location_a.id}))
+        self.assertEqual(200, response.status_code)
+
+    def test_edit_endpoint_cross_product_is_denied_and_unchanged(self):
+        original_host = self.location_b.url.host
+        response = self.client.post(
+            reverse("edit_endpoint", kwargs={"location_id": self.location_b.id}),
+            {"protocol": "https", "host": "changed.example.test"},
+        )
+        self.assertEqual(404, response.status_code)
+        self.location_b.url.refresh_from_db()
+        self.assertEqual(original_host, self.location_b.url.host)
+
+    def test_delete_endpoint_cross_product_is_denied_and_persists(self):
+        response = self.client.post(
+            reverse("delete_endpoint", kwargs={"location_id": self.location_b.id}),
+            {"id": self.location_b.id},
+        )
+        self.assertEqual(404, response.status_code)
+        self.assertTrue(Location.objects.filter(pk=self.location_b.id).exists())


### PR DESCRIPTION
### Description

The endpoint (Location) views under the V3 Locations feature each resolved their `Location` with an ad-hoc `get_object_or_404` (and one `Location.objects.get`). This routes them all through a single small helper that fetches the `Location` from the standard location queryset, so object retrieval in these views is consistent with the list and host views that already use `get_authorized_locations`.

No new endpoints; a straightforward tidy-up of how the existing views look up their object.

### Test

Adds `unittests/test_location_cross_product_authz.py` covering the endpoint view lookups.
