### PR TITLE
docs(connectors): add Intruder connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/about_connectors.md
+++ b/docs/content/import_data/pro/connectors/about_connectors.md
@@ -34,6 +34,7 @@ We currently support Connectors for the following tools, with more on the way:
 * **Checkmarx ONE**
 * **Dependency-Track**
 * **Group-IB ASM**
+* **Intruder** (cloud vulnerability scanner: pulls targets, issues, and occurrences)
 * **IriusRisk**
 * **JFrog Xray**
 * **Probely**

--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -513,6 +513,19 @@ DefectDojo creates a separate Record for each domain you have verified with HIBP
 
 See the [Have I Been Pwned API documentation](https://haveibeenpwned.com/API/v3) for more information.
 
+## **Intruder**
+
+The Intruder connector uses the [Intruder REST API](https://developers.intruder.io/) to pull your whole account's posture into DefectDojo. Each Intruder **target** is discovered as a Record (Product); each **occurrence** of an issue on a target becomes a Finding.
+
+#### Connector Mappings
+
+1. Leave the **Location** field as `https://api.intruder.io/` (the default Intruder API server).
+2. Enter an Intruder **API access token** in the **Secret** field.
+
+Generate an access token in Intruder under **My account > API Access Tokens** (you'll need your account password to create it, and the token is shown only once). See the [Intruder API documentation](https://developers.intruder.io/docs/creating-an-access-token) for details.
+
+Findings are derived per occurrence: severity comes from the issue severity, CVEs and CVSS from the occurrence, the location from the target/port, and a snoozed occurrence is imported as an inactive (false-positive or risk-accepted) finding.
+
 ## **IriusRisk**
 
 The IriusRisk connector uses an API token to pull threat modeling data from your IriusRisk instance.


### PR DESCRIPTION
Documents the new **Intruder.io** connector on the Pro connectors reference.

Companion PRs: Go connector DefectDojo-Inc/connectors#730 · Pro registration DefectDojo-Inc/dojo-pro#1937.

## Changes
- **`connectors_tool_reference.md`** — new `## Intruder` section (alphabetical): uses the Intruder REST API with a Bearer **API access token**; whole-account (targets → issues → occurrences), target → Product, occurrence → Finding; connector mappings (Location, Secret) + how to generate the token.
- **`about_connectors.md`** — add Intruder to the supported-connectors list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)