### PR TITLE
docs(connectors): Rapid7 InsightAppSec connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -671,6 +671,26 @@ A Qualys user account with **VMDR API access**, and your subscription's **API se
 
 Each Qualys host becomes a Record. Detections Qualys has marked **Fixed** are excluded, so reimport closes remediated findings.
 
+## **Rapid7 InsightAppSec**
+
+The Rapid7 InsightAppSec connector imports **DAST vulnerability findings** from the InsightAppSec cloud platform, enriched with attack\-module metadata (for example *SQL Injection*), CVSS scores, and the evidence collected by the scan. DefectDojo creates a Record for each InsightAppSec **app**.
+
+**Please note:** this Connector is distinct from the **Rapid7 InsightVM** connector below — InsightAppSec is Rapid7's cloud DAST product on the Insight platform, while InsightVM findings come from your own Security Console.
+
+#### Prerequisites
+
+An Insight platform account with InsightAppSec, and a platform **API key**: in the [Rapid7 Insight platform](https://insight.rapid7.com), open the settings (gear) menu \> **API Keys** and generate a **User Key** (any role) or an **Organization Key** (platform admins). Copy the key when it is shown — it is displayed only once.
+
+You also need your platform **region**, visible in your Insight URL (for example `us`, `us2`, `us3`, `eu`, `ca`, `au`, or `ap`).
+
+#### Connector Mappings
+
+1. Enter your regional API endpoint in the **Location** field — for example `https://us.api.insight.rapid7.com` (replace `us` with your region).
+2. Enter the Insight platform API key in the **API Key** field.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each InsightAppSec app becomes a Record. Only **open** vulnerabilities (Unreviewed or Verified) are imported — findings Rapid7 has marked Remediated, a False Positive, Ignored, or Duplicate are excluded, so reimport closes them in DefectDojo. Severities map directly (`SAFE` and `INFORMATIONAL` import as Info).
+
 ## **Rapid7 InsightVM**
 
 The Rapid7 InsightVM connector imports asset vulnerability findings from your InsightVM **Security Console** (API v3), enriched with the console's global vulnerability catalog. DefectDojo creates a Record for each InsightVM **site**.


### PR DESCRIPTION
Adds the **Rapid7 InsightAppSec** connector to the connectors tool reference, documenting setup and usage:

- **Prerequisites** — Insight platform API key (User or Organization key from the platform's gear menu → API Keys) and the platform region.
- **Connector Mappings** — regional API endpoint in Location (`https://us.api.insight.rapid7.com` etc.), API key, optional Minimum Severity.
- **Behavior** — one Record per InsightAppSec app; only open (Unreviewed/Verified) vulnerabilities import, so reimport closes findings Rapid7 has remediated or triaged away; severity mapping note.

Placed alphabetically before Rapid7 InsightVM, with a note distinguishing the two Rapid7 connectors (cloud Insight platform vs. on-prem Security Console). Pairs with the connector implementation (DefectDojo-Inc/connectors#709) and Pro registration (dojo-pro#1899).

Story: sc-13704