### PR TITLE
Docs: Censys connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -114,6 +114,31 @@ See [Burp Documentation](https://portswigger.net/burp/documentation/enterprise/u
 
 See the official [Burp documentation](https://portswigger.net/burp/extensibility/enterprise/graphql-api/index.html) for more information on the Burp API.
 
+## **Censys**
+
+The Censys connector reads host assets from the Censys Platform and imports each host's exposed services as findings. It uses the Censys Platform global search API to enumerate the hosts you scope it to.
+
+#### Prerequisites
+
+You will need a Censys **Platform** account with API access:
+
+* A **Personal Access Token**, created in the Censys Platform Console under Personal Access Tokens.
+* Your **Organization ID**, shown on the same settings page under "Current Organization". API access to the search endpoint requires an organization, so a Starter tier or higher is needed. Free\-tier tokens have no organization ID and cannot use the search API.
+
+Per\-host CVE and risk data is available only on Censys Core (enterprise) tiers, so on lower tiers findings represent exposed services rather than vulnerabilities.
+
+See the [Censys Platform API documentation](https://docs.censys.com/reference/get-started) for more information.
+
+#### Connector Mappings
+
+1. Enter `https://api.platform.censys.io` in the **Location** field.
+2. Enter your Personal Access Token in the **API Key** field.
+3. Enter your **Organization ID**.
+4. Enter a **Search Query** that scopes the import to your own assets, for example `host.autonomous_system.asn: <your ASN>` or `host.ip: 203.0.113.0/24`.
+5. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo creates a Record for each host and imports its exposed services as findings.
+
 ## **Checkmarx ONE**
 
 DefectDojo's Checkmarx ONE connector calls the Checkmarx API to fetch data.


### PR DESCRIPTION
## Censys connector reference

Adds a **Censys** section to the Pro connectors tool reference (`docs/content/import_data/pro/connectors/connectors_tool_reference.md`), placed alphabetically between BurpSuite and Checkmarx ONE, following the existing description / Prerequisites / Connector Mappings format.

It covers:
- The connector reads host assets from the **Censys Platform** and imports each host's exposed services as findings.
- The tier and credentials required: a Platform **Personal Access Token** and **Organization ID** (Starter tier or higher; Free-tier tokens have no organization ID and cannot use the search API).
- That per-host CVE/risk data is Censys Core (enterprise) only, so on lower tiers findings represent exposed services rather than vulnerabilities.
- The **Location** (`https://api.platform.censys.io`), the API Key / Organization ID / Search Query fields, and the optional Minimum Severity.
- That DefectDojo creates a Record per host.

Pairs with the Go connector (DefectDojo-Inc/connectors) and the DD Pro registration.

Note: parallel in-flight connector doc PRs touch this same file; the alphabetical adjacency can be reconciled at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
