### PR TITLE
docs(connectors): Acunetix 360 connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -30,6 +30,25 @@ Azure DevOps, Bitbucket, GitHub, GitLab, and Jira Service Management Assets are 
 
 # **Supported Connectors**
 
+## **Acunetix 360**
+
+The Acunetix 360 connector imports **DAST vulnerability findings** from the Acunetix 360 cloud platform (the Invicti platform). DefectDojo discovers your account's scanned websites and creates a Record for each **website**; the findings for a website come from its latest completed scan.
+
+**Please note:** this connector is for **Acunetix 360** (the cloud product at `online.acunetix360.com`). It is not for the on\-premises Acunetix Standard/Premium scanner, which has a different API.
+
+#### Prerequisites
+
+An Acunetix 360 account and an **API credential**: in Acunetix 360, open your account menu \> **API Settings**, and note the **API User ID** and generate an **API Token**. The connector authenticates with these as HTTP Basic credentials, so a dedicated service account is recommended to distinguish automated activity from manual team actions.
+
+#### Connector Mappings
+
+1. Enter your Acunetix 360 URL in the **Location** field: `https://online.acunetix360.com`.
+2. Enter the API User ID in the **API User ID** field.
+3. Enter the API Token in the **API Token** field.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each scanned website becomes a Record. Findings come from the website's latest completed scan; vulnerabilities Acunetix 360 has marked **Accepted Risk** or **False Positive** are still imported but flagged inactive (risk\-accepted or false\-positive) so the DefectDojo product reflects the vendor's triage.
+
 ## **Akamai API Security**
 
 The Akamai API Security connector uses an API key to pull security findings from the Akamai API. DefectDojo will discover your Akamai environment and create separate Records for each **Application** and **Host** configured in your account.


### PR DESCRIPTION
Adds the **Acunetix 360** connector to the connectors tool reference (placed first, alphabetically), documenting setup and usage:

- **Prerequisites** — API User ID + API Token (HTTP Basic) from the account's API Settings page.
- **Connector Mappings** — cloud Location (`https://online.acunetix360.com`), API User ID, API Token, optional Minimum Severity.
- **Behavior** — one Record per scanned website; findings from the website's latest completed scan; Accepted-Risk / False-Positive vulnerabilities imported but flagged inactive.
- A note distinguishing the **cloud** Acunetix 360 product from the on-prem Acunetix Standard scanner (different API).

Pairs with the connector implementation (DefectDojo-Inc/connectors#713) and Pro registration (DefectDojo-Inc/dojo-pro#1903). Draft until those land.

Story: sc-13709