### PR TITLE
docs: use "DefectDojo, Inc." consistently in company name references

### DIFF
--- a/docs/config/_default/hugo.toml
+++ b/docs/config/_default/hugo.toml
@@ -16,7 +16,7 @@ defaultContentLanguage = "en"
 disableLanguages = ["de", "nl"]
 defaultContentLanguageInSubdir = false
 
-copyRight = "Copyright (c) 2020-2025 DefectDojo Inc."
+copyRight = "Copyright (c) 2020-2025 DefectDojo, Inc."
 
 [build.buildStats]
   enable = true

--- a/docs/content/asset_modelling/PRO_hierarchy/priority_sla.md
+++ b/docs/content/asset_modelling/PRO_hierarchy/priority_sla.md
@@ -35,7 +35,7 @@ vulnerabilities in your organization, and also provides a framework to assist in
 compliance with regulatory standards.
 
 
-Learn more about Priority and Risk with DefectDojo Inc's May 2025 Office Hours:
+Learn more about Priority and Risk with DefectDojo, Inc.'s May 2025 Office Hours:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/4SN0BWWsVm4?si=VYUzEGNeijjhoD22" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 

--- a/docs/content/get_started/about/about_defectdojo.md
+++ b/docs/content/get_started/about/about_defectdojo.md
@@ -19,7 +19,7 @@ aliases:
 </div>
 
 
-<span style="background-color:rgba(242, 86, 29, 0.3)">DefectDojo Inc. and open-source contributors maintain this documentation to support both the Community and Pro editions of DefectDojo.</span>
+<span style="background-color:rgba(242, 86, 29, 0.3)">DefectDojo, Inc. and open-source contributors maintain this documentation to support both the Community and Pro editions of DefectDojo.</span>
 
 ## What is DefectDojo?
 
@@ -79,7 +79,7 @@ If you run into trouble with an Open-Source install, we highly recommend asking 
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/XUES0mCCGOI?si=2GEnd1iHlLcQE0R3" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-DefectDojo Inc. hosts a Pro edition of this software for commercial purposes.  Along with a sleek, modern UI, DefectDojo Pro includes:
+DefectDojo, Inc. hosts a Pro edition of this software for commercial purposes.  Along with a sleek, modern UI, DefectDojo Pro includes:
 
 * [Connectors](/import_data/pro/connectors/about_connectors/): out-of-the-box API integrations with enterprise-level scanners (such as Checkmarx One, BurpSuite, Semgrep and more)
 * **Configurable Import Methods**: [Universal Parser](/supported_tools/parsers/universal_parser/), [Smart Upload](/import_data/pro/specialized_import/smart_upload/)
@@ -120,7 +120,7 @@ Whether you’re a Pro or an Open-Source user, we have many resources to help yo
 
 ## Connect With Us
 
-To get in touch with the DefectDojo Inc team, you can always reach out to [hello@defectdojo.com](mailto:hello@defectdojo.com).
+To get in touch with the DefectDojo, Inc. team, you can always reach out to [hello@defectdojo.com](mailto:hello@defectdojo.com).
 
 We regularly on [LinkedIn](https://www.linkedin.com/company/33245534) and also host online presentations for AppSec professionals that can be accessed live or on demand. You can learn about upcoming events on our [Events page](https://defectdojo.com/events) or watch past presentations on our [YouTube Channel](https://www.youtube.com/@defectdojo).
 

--- a/docs/content/get_started/about/ui_pro_vs_os.md
+++ b/docs/content/get_started/about/ui_pro_vs_os.md
@@ -7,7 +7,7 @@ audience: pro
 aliases:
   - /en/about_defectdojo/ui_pro_vs_os
 ---
-In late 2023, DefectDojo Inc. released a new UI for DefectDojo Pro, which is now the default UI for this edition.
+In late 2023, DefectDojo, Inc. released a new UI for DefectDojo Pro, which is now the default UI for this edition.
 
 The Pro UI brings the following enhancements to DefectDojo:
 

--- a/docs/content/get_started/common_use_cases/common_use_cases.md
+++ b/docs/content/get_started/common_use_cases/common_use_cases.md
@@ -7,7 +7,7 @@ chapter: true
 aliases:
   - /en/about_defectdojo/examples_of_use
 ---
-This article is based on DefectDojo Inc's February 2025 Office Hours: "Tackling Common Use Cases".
+This article is based on DefectDojo, Inc.'s February 2025 Office Hours: "Tackling Common Use Cases".
 <iframe width="560" height="315" src="https://www.youtube.com/embed/44vv-KspHBs?si=ilRBlfo-wvX5DPVg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Examples of Use Cases

--- a/docs/content/help/contact_support.md
+++ b/docs/content/help/contact_support.md
@@ -21,7 +21,7 @@ See our [Community Site](https://defectdojo.com/open-source) for more informatio
 
 ## DefectDojo Pro Support
 
-DefectDojo Pro subscriptions come with full support from the DefectDojo Inc. team during the initial trial period and beyond.
+DefectDojo Pro subscriptions come with full support from the DefectDojo, Inc. team during the initial trial period and beyond.
 
 ### Email
 

--- a/docs/layouts/home.html
+++ b/docs/layouts/home.html
@@ -22,7 +22,7 @@
         <h1 class="hero-title">{{ .Title }}</h1>
         <p class="hero-subtitle">
           Official documentation for DefectDojo Pro and Open-Source editions,<br>
-          maintained by DefectDojo Inc. and the Open-Source community.
+          maintained by DefectDojo, Inc. and the Open-Source community.
         </p>
         {{ with .Params.lead }}<p class="lead">{{ . }}</p>{{ end }}
         <button type="button" id="ddHomeSearch" class="dd-hero-search">
@@ -144,7 +144,7 @@
         </div>
         <div class="col-lg-5">
           <h2 class="h4">Sign up for a trial</h2>
-          <p>Ready to go Pro? Request a quote from the DefectDojo Inc team <a href="https://defectdojo.com/pricing">here</a>.</p>
+          <p>Ready to go Pro? Request a quote from the DefectDojo, Inc. team <a href="https://defectdojo.com/pricing">here</a>.</p>
         </div>
         <div class="col-lg-5">
           <h2 class="h4">Reach out to Support</h2>


### PR DESCRIPTION
## Summary

Standardizes the company name to **DefectDojo, Inc.** everywhere it appears in the documentation site. The name was previously rendered inconsistently as "DefectDojo Inc" or "DefectDojo Inc." (missing the comma).

## Changes

11 references across 8 files, text-only (no structural or presentation changes):

- `docs/config/_default/hugo.toml` — site copyright string
- `docs/layouts/_partials/footer/footer.html` — footer copyright
- `docs/layouts/home.html` — hero subtitle and trial CTA
- `docs/content/get_started/about/about_defectdojo.md` — 3 references
- `docs/content/get_started/about/ui_pro_vs_os.md`
- `docs/content/get_started/common_use_cases/common_use_cases.md` — possessive form
- `docs/content/asset_modelling/PRO_hierarchy/priority_sla.md` — possessive form
- `docs/content/help/contact_support.md`

Possessive uses become "DefectDojo, Inc.'s".

🤖 Generated with [Claude Code](https://claude.com/claude-code)