### PR TITLE
docs(connectors): runZero asset connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -688,6 +688,25 @@ Network access from DefectDojo to your Security Console, and a console **user ac
 
 Each InsightVM site becomes a Record; the connector walks the site's assets and imports their vulnerable findings.
 
+## **runZero**
+
+The runZero connector uses the runZero Export API to sync your whole organization's asset inventory into DefectDojo. It is primarily an **asset** connector: DefectDojo discovers every asset and creates a Record for each, grouped into a Product Type by its runZero **site**. It can optionally also import runZero's vulnerabilities as findings.
+
+#### Prerequisites
+
+You will need an organization **Export Token** from runZero (Account → API), which is prefixed `XT`. The token is organization-scoped (the organization is encoded in the token), read-only, and is sent as a Bearer token — it is never logged. A community/starter tier is available.
+
+#### Connector Mappings
+
+1. Enter your runZero console URL in the **Location** field, for example `https://console.runzero.com`. The URL must be HTTPS.
+2. Enter the Export Token in the **Secret** field.
+3. Optionally set **Import Vulnerabilities** to `true` to also import runZero vulnerabilities as findings; leave it blank to sync assets only.
+4. Optionally, set a **Minimum Severity** to limit which vulnerability findings are imported (applies only when vulnerabilities are imported).
+
+DefectDojo maps each runZero **asset** to a Record (VEP): the display name comes from the asset's name or address, and its site, type, OS, addresses and tags are attached as attributes; the asset's **site** becomes its Product Type. Assets are synced with a full export that DefectDojo reconciles (adds/removes). When **Import Vulnerabilities** is enabled, each runZero vulnerability becomes a finding on its asset — mapping the severity, CVSS score, CVE, affected service (`protocol://address:port`) endpoint and the remediation.
+
+See the [runZero API documentation](https://help.runzero.com/) for more information.
+
 ## **Semgrep**
 
 This connector uses the Semgrep REST API to fetch data.


### PR DESCRIPTION
## What

Adds the **runZero** connector to the Pro connector tool reference. runZero is an asset / attack-surface discovery platform; the connector syncs the whole organization's asset inventory into DefectDojo (asset → Record, grouped by site), with an optional vulnerability → findings import.

Companion to:
- DefectDojo-Inc/connectors#732 (the Go connector)
- DefectDojo-Inc/dojo-pro#1939 (Pro-UI registration)

## Section covers

- Prerequisites: an `XT`-prefixed, org-scoped Export Token (community tier available), sent as a Bearer token.
- Connector mappings: HTTPS **Location** (`https://console.runzero.com`), token in **Secret**, **Import Vulnerabilities** toggle, optional **Minimum Severity**.
- Mapping model: asset → Record (site → Product Type; type/OS/addresses/tags as attributes); optional vuln → finding (severity, CVSS, CVE, `protocol://address:port` endpoint, remediation).

Live validation needs a runZero export token and is an outstanding follow-up; details in connectors#732.

Base: `bugfix`.
