### PR TITLE
fix(watson): only intermediate-flush the global search context singleton

### DIFF
--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -312,6 +312,15 @@ def install_intermediate_flush_hook():
 
     def add_to_context_with_flush(self, engine, obj):
         original_add(self, engine, obj)
+        # The intermediate flush is a request-path optimization on the global singleton
+        # context (AsyncSearchContextMiddleware). The async reindex task
+        # update_watson_search_index_for_model() builds its OWN SearchContextManager and
+        # IS the drain target -- if it re-drained its batch it would dispatch a clone of
+        # itself, discard those pks unindexed, and loop forever (queue ~0, worker pegged,
+        # nothing indexed). Only the singleton intermediate-flushes; any ad-hoc context
+        # manager indexes its own batch on end().
+        if self is not search_context_manager:
+            return
         threshold = getattr(settings, "WATSON_ASYNC_INDEX_UPDATE_BATCH_SIZE", 1000)
         if threshold <= 0 or not self._stack:
             return

--- a/unittests/test_watson_intermediate_flush.py
+++ b/unittests/test_watson_intermediate_flush.py
@@ -10,7 +10,7 @@ from the in-memory set.
 from unittest.mock import patch
 
 from django.test import override_settings
-from watson.search import search_context_manager
+from watson.search import SearchContextManager, search_context_manager
 
 from dojo.middleware import (
     _drain_search_context_to_async,  # noqa: PLC2701 -- internal helper under test
@@ -119,3 +119,22 @@ class TestIntermediateFlushHook(DojoTestCase):
                 # hook should detect the invalid flag and bail out.
                 search_context_manager.add_to_context(engine_marker, p)
             drain.assert_not_called()
+
+    @override_settings(WATSON_ASYNC_INDEX_UPDATE_BATCH_SIZE=2)
+    def test_ad_hoc_context_manager_does_not_drain(self):
+        """
+        The intermediate flush is a request-path optimization on the global singleton. An
+        ad-hoc SearchContextManager -- e.g. the one update_watson_search_index_for_model builds to
+        index its own batch -- must NOT drain, or it would dispatch a clone of itself and loop
+        forever (queue ~0, worker pegged, nothing indexed).
+        """
+        adhoc = SearchContextManager()
+        adhoc.start()
+        try:
+            with patch("dojo.middleware._drain_search_context_to_async") as drain:
+                for p in self.products[:3]:  # past the threshold of 2
+                    adhoc.add_to_context(object(), p)
+                drain.assert_not_called()
+        finally:
+            adhoc.invalidate()
+            adhoc.end()


### PR DESCRIPTION
## Summary

Minimal extraction of the singleton guard from #15165 (credit @dogboat), targeted at `bugfix` because the affected code shipped there when the branch was cut from `dev` (the bug landed in #14881 in 3.1.0).

### The bug

`install_intermediate_flush_hook()` patches `SearchContextManager.add_to_context` at **class** level, so it also fires inside `update_watson_search_index_for_model()`'s own ad-hoc `SearchContextManager`. A reindex task processing a full `WATSON_ASYNC_INDEX_UPDATE_BATCH_SIZE` (default 1000) batch hits the flush threshold from within the worker and re-dispatches a clone of itself, then discards those pks unindexed. Observed live on a dev stack: the worker republishes the same 1000-pk batches forever — queue length stays ~0 (consumed as fast as republished), worker pegged, nothing indexed. Flushing the broker doesn't help; in-flight tasks reseed the loop on warm shutdown.

Note the trigger is any request that saves ≥1000 watson-registered objects individually on the request thread (bulk edits, mass status changes) so the middleware drains a full-batch task. Plain imports on current code do not produce such a task (findings are bulk-created signal-less in-request and saved per-instance in worker post-processing without an active context) — but the loop detonates deterministically the moment any full-batch task is enqueued.

### The fix

Guard the hook so only the global watson singleton — the request-path context managed by `AsyncSearchContextMiddleware` — intermediate-flushes:

```python
if self is not search_context_manager:
    return
```

Ad-hoc context managers index their own batch synchronously on `end()`, as stock watson does. No behavior change on the request path; no call-site changes. Further improvements will follow on `dev` in #15172.

### Verification (local, JFrog Xray Unified file with 1373 findings)

| Code | Trigger | Result |
|---|---|---|
| unguarded (3.1.0 / OSS stack) | direct dispatch of one 1000-pk reindex task | task count grows without bound (10 → 50 → 200+ in ~3 min) until worker killed |
| guarded | same direct dispatch | exactly 1 execution (6.9s), batch indexed, silence |
| guarded | foreground API import | 7 watson tasks, all 1373 findings indexed, no loop |
| guarded | background (async importer) import | 3 watson tasks, all 1373 findings indexed, no loop |

### Tests

Adds `test_ad_hoc_context_manager_does_not_drain` to the existing `unittests/test_watson_intermediate_flush.py`. Full module passes locally (5/5).