### PR TITLE
docs(connectors): Black Duck connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -186,6 +186,22 @@ With **Auto\-Map** enabled, a single Discover \+ Sync builds the complete Produc
 
 **A note on the reverse direction:** displaying DefectDojo findings and grades *inside* Backstage (on entity pages) is a natural follow\-on that would be built as a Backstage frontend plugin consuming the DefectDojo REST API — it is deliberately out of scope for this connector, which only pulls catalog data into DefectDojo.
 
+## **Black Duck**
+
+The Black Duck connector imports **software composition analysis (SCA)** findings from a Black Duck (Synopsys / Black Duck) Hub instance. DefectDojo discovers every project in the instance and creates a Record for each **project**; the findings for a project come from the vulnerable BOM components of its selected version.
+
+#### Prerequisites
+
+A Black Duck **API token** for a user that can see the projects you want to import. In Black Duck, open your user menu \> **My Access Tokens** \> **Create New Token**, grant it (at least) read access, and copy the token when it is shown — it is displayed only once. The connector exchanges this token for a short\-lived bearer on each sync; it is never stored in cleartext beyond the connector's secret field.
+
+#### Connector Mappings
+
+1. Enter your Black Duck hub URL in the **Location** field — for example `https://your-company.app.blackduck.com`.
+2. Enter the API token in the **Secret** field.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each Black Duck project becomes a Record. By default the connector imports the project's **released** version (falling back to its first version); each vulnerable BOM component of that version becomes a finding, titled `{vulnerability} in {component}:{version}`.
+
 ## **Bitbucket**
 
 The Bitbucket connector is an **Asset Connector**: it enumerates the repositories in the Bitbucket Cloud workspaces you name and creates a DefectDojo Asset for each repository, grouped into Organizations by Bitbucket project. No findings are imported.


### PR DESCRIPTION
Adds the **Black Duck** connector to the connectors tool reference (alphabetically between Backstage and Bitbucket), documenting setup and usage:

- **Prerequisites** — a Black Duck API token (My Access Tokens), which the connector exchanges for a short-lived bearer on each sync.
- **Connector Mappings** — hub Location (`https://your-company.app.blackduck.com`), API token in the Secret field, optional Minimum Severity.
- **Behavior** — one Record per project; findings from the project's released version's vulnerable BOM components; finding titles `{vulnerability} in {component}:{version}`.

Pairs with the connector implementation (DefectDojo-Inc/connectors#717) and Pro registration (DefectDojo-Inc/dojo-pro#1910). Draft until those land.

Story: sc-13723