### PR TITLE
docs(connectors): add Kubescape connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/about_connectors.md
+++ b/docs/content/import_data/pro/connectors/about_connectors.md
@@ -36,6 +36,7 @@ We currently support Connectors for the following tools, with more on the way:
 * **Group-IB ASM**
 * **IriusRisk**
 * **JFrog Xray**
+* **Kubescape** (Kubernetes posture: reads the Kubescape operator's in-cluster results)
 * **Probely**
 * **Semgrep**
 * **SonarQube**

--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -579,6 +579,23 @@ The JSM Assets connector is an **Asset Connector**: it enumerates the objects in
 
 Each Assets object becomes a Record named after the object's label, grouped by its **object schema**.
 
+## **Kubescape**
+
+The Kubescape connector reads Kubernetes posture (misconfiguration) results produced by the [Kubescape operator](https://kubescape.io/docs/install-operator/) directly from the cluster's Kubernetes API — no ARMO SaaS account is required. It reads the `WorkloadConfigurationScan` objects served by the operator's in-cluster storage aggregated API (`spdx.softwarecomposition.kubescape.io/v1beta1`). Each Kubernetes **namespace** that has posture results is mapped to a Record (Product); each failed control on a workload becomes a Finding.
+
+#### Prerequisites
+
+- The Kubescape operator must be installed in the target cluster with configuration scanning enabled (see [Installing in your cluster](https://kubescape.io/docs/install-operator/)). Confirm results exist with `kubectl get workloadconfigurationscans -A`.
+- A **kubeconfig** granting read access to the `spdx.softwarecomposition.kubescape.io` API group (list/get on `workloadconfigurationscans`) for the target cluster.
+
+#### Connector Mappings
+
+1. Enter the cluster's API server URL (or a friendly cluster identifier) in the **Location** field.
+2. Paste the **kubeconfig** for the target cluster in the `kubeconfig` field. Optionally set `kube_context` to select a context within it, and `cluster_name` to label the discovered Products.
+3. Each namespace with posture results is discovered as a Record; map the ones you want to import to DefectDojo Products.
+
+Findings are derived per failed control: the control name and workload identify the Finding, severity comes from the control's score factor, the control ID becomes the vulnerability ID, and each Finding links to its control reference at `https://hub.armosec.io/docs/`.
+
 ## **Microsoft Defender**
 
 The Microsoft Defender connector imports device vulnerability findings from **Microsoft Defender Vulnerability Management (MDVM)** — one finding per device / software version / CVE combination, including severity, CVSS score, exploitability level and recommended security updates. DefectDojo will discover your Defender **device groups** and create a Record for each one; devices that aren't assigned to any device group are collected under a synthetic **Unassigned** group.


### PR DESCRIPTION
Documents the new **Kubescape** connector on the Pro connectors reference.

Companion PRs:
- Connector (Go): DefectDojo-Inc/connectors#728
- Pro registration: DefectDojo-Inc/dojo-pro (separate PR)

## Changes

- **`connectors_tool_reference.md`** — new `## Kubescape` section (alphabetical): reads the Kubescape operator's in-cluster posture results (`WorkloadConfigurationScan`, `spdx.softwarecomposition.kubescape.io/v1beta1`) via the Kubernetes API, **no ARMO SaaS account required**; namespace → Product, failed control → Finding; prerequisites (operator installed + kubeconfig) and connector mappings (Location, kubeconfig, kube_context, cluster_name).
- **`about_connectors.md`** — add Kubescape to the supported-connectors list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)