### PR TITLE
Docs: Wazuh connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -264,6 +264,28 @@ On\-premise Tenable Connectors are not available at this time.
 
 See [Tenable's API Documentation](https://docs.tenable.com/vulnerability-management/Content/Settings/my-account/GenerateAPIKey.htm) for more info.
 
+## **Wazuh**
+
+The Wazuh connector uses the Wazuh Indexer (OpenSearch) to fetch vulnerability findings. Wazuh 4.8 and later store detected CVEs in the Indexer rather than the Wazuh server API, so this connector reads them directly from the `wazuh-states-vulnerabilities-*` index.
+
+DefectDojo creates a Record for each Wazuh agent (endpoint) and imports that agent's detected CVEs as findings on a scheduled basis.
+
+#### Prerequisites
+
+You will need:
+
+* The base URL of your Wazuh Indexer, including the port (the Indexer listens on port 9200 by default). DefectDojo connects to the Indexer directly, so this endpoint must be reachable from DefectDojo. For self\-managed deployments this is the host running the Wazuh Indexer. For Wazuh Cloud, use the Indexer endpoint shown in your Wazuh Cloud console, which is separate from the Wazuh dashboard URL.
+* An Indexer user and password with read access to the `wazuh-states-vulnerabilities-*` index. We recommend creating a dedicated user for DefectDojo.
+
+Vulnerability detection must be enabled in Wazuh so that the vulnerability\-state index is populated. See the [Wazuh vulnerability detection documentation](https://documentation.wazuh.com/current/user-manual/capabilities/vulnerability-detection/index.html) for more information.
+
+#### Connector Mappings
+
+1. Enter your Wazuh Indexer base URL in the **Location** field, including the scheme and port, for example `https://your-indexer.example.com:9200`. Do not include a trailing path. DefectDojo constructs the search paths automatically.
+2. Enter the Indexer username in the **Username** field.
+3. Enter the Indexer password in the **Password** field.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported. Findings below the selected severity will not be imported.
+
 ## Wiz
 
 Using the Wiz connector requires you to create a service account: see the [Wiz documentation](https://docs.wiz.io/wiz-docs/docs/service-accounts-settings#add-a-service-account) for more info.  You will need a Wiz account to access the documentation.


### PR DESCRIPTION
## Wazuh connector reference

Adds a **Wazuh** section to the Pro connectors tool reference (`docs/content/import_data/pro/connectors/connectors_tool_reference.md`), placed alphabetically before Wiz and following the existing description / Prerequisites / Connector Mappings format.

It covers:
- The connector reads from the Wazuh **Indexer** (`wazuh-states-vulnerabilities-*`), since Wazuh 4.8+ stores CVEs there rather than in the server API.
- Where to get the Indexer endpoint and credentials (self-managed host, or the Indexer endpoint in the Wazuh Cloud console, which is separate from the dashboard URL).
- That the **Location** is the Indexer base URL including port (9200 by default) and must be reachable from DefectDojo.
- That DefectDojo creates a Record per Wazuh agent and imports its detected CVEs as findings.
- The Username / Password fields and the optional Minimum Severity.

Pairs with the Go connector (DefectDojo-Inc/connectors) and the DD Pro registration.

Note: parallel in-flight connector doc PRs touch this same file; the alphabetical adjacency can be reconciled at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
