### PR TITLE
Update migration dependency for global search FTS trigram indexes

### DIFF
--- a/dojo/db_migrations/0279_jira_project_transition_fields.py
+++ b/dojo/db_migrations/0279_jira_project_transition_fields.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dojo', '0277_seed_deduplication_execution_mode'),
+        ('dojo', '0278_global_search_fts_trigram_indexes'),
     ]
 
     operations = [


### PR DESCRIPTION
This pull request updates the migration dependencies in the `dojo/db_migrations/0279_jira_project_transition_fields.py` file (renamed from `0278_jira_project_transition_fields.py`). The dependency now correctly points to the latest migration, ensuring the migration chain is accurate.

- Migration dependency update:
  * Updated the `dependencies` list to reference `'0278_global_search_fts_trigram_indexes'` instead of `'0277_seed_deduplication_execution_mode'` in the `Migration` class.