### PR TITLE
docs(connectors): OpenVAS / Greenbone connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -642,6 +642,24 @@ Unlike the device\-based Microsoft Defender connector, no API permissions or adm
 
 Each enabled Azure subscription becomes a Record. Findings are read through Azure Resource Graph, so they surface promptly once Defender for Cloud has scanned your resources — but the scans themselves run on Microsoft's schedule: container\-registry images are usually scanned within an hour of being pushed, while a VM's first agentless vulnerability scan can take several hours. A newly enabled subscription will legitimately Sync zero findings until its resources have been scanned.
 
+## **OpenVAS / Greenbone**
+
+The OpenVAS / Greenbone connector imports **network vulnerability findings** from a Greenbone (Greenbone Community Edition or Greenbone Enterprise) instance. It talks to `gvmd` over **GMP (Greenbone Management Protocol)** — an XML protocol over a TLS socket, not HTTP — and syncs the whole instance: it enumerates scan **tasks** and creates a DefectDojo product for each, importing the results of each task's latest report.
+
+#### Prerequisites
+
+A Greenbone **GMP user** (username + password) and network access to gvmd's GMP TLS port (default **9390**). The Greenbone Community Edition compose stack fronts gvmd via a unix socket, so to reach it from a networked connector you either run the connector where it can reach the socket or expose the GMP TLS port (for example a `socat` TLS bridge to `gvmd.sock`).
+
+#### Connector Mappings
+
+1. Enter the gvmd host in the **Location** field (host or `host:port`).
+2. Enter the GMP **Username** and **Password**.
+3. Optionally set the **GMP Port** (defaults to 9390).
+4. For gvmd's default self\-signed certificate, either provide a **CA Certificate (PEM)** to verify against, or set **Skip TLS Verification** to `true`.
+5. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each Greenbone task becomes a Record. Findings come from the task's latest finished report — one per `<result>`. Severity is taken from the result's threat level (Greenbone's `Log`/`Debug` informational levels map to Info), with the numeric CVSS score recorded; CVE references become vulnerability ids, the NVT solution becomes the mitigation, and each result's host/port becomes an endpoint.
+
 ## Probely
 
 This connector uses the Probely REST API to fetch data.


### PR DESCRIPTION
Adds the **OpenVAS / Greenbone** connector to the connectors tool reference (alphabetically before Probely), documenting setup and usage:

- **Prerequisites** — a Greenbone GMP user (username + password) and reachability to gvmd's GMP TLS port (9390); notes the CE socket-vs-TLS-port reality.
- **Connector Mappings** — gvmd host in Location, Username/Password, optional GMP Port, TLS options (CA cert or skip-verify), optional Minimum Severity.
- **Behavior** — GMP (XML over TLS) transport; whole-instance sync; one product per task; one finding per `<result>`; threat→severity (Log/Debug→Info); host/port→endpoint; CVE refs + NVT solution mapped.

Pairs with the connector implementation (DefectDojo-Inc/connectors#723) and Pro registration (DefectDojo-Inc/dojo-pro#1916). Draft until those land.

Story: sc-13731