### PR TITLE
fix(docker): install PostgreSQL 18 client so dbbackup works

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -5,7 +5,7 @@
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.14.5-alpine3.22@sha256:6b91e66ab2a880ce9ca5a1b91c70f45963ff71ff68268df056336e1a657d5efd AS base
+FROM python:3.14.6-alpine3.23@sha256:b165067c5afc37fa5608a3c05609cc3d51aafd808a30fbfd822ee594fef55ad4 AS base
 FROM base AS build
 WORKDIR /app
 RUN \
@@ -15,7 +15,7 @@ RUN \
     gcc \
     build-base \
     bind-tools \
-    postgresql16-client \
+    postgresql18-client \
     xmlsec \
     git \
     util-linux \
@@ -49,7 +49,7 @@ RUN \
     xmlsec \
     git \
     util-linux \
-    postgresql16-client \
+    postgresql18-client \
     curl-dev \
     openssl \
     # needed for integration-tests

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -43,6 +43,15 @@ RUN \
   apt-get -y upgrade && \
   # ugly fix to install postgresql-client without errors
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
+  # ca-certificates + curl are needed to fetch the PostgreSQL APT (PGDG) signing key
+  apt-get -y install --no-install-recommends ca-certificates curl && \
+  # Debian trixie only ships postgresql-client-17, but the bundled PostgreSQL
+  # server is 18. pg_dump refuses to dump a server newer than itself, which
+  # breaks `manage.py dbbackup`, so pull the matching v18 client from PGDG.
+  install -d /usr/share/postgresql-common/pgdg && \
+  curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc && \
+  echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt trixie-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+  apt-get -y update && \
   apt-get -y install --no-install-recommends \
     # libopenjp2-7 libjpeg62 are required by the pillow package
     libopenjp2-7 \
@@ -52,8 +61,9 @@ RUN \
     git \
     uuid-runtime \
     libpq-dev \
-    # only required for the dbshell (used by the initializer job)
-    postgresql-client \
+    # only required for the dbshell (used by the initializer job) and dbbackup;
+    # must match the server major version (18) for pg_dump to work
+    postgresql-client-18 \
     # libcurl4-openssl-dev is required for installing pycurl python package
     libcurl4-openssl-dev \
     && \

--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -5,7 +5,7 @@
 # Dockerfile.django-alpine to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.14.5-alpine3.22@sha256:6b91e66ab2a880ce9ca5a1b91c70f45963ff71ff68268df056336e1a657d5efd AS base
+FROM python:3.14.6-alpine3.23@sha256:b165067c5afc37fa5608a3c05609cc3d51aafd808a30fbfd822ee594fef55ad4 AS base
 FROM base AS build
 WORKDIR /app
 RUN \
@@ -15,7 +15,7 @@ RUN \
     gcc \
     build-base \
     bind-tools \
-    postgresql16-client \
+    postgresql18-client \
     xmlsec \
     git \
     util-linux \


### PR DESCRIPTION
## Summary

- Fixes #15301: `./manage.py dbbackup` fails with `pg_dump: error: aborting because of server version mismatch` because the PostgreSQL **client** tools in the images are older than the bundled PostgreSQL **18** server, and `pg_dump` refuses to dump a server newer than itself.
- The server was bumped to 18.x, but the client tooling was never bumped to match: the Debian image shipped v17 (generic `postgresql-client` on trixie), and the Alpine/nginx images shipped v16 (`postgresql16-client`).
- **Alpine (`Dockerfile.django-alpine`, `Dockerfile.nginx-alpine`)**: bump the base image to `alpine3.23` and install `postgresql18-client`. The v18 client is not available in the `alpine3.22` package repos, so the base bump is required. The nginx build-stage base is kept identical to the django build stage to preserve Docker layer caching.
- **Debian (`Dockerfile.django-debian`)**: Debian trixie only ships `postgresql-client-17`, so add the PostgreSQL APT (PGDG) repository and install `postgresql-client-18` in the release stage.
- Keeps the PostgreSQL server at 18 (no data-directory migration for existing deployments); only the client tooling is aligned upward.
