### PR TITLE
docs(connectors): document the YesWeHack connector

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -1294,6 +1294,25 @@ Using the Wiz connector requires you to create a service account: see the [Wiz d
 
 ## **YesWeHack**
 
+The YesWeHack connector uses the YesWeHack REST API to import reports from your bug bounty and vulnerability disclosure programs. DefectDojo creates a Record for each program your token can access and imports its reports as findings.
+
+#### Prerequisites
+
+You will need a YesWeHack **Personal Access Token (PAT)**. Read access to your programs is sufficient. Some accounts require TOTP/MFA when creating a token; once created, the token value itself is what the connector uses.
+
+1. In YesWeHack, open your account settings and go to **API / Personal Access Tokens**.
+2. Create a token and copy its value. It is only shown once.
+
+#### Connector Mappings
+
+1. Enter `https://api.yeswehack.com/` in the **Location** field.
+2. Enter your Personal Access Token in the **Secret** field.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported. Findings below the selected severity will not be imported.
+
+DefectDojo creates a separate Record for each program your token can access, and imports each report as a finding. The finding's severity is taken from the report's CVSS rating (falling back to the triage priority), and its status reflects the report's workflow state — for example, resolved reports are imported as mitigated, and reports marked invalid or out of scope are imported as inactive.
+
+## **YesWeHack**
+
 The YesWeHack connector uses the YesWeHack API to import bug bounty reports as findings. DefectDojo creates a Record for each **program**.
 
 #### Prerequisites


### PR DESCRIPTION
## Document the YesWeHack connector

Documentation for the new **YesWeHack** bug-bounty findings connector.

- **`connectors_tool_reference.md`** — adds a YesWeHack section (alphabetical) covering:
  - Personal Access Token prerequisite (noting some accounts require TOTP/MFA at token creation).
  - Connector mappings: `https://api.yeswehack.com/` in Location, the PAT in Secret, optional Minimum Severity.
  - The whole-account model — a Record per program the token can access — and how findings are mapped: severity from the report's CVSS rating (falling back to triage priority) and status from the report's workflow state (resolved → mitigated, invalid/out-of-scope → inactive).
- **`about_connectors.md`** — lists YesWeHack among the supported connectors.

Companion PRs: connector implementation (DefectDojo-Inc/connectors#733) and DefectDojo-side registration (dojo-pro#1941).
