### PR TITLE
docs(connectors): Prowler connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -654,6 +654,24 @@ This connector uses the Probely REST API to fetch data.
 You can find an API key under the User \> API Keys menu in Probely.  
 See [Probely documentation](https://help.probely.com/en/articles/8592281-how-to-generate-an-api-key) for more info.
 
+## Prowler
+
+The Prowler connector uses the **Prowler App** REST API to import cloud security posture (CSPM) findings from a self-hosted Prowler App instance. DefectDojo discovers each Prowler **provider** (cloud account) as a Record and imports the **FAIL** findings of that provider's latest completed scan.
+
+#### Prerequisites
+
+You will need a running, self-hosted **Prowler App** instance and either a user email + password (for JWT authentication) or a Prowler App **API key**. Findings only appear once you have connected a cloud account (AWS, GCP, Azure, Kubernetes, ...) in Prowler App and run a scan.
+
+#### Connector Mappings
+
+1. Enter your Prowler App URL in the **Location** field (for example `https://prowler.your-company.com`).
+2. For JWT authentication, enter the Prowler App user **Email** and **Password**. Alternatively, leave those blank and enter a Prowler App **API Key**. If both are provided, the email/password (JWT) is used.
+3. Optionally set a **Minimum Severity** to limit which findings are imported. Findings below the selected severity are not imported.
+
+DefectDojo creates a Record for each Prowler provider and imports the FAIL findings of its latest completed scan, mapping Prowler severities to DefectDojo severities, the affected cloud resource (ARN/resource id) as the component, and the check's remediation and risk into the finding. Muted findings are skipped. Cloud account, region, and service are attached as tags.
+
+For more information, see the **[Prowler App API documentation](https://api.prowler.com/api/v1/docs)**.
+
 ## Qualys
 
 The Qualys connector imports **VMDR host vulnerability detections** — each joined with its Qualys KnowledgeBase (QID) metadata — from the Qualys Cloud Platform. DefectDojo creates a Record for each Qualys **host** in your subscription.


### PR DESCRIPTION
## Summary

Documents the **Prowler** multi-cloud CSPM connector (story [sc-13763](https://app.shortcut.com/defectdojo/story/13763)) in the connectors tool reference — self-hosted Prowler App URL, JWT (email+password) or API-key auth, the whole-tenant provider→Record model (importing each provider's latest completed scan's FAIL findings), minimum-severity filtering, and the resource/remediation/risk/tag mapping. Placed alphabetically after Probely.

## Companion PRs

- Go connector: [connectors#727](https://github.com/DefectDojo-Inc/connectors/pull/727)
- dojo-pro registration: [dojo-pro#1934](https://github.com/DefectDojo-Inc/dojo-pro/pull/1934)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
