### PR TITLE
docs: add upgrade guide for DefectDojo Pro on-premise (Helm) deployments

### DIFF
--- a/docs/content/get_started/pro/onprem/upgrading.md
+++ b/docs/content/get_started/pro/onprem/upgrading.md
@@ -1,0 +1,31 @@
+---
+title: "Upgrading DefectDojo Pro (On-Premise)"
+description: "Supported upgrade procedure for self-hosted DefectDojo Pro deployments using the Helm chart"
+draft: false
+weight: 5
+audience: pro
+---
+
+This page describes the supported upgrade procedure for self-hosted DefectDojo Pro deployments that use the DefectDojo Pro Helm chart.
+
+## Upgrade everything as one unit
+
+Each DefectDojo Pro release consists of a Helm chart version, container image versions, and the Pro settings files. These are built and tested together and must be upgraded together as one unit.
+
+Upgrading only the image tags is not supported and will break your deployment.
+
+## Settings files and upgrades
+
+DefectDojo Pro ships a `pro_settings.py` file with every release, and the file changes with nearly every version. Do not carry a copy of `pro_settings.py` forward across upgrades, and do not patch an older copy by hand. The application must always run the `pro_settings.py` that matches its version.
+
+Put your own customizations in `local_settings.py`, never in `pro_settings.py`. Your `local_settings.py` is preserved across upgrades.
+
+The Helm chart ships and mounts the matching `pro_settings.py` and your `local_settings.py` automatically. When you upgrade using the chart, there is nothing to copy or migrate by hand.
+
+## Supported upgrade procedure
+
+1. Review the release notes for every version between your current version and your target version, not just the target itself. See the [DefectDojo Pro Changelog](/releases/pro/changelog/) and the version-specific [upgrade notes](/releases/os_upgrading/upgrading_guide/).
+2. Back up your database.
+3. Upgrade to the Helm chart release that matches your target application version, reusing your existing values files. Do not change image tags independently of the chart version.
+
+If you have questions about upgrading your on-premise deployment, contact [support@defectdojo.com](mailto:support@defectdojo.com).


### PR DESCRIPTION
**Description**

Adds a documentation page describing the supported upgrade procedure for self-hosted DefectDojo Pro deployments that use the DefectDojo Pro Helm chart.

The page covers:

- The Helm chart version, container image versions, and Pro settings files are released and tested together and must be upgraded together as one unit. Upgrading only image tags is not supported.
- `pro_settings.py` ships with each release and changes with nearly every version. Copies must not be carried forward across upgrades or patched by hand.
- Customizations belong in `local_settings.py`, not `pro_settings.py`.
- The supported upgrade path: review the release notes for each version crossed, back up the database, then upgrade to the chart release matching the target application version using existing values files.

New file: `docs/content/get_started/pro/onprem/upgrading.md`, placed in the existing DefectDojo Pro (On-Premise) section with `audience: pro` so it appears in the Pro version of the sidebar only.

**Test results**

Docs-only change. Verified with a local Hugo build: the site builds without errors, the page renders at `/get_started/pro/onprem/upgrading/`, it appears in the Pro sidebar menu and not in the Open Source menu, and both internal links resolve.

**Documentation**

This PR is documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)