### PR TITLE
Guard authorized_users on the product/product type API serializers

### DIFF
--- a/dojo/asset/api/serializers.py
+++ b/dojo/asset/api/serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
 
 from dojo.api_v2.serializers import ProductMetaSerializer, TagListSerializerField
+from dojo.authorization.authorization import raise_if_unauthorized_authorized_users_change
+from dojo.authorization.roles_permissions import Permissions
 from dojo.models import (
     Dojo_User,
     Product,
@@ -65,6 +67,7 @@ class AssetSerializer(serializers.ModelSerializer):
             if new_sla_config and old_sla_config and new_sla_config != old_sla_config:
                 msg = "Finding SLA expiration dates are currently being recalculated. The SLA configuration for this asset cannot be changed until the calculation is complete."
                 raise serializers.ValidationError(msg)
+        raise_if_unauthorized_authorized_users_change(self, data, Permissions.Product_Manage_Members)
         return data
 
     def get_findings_count(self, obj) -> int:

--- a/dojo/authorization/authorization.py
+++ b/dojo/authorization/authorization.py
@@ -219,6 +219,31 @@ def user_has_global_permission_or_403(user: Dojo_User, permission) -> None:
         raise PermissionDenied
 
 
+def raise_if_unauthorized_authorized_users_change(serializer, data, permission) -> None:
+    """
+    Guard the writable ``authorized_users`` M2M exposed on the Product /
+    Product_Type API serializers (and the V3 asset / organization aliases).
+
+    Changing who is authorized on an object is membership management, which
+    requires the object's ``*_Manage_Members`` permission -- the same
+    permission the server-rendered membership views enforce -- not plain edit
+    access. Without this guard, edit access alone would let a caller add or
+    remove authorized users through the API.
+
+    No-op on create and when the submitted set matches the current set.
+    """
+    if serializer.instance is None or "authorized_users" not in data:
+        return
+    if set(data["authorized_users"]) == set(serializer.instance.authorized_users.all()):
+        return
+    user = getattr(serializer.context.get("request"), "user", None)
+    if not user_has_permission(user, serializer.instance, permission):
+        from rest_framework.exceptions import PermissionDenied as DRFPermissionDenied  # noqa: PLC0415
+
+        msg = "You are not permitted to change the authorized users."
+        raise DRFPermissionDenied(msg)
+
+
 # ---------------------------------------------------------------------------
 # Inert role-based helpers.
 #

--- a/dojo/organization/api/serializers.py
+++ b/dojo/organization/api/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from dojo.authorization.authorization import raise_if_unauthorized_authorized_users_change
+from dojo.authorization.roles_permissions import Permissions
 from dojo.models import Product_Type
 from dojo.product_type.queries import get_authorized_product_types
 
@@ -16,3 +18,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product_Type
         exclude = ("critical_product", "key_product")
+
+    def validate(self, data):
+        raise_if_unauthorized_authorized_users_change(self, data, Permissions.Product_Type_Manage_Members)
+        return data

--- a/dojo/product/api/serializer.py
+++ b/dojo/product/api/serializer.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from dojo.authorization.authorization import raise_if_unauthorized_authorized_users_change
+from dojo.authorization.roles_permissions import Permissions
 from dojo.models import DojoMeta, Product, Product_API_Scan_Configuration
 
 
@@ -50,6 +52,7 @@ class ProductSerializer(serializers.ModelSerializer):
             if new_sla_config and old_sla_config and new_sla_config != old_sla_config:
                 msg = "Finding SLA expiration dates are currently being recalculated. The SLA configuration for this product cannot be changed until the calculation is complete."
                 raise serializers.ValidationError(msg)
+        raise_if_unauthorized_authorized_users_change(self, data, Permissions.Product_Manage_Members)
         return data
 
     def get_findings_count(self, obj) -> int:

--- a/dojo/product_type/api/serializer.py
+++ b/dojo/product_type/api/serializer.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from dojo.authorization.authorization import raise_if_unauthorized_authorized_users_change
+from dojo.authorization.roles_permissions import Permissions
 from dojo.product_type.models import Product_Type
 
 
@@ -7,3 +9,7 @@ class ProductTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product_Type
         fields = "__all__"
+
+    def validate(self, data):
+        raise_if_unauthorized_authorized_users_change(self, data, Permissions.Product_Type_Manage_Members)
+        return data

--- a/unittests/test_authorized_users_api_authz.py
+++ b/unittests/test_authorized_users_api_authz.py
@@ -1,0 +1,122 @@
+"""
+Regression tests for authorization on the writable ``authorized_users`` M2M
+exposed by the Product / Product_Type API serializers and their V3 asset /
+organization aliases.
+
+Membership management is guarded in the server-rendered views by the
+``*_Manage_Members`` permission, but the API serializers exposed
+``authorized_users`` as a plain writable field, so a caller with only edit
+access to an object could add or remove authorized users through the API.
+These tests fix that contract:
+
+* a member with edit access but without the manage-members permission cannot
+  change ``authorized_users`` through the API;
+* that member can still edit other fields of the object;
+* a superuser can still manage ``authorized_users`` through the API.
+"""
+from django.urls import reverse
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient, APITestCase
+
+from dojo.models import Dojo_User, Product, Product_Type, User
+from unittests.dojo_test_case import skip_unless_v3, versioned_fixtures
+
+
+@versioned_fixtures
+class AuthorizedUsersApiAuthorizationTest(APITestCase):
+
+    """
+    ``member`` has edit access to the product and product type (legacy
+    ``authorized_users`` membership) but is not staff, so it lacks the
+    manage-members permission. ``outsider`` is the account the member tries to
+    smuggle in.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.prod_type = Product_Type.objects.create(name="authz_users_pt")
+        cls.product = Product.objects.create(
+            name="authz_users_product", description="d", prod_type=cls.prod_type,
+        )
+
+        cls.member = Dojo_User.objects.create(username="authz_users_member", is_active=True)
+        cls.outsider = Dojo_User.objects.create(username="authz_users_outsider", is_active=True)
+        # Legacy edit access on both objects, but not staff -> no manage-members.
+        cls.product.authorized_users.add(cls.member)
+        cls.prod_type.authorized_users.add(cls.member)
+
+        cls.admin = User.objects.get(username="admin")
+
+    def _client(self, user):
+        token, _ = Token.objects.get_or_create(user=user)
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+        return client
+
+    # ------------------------------------------------------------------
+    # products
+    # ------------------------------------------------------------------
+    def test_member_cannot_add_authorized_user_to_product(self):
+        client = self._client(self.member)
+        response = client.patch(
+            reverse("product-detail", args=(self.product.id,)),
+            {"authorized_users": [self.member.id, self.outsider.id]},
+        )
+        self.assertEqual(response.status_code, 403, response.content[:1000])
+        self.assertNotIn(self.outsider, self.product.authorized_users.all())
+
+    def test_member_can_still_edit_other_product_fields(self):
+        client = self._client(self.member)
+        response = client.patch(
+            reverse("product-detail", args=(self.product.id,)),
+            {"description": "changed by member"},
+        )
+        self.assertEqual(response.status_code, 200, response.content[:1000])
+        self.product.refresh_from_db()
+        self.assertEqual(self.product.description, "changed by member")
+
+    def test_superuser_can_change_product_authorized_users(self):
+        client = self._client(self.admin)
+        response = client.patch(
+            reverse("product-detail", args=(self.product.id,)),
+            {"authorized_users": [self.member.id, self.outsider.id]},
+        )
+        self.assertEqual(response.status_code, 200, response.content[:1000])
+        self.assertIn(self.outsider, self.product.authorized_users.all())
+
+    # ------------------------------------------------------------------
+    # product_types
+    # ------------------------------------------------------------------
+    def test_member_cannot_add_authorized_user_to_product_type(self):
+        client = self._client(self.member)
+        response = client.patch(
+            reverse("product_type-detail", args=(self.prod_type.id,)),
+            {"authorized_users": [self.member.id, self.outsider.id]},
+        )
+        self.assertEqual(response.status_code, 403, response.content[:1000])
+        self.assertNotIn(self.outsider, self.prod_type.authorized_users.all())
+
+    # ------------------------------------------------------------------
+    # V3 aliases: assets (Product) and organizations (Product_Type)
+    # ------------------------------------------------------------------
+    @skip_unless_v3
+    def test_member_cannot_add_authorized_user_to_asset(self):
+        client = self._client(self.member)
+        response = client.patch(
+            reverse("asset-detail", args=(self.product.id,)),
+            {"authorized_users": [self.member.id, self.outsider.id]},
+        )
+        self.assertEqual(response.status_code, 403, response.content[:1000])
+        self.assertNotIn(self.outsider, self.product.authorized_users.all())
+
+    @skip_unless_v3
+    def test_member_cannot_add_authorized_user_to_organization(self):
+        client = self._client(self.member)
+        response = client.patch(
+            reverse("organization-detail", args=(self.prod_type.id,)),
+            {"authorized_users": [self.member.id, self.outsider.id]},
+        )
+        self.assertEqual(response.status_code, 403, response.content[:1000])
+        self.assertNotIn(self.outsider, self.prod_type.authorized_users.all())


### PR DESCRIPTION
### Description

Changing who is authorized on a product or product type goes through the `*_Manage_Members` permission in the server-rendered membership views. This applies the same permission check when `authorized_users` is written through the API serializers, so membership changes require the same permission regardless of entry point.

Covered serializers:
- `ProductSerializer` (`/api/v2/products/`)
- `ProductTypeSerializer` (`/api/v2/product_types/`)
- `AssetSerializer` (`/api/v2/assets/`, V3)
- `OrganizationSerializer` (`/api/v2/organizations/`, V3)

A shared helper (`raise_if_unauthorized_authorized_users_change`) performs the check so behavior is identical across all four. Users with the manage-members permission (and superusers) are unaffected, and other field edits are unaffected.

### Test results

Adds `unittests/test_authorized_users_api_authz.py` covering the `authorized_users` write paths for products, product types, and the V3 asset/organization aliases.