### PR TITLE
docs: add Pro changelog entry for 3.1.100

### DIFF
--- a/docs/content/releases/pro/changelog.md
+++ b/docs/content/releases/pro/changelog.md
@@ -12,6 +12,22 @@ For Open Source release notes, please see the [Releases page on GitHub](https://
 
 ## July 2026: v3.1
 
+### July 13, 2026: v3.1.100
+
+* **(Connectors)** Added a large batch of new Connectors. New findings connectors: CrowdStrike Falcon, Microsoft Defender Vulnerability Management, Microsoft Defender for Cloud, Veracode, Qualys, Rapid7 InsightVM, GitHub Advanced Security, HackerOne, Contrast, Google Cloud Security Command Center, Shodan, Wazuh, Cloudflare, Censys, Docker Scout, and Have I Been Pwned. New asset connectors: GitLab, Atlassian JSM Assets, Bitbucket Cloud, Azure DevOps, Backstage, and Group-IB ASM. Added a GitGuardian secrets connector.
+* **(Integrations)** Added new outbound integrators for Jira (Cloud and Data Center, with per-transition custom fields, ticket templates, and a test-render path), PagerDuty, Shortcut, and Bitbucket Cloud. Jira integrations now support setting fields on close/reopen transitions and Jira Cloud OAuth.
+* **(Search)** Added cross-model global search backed by native Postgres full-text search and trigram indexes, so you can search across findings and related objects from one place.
+* **(Findings)** Added a public API endpoint for merging findings, and "Not X" negation options on the finding status filter.
+* **(Notes)** You can now @mention users in notes with autocomplete; mentioned users receive a notification.
+* **(Users)** Added bulk API-token and password resets from the users list.
+* **(Sensei)** Added candidate triage directly in the findings table
+* **(Pro UI)** Reworked the big-table toolbar menu. Long unbroken names now wrap instead of being clipped, table scrollbars stay visible on hover, and in-page navigation refreshes data in place instead of triggering a full-page reload. Added a classic-UI deprecation banner with one-click opt-in to the Pro UI. The test page now shows the effective deduplication matching policy.
+* **(Authorization)** Tightened authorization on product reassignment, V3 location routes, location-reference writes, and questionnaire relink routes.
+* **(Performance)** `close_old_findings` now fetches only the columns it needs, and uWSGI workers and Celery prefork children are recycled by memory to keep long-running instances healthy.
+* **(Import)** Fixed reimport so it dispatches post-processing with the correct per-finding `push_to_jira` value, stopped dynamic Test Type names from doubling the `(scan_type)` suffix, and made risk-acceptance findings reinstate correctly when the expiration date is updated via the API.
+* **(Tools)** Checkmarx One parser now handles explicit null scanner sections in filtered reports, and the CSV universal parser no longer strips backticks from imported values.
+* **(Bug Fixes)** After deleting the object you were viewing, the Pro UI now lands on its parent context instead of erroring; a background sub-fetch 404 no longer ejects authorized users to the 404 page; the global loader no longer gets stuck open in bulk menus; and audit-log history context is now JSON-safe before Celery dispatch.
+
 ### July 7, 2026: v3.1.0
 
 * **(Insights)** Added export functionality and per-metric descriptions to Insights charts.


### PR DESCRIPTION
**Shortcut:** [sc-13673](https://app.shortcut.com/defectdojo/story/13673)

Adds the DefectDojo Pro changelog entry for release **3.1.100** (July 13, 2026), placed at the top of the July 2026 section.

Summarized from the release PR list, grouped by type:

- **Connectors** — large batch of new findings/asset/secrets connectors (CrowdStrike Falcon, Microsoft Defender VM & Defender for Cloud, Veracode, Qualys, Rapid7 InsightVM, GitHub Advanced Security, HackerOne, Contrast, Google Cloud SCC, Shodan, Wazuh, Cloudflare, Censys, Docker Scout, Have I Been Pwned, GitGuardian; asset: GitLab, JSM Assets, Bitbucket Cloud, Azure DevOps, Backstage, Group-IB ASM)
- **Integrations** — new Jira / PagerDuty / Shortcut / Bitbucket Cloud integrators
- **Search** — cross-model global search (Postgres FTS + trigram)
- **Findings / Notes / Users / Sensei / Pro UI** — merge API, status-filter negation, @mentions, bulk token/password resets, candidate triage, table UX improvements
- **Licensing / Authorization / Performance / Import / Tools / Bug Fixes**

Dependency bumps, CI/lint chores, internal refactors, and pure-docs PRs were excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
