### PR TITLE
docs(connectors): Sysdig Secure connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -893,6 +893,23 @@ You will need a Sonatype IQ user account with the **View IQ Elements** permissio
 5. Optionally, set a **Minimum Severity** to limit which findings are imported.
 
 Each application becomes a Record, and each security issue in that application's latest report for the selected stage is imported as a finding. Severity is derived from the issue's numeric score, and CVE references, CWE, the CVSS vector, and the affected component's package URL (PURL) are included where available.
+## **Sysdig Secure**
+
+The Sysdig Secure connector imports **container / CNAPP vulnerability findings** from Sysdig Secure's vulnerability management API. It syncs the whole account across the configured scope(s) and creates a DefectDojo product for each scanned asset grouping.
+
+#### Prerequisites
+
+A Sysdig Secure **API token**: in Sysdig Secure, go to **Settings \> Sysdig Secure API Token** and copy the token. You also need your Sysdig **region URL** (for example `https://us2.app.sysdig.com`, `https://eu1.app.sysdig.com`, or your on\-premises host).
+
+#### Connector Mappings
+
+1. Enter your Sysdig region/base URL in the **Location** field.
+2. Enter the API token in the **Secret** field.
+3. Optionally set **Scopes** — a comma\-separated list of `runtime`, `registry`, and/or `pipeline` (leave blank for `runtime`, the deployed\-workload scope).
+4. Optionally set **Runtime Product Grouping** — how runtime results map to products: `cluster`, `namespace`, `workload`, or `image` (leave blank for `namespace`). Registry and pipeline results always group by image repository.
+5. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each asset grouping becomes a Record. For each scan result the connector imports every vulnerable package as a finding. **Runtime** findings (deployed workloads) are recorded as dynamic findings and tagged with their Kubernetes cluster / namespace / workload / container context; **registry** and **pipeline** findings are recorded as static image\-scan findings. Sysdig's `NEGLIGIBLE` severity maps to Info.
 
 ## Tenable
 


### PR DESCRIPTION
Adds the **Sysdig Secure** connector to the connectors tool reference (alphabetically between Snyk and Tenable), documenting setup and usage:

- **Prerequisites** — a Sysdig Secure API token (Settings → Sysdig Secure API Token) and the region/base URL.
- **Connector Mappings** — Location (region URL), API token in the Secret field, optional Scopes (runtime/registry/pipeline) and Runtime Product Grouping (cluster/namespace/workload/image), optional Minimum Severity.
- **Behavior** — whole-account sync; one Record per asset grouping; runtime findings are dynamic + tagged with k8s context, registry/pipeline findings are static image scans; NEGLIGIBLE → Info.

Pairs with the connector implementation (DefectDojo-Inc/connectors#720) and Pro registration (DefectDojo-Inc/dojo-pro#1913). Draft until those land.

Story: sc-13726