### PR TITLE
Docs: Have I Been Pwned connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -148,6 +148,26 @@ To generate a Dependency\-Track API key:
 
 For more information, see **[Dependency\-Track Documentation](https://docs.dependencytrack.org/integrations/rest-api/)**.
 
+## **Have I Been Pwned**
+
+The Have I Been Pwned (HIBP) connector uses the HIBP REST API to report which accounts on your organization's own domains have appeared in known data breaches. DefectDojo discovers each domain you have verified with HIBP and imports one finding per breach affecting that domain.
+
+#### Prerequisites
+
+You will need a Have I Been Pwned API key with domain search, which requires a **Core** subscription tier or higher. You can obtain a key from your [Have I Been Pwned account](https://haveibeenpwned.com/API/Key).
+
+You must also **verify at least one domain** on your HIBP account before any breach data is available. HIBP lets you verify a domain by DNS TXT record, meta tag, file upload, or email, under **Domain search** in your account. Until a domain is verified, the connector discovers no domains and imports no findings.
+
+#### Connector Mappings
+
+1. Enter `https://haveibeenpwned.com` in the **Location** field.
+2. Enter your API key in the **Secret** field.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported. Findings below the selected severity will not be imported.
+
+DefectDojo creates a separate Record for each domain you have verified with HIBP, and imports one finding per breach affecting accounts on that domain. Each finding's severity reflects the kind of data the breach exposed, and its description lists the affected accounts on your domain so your team can act on them.
+
+See the [Have I Been Pwned API documentation](https://haveibeenpwned.com/API/v3) for more information.
+
 ## **IriusRisk**
 
 The IriusRisk connector uses an API token to pull threat modeling data from your IriusRisk instance.


### PR DESCRIPTION
## Docs: Have I Been Pwned connector reference

Adds a **Have I Been Pwned** section to the Pro connectors tool reference, placed alphabetically between Dependency-Track and IriusRisk.

Companion to the connector (DefectDojo-Inc/connectors#674) and its DD Pro registration.

The section covers:
- Requires a **Core-tier (or higher)** HIBP API key with domain search.
- You must **add and verify a domain** on your HIBP account (DNS TXT, meta tag, file, or email) before any breach data appears; until then the connector discovers no domains and imports no findings.
- Mappings: **Location** = `https://haveibeenpwned.com`, **Secret** = API key, optional **Minimum Severity**.
- DefectDojo auto-discovers your verified domains, creates a Record per domain, and imports one finding per breach affecting it.

Prose matches the neighboring sections (no em dashes). Other in-flight connector-doc PRs touch this same file; the maintainer may reconcile alphabetical adjacency on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
