### PR TITLE
docs: add copy-to-clipboard to Report Builder LLM prompt and API blocks

### DIFF
--- a/docs/content/metrics_reports/reports/PRO__report_builder_api.md
+++ b/docs/content/metrics_reports/reports/PRO__report_builder_api.md
@@ -22,7 +22,7 @@ export DD_IMPORTER_DOJO_API_TOKEN="YOUR_API_TOKEN"
 
 The base URL for all calls is your instance plus `/api/v2`:
 
-```
+```text
 https://[YOUR-INSTANCE].cloud.defectdojo.com/api/v2
 ```
 

--- a/docs/content/metrics_reports/reports/PRO__report_builder_llm.md
+++ b/docs/content/metrics_reports/reports/PRO__report_builder_llm.md
@@ -37,7 +37,7 @@ export DD_IMPORTER_DOJO_API_TOKEN=<paste-token-here>
 
 Copy the entire fenced block below and paste it into Claude, ChatGPT, or any other capable LLM. The prompt is self-contained — the model will ask you for your tenant URL, token environment variable, and report audiences, then walk you through discovery → design → create → verify → run → download.
 
-```
+```text
 You are helping me build, run, and download custom reports in DefectDojo Pro
 using its REST API and "Report Generator" (Themes / Blocks / Templates /
 Generated Reports).


### PR DESCRIPTION
## Description

The Report Builder LLM guide (added in #15008) presents a large, self-contained prompt that users are meant to copy in one shot and paste into Claude/ChatGPT — but that block had no copy-to-clipboard button, unlike the equivalent block in the Dashboards LLM guide (#15111).

**Root cause:** the docs theme (Doks / `@thulite/doks-core`) adds its copy button via `clipboard.js`, which targets every element with class `highlight`. Hugo only wraps a fenced code block in `<div class="highlight">` when the fence declares a language. Two Report Builder blocks used a bare ` ``` ` fence, so they rendered as plain `<pre>` with no copy button.

## Change

Tag the two bare fences as ` ```text ` (matching the working Dashboards LLM guide):

- `PRO__report_builder_llm.md` — the self-contained LLM prompt
- `PRO__report_builder_api.md` — the API base-URL example

Every other fence in the Report Builder docs already declared `bash`/`json`/`python`/`shell`, so they already had copy buttons. After this change, **all** API and LLM code/prompt blocks in the Report Builder docs are copy-to-clipboard capable.

## Verification

Built the site locally with Hugo (`hugo --gc`) and confirmed:

- `report-builder-llm/` went from 1 → **2** `.highlight` blocks; the prompt now renders as `<code class="language-text">` inside `<div class="highlight">`.
- `report-builder-api/` shows all fences wrapped in `.highlight`.

Docs-only change; no code paths affected.

Generated with Claude Code under the direction of T. Walker (skywalke34) - DefectDojo
