### PR TITLE
docs(features): document Feature Flags page and correct feature enablement

### DIFF
--- a/docs/content/admin/feature_flags/PRO__feature_flags.md
+++ b/docs/content/admin/feature_flags/PRO__feature_flags.md
@@ -1,0 +1,97 @@
+---
+title: "Feature Flags"
+description: "Turn optional DefectDojo Pro features on and off from the DefectDojo UI"
+weight: 1
+audience: pro
+---
+
+Feature Flags let you turn optional DefectDojo Pro capabilities on and off for your own instance — features that previously could only be enabled by contacting DefectDojo Support can now be self-served from the UI.
+
+The Feature Flags page is visible to **superusers** only. Other users, including Global Owners, do not see it.
+
+## Opening the Feature Flags page
+
+Go to **Settings > Feature Flags** in the left sidebar.
+
+The page lists every optional feature with:
+
+* **Name** — the feature, with a **BETA** tag when it is still in beta
+* **Description** — what the feature does
+* **Documentation link** — where documentation exists for that feature
+* **Toggle** — whether the feature is currently on
+
+Use the search box to filter the list by feature name or description.
+
+## Turning a feature on or off
+
+1. Find the feature in the list.
+2. Click its toggle.
+3. The change takes effect immediately. You do not need to restart anything, and other users pick the change up on their next page load.
+
+Some features show a confirmation dialog before the change is applied. This happens when enabling a feature that carries a warning (for example one that requires a restart or may affect existing data), or one that cannot be turned back off.
+
+Turning a feature off is normally just the reverse of turning it on. The exceptions are called out in the next section.
+
+## When a toggle is locked
+
+A feature you cannot change is shown with a lock badge explaining why:
+
+| Badge | What it means | What to do |
+| --- | --- | --- |
+| **Managed by DefectDojo** | DefectDojo has set this feature centrally for your instance. Your setting cannot override it. | Contact [DefectDojo Support](mailto:support@defectdojo.com) if you need it changed. |
+| **Unavailable on This Deployment** | The feature is not offered on your installation type. See [Feature availability](#feature-availability) below. | Nothing. The feature is not applicable to your instance. |
+| **Cannot Be Disabled** | The feature is already on and is one way. There is no mechanism to reverse it. | Nothing. This is expected. |
+| **Managed by deployment** | The feature is controlled by your deployment configuration rather than by this page. | See [DefectDojo Pro (On-Premise)](#defectdojo-pro-on-premise) below. |
+
+## DefectDojo Pro (Cloud)
+
+On [DefectDojo Pro (Cloud)](/get_started/pro/cloud/), **Settings > Feature Flags** is the only place you need. Toggle a feature on and it is live.
+
+Two things are handled by DefectDojo rather than by you:
+
+* **Managed by DefectDojo** — the feature is pinned centrally. Contact [DefectDojo Support](mailto:support@defectdojo.com) to have it changed.
+* **Managed by deployment** — the feature is part of how your instance is provisioned. Contact Support for these as well, since Cloud instances do not expose deployment configuration to customers.
+
+Cloud instances also have access to features that are not offered on-premise. See [Feature availability](#feature-availability).
+
+## DefectDojo Pro (On-Premise)
+
+On [DefectDojo Pro (On-Premise)](/get_started/pro/onprem/), most features work exactly as they do on Cloud: open **Settings > Feature Flags** and toggle them.
+
+A small number of features are read from your deployment configuration instead — they change how the application starts, so they cannot be flipped at runtime. These appear on the page as read-only, labeled **Managed by deployment**, and name the environment variable that controls them, for example `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL`.
+
+Because these features require a restart, and some of them cannot be reversed once enabled, check the feature's own documentation before changing one. Several are best enabled with help from [DefectDojo Support](mailto:support@defectdojo.com).
+
+To change one of those features:
+
+1. Set the environment variable on your DefectDojo deployment. The page tells you which variable to set.
+2. Restart DefectDojo so the new value is read at startup.
+3. Reload the Feature Flags page to confirm the new state.
+
+Because these values are read at startup, changing them in the UI is not possible, and toggling them in your environment without a restart has no effect.
+
+Features that are offered only on Cloud appear as **Unavailable on This Deployment** on an on-premise instance. This is expected and is not a licensing problem.
+
+## Feature availability
+
+Most features are available on both installation types. The exceptions are:
+
+| Feature | Availability | How it is controlled |
+| --- | --- | --- |
+| Downstream Connections | [DefectDojo Pro (Cloud)](/get_started/pro/cloud/) only | Feature Flags page. Shown as **Unavailable on This Deployment** on-premise, which does not run the required infrastructure. See [Pro Integrations](/issue_tracking/pro_integration/integrations/). |
+| Request a New Connector | [DefectDojo Pro (Cloud)](/get_started/pro/cloud/) only | Feature Flags page. Shown as **Unavailable on This Deployment** on-premise. |
+| Locations | Both | Deployment configuration. Locations is in Beta and cannot be turned back off once enabled, so contact [DefectDojo Support](mailto:support@defectdojo.com) to have it enabled. See [Locations Overview](/asset_modelling/locations/pro__locations_overview/). |
+| Organization / Asset Relabeling | Both | Deployment configuration: `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL`. |
+
+Every other optional feature is toggled directly on the Feature Flags page on both Cloud and On-Premise instances.
+
+## Frequently asked questions
+
+**A feature I want is not in the list.**
+The list shows optional features only. Capabilities that are always on do not appear. If you expected a feature that is missing, confirm your license includes it, then contact [DefectDojo Support](mailto:support@defectdojo.com).
+
+**I turned a feature on but I do not see it.**
+Reload the page — menu entries and routes are evaluated when the page loads, so a newly enabled feature appears on the next load rather than instantly in the current view.
+
+**Will upgrading change my settings?**
+No. Upgrading preserves the features you have turned on and the ones you have turned off.

--- a/docs/content/admin/feature_flags/_index.md
+++ b/docs/content/admin/feature_flags/_index.md
@@ -1,0 +1,22 @@
+---
+title: "Feature Flags"
+description: "Turn optional DefectDojo Pro features on and off for your instance"
+summary: ""
+date: 2026-07-20T00:00:00+00:00
+lastmod: 2026-07-20T00:00:00+00:00
+draft: false
+weight: 4
+chapter: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  robots: "" # custom robot tags (optional)
+exclude_search: true
+---
+
+Many DefectDojo Pro capabilities ship behind a feature flag so that you can adopt them when you are ready rather than on the release that introduces them.
+
+Feature Flags are a DefectDojo Pro feature. Open-source DefectDojo does not have a feature flag surface.
+
+* [Feature Flags](./pro__feature_flags/) — view every optional feature, turn features on and off, and understand why a feature might be unavailable on your instance.

--- a/docs/content/asset_modelling/PRO_hierarchy/assets_organizations.md
+++ b/docs/content/asset_modelling/PRO_hierarchy/assets_organizations.md
@@ -14,18 +14,24 @@ Currently, this feature is in Beta.
 
 Hierarchy features ship with new versions of DefectDojo Pro by default, but existing customers who wish to migrate these features can do so using the following methods
 
-### Cloud Customers
+The two pieces are enabled separately, and by different means.
 
-The hierarchy feature and label changes must be enabled by DefectDojo Support. Email [support@defectdojo.com](mailto:support@defectdojo.com) with your instance URL and request:
+### Asset Hierarchy
 
-1. **Asset Hierarchy** — enables parent/child relationships between Assets. Once enabled, the hierarchy can be viewed and managed from the **Product** tab in the navigation.
-2. **Label Changes** (optional) — renames "Product Type" to "Organization" and "Product" to "Asset" throughout the UI. This is a separate step from enabling the hierarchy and can be requested at the same time or later.
+**Asset Hierarchy** enables parent/child relationships between Assets. Once enabled, the hierarchy can be viewed and managed from the **Product** tab in the navigation.
+
+A superuser can turn it on from **Settings > Feature Flags**, on both Cloud and On-Premise instances. See [Feature Flags](/admin/feature_flags/pro__feature_flags/).
+
+### Label Changes (optional)
+
+**Label Changes** renames "Product Type" to "Organization" and "Product" to "Asset" throughout the UI. This is a separate step from enabling the hierarchy and can be done at the same time or later.
+
+Label changes are read from your deployment configuration when DefectDojo starts, so they are not toggled from the Feature Flags page:
+
+* **[DefectDojo Pro (Cloud)](/get_started/pro/cloud/)** — email [support@defectdojo.com](mailto:support@defectdojo.com) with your instance URL.
+* **[DefectDojo Pro (On-Premise)](/get_started/pro/onprem/)** — set `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL` and restart DefectDojo. Contact Support if you would like guidance before making the change.
 
 Note that label changes are cosmetic only: API endpoints and field names remain unchanged, so existing automation will continue to work.
-
-### On-Premise Customers
-
- Contact Support for guidance on enabling these features via your instance configuration.
 
 ## Significant Changes
 

--- a/docs/content/automation/rules_engine/about.md
+++ b/docs/content/automation/rules_engine/about.md
@@ -12,6 +12,10 @@ DefectDojo's Rules Engine allows you to build custom workflows and bulk actions 
 
 Rules Engine can only be accessed through the [Pro UI](/get_started/about/ui_pro_vs_os/).
 
+## Enabling Rules Engine
+
+Rules Engine is in Beta and is off by default. A superuser can turn it on from **Settings > Feature Flags**, on both Cloud and On-Premise instances. See [Feature Flags](/admin/feature_flags/pro__feature_flags/).
+
 Currently, Rules can only be created for Findings, however more object types will be supported in the future.
 
 Rules can be triggered manually from the **All Rules** page, or scheduled to run automatically on a recurring schedule.  When a rule is triggered, it will be applied to all existing Findings that match the filter conditions set.

--- a/docs/content/automation/rules_engine/scheduling.md
+++ b/docs/content/automation/rules_engine/scheduling.md
@@ -8,6 +8,8 @@ audience: pro
 
 Rules can be scheduled to run automatically rather than triggered manually each time.  A scheduled rule will execute against all Findings that match its filter conditions at the configured time.
 
+Scheduling is off by default. A superuser can turn on the **Scheduling Service** from **Settings > Feature Flags**, on both Cloud and On-Premise instances (see [Feature Flags](/admin/feature_flags/pro__feature_flags/)); the **Schedule Rule** option appears once it is enabled.
+
 The user setting up the schedule must have the **Change Scheduling Service Schedule** configuration permission.
 
 ## Schedule Types

--- a/docs/content/get_started/pro/pro_features.md
+++ b/docs/content/get_started/pro/pro_features.md
@@ -104,6 +104,12 @@ See our [Universal Parser Guide](/import_data/pro/specialized_import/universal_p
 
 ![image](images/universal_parser_3.png)
 
+## Managing optional features
+
+Many of the capabilities above are optional and ship behind a feature flag, so you can adopt them when you are ready. A superuser can turn most of them on and off directly from **Settings > Feature Flags**, without contacting support.
+
+See the [Feature Flags](/admin/feature_flags/pro__feature_flags/) guide for how to enable a feature, and for why a feature might be locked or unavailable on your installation type.
+
 ## Support
 
 DefectDojo Pro subscriptions include world-class support for both on-premise and Cloud installations.  Our team is available to help your organization implement and maximize your use of DefectDojo Pro.  Your subscription includes:

--- a/docs/content/issue_tracking/pro_integration/integrations.md
+++ b/docs/content/issue_tracking/pro_integration/integrations.md
@@ -7,6 +7,8 @@ aliases:
 ---
 **Availability:** Integrations is currently in **Beta** and is only available for **Cloud-hosted** DefectDojo Pro instances. On-premise deployments do not yet have the required infrastructure to support Integrations. If you are an on-premise customer interested in this feature, please contact [support@defectdojo.com](mailto:support@defectdojo.com) for updates on availability.
 
+**Enabling Integrations:** On a Cloud instance, a superuser can turn Integrations on from **Settings > Feature Flags**, where it is listed as **Downstream Connections**. See [Feature Flags](/admin/feature_flags/pro__feature_flags/). On an on-premise instance it is shown as **Unavailable on This Deployment**.
+
 DefectDojo Pro's Integrations let you push your Findings and Finding Groups to ticket tracking systems to easily integrate security remediation with your teams existing development workflow.
 
 Supported Integrations:

--- a/docs/content/metrics_reports/dashboards/PRO__custom_dashboards.md
+++ b/docs/content/metrics_reports/dashboards/PRO__custom_dashboards.md
@@ -9,7 +9,7 @@ aliases:
   - /en/customize_dojo/dashboards/about_custom_dashboard_tiles
   - /metrics_reports/dashboards/about_custom_dashboard_tiles
 ---
-<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Customizable Dashboards (layouts, widgets, and the widget catalog) are a DefectDojo Pro feature, currently in beta. Beta features are available to DefectDojo Pro Cloud subscriptions — contact DefectDojo support or your customer success advocate to enable it for your instance.</span>
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Customizable Dashboards (layouts, widgets, and the widget catalog) are a DefectDojo Pro feature. They are off by default — a superuser can turn them on from **Settings > Feature Flags** on both Cloud and On-Premise instances.</span>
 
 DefectDojo Pro Customizable Dashboards let each user assemble their own home page out of **widgets** — counts, charts, leaderboards, feeds, and notes — arranged on a drag-and-drop grid. Instead of a single fixed dashboard for everyone, you build the **layouts** that matter to you: an executive overview, a triage queue, a remediation-velocity board, a scanner-effectiveness view. You can keep layouts private, publish them to your whole team, set one as your default landing page, and clone any layout (yours or a shared template) as a starting point.
 
@@ -23,13 +23,13 @@ DefectDojo Pro replaces that fixed page with **per-user customizable dashboards*
 
 > **💡 Tip:** In DefectDojo Pro, **Assets** were formerly called **Products** and **Organizations** were formerly **Product Types**. The UI uses the new wording, but some underlying widget settings still use the legacy names — for example, most widgets take a `model` of `finding`, `product`, `engagement`, or `test`. Where this matters, it is called out below.
 
-## Enabling the beta
+## Enabling Customizable Dashboards
 
-Customizable Dashboards are off by default while in beta. Beta features are enabled per instance for DefectDojo Pro Cloud subscriptions — contact DefectDojo support ([support@defectdojo.com](mailto:support@defectdojo.com)) or your customer success advocate to turn on Customizable Dashboards for your instance.
+Customizable Dashboards are off by default. A superuser can turn them on from **Settings > Feature Flags**, on both Cloud and On-Premise instances. See [Feature Flags](/admin/feature_flags/pro__feature_flags/).
 
 Once it is enabled, the **🏠 Home** page shows your customizable dashboard and the [Dashboards REST API](../custom-dashboards-api/) becomes available.
 
-> **🔑 Important:** While the flag is off, the home page keeps the previous dashboard and every `/api/v2/dashboards/` endpoint returns `403 Dashboard V2 is not enabled.` Enabling the flag does **not** change anyone's data access — every widget still respects DefectDojo's role-based access control, so each user only ever sees the Findings, Assets, and other records they are authorized to view.
+> **🔑 Important:** While the feature is off, the home page keeps the previous dashboard and every `/api/v2/dashboards/` endpoint returns `403 Dashboard V2 is not enabled.` Turning it on does **not** change anyone's data access — every widget still respects DefectDojo's role-based access control, so each user only ever sees the Findings, Assets, and other records they are authorized to view.
 
 ## Core concepts
 

--- a/docs/content/metrics_reports/dashboards/PRO__custom_dashboards_api.md
+++ b/docs/content/metrics_reports/dashboards/PRO__custom_dashboards_api.md
@@ -6,7 +6,7 @@ audience: pro
 weight: 11
 slug: custom-dashboards-api
 ---
-<span style="background-color:rgba(242, 86, 29, 0.3)">Note: The Customizable Dashboards REST API (layouts, widget catalog, and widget data) is a DefectDojo Pro feature, currently in beta. Beta features are available to DefectDojo Pro Cloud subscriptions — contact DefectDojo support or your customer success advocate to enable it for your instance.</span>
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: The Customizable Dashboards REST API (layouts, widget catalog, and widget data) is a DefectDojo Pro feature. It is off by default — a superuser can turn on Customizable Dashboards from **Settings > Feature Flags** on both Cloud and On-Premise instances.</span>
 
 The Customizable Dashboards REST API lets you build the same dashboards you assemble by hand in the [Dashboards UI](../custom-dashboards/) — entirely from code. You can discover the widget catalog, create and update layouts, set your default, share layouts with your team, and even render a widget's data on demand without re-implementing DefectDojo's filtering. The layouts surface was designed as the primary entry point for AI agents building dashboards, so the request shapes are deliberately introspectable.
 
@@ -45,7 +45,7 @@ curl -s \
   "https://[YOUR-INSTANCE].cloud.defectdojo.com/api/v2/dashboards/widget_catalog/"
 ```
 
-> **🔑 Important:** The entire Dashboards API is part of the beta. Until it is enabled for your instance, every endpoint returns `403 Dashboard V2 is not enabled.` — see [Enabling the beta](../custom-dashboards/#enabling-the-beta).
+> **🔑 Important:** The entire Dashboards API depends on the Customizable Dashboards feature. Until it is turned on, every endpoint returns `403 Dashboard V2 is not enabled.` — see [Enabling Customizable Dashboards](../custom-dashboards/#enabling-customizable-dashboards).
 
 > **⚠️ Security Notice:** Your API token grants full access to your DefectDojo data. Never paste it into a chat, screenshot, ticket, or committed file. Read it from an environment variable, rotate it if it is ever exposed, and scope tokens to service accounts where possible.
 

--- a/docs/content/metrics_reports/dashboards/PRO__custom_dashboards_llm.md
+++ b/docs/content/metrics_reports/dashboards/PRO__custom_dashboards_llm.md
@@ -6,7 +6,7 @@ audience: pro
 weight: 12
 slug: custom-dashboards-llm
 ---
-<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Automating Customizable Dashboards with the REST API and an LLM is a DefectDojo Pro feature, currently in beta. Beta features are available to DefectDojo Pro Cloud subscriptions — contact DefectDojo support or your customer success advocate to enable it for your instance.</span>
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Automating Customizable Dashboards with the REST API and an LLM is a DefectDojo Pro feature. It is off by default — a superuser can turn on Customizable Dashboards from **Settings > Feature Flags** on both Cloud and On-Premise instances.</span>
 
 DefectDojo Pro's Customizable Dashboards are fully driven by the REST API — and the layouts surface was designed with AI agents in mind. That means you can hand the whole job to an LLM: paste one self-contained prompt into Claude, ChatGPT, or any other capable model, describe the dashboards you want, and it will interrogate your tenant's live widget catalog, propose layouts, emit a runnable Python script, create the layouts, verify them, and optionally set your default.
 
@@ -22,7 +22,7 @@ This guide pairs with the [Dashboards API guide](../custom-dashboards-api/), whi
 export DD_IMPORTER_DOJO_API_TOKEN=<paste-token-here>
 ```
 
-2. **Confirm the beta is enabled.** Customizable Dashboards must be enabled for your instance — contact DefectDojo support or your customer success advocate — otherwise every API call returns `403`.
+2. **Confirm the feature is on.** Customizable Dashboards must be turned on for your instance from **Settings > Feature Flags** — otherwise every API call returns `403`.
 
 3. **Decide your dashboards.** The LLM will ask what you want. Common choices:
 

--- a/docs/content/metrics_reports/reports/PRO__report_builder.md
+++ b/docs/content/metrics_reports/reports/PRO__report_builder.md
@@ -106,7 +106,7 @@ A Generated Report moves through these statuses as it is built:
 | Completed | The report is ready to download. |
 | Failed | The report could not be generated. |
 
-> **🔑 Important:** Reporting must be enabled on your instance, and viewing respects DefectDojo's role-based access control (RBAC) — users only ever see data they are authorized to view, even inside a report.
+> **🔑 Important:** Reporting is on by default. A superuser can turn it on or off from **Settings > Feature Flags** (see [Feature Flags](/admin/feature_flags/pro__feature_flags/)). Viewing respects DefectDojo's role-based access control (RBAC) — users only ever see data they are authorized to view, even inside a report.
 
 You can build this in the UI (below) or automate it with the [API](../report-builder-api/).
 

--- a/docs/content/triage_findings/finding_deduplication/PRO__global_component_deduplication.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__global_component_deduplication.md
@@ -11,7 +11,7 @@ Unlike the other deduplication algorithms, Global Component matching is **not sc
 
 ## Enabling the Global Component Algorithm
 
-Global Component Deduplication is gated behind a feature flag and is **off by default**. To request that it be enabled on your instance, contact [DefectDojo Support](mailto:support@defectdojo.com).
+Global Component Deduplication is gated behind a feature flag and is **off by default**. A superuser can turn it on from **Settings > Feature Flags** on both Cloud and On-Premise instances. See [Feature Flags](/admin/feature_flags/pro__feature_flags/).
 
 Once the feature is enabled, **Global Component** will become available as an option in the **Deduplication Algorithm** dropdown for both Same Tool and Cross Tool Deduplication settings in the Tuner.
 


### PR DESCRIPTION
## What

DefectDojo Pro's feature flags can now be turned on and off by a superuser from **Settings > Feature Flags**, instead of requiring a request to support. This documents that page and brings the affected feature docs in line with the new behavior.

## Changes

**New guide** — `admin/feature_flags/`
- How superusers view and toggle optional features
- What each lock badge means (Managed by DefectDojo, Unavailable on This Deployment, Cannot Be Disabled, Managed by deployment)
- How Cloud and On-Premise differ, including deployment-managed features that require a restart, and which features are Cloud-only

**Discoverability + enablement**
- Pointer to the Feature Flags guide from the Pro features overview
- "How to enable" notes added to Rules Engine and Rules Engine Scheduling

**Corrected stale enablement wording** — these docs told customers to contact support, or claimed beta/Cloud-only status that no longer matches the product:
- Customizable Dashboards (overview, API, LLM) — now self-serve, available on both editions
- Report Builder — on by default rather than "must be enabled"
- Asset Hierarchy — split the self-serve hierarchy toggle from the deployment-managed label changes
- Global Component Deduplication — self-serve
- Pro Integrations — kept the Beta/Cloud-only statement, added how a Cloud superuser enables it (listed as Downstream Connections)

## Notes

- Docs only; no application code.
- Base is `bugfix` so the docs land alongside the release that introduces the Feature Flags page.