### PR TITLE
fix(auditlog): make pghistory context JSON-safe before Celery dispatch

### DIFF
--- a/dojo/auditlog/helpers.py
+++ b/dojo/auditlog/helpers.py
@@ -166,18 +166,43 @@ def process_events_for_display(events):
 # ---------------------------------------------------------------------------
 
 
+def _json_safe_metadata_value(value):
+    """
+    Coerce a pghistory context metadata value into something the JSON task
+    serializer can encode.
+
+    The context is injected into Celery task kwargs as ``_pgh_context`` and
+    serialized by kombu's JSON encoder at dispatch time. A stray model instance
+    in the metadata (e.g. a ``user`` set to a ``User`` object instead of its pk)
+    raises ``EncodeError: Object of type User is not JSON serializable`` and
+    aborts the whole task dispatch. Reduce model instances to their pk and
+    recurse into dict/list/tuple so nested values are covered too.
+    """
+    from django.db.models import Model  # noqa: PLC0415 -- avoid import cycle at app load
+
+    if isinstance(value, Model):
+        return value.pk
+    if isinstance(value, dict):
+        return {k: _json_safe_metadata_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_metadata_value(v) for v in value]
+    return value
+
+
 def get_serializable_pghistory_context():
     """
     Capture the current pghistory context for passing to Celery tasks.
 
     Returns a JSON-serializable dict with context id and metadata,
-    or None if no context is active.
+    or None if no context is active. Metadata values are coerced to
+    JSON-safe types (model instances -> pk) so a non-serializable value in
+    the active context can never crash Celery task dispatch.
     """
     if hasattr(pghistory_runtime._tracker, "value"):
         ctx = pghistory_runtime._tracker.value
         return {
             "id": str(ctx.id),
-            "metadata": ctx.metadata.copy(),
+            "metadata": {k: _json_safe_metadata_value(v) for k, v in ctx.metadata.items()},
         }
     return None
 

--- a/unittests/test_pghistory_context_serialization.py
+++ b/unittests/test_pghistory_context_serialization.py
@@ -1,0 +1,62 @@
+"""
+Regression: dispatching a Celery task while the active pghistory context holds a
+non-JSON-serializable metadata value (e.g. a ``user`` set to a User *object*
+instead of its pk) crashed dispatch with
+``EncodeError: Object of type User is not JSON serializable``.
+
+``get_serializable_pghistory_context`` must coerce metadata to JSON-safe values
+so the injected ``_pgh_context`` can always be serialized by kombu.
+"""
+
+import pghistory
+from kombu.utils.json import dumps as kombu_json_dumps
+
+from dojo.auditlog.helpers import get_serializable_pghistory_context
+from dojo.models import Dojo_User
+
+from .dojo_test_case import DojoTestCase
+
+
+class TestPghistoryContextSerialization(DojoTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.user = Dojo_User.objects.create(username="pgh-ctx-serialize-user")
+
+    def test_model_instance_in_context_metadata_is_coerced_to_pk(self):
+        # A model instance in the context metadata must be reduced to its pk.
+        with pghistory.context(user=self.user, url="/api/v2/products/1/"):
+            ctx = get_serializable_pghistory_context()
+
+        self.assertEqual(
+            ctx["metadata"]["user"], self.user.pk,
+            msg=f"expected user coerced to pk={self.user.pk}, got {ctx['metadata']['user']!r}",
+        )
+
+    def test_context_with_model_instance_is_kombu_serializable(self):
+        # This is the exact operation Celery dispatch performs on the injected
+        # `_pgh_context`; it raised EncodeError before the fix.
+        with pghistory.context(user=self.user, url="/api/v2/products/1/"):
+            ctx = get_serializable_pghistory_context()
+
+        payload = {"kwargs": {"_pgh_context": ctx}}
+        # Must not raise.
+        kombu_json_dumps(payload)
+
+    def test_nested_model_instance_is_coerced(self):
+        with pghistory.context(actors=[self.user], details={"owner": self.user}):
+            ctx = get_serializable_pghistory_context()
+
+        self.assertEqual(ctx["metadata"]["actors"], [self.user.pk])
+        self.assertEqual(ctx["metadata"]["details"], {"owner": self.user.pk})
+        kombu_json_dumps({"kwargs": {"_pgh_context": ctx}})
+
+    def test_plain_metadata_is_unchanged(self):
+        # Control: already-serializable metadata (pk int, strings) passes through.
+        with pghistory.context(user=self.user.pk, url="/x", remote_addr="1.2.3.4"):
+            ctx = get_serializable_pghistory_context()
+
+        self.assertEqual(ctx["metadata"]["user"], self.user.pk)
+        self.assertEqual(ctx["metadata"]["url"], "/x")
+        self.assertEqual(ctx["metadata"]["remote_addr"], "1.2.3.4")
+        kombu_json_dumps({"kwargs": {"_pgh_context": ctx}})


### PR DESCRIPTION
[sc-13581]

## Summary

When a Celery task is dispatched during a request, `dojo_dispatch_task` injects the active pghistory context into the task kwargs as `_pgh_context` via `get_serializable_pghistory_context()`. That function returned `ctx.metadata.copy()` verbatim, so a non-JSON-serializable value in the context metadata (e.g. a `user` set to a `User` object instead of its pk) made kombu raise `EncodeError: Object of type User is not JSON serializable` and abort the entire task dispatch.

Reported in production on `PATCH /api/v2/products/{pk}/` (the product `post_save` signal dispatches a task), 700+ events (Sentry DJANGO-42W8).

## Fix

Coerce the captured context metadata to JSON-safe values: reduce Django model instances to their pk and recurse into dict/list/tuple. Defensive and behavior-preserving for already-serializable metadata (the common case — the standard `HistoryMiddleware` stores the user as a pk).

## Tests

`unittests/test_pghistory_context_serialization.py`:
- model instance in metadata is coerced to pk
- the captured context is kombu-JSON-serializable (the exact dispatch operation that raised before)
- nested model instances (list/dict) are coerced
- already-serializable metadata is unchanged (control)

Verified fail-before / pass-after. Run:
```
SECURE_SSL_REDIRECT=False python manage.py test unittests.test_pghistory_context_serialization --keepdb
```

Fixes DJANGO-42W8
