### PR TITLE
fix: render report summary charts after the table-of-contents rebuild

### DIFF
--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -285,7 +285,7 @@
     <script src="{{ host }}{% static "chartjs-adapter-moment/dist/chartjs-adapter-moment.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var data = {};
             var data_1 = [];
             var ticks = [];
@@ -346,8 +346,9 @@
                 [4, info],
             ];
             open_findings(d1, d2, d3, d4, d5, ticks);
-        });
+        }
 
+        {% if include_table_of_contents%}
         window.onload = function () {
             var toc = "";
             var level = 3;
@@ -417,7 +418,18 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted Chart.js canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
 
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -420,7 +420,7 @@
     <script src="{{ host }}{% static "chartjs-adapter-moment/dist/chartjs-adapter-moment.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var data = {};
             var data_1 = [];
             var ticks = [];
@@ -497,7 +497,7 @@
                 opened_per_month_2(critical, high, medium, low);
             {% endif %}
 
-        });
+        }
 
         {% if include_table_of_contents%}
         window.onload = function () {
@@ -569,7 +569,17 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted Chart.js canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
         {% endif %}
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -270,7 +270,7 @@
     <script src="{{ host }}{% static "chartjs-adapter-moment/dist/chartjs-adapter-moment.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var data = {};
             var data_1 = [];
             var ticks = [];
@@ -331,8 +331,9 @@
                 [4, info],
             ];
             open_findings(d1, d2, d3, d4, d5, ticks);
-        });
+        }
 
+        {% if include_table_of_contents%}
         window.onload = function () {
             var toc = "";
             var level = 3;
@@ -406,7 +407,18 @@
             if (document.getElementById("toc") != null) {
                 document.getElementById("toc").innerHTML += toc;
             }
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted Chart.js canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
 
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -338,7 +338,7 @@
         <script src="{% static "dojo/js/metrics.js" %}"></script>
     {% endblock metrics %}
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var critical = 0;
             var high = 0;
             var medium = 0;
@@ -471,8 +471,9 @@
                 i++;
             });
             finding_age(data_1, ticks);
-        });
+        }
 
+        {% if include_table_of_contents%}
         window.onload = function () {
             var toc = "";
             var level = 3;
@@ -542,6 +543,17 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted Chart.js canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -391,7 +391,7 @@
     <script src="{{ host }}{% static "chartjs-adapter-moment/dist/chartjs-adapter-moment.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var critical = 0;
             var high = 0;
             var medium = 0;
@@ -488,8 +488,9 @@
                 i++;
             });
             finding_age(data_1, ticks);
-        });
+        }
 
+        {% if include_table_of_contents%}
 		window.onload = function () {
             var toc = "";
             var level = 3;
@@ -559,6 +560,17 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted Chart.js canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
   </script>
 {% endblock %}

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -320,7 +320,7 @@
     <script src="{{ host }}{% static "chartjs-adapter-moment/dist/chartjs-adapter-moment.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var critical = 0;
             var high = 0;
             var medium = 0;
@@ -375,7 +375,7 @@
                 {% endfor %}
                 opened_per_month_2(critical, high, medium, low);
             {% endif %}
-        });
+        }
 
         {% if include_table_of_contents%}
             window.onload = function () {
@@ -447,7 +447,17 @@
                 }
 
                 document.getElementById("toc").innerHTML += toc;
+
+                // Render the summary charts AFTER the table-of-contents builder has
+                // rewritten #contents.innerHTML. Rendering earlier (on
+                // DOMContentLoaded) means this reassignment re-parses the subtree and
+                // discards the already-painted Chart.js canvases, leaving blank charts.
+                renderReportCharts();
             };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
         {% endif %}
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -434,7 +434,7 @@
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
         {% if include_executive_summary %}
-            $(function () {
+            function renderReportCharts() {
                 var critical = 0;
                 var high = 0;
                 var medium = 0;
@@ -474,7 +474,6 @@
                     [4, info],
                 ];
                 open_findings(d1, d2, d3, d4, d5, ticks);
-            });
 
             var data = {};
             var data_1 = []
@@ -510,8 +509,10 @@
             {% if endpoint_opened_per_month %}
                 opened_per_month_2(critical, high, medium, low);
             {%  endif %}
+            }
         {% endif %}
 
+        {% if include_table_of_contents%}
         window.onload = function () {
             var toc = "";
             var level = 3;
@@ -582,6 +583,21 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            {% if include_executive_summary %}
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted Chart.js canvases, leaving blank charts.
+            renderReportCharts();
+            {% endif %}
         };
+        {% else %}
+        {% if include_executive_summary %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
+        {% endif %}
     </script>
 {% endblock %}

--- a/dojo/templates_classic/dojo/endpoint_pdf_report.html
+++ b/dojo/templates_classic/dojo/endpoint_pdf_report.html
@@ -287,7 +287,7 @@
     <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/classic/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var data = {};
             var data_1 = [];
             var ticks = [];
@@ -348,8 +348,9 @@
                 [4, info],
             ];
             open_findings(d1, d2, d3, d4, d5, ticks);
-        });
+        }
 
+        {% if include_table_of_contents%}
         window.onload = function () {
             var toc = "";
             var level = 3;
@@ -419,7 +420,18 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted chart canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
 
     </script>
 {% endblock %}

--- a/dojo/templates_classic/dojo/engagement_pdf_report.html
+++ b/dojo/templates_classic/dojo/engagement_pdf_report.html
@@ -422,7 +422,7 @@
     <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/classic/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var data = {};
             var data_1 = [];
             var ticks = [];
@@ -499,7 +499,7 @@
                 opened_per_month_2(critical, high, medium, low);
             {% endif %}
 
-        });
+        }
 
         {% if include_table_of_contents%}
         window.onload = function () {
@@ -571,7 +571,17 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted chart canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
         {% endif %}
     </script>
 {% endblock %}

--- a/dojo/templates_classic/dojo/finding_pdf_report.html
+++ b/dojo/templates_classic/dojo/finding_pdf_report.html
@@ -266,7 +266,7 @@
     <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/classic/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var data = {};
             var data_1 = [];
             var ticks = [];
@@ -327,8 +327,9 @@
                 [4, info],
             ];
             open_findings(d1, d2, d3, d4, d5, ticks);
-        });
+        }
 
+        {% if include_table_of_contents%}
         window.onload = function () {
             var toc = "";
             var level = 3;
@@ -402,7 +403,18 @@
             if (document.getElementById("toc") != null) {
                 document.getElementById("toc").innerHTML += toc;
             }
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted chart canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
 
     </script>
 {% endblock %}

--- a/dojo/templates_classic/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates_classic/dojo/product_endpoint_pdf_report.html
@@ -344,7 +344,7 @@
         <script src="{% static "dojo/js/classic/metrics.js" %}"></script>
     {% endblock metrics %}
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var critical = 0;
             var high = 0;
             var medium = 0;
@@ -477,8 +477,9 @@
                 i++;
             });
             finding_age(data_1, ticks);
-        });
+        }
 
+        {% if include_table_of_contents%}
         window.onload = function () {
             var toc = "";
             var level = 3;
@@ -548,6 +549,17 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted chart canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
     </script>
 {% endblock %}

--- a/dojo/templates_classic/dojo/product_pdf_report.html
+++ b/dojo/templates_classic/dojo/product_pdf_report.html
@@ -397,7 +397,7 @@
     {% endif %}
     <script src="{{ host }}{% static "dojo/js/classic/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var critical = 0;
             var high = 0;
             var medium = 0;
@@ -494,8 +494,9 @@
                 i++;
             });
             finding_age(data_1, ticks);
-        });
+        }
 
+        {% if include_table_of_contents%}
 		window.onload = function () {
             var toc = "";
             var level = 3;
@@ -565,6 +566,17 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted chart canvases, leaving blank charts.
+            renderReportCharts();
         };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
   </script>
 {% endblock %}

--- a/dojo/templates_classic/dojo/product_type_pdf_report.html
+++ b/dojo/templates_classic/dojo/product_type_pdf_report.html
@@ -322,7 +322,7 @@
     <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/classic/metrics.js" %}"></script>
     <script type="text/javascript">
-        $(function () {
+        function renderReportCharts() {
             var critical = 0;
             var high = 0;
             var medium = 0;
@@ -377,7 +377,7 @@
                 {% endfor %}
                 opened_per_month_2(critical, high, medium, low);
             {% endif %}
-        });
+        }
 
         {% if include_table_of_contents%}
             window.onload = function () {
@@ -449,7 +449,17 @@
                 }
 
                 document.getElementById("toc").innerHTML += toc;
+
+                // Render the summary charts AFTER the table-of-contents builder has
+                // rewritten #contents.innerHTML. Rendering earlier (on
+                // DOMContentLoaded) means this reassignment re-parses the subtree and
+                // discards the already-painted chart canvases, leaving blank charts.
+                renderReportCharts();
             };
+        {% else %}
+        $(function () {
+            renderReportCharts();
+        });
         {% endif %}
     </script>
 {% endblock %}

--- a/dojo/templates_classic/dojo/test_pdf_report.html
+++ b/dojo/templates_classic/dojo/test_pdf_report.html
@@ -436,7 +436,7 @@
     <script src="{{ host }}{% static "dojo/js/classic/metrics.js" %}"></script>
     <script type="text/javascript">
         {% if include_executive_summary %}
-            $(function () {
+            function renderReportCharts() {
                 var critical = 0;
                 var high = 0;
                 var medium = 0;
@@ -476,7 +476,6 @@
                     [4, info],
                 ];
                 open_findings(d1, d2, d3, d4, d5, ticks);
-            });
 
             var data = {};
             var data_1 = []
@@ -512,8 +511,10 @@
             {% if endpoint_opened_per_month %}
                 opened_per_month_2(critical, high, medium, low);
             {%  endif %}
+            }
         {% endif %}
 
+        {% if include_table_of_contents%}
         window.onload = function () {
             var toc = "";
             var level = 3;
@@ -584,6 +585,21 @@
             }
 
             document.getElementById("toc").innerHTML += toc;
+
+            {% if include_executive_summary %}
+            // Render the summary charts AFTER the table-of-contents builder has
+            // rewritten #contents.innerHTML. Rendering earlier (on
+            // DOMContentLoaded) means this reassignment re-parses the subtree and
+            // discards the already-painted chart canvases, leaving blank charts.
+            renderReportCharts();
+            {% endif %}
         };
+        {% else %}
+        {% if include_executive_summary %}
+        $(function () {
+            renderReportCharts();
+        });
+        {% endif %}
+        {% endif %}
     </script>
 {% endblock %}

--- a/tests/report_builder_test.py
+++ b/tests/report_builder_test.py
@@ -3,6 +3,7 @@ import unittest
 
 from base_test_class import BaseTestCase
 from product_test import ProductTest
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
@@ -29,6 +30,40 @@ class ReportBuilderTest(BaseTestCase):
                     field.send_keys("cover words")
             if "wysiwyg-content" in class_names:
                 widget.find_element(By.CLASS_NAME, "editor").send_keys("wysiwyg")
+
+    # Regression guard for the report-chart / table-of-contents race: the
+    # executive-summary charts are rendered from a ready handler, while the
+    # table-of-contents builder runs on window.onload and reassigns
+    # #contents.innerHTML. That reassignment re-parses the subtree and
+    # destroys any chart canvases painted before it (Chart.js in the new UI,
+    # Flot in the classic UI). With executive summary AND table of contents
+    # both enabled, every chart must end up painted once the page settles.
+    def assert_report_charts_painted(self, chart_ids):
+        driver = self.driver
+        charts_painted = (
+            "return arguments[0].map(function (id) {"
+            "  var el = document.getElementById(id);"
+            "  if (!el) { return false; }"
+            "  var canvases = el.querySelectorAll('canvas');"
+            "  for (var i = 0; i < canvases.length; i++) {"
+            "    if (!canvases[i].width || !canvases[i].height) { continue; }"
+            "    var ctx = canvases[i].getContext('2d');"
+            "    var data = ctx.getImageData(0, 0, canvases[i].width, canvases[i].height).data;"
+            "    for (var j = 3; j < data.length; j += 64) {"
+            "      if (data[j] > 0) { return true; }"
+            "    }"
+            "  }"
+            "  return false;"
+            "});"
+        )
+        try:
+            WebDriverWait(driver, 20).until(lambda d: all(d.execute_script(charts_painted, chart_ids)))
+        except TimeoutException:
+            self.fail(
+                "Executive-summary charts were not painted after page load "
+                f"({chart_ids} painted: {driver.execute_script(charts_painted, chart_ids)}); "
+                "the table-of-contents builder likely destroyed them.",
+            )
 
     def generate_HTML_report(self):
         driver = self.driver
@@ -59,6 +94,10 @@ class ReportBuilderTest(BaseTestCase):
 
         driver.find_element(By.NAME, "_generate").click()
 
+        # opened_per_month_2 is only rendered when the product type has
+        # endpoint-per-month data, so only the unconditional chart is asserted.
+        self.assert_report_charts_painted(["open_findings"])
+
     def test_product_report(self):
         driver = self.driver
         self.goto_product_overview(driver)
@@ -76,6 +115,8 @@ class ReportBuilderTest(BaseTestCase):
         my_select.select_by_index(1)
 
         driver.find_element(By.NAME, "_generate").click()
+
+        self.assert_report_charts_painted(["open_findings", "finding_age"])
 
     def test_engagement_report(self):
         driver = self.driver
@@ -97,6 +138,8 @@ class ReportBuilderTest(BaseTestCase):
 
         driver.find_element(By.NAME, "_generate").click()
 
+        self.assert_report_charts_painted(["open_findings", "finding_age"])
+
     def test_test_report(self):
         driver = self.driver
         self.goto_product_overview(driver)
@@ -117,6 +160,8 @@ class ReportBuilderTest(BaseTestCase):
         my_select.select_by_index(1)
 
         driver.find_element(By.NAME, "_generate").click()
+
+        self.assert_report_charts_painted(["open_findings", "finding_age"])
 
     def test_product_endpoint_report(self):
         driver = self.driver
@@ -144,7 +189,14 @@ class ReportBuilderTest(BaseTestCase):
 
         driver.find_element(By.NAME, "_generate").click()
 
+        self.assert_report_charts_painted(["accepted_findings", "open_findings", "closed_findings", "finding_age"])
+
     def test_product_list_report(self):
+        # Unlike the report tests above, this does not call
+        # assert_report_charts_painted(): it generates the Findings Report,
+        # whose view currently errors before the report (and its charts)
+        # render, so there are no chart canvases to assert on. This test only
+        # exercises the generate action until that view is fixed.
         driver = self.driver
         self.goto_product_overview(driver)
         driver.find_element(By.ID, "dropdownMenu1").click()


### PR DESCRIPTION
**Description**

Fixes a long-standing bug where the Executive-Summary charts on generated HTML reports
render as empty boxes. It was reported as far back as #2294 and #3253 (2020, Flot era);
both were auto-closed by the stale bot and the cause was never identified.

The charts are not failing to build — they are built and then silently destroyed. In
every `*_pdf_report.html` template the charts render from a jQuery `ready` handler, while
the table-of-contents builder runs on `window.onload` and rebuilds the TOC by reassigning
`#contents.innerHTML`. The chart containers live inside `#contents`, so an `innerHTML`
round-trip re-serializes and re-parses that subtree — and a `<canvas>`'s painted bitmap
and its Chart.js/Flot instance registration do not survive serialization. Whenever the
charts paint before the TOC rebuild, they are replaced with blank canvases. No exception
is thrown, which is why this reads as a data/charting problem.

The two orderings race. On a warm local cache the async `ready` callback can occasionally
land after `onload` and the charts survive; with realistic static-asset latency `onload`
fires late, the charts paint first, and they are destroyed near-deterministically — which
matches how #2294/#3253 described it as always-blank in real deployments. Throttling
static assets by a few hundred ms reproduces it every time locally; toggling only the
Table of Contents flag flips the failure on and off.

**The fix:** wrap the chart-rendering code in a `renderReportCharts()` function and invoke
it *after* the TOC builder finishes (or from the `ready` handler when the TOC is disabled),
so the charts are always created into the final DOM. Applied to all seven report types
(engagement, product, product type, test, endpoint, finding, product endpoint) in both
template trees — `dojo/templates/` (new UI, Chart.js) and `dojo/templates_classic/`
(classic UI, Flot) — 14 templates in total.

Two template-specific notes:

- In five of the seven types (product, test, endpoint, finding, product endpoint) the
  `window.onload` TOC builder was missing the `{% if include_table_of_contents %}` guard
  its siblings have, so it ran even with the TOC disabled. Because the `#contents` wrapper
  is itself rendered only when the TOC is enabled, the ungated handler dereferences a null
  `#contents` on its first line and throws an uncaught `TypeError` before it can rewrite
  anything (the finding template null-checks `#contents` and stays silent) — so the charts
  survive in that configuration, but every such report logs a console error. These five now
  carry the same guard, so the handler is not emitted when the TOC is off.
- In the test template the chart code was split between a `ready` handler and top-level
  script code; both pieces are consolidated into `renderReportCharts()` preserving their
  order. Its call sites stay inside `{% if include_executive_summary %}` because the
  function definition is only rendered with the executive summary.

**Test results**

Added a regression assertion to the Selenium report tests (`tests/report_builder_test.py`):
with Executive Summary and Table of Contents both enabled, the summary charts end up with
painted (non-blank) canvas pixels. The check is chart-library-agnostic — it inspects
rendered pixels, not the DOM — so a blank `<canvas>` element (which exists in both the
broken and fixed states) does not pass it, and it holds on both the Chart.js and classic
Flot report pages. Factored into a helper and applied to the product type, product,
engagement, test, and product-endpoint report tests.

Manually verified on a live 3.0.0 instance across both UI trees: with static-asset
throttling forcing the race, the URL-routable report types render their charts with the
TOC enabled (previously blank) and with it disabled (regression check), with no console
errors. `ruff` clean.

A note on the secondary (ungated-`onload`) fix: I verified it manually (a load probe
across the report types confirms no console error with the TOC disabled) rather than with
a dedicated assertion, because the test harness globally whitelists
`Uncaught TypeError: Cannot read properties of null (reading 'innerHTML')` in
`assertNoConsoleErrors()` — which is exactly the error these ungated handlers throw. That
whitelist entry can't simply be removed, because `dojo/templates/dojo/custom_html_toc.html`
(the report *builder's* TOC, exercised by `generate_HTML_report`) has an independent,
still-unfixed null-dereference of the same shape. I've left the whitelist in place and
kept this PR scoped to the per-report-type templates; tightening the whitelist and fixing
`custom_html_toc.html` is noted as follow-up below.

**Known trade-offs and follow-ups** *(disclosed for reviewers; not addressed here to keep the change minimal)*

- *Charts now render on `window.onload` instead of DOM-ready in the TOC-enabled path.*
  Rendering after the TOC rebuild is what fixes the race, but it does mean charts appear
  slightly later on very large reports (`onload` waits for all subresources, e.g. embedded
  finding images). This is a deliberate trade of a little latency for correctness. The
  only way to keep charts on the fast ready handler *and* avoid the race would be to change
  the TOC builder itself (next point).
- *Root cause left in place:* the TOC builder rebuilds anchors by reassigning
  `#contents.innerHTML`, and that serialize/re-parse is what destroys live canvases. A
  more thorough fix would build the TOC by walking the DOM instead of round-tripping
  `innerHTML`, which would also eliminate the latency trade-off above. That's a larger
  change to long-standing code; I kept this PR to the minimal ordering fix.
- *Duplication:* the chart block and the ~50-line TOC builder are near-identical across all
  seven report types in both trees, which is why this bug existed in seven places and why
  five copies had drifted to the ungated form. Extracting the shared logic into a single
  static JS module would prevent future drift; out of scope here but worth doing.

**Documentation**

No documentation changes — this is a rendering bugfix with no user-facing feature or
settings change.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR. *(bugfix)*

