### PR TITLE
chore(ci): migrate release-drafter to `when` and build OAS from the release tag

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,50 +6,65 @@ branches:
 
 categories:
   - title: '💣 Breaking changes'
-    labels:
-      - 'Breaking Changes'
+    when:
+      labels:
+        - 'Breaking Changes'
   - title: '🚩 Changes to `settings.dist.py` / `local_settings.py`'
-    labels:
-      - 'settings_changes'
+    when:
+      labels:
+        - 'settings_changes'
   - title: '🚩 Database migration'
-    labels:
-      - 'New Migration'
+    when:
+      labels:
+        - 'New Migration'
   - title: '🚩 Requires hash code recomputation'
-    labels:
-      - 'hashcode-update-needed'
+    when:
+      labels:
+        - 'hashcode-update-needed'
   - title: '🚩 Security'
-    labels:
-      - 'security'
+    when:
+      labels:
+        - 'security'
   - title: '🚀 New importers'
-    labels:
-      - 'Import Scans'
+    when:
+      labels:
+        - 'Import Scans'
   - title: '🚀 General features and enhancements'
-    labels:
-      - 'feature'
-      - 'enhancement'
-      - 'performance'
+    when:
+      labels:
+        - 'feature'
+        - 'enhancement'
+        - 'performance'
   - title: '🚀 API features and enhancements'
-    label: 'apiv2'
+    when:
+      label: 'apiv2'
   - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
+    when:
+      labels:
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
   - title: 📝 Documentation updates
-    label: 'documentation'
+    when:
+      label: 'documentation'
   - title: '🖌 Updates in UI'
-    label: 'ui'
+    when:
+      label: 'ui'
   - title: '🗣 Updates in localization'
-    label: 'localization'
+    when:
+      label: 'localization'
   - title: '🔧 Improved code quality with linters'
-    label: 'lint'
+    when:
+      label: 'lint'
   - title: '⚙️ Improvemets of GitHub Actions'
-    label: 'gha'
+    when:
+      label: 'gha'
   - title: '🧰 Maintenance'
     collapse-after: 3
-    labels:
-      - 'dependencies'
-      - 'maintenance'
+    when:
+      labels:
+        - 'dependencies'
+        - 'maintenance'
 exclude-labels:
   - 'skip-changelog'
 

--- a/.github/workflows/fetch-oas.yml
+++ b/.github/workflows/fetch-oas.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: release/${{ env.release_version }}
+          ref: ${{ env.release_version }}
 
       - name: Load docker images
         run: |-


### PR DESCRIPTION
[sc-13706]

## What

Two release-pipeline fixes surfaced by running the Pro `release.sh`:

1. **release-drafter deprecation** — v7.5.1 warns that `categories[*].label` / `categories[*].labels` are deprecated and slated for removal. Migrated every category to the equivalent `when:` condition per the [upstream migration](https://github.com/release-drafter/release-drafter/pull/1558). No change to how PRs are categorized.
2. **OAS built from the wrong ref** — `fetch-oas.yml` checked out `release/x.y.z` (the pre-merge release branch) to generate the OpenAPI schema, while the release images are built from the **tag** (`release-x-manual-docker-containers.yml` uses `ref: <release_number>`). Changed `fetch-oas.yml` to check out the tag so the published schema matches the released images.

## Why

Clears the `update_release_draft` deprecation warning and keeps the OAS consistent with the exact code the release images ship.

## Notes

Only `django-DefectDojo` runs release-drafter v7 (other repos are on v5, where these fields are still valid and `when` is unsupported), so this migration is scoped to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)