### PR TITLE
docs(connectors): add CrowdStrike Falcon connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -129,6 +129,23 @@ DefectDojo's Checkmarx ONE connector calls the Checkmarx API to fetch data.
 3. Enter your tenant location in the **Location** field. This URL is formatted as follows:  
 ​`https://<your-region>.ast.checkmarx.net/` . Your Region can be found at the beginning of your Checkmarx URL when using the Checkmarx app. **<https://ast.checkmarx.net>** is the primary US server (which has no region prefix).
 
+## **CrowdStrike Falcon**
+
+The CrowdStrike Falcon connector imports **Spotlight vulnerabilities** and **EDR detections** from the Falcon platform, as two separate finding types (`CrowdStrike:Spotlight` and `CrowdStrike:Detections`). DefectDojo creates a Record for each Falcon **host**.
+
+#### Prerequisites
+
+A Falcon **API client** (Client ID and secret), created in the Falcon console under **Support \> API Clients and Keys**. Grant it the scopes for the data you want to import: **Hosts: Read** (required, for host discovery), **Vulnerabilities (Spotlight): Read** (for Spotlight findings), and **Alerts: Read** (for EDR detections). The two finding types are independent — if the client lacks a scope, that finding type is skipped rather than failing the sync, so a client without **Alerts: Read** still imports Spotlight vulnerabilities.
+
+#### Connector Mappings
+
+1. Enter your Falcon cloud's API base URL in the **Location** field, matching your console region — for example `https://api.crowdstrike.com` (US\-1), `https://api.us-2.crowdstrike.com` (US\-2), `https://api.eu-1.crowdstrike.com` (EU\-1), or `https://api.laggar.gcw.crowdstrike.com` (US\-GOV\-1).
+2. Enter the API client's Client ID in the **Client ID** field.
+3. Enter the API client's secret in the **Client Secret** field.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each Falcon host becomes a Record, named for its hostname, OS, and type. Only **open** and **reopened** Spotlight vulnerabilities are imported, so reimport closes remediated findings.
+
 ## Dependency\-Track
 
 This connector fetches data from a on\-premise Dependency\-Track instance, via REST API.


### PR DESCRIPTION
Shortcut: [sc-13584](https://app.shortcut.com/defectdojo/story/13584)

## What

Adds the **CrowdStrike Falcon** entry to the connectors tool reference (`connectors_tool_reference.md`), matching the style of the recent connector reference PRs.

## Contents

- Data types imported: Spotlight vulnerabilities (`CrowdStrike:Spotlight`) and EDR detections (`CrowdStrike:Detections`); one Record per Falcon host.
- Prerequisites: Falcon API client + required scopes (Hosts / Vulnerabilities / Alerts read), with the note that a missing scope skips that finding type rather than failing the sync.
- Connector mappings: region-specific base URLs (US-1/US-2/EU-1/US-GOV-1), Client ID, Client Secret, minimum severity.
- Closing note on Record granularity and open+reopened → reimport-closure behavior.

Companion to the connectors (Go) and dojo-pro (registry/UI) PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)