### PR TITLE
docs(connectors): Intigriti connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -815,6 +815,24 @@ See the [Have I Been Pwned API documentation](https://haveibeenpwned.com/API/v3)
 
 ## **Intigriti**
 
+The Intigriti connector uses the Intigriti external company API to pull bug-bounty / pentest **submissions** into DefectDojo. It syncs the whole company account: DefectDojo discovers every program the token can access and creates a Record for each, then imports that program's submissions as findings.
+
+#### Prerequisites
+
+You will need an Intigriti **company API token**. In the Intigriti company portal, under **Company Settings > API** (the `company_external_api` scope), generate an access token with read access to your programs and submissions. A dedicated token for DefectDojo is recommended. The token is sent as a Bearer token and is never logged.
+
+#### Connector Mappings
+
+1. Enter the Intigriti external company API base URL in the **Location** field: `https://api.intigriti.com/external/company`. The URL must be HTTPS.
+2. Enter the company API token in the **Secret** field.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo maps each Intigriti **program** to a Record and each **submission** to a finding, keyed by the submission code. The finding severity follows Intigriti's rating (Exceptional/Critical → Critical, then High/Medium/Low, otherwise Informational), and the submission's lifecycle state maps to the finding's status: open/triage submissions are active, accepted submissions are verified, and closed submissions become mitigated, a duplicate, out-of-scope, false-positive or risk-accepted according to their close reason. The finding description carries the report's vulnerability type, affected asset, proof of concept and the researcher's answers.
+
+See the [Intigriti API documentation](https://kb.intigriti.com/en/articles/6117846-intigriti-api) for more information.
+
+## **Intigriti**
+
 The Intigriti connector uses the Intigriti company API to import submissions as findings. DefectDojo creates a Record for each **program**.
 
 #### Prerequisites


### PR DESCRIPTION
## What

Adds the **Intigriti** connector to the Pro connector tool reference. Intigriti is a bug-bounty / agile-pentest platform; the connector syncs a whole company account, mapping each program to a product and each submission to a finding.

Companion to:
- DefectDojo-Inc/connectors#731 (the Go connector)
- DefectDojo-Inc/dojo-pro#1938 (Pro-UI registration)

## Section covers

- Prerequisites: an Intigriti company API token (`company_external_api` scope), sent as a Bearer token.
- Connector mappings: HTTPS **Location** (`https://api.intigriti.com/external/company`), token in **Secret**, optional **Minimum Severity**.
- Mapping model: program → Record, submission → finding (keyed by code); severity map; the Intigriti lifecycle → DefectDojo status (open/triage → active, accepted → verified, closed → mitigated / duplicate / out-of-scope / false-positive / risk-accepted by close reason).

Live validation is customer-gated (needs a company API token) and is an outstanding follow-up; details in connectors#731.

Base: `bugfix`.
