### PR TITLE
docs(connectors): Endor Labs connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -362,6 +362,29 @@ DefectDojo creates a separate Record for each Docker Scout stream, and imports o
 
 See the [Docker Scout documentation](https://docs.docker.com/scout/) for more information.
 
+## **Endor Labs**
+
+The Endor Labs connector uses the Endor Labs REST API to sync an entire Endor Labs **namespace**. DefectDojo discovers each Endor **project** as a Record and imports that project's findings, carrying Endor's **reachability** verdict so you can prioritize vulnerabilities whose affected code is actually reachable.
+
+#### Prerequisites
+
+You will need an Endor Labs **API key** (a key identifier plus its secret) and the **namespace** you want to sync. Create the key in the Endor Labs platform under **Settings \> Access \> API Keys**; the key needs read access to the projects and findings in that namespace.
+
+The connector authenticates by exchanging the API key and secret for a short-lived bearer token — the secret is used only for that exchange and is never stored in cleartext.
+
+#### Connector Mappings
+
+1. Enter `https://api.endorlabs.com` in the **Location** field. If your tenant is hosted in a different region, use that region's API base URL instead.
+2. Enter the Endor Labs **Namespace** to sync (for example `your-org` or `your-org.team`).
+3. Enter the **API Key** identifier.
+4. Enter the **API Secret** paired with the key.
+5. Optionally set **Traverse Child Namespaces** to `true` to also import findings from child namespaces of the configured namespace.
+6. Optionally set a **Minimum Severity** to limit which findings are imported. Findings below the selected severity are not imported.
+
+DefectDojo creates a Record for each Endor Labs project in the namespace and imports its findings, mapping Endor severity levels to DefectDojo severities, the CVE/GHSA identifiers and CVSS score of each vulnerability, and Endor's reachability tags. The reachability verdict (for example *Reachable — vulnerable function is called* or *Unreachable*) is surfaced as the finding's Impact and as a tag.
+
+For more information, see the **[Endor Labs REST API documentation](https://docs.endorlabs.com/rest-api/)**.
+
 ## **GitGuardian**
 
 The GitGuardian connector uses the GitGuardian REST API to import **secret incidents** — exposed credentials GitGuardian has detected across your monitored sources. DefectDojo creates a Record for each monitored source (repository or perimeter) that currently has open incidents, and imports each open incident as a finding.


### PR DESCRIPTION
## Summary

Documents the **Endor Labs** SCA connector (story [sc-13761](https://app.shortcut.com/defectdojo/story/13761)) in the connectors tool reference — namespace sync via an API key+secret bearer exchange, the region base URL, the optional *Traverse Child Namespaces* scoping, minimum-severity filtering, and how Endor's **reachability** verdict surfaces on each finding (Impact + tag). Placed alphabetically between Docker Scout and GitGuardian.

## Companion PRs

- Go connector: [connectors#726](https://github.com/DefectDojo-Inc/connectors/pull/726)
- dojo-pro registration: [dojo-pro#1933](https://github.com/DefectDojo-Inc/dojo-pro/pull/1933)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
