### PR TITLE
fix(trivy): initialize resource_name for cluster-scoped k8s resources

### DIFF
--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -218,6 +218,7 @@ class TrivyParser:
                 namespace = resource.get("Namespace")
                 kind = resource.get("Kind")
                 name = resource.get("Name")
+                resource_name = ""
                 if namespace:
                     resource_name = f"{namespace} / "
                 if kind:

--- a/unittests/scans/trivy/kubernetes_cluster_scoped_resources.json
+++ b/unittests/scans/trivy/kubernetes_cluster_scoped_resources.json
@@ -1,0 +1,132 @@
+{
+ "ClusterName": "kind-voc-lab",
+ "Resources": [
+  {
+   "Kind": "ClusterRole",
+   "Name": "system:controller:bootstrap-signer",
+   "Results": [
+    {
+     "Target": "ClusterRole/system:controller:bootstrap-signer",
+     "Class": "config",
+     "Type": "rbac",
+     "MisconfSummary": {
+      "Successes": 0,
+      "Failures": 1,
+      "Exceptions": 0
+     },
+     "Misconfigurations": [
+      {
+       "Type": "Kubernetes Security Check",
+       "ID": "KSV113",
+       "Title": "Manage namespace secrets",
+       "Description": "Check whether role permits managing namespace secrets",
+       "Message": "ClusterRole 'system:controller:bootstrap-signer' shouldn't have access to manage secrets in namespace 'kube-system'",
+       "Namespace": "builtin.kubernetes.KSV113",
+       "Query": "data.builtin.kubernetes.KSV113.deny",
+       "Resolution": "Manage namespace secrets are not allowed. Remove resource 'secrets' from role",
+       "Severity": "MEDIUM",
+       "PrimaryURL": "https://avd.aquasec.com/misconfig/ksv113",
+       "References": [
+        "https://kubernetes.io/docs/concepts/security/rbac-good-practices/",
+        "https://avd.aquasec.com/misconfig/ksv113"
+       ],
+       "Status": "FAIL",
+       "Layer": {},
+       "CauseMetadata": {
+        "Provider": "Kubernetes",
+        "Service": "general",
+        "StartLine": 1,
+        "EndLine": 1
+       }
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "Namespace": "default",
+   "Kind": "Deployment",
+   "Name": "redis-follower",
+   "Results": [
+    {
+     "Target": "Deployment/redis-follower",
+     "Class": "config",
+     "Type": "kubernetes",
+     "MisconfSummary": {
+      "Successes": 23,
+      "Failures": 1,
+      "Exceptions": 0
+     },
+     "Misconfigurations": [
+      {
+       "Type": "Kubernetes Security Check",
+       "ID": "KSV001",
+       "Title": "Process can elevate its own privileges",
+       "Description": "A program inside the container can elevate its own privileges and run as root, which might give the program control over the container and node.",
+       "Message": "Container 'follower' of Deployment 'redis-follower' should set 'securityContext.allowPrivilegeEscalation' to false",
+       "Namespace": "builtin.kubernetes.KSV001",
+       "Query": "data.builtin.kubernetes.KSV001.deny",
+       "Resolution": "Set 'set containers[].securityContext.allowPrivilegeEscalation' to 'false'.",
+       "Severity": "MEDIUM",
+       "PrimaryURL": "https://avd.aquasec.com/misconfig/ksv001",
+       "References": [
+        "https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted",
+        "https://avd.aquasec.com/misconfig/ksv001"
+       ],
+       "Status": "FAIL",
+       "Layer": {},
+       "CauseMetadata": {
+        "Provider": "Kubernetes",
+        "Service": "general",
+        "StartLine": 132,
+        "EndLine": 143
+       }
+      }
+     ]
+    }
+   ]
+  },
+  {
+   "Kind": "ClusterRoleBinding",
+   "Name": "cluster-admin",
+   "Results": [
+    {
+     "Target": "ClusterRoleBinding/cluster-admin",
+     "Class": "config",
+     "Type": "rbac",
+     "MisconfSummary": {
+      "Successes": 0,
+      "Failures": 1,
+      "Exceptions": 0
+     },
+     "Misconfigurations": [
+      {
+       "Type": "Kubernetes Security Check",
+       "ID": "KSV111",
+       "Title": "User with admin access",
+       "Description": "ClusterRoleBindings with cluster-admin role is being used",
+       "Message": "ClusterRoleBinding 'cluster-admin' should not bind to role 'cluster-admin'",
+       "Namespace": "builtin.kubernetes.KSV111",
+       "Query": "data.builtin.kubernetes.KSV111.deny",
+       "Resolution": "Create a role which gives less access to the user",
+       "Severity": "LOW",
+       "PrimaryURL": "https://avd.aquasec.com/misconfig/ksv111",
+       "References": [
+        "https://kubernetes.io/docs/concepts/security/rbac-good-practices/",
+        "https://avd.aquasec.com/misconfig/ksv111"
+       ],
+       "Status": "FAIL",
+       "Layer": {},
+       "CauseMetadata": {
+        "Provider": "Kubernetes",
+        "Service": "general",
+        "StartLine": 1,
+        "EndLine": 1
+       }
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -180,6 +180,26 @@ Number  Content
             self.assertIsNone(finding.component_version)
             self.assertEqual("default / Deployment / redis-follower", finding.service)
 
+    def test_kubernetes_cluster_scoped_resources(self):
+        """Resources whose first entry is cluster-scoped (no Namespace) must parse without UnboundLocalError"""
+        with sample_path("kubernetes_cluster_scoped_resources.json").open(encoding="utf-8") as test_file:
+            parser = TrivyParser()
+            findings = parser.get_findings(test_file, Test())
+            self.assertEqual(len(findings), 3)
+            finding = findings[0]
+            self.assertEqual("KSV113 - Manage namespace secrets", finding.title)
+            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("ClusterRole / system:controller:bootstrap-signer", finding.service)
+            finding = findings[1]
+            self.assertEqual("KSV001 - Process can elevate its own privileges", finding.title)
+            self.assertEqual("default / Deployment / redis-follower", finding.service)
+            # a cluster-scoped resource following a namespaced one must not
+            # inherit the previous resource's namespace/kind/name
+            finding = findings[2]
+            self.assertEqual("KSV111 - User with admin access", finding.title)
+            self.assertEqual("Low", finding.severity)
+            self.assertEqual("ClusterRoleBinding / cluster-admin", finding.service)
+
     def test_license_scheme(self):
         with sample_path("license_scheme.json").open(encoding="utf-8") as test_file:
             parser = TrivyParser()


### PR DESCRIPTION
**Description**

The kubernetes-report branch of the Trivy parser (`ClusterName` reports produced by `trivy k8s --report all --format json`) crashes with an `UnboundLocalError` when the first entry of the `Resources` array is a cluster-scoped resource (e.g. `ClusterRole`, `ClusterRoleBinding` — no `Namespace` key). Through `/api/v2/import-scan/` this surfaces as an HTTP 500.

Root cause: in the `Resources` loop of `dojo/tools/trivy/parser.py`, `resource_name` is never initialized before the conditional concatenations — unlike the two twin loops just above (`Vulnerabilities`, `Misconfigurations`), which both reset `service_name = ""` on every iteration:

- if the **first** resource has no `Namespace`, the `if namespace:` assignment is skipped and `resource_name += f"{kind} / "` raises `UnboundLocalError`;
- if a cluster-scoped resource **follows** a namespaced one, it silently inherits the previous iteration's value and is imported with a corrupted service name.

The fix initializes `resource_name = ""` at the top of each iteration, matching the loops above.

Reproduced against a kind cluster with the current published image (`defectdojo/defectdojo-django:latest`, 2026-07-15):

```
File "dojo/tools/trivy/parser.py", line 224, in get_findings
    resource_name += f"{kind} / "
    ^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'resource_name' where it is not associated with a value
```

**Test results**

Added `unittests/scans/trivy/kubernetes_cluster_scoped_resources.json` — a `ClusterName` report whose `Resources` array contains a cluster-scoped resource first (crash case), then a namespaced one, then a second cluster-scoped one (carry-over case) — and `test_kubernetes_cluster_scoped_resources` in `unittests/tools/test_trivy_parser.py` asserting the three findings parse with the expected service names (`ClusterRole / system:controller:bootstrap-signer`, `default / Deployment / redis-follower`, `ClusterRoleBinding / cluster-admin`).

Verified: the sample raises `UnboundLocalError` with the current parser and parses cleanly (3 findings, correct service names) with the fix.

**Documentation**

No documentation change needed — one-line bugfix, no behavior change for valid inputs.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
