### PR TITLE
fix(forms): avoid DB access at import time in Import/ReImport forms

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -324,15 +324,18 @@ class ImportScanForm(forms.Form):
         initial=False,
     )
 
-    if is_finding_groups_enabled():
-        group_by = forms.ChoiceField(required=False, choices=Finding_Group.GROUP_BY_OPTIONS, help_text="Choose an option to automatically group new findings by the chosen option.")
-        create_finding_groups_for_all_findings = forms.BooleanField(help_text="If unchecked, finding groups will only be created when there is more than one grouped finding", required=False, initial=True)
-
     def __init__(self, *args, **kwargs):
         environment = kwargs.pop("environment", None)
         endpoints = kwargs.pop("endpoints", None)
         api_scan_configuration = kwargs.pop("api_scan_configuration", None)
         super().__init__(*args, **kwargs)
+        # Finding-group fields depend on a DB-backed system setting. Add them here
+        # rather than in the class body so that importing this module never issues
+        # a query (which triggers Django's "database access during app
+        # initialization" warning when the module is imported at startup).
+        if is_finding_groups_enabled():
+            self.fields["group_by"] = forms.ChoiceField(required=False, choices=Finding_Group.GROUP_BY_OPTIONS, help_text="Choose an option to automatically group new findings by the chosen option.")
+            self.fields["create_finding_groups_for_all_findings"] = forms.BooleanField(help_text="If unchecked, finding groups will only be created when there is more than one grouped finding", required=False, initial=True)
         self.fields["active"].initial = self.active_verified_choices[0]
         self.fields["verified"].initial = self.active_verified_choices[0]
         if environment:
@@ -448,15 +451,18 @@ class ReImportScanForm(forms.Form):
         initial=False,
     )
 
-    if is_finding_groups_enabled():
-        group_by = forms.ChoiceField(required=False, choices=Finding_Group.GROUP_BY_OPTIONS, help_text="Choose an option to automatically group new findings by the chosen option")
-        create_finding_groups_for_all_findings = forms.BooleanField(help_text="If unchecked, finding groups will only be created when there is more than one grouped finding", required=False, initial=True)
-
     def __init__(self, *args, test=None, **kwargs):
         endpoints = kwargs.pop("endpoints", None)
         api_scan_configuration = kwargs.pop("api_scan_configuration", None)
         api_scan_configuration_queryset = kwargs.pop("api_scan_configuration_queryset", None)
         super().__init__(*args, **kwargs)
+        # Finding-group fields depend on a DB-backed system setting. Add them here
+        # rather than in the class body so that importing this module never issues
+        # a query (which triggers Django's "database access during app
+        # initialization" warning when the module is imported at startup).
+        if is_finding_groups_enabled():
+            self.fields["group_by"] = forms.ChoiceField(required=False, choices=Finding_Group.GROUP_BY_OPTIONS, help_text="Choose an option to automatically group new findings by the chosen option")
+            self.fields["create_finding_groups_for_all_findings"] = forms.BooleanField(help_text="If unchecked, finding groups will only be created when there is more than one grouped finding", required=False, initial=True)
         self.fields["active"].initial = self.active_verified_choices[0]
         self.fields["verified"].initial = self.active_verified_choices[0]
         self.scan_type = None


### PR DESCRIPTION
[sc-13664]

## What

`ImportScanForm` and `ReImportScanForm` declared their finding-group fields (`group_by`, `create_finding_groups_for_all_findings`) in the **class body**, guarded by `is_finding_groups_enabled()`. That helper reads a DB-backed system setting, so simply *importing* `dojo.forms` issued a `SELECT ... FROM system_settings`.

When the module is imported during app initialization (e.g. from an `AppConfig.ready()` hook), Django emits:

```
RuntimeWarning: Accessing the database during app initialization is discouraged.
To fix this warning, avoid executing queries in AppConfig.ready() or when your
app modules are imported.
```

## Fix

Move the conditional field construction from the class body into each form's `__init__` (after `super().__init__()`), so importing the module never touches the database.

Behavior is unchanged:
- Instances still gain `group_by` / `create_finding_groups_for_all_findings` when finding groups are enabled.
- The fields keep their original position (they were the last declared fields; adding them in `__init__` appends them last).
- The existing empty-default-choice insertion (`if "group_by" in self.fields:`) still runs.

Evaluating the setting per-instance rather than once at import is also slightly more correct: a change to the setting is picked up without a process restart.

## Testing

- `base_fields` no longer contains the fields; a fresh `ImportScanForm()` / `ReImportScanForm()` instance still has them (with the `("", "---------")` default first) when finding groups are enabled.
- `python manage.py test unittests.test_importers_importer.TestDojoImporterBatchPushToJira` — passes (grouping path).
- `ruff --config ruff.toml dojo/forms.py` — clean.

## Note

Other spots use the same import-time anti-pattern (the `FindingFilter` `FilterSet` classes in `dojo/finding/ui/filters.py`, via `get_finding_filterset_fields()` in `dojo/filters.py`). Those are intentionally out of scope here — `Meta.fields` is consumed by django_filters at class-definition time, so making them import-safe is a larger refactor that deserves its own PR and filter tests.
