### PR TITLE
docs(connectors): Sonatype IQ setup

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -251,6 +251,24 @@ The Snyk connector uses the Snyk REST API to fetch data.
 
 See the [Snyk API documentation](https://docs.snyk.io/snyk-api) for more info.
 
+## **Sonatype IQ**
+
+The Sonatype IQ connector uses the Sonatype IQ Server (Nexus Lifecycle) REST API to import open\-source component vulnerabilities. It enumerates every application in your IQ organization and, for each one, imports the component vulnerabilities from that application's latest report at the lifecycle stage you configure. DefectDojo creates a Record for each application automatically — there is no per\-application configuration.
+
+#### Prerequisites
+
+You will need a Sonatype IQ user account with the **View IQ Elements** permission on the applications you want to import. Sonatype recommends authenticating with a **user token** (generated under **My Profile > User Token** in IQ Server) rather than a password; the token's two parts map to the Username and User Token fields below. The connector works with both self\-hosted IQ Server and Sonatype\-hosted (SaaS) instances.
+
+#### Connector Mappings
+
+1. In the **Location** field, enter your IQ Server base URL — for a self\-hosted server, `https://iq.example.com`; for a Sonatype\-hosted instance, `https://<tenant>.sonatype.app/platform`.
+2. Enter the IQ user (or the user\-code part of your user token) in the **Username** field.
+3. Enter the IQ user token (or password) in the **User Token** field.
+4. Optionally, set a **Stage** to choose which lifecycle stage's report is imported per application (`build`, `stage-release`, `release`, and so on). Leave it blank to use `build`.
+5. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each application becomes a Record, and each security issue in that application's latest report for the selected stage is imported as a finding. Severity is derived from the issue's numeric score, and CVE references, CWE, the CVSS vector, and the affected component's package URL (PURL) are included where available.
+
 ## Tenable
 
 The Tenable connector uses the **Tenable.io** REST API to fetch data.  Currently, only vulnerability scans are imported - Web App Scans cannot be imported with the Connector.


### PR DESCRIPTION
## What

Adds a **Sonatype IQ (Nexus Lifecycle)** section to the Connectors tool reference, mirroring the existing connector entries (Prerequisites + Connector Mappings).

Pairs with:
- Connector: **DefectDojo-Inc/connectors#712**
- DD Pro registration: **DefectDojo-Inc/dojo-pro#1905**
- Story: **[sc-13712](https://app.shortcut.com/defectdojo/story/13712)**

## Section contents

- **Prerequisites** — a Sonatype IQ account with the *View IQ Elements* permission; user-token auth (My Profile → User Token); works with self-hosted IQ Server and Sonatype-hosted (SaaS) instances.
- **Connector Mappings** — Location (on-prem `https://iq.example.com` or SaaS `https://<tenant>.sonatype.app/platform`), Username, User Token, optional Stage (`build` default), optional Minimum Severity.
- Notes that the connector is account-wide (a Record per application, auto-mapped) and that CVE / CWE / CVSS vector / PURL are carried onto findings where available.

Single-section addition, placed alphabetically after Snyk.
