### PR TITLE
perf(migration): batch endpoint tags and restore inheritance

### DIFF
--- a/dojo/management/commands/migrate_endpoints_to_locations.py
+++ b/dojo/management/commands/migrate_endpoints_to_locations.py
@@ -5,13 +5,14 @@ import time
 from collections import defaultdict
 
 from django.core.management.base import BaseCommand
-from django.db import connection
+from django.db import connection, transaction
 from django.db.models import Prefetch
 from django.utils import timezone
 
 from dojo.location.models import Location, LocationFindingReference, LocationProductReference
 from dojo.location.status import FindingLocationStatus, ProductLocationStatus
 from dojo.models import DojoMeta, Endpoint, Endpoint_Status, Product
+from dojo.tags.utils import bulk_add_tag_mapping
 from dojo.url.models import URL
 
 logger = logging.getLogger(__name__)
@@ -45,7 +46,7 @@ def _suspend_auto_now_add(model, field_name: str):
 PHASES = (
     "fetch_endpoint",   # iterator yields the next endpoint
     "url_create",       # URL.get_or_create_from_values + Location side-effect
-    "tags",             # endpoint tag copy onto the location
+    "tags",             # batched endpoint tag copy onto locations
     "meta",             # DojoMeta copy onto the location
     "finding_refs",     # LocationFindingReference creation per Endpoint_Status
     "product_refs",     # LocationProductReference creation
@@ -108,11 +109,11 @@ class Command(BaseCommand):
         The migration creates locations that may be linked to multiple products
         (via the endpoint's own product and via each finding's product). We
         collect every contributing product per location so the post-pass can
-        call ``LocationManager(product)._bulk_inherit_tags(locations)`` once
-        per product group — covering the case where a location is shared
-        across products with differing ``enable_product_tag_inheritance``
-        flags (the helper short-circuits via its own diff check on repeat
-        visits, so redundancy is safe).
+        call ``apply_inherited_tags_for_locations`` once per product group —
+        covering the case where a location is shared across products with
+        differing ``enable_product_tag_inheritance`` flags (the helper
+        short-circuits via its own diff check on repeat visits, so redundancy
+        is safe).
         """
         if product is None or product.id is None:
             return
@@ -121,6 +122,79 @@ class Command(BaseCommand):
         self.locations_by_product_id[product.id].add(location.id)
         self.product_obj_by_id.setdefault(product.id, product)
         self.location_obj_by_id.setdefault(location.id, location)
+
+    # -- Endpoint tag batching -----------------------------------------------
+
+    def _queue_location_tags(
+        self,
+        endpoint: Endpoint,
+        location: Location,
+        tag_names: set[str],
+    ) -> None:
+        """Queue endpoint tags for a batched write to their destination Location."""
+        if endpoint.id is None or location.id is None:
+            return
+        for tag_name in tag_names:
+            # Multiple legacy Endpoints may normalize to the same Location.
+            # Deduplicate by Location id so the through row and Tagulous count
+            # are each updated exactly once.
+            self.pending_tag_locations[tag_name][location.id] = location
+        self.pending_endpoint_tags[endpoint.id] = (location, tag_names)
+
+    def _record_endpoint_failure(self, endpoint_id: int | None, exc: Exception) -> None:
+        """Record an Endpoint once even if more than one migration phase fails."""
+        if endpoint_id in self.failed_endpoint_ids:
+            return
+        self.failed_endpoint_ids.add(endpoint_id)
+        self.failed_endpoints.append((endpoint_id, str(exc)))
+
+    def _flush_location_tags(self) -> None:
+        """Persist queued tags, retrying per Endpoint if the batch write fails."""
+        if not self.pending_tag_locations:
+            return
+
+        tag_to_locations = {
+            tag_name: list(locations_by_id.values())
+            for tag_name, locations_by_id in self.pending_tag_locations.items()
+        }
+        t = self._bench_start()
+        try:
+            try:
+                # bulk_add_tag_mapping creates tags, through rows, and updates
+                # Tagulous counters in separate steps. The outer transaction
+                # makes the complete batch atomic if any step fails.
+                with transaction.atomic():
+                    bulk_add_tag_mapping(tag_to_locations, batch_size=self.batch_size)
+            except Exception:
+                endpoint_ids = list(self.pending_endpoint_tags)
+                logger.exception(
+                    "Batched endpoint tag copy failed for %d tagged endpoint(s); "
+                    "first endpoint ids=%s; retrying one endpoint at a time",
+                    len(endpoint_ids),
+                    endpoint_ids[:10],
+                )
+
+                # Preserve the command's documented per-row resilience. This
+                # slower path runs only after a failed batch and isolates a bad
+                # Endpoint without discarding valid tag writes for its peers.
+                for endpoint_id, (location, tag_names) in self.pending_endpoint_tags.items():
+                    endpoint_mapping = {
+                        tag_name: [location]
+                        for tag_name in tag_names
+                    }
+                    try:
+                        with transaction.atomic():
+                            bulk_add_tag_mapping(endpoint_mapping, batch_size=self.batch_size)
+                    except Exception as exc:
+                        logger.exception(
+                            "Failed to copy tags for endpoint id=%s; continuing",
+                            endpoint_id,
+                        )
+                        self._record_endpoint_failure(endpoint_id, exc)
+        finally:
+            self._bench_end("tags", t)
+            self.pending_tag_locations.clear()
+            self.pending_endpoint_tags.clear()
 
     # -- Migration logic --------------------------------------------------
 
@@ -139,13 +213,12 @@ class Command(BaseCommand):
         )
         self._bench_end("url_create", t)
 
-        # Add the endpoint tags to the location tags. Read names from the
-        # prefetched `tags` manager and add them in a single splat call so we
-        # do one round-trip per endpoint instead of one per tag.
+        # Queue endpoint tags for one bulk write per migration batch instead
+        # of making Tagulous look up and attach tags once per endpoint.
         t = self._bench_start()
         tag_names = {tag.name for tag in endpoint.tags.all()}
         if tag_names:
-            url.location.tags.add(*tag_names)
+            self._queue_location_tags(endpoint, url.location, tag_names)
         self._bench_end("tags", t)
 
         # Add any metadata from the endpoint to the location.
@@ -330,22 +403,21 @@ class Command(BaseCommand):
 
     def _run_tag_inheritance(self) -> None:
         """
-        Drive `LocationManager._bulk_inherit_tags` once per contributing product.
+        Apply inherited tags once per contributing product.
 
-        Each `LocationManager` call is wrapped in its own try/except so a
+        Each product batch is wrapped in its own try/except so a
         failure on one product group doesn't prevent the rest from running —
-        same philosophy as the per-endpoint loop. Tag inheritance is a
-        purely additive post-pass; the underlying location/reference rows
-        are already committed by the main loop, so partial failure here
-        leaves a consistent (if incomplete-inheritance) state that a
-        targeted re-run can finish.
+        same philosophy as the per-endpoint loop. The underlying
+        location/reference rows are already committed by the main loop, so
+        partial failure here leaves a consistent (if incompletely reconciled)
+        inheritance state that a targeted re-run can finish.
         """
         if not self.locations_by_product_id:
             return
 
-        # Lazy import: dojo.importers.* pulls in a lot of modules and we
-        # don't want it loaded at management-command discovery time.
-        from dojo.importers.location_manager import LocationManager  # noqa: PLC0415
+        # Lazy import: the inheritance module imports the full model layer, so
+        # keep it out of management-command discovery.
+        from dojo.tags import inheritance as tag_inheritance  # noqa: PLC0415
 
         t0 = time.time()
         n_products = len(self.locations_by_product_id)
@@ -356,7 +428,10 @@ class Command(BaseCommand):
             product = self.product_obj_by_id[prod_id]
             locations = [self.location_obj_by_id[lid] for lid in loc_ids]
             try:
-                LocationManager(product)._bulk_inherit_tags(locations)
+                tag_inheritance.apply_inherited_tags_for_locations(
+                    locations,
+                    product=product,
+                )
             except Exception:
                 logger.exception(
                     "Tag inheritance pass failed for product id=%s "
@@ -391,16 +466,22 @@ class Command(BaseCommand):
         # `locations_by_product_id` maps product.id -> set of location.ids
         # contributed by that product (via endpoint.product OR finding.test.
         # engagement.product). We hold the Product/Location objects in
-        # parallel maps so the post-pass can hand them directly to
-        # `LocationManager(product)._bulk_inherit_tags(locations)` without
-        # extra DB lookups.
+        # parallel maps so the post-pass can hand them directly to the bulk
+        # inheritance helper.
         self.locations_by_product_id: dict[int, set[int]] = defaultdict(set)
         self.product_obj_by_id: dict[int, Product] = {}
         self.location_obj_by_id: dict[int, Location] = {}
 
+        # Endpoint tags are copied to Locations once per migration batch.
+        # The nested Location-id mapping prevents duplicate through rows and
+        # tag-count drift when multiple Endpoints normalize to one Location.
+        self.pending_tag_locations: dict[str, dict[int, Location]] = defaultdict(dict)
+        self.pending_endpoint_tags: dict[int, tuple[Location, set[str]]] = {}
+
         # Collected per-endpoint failures so a single bad row doesn't abort
         # a multi-hour migration. Each entry is (endpoint_id, exception_str).
         self.failed_endpoints: list[tuple[int | None, str]] = []
+        self.failed_endpoint_ids: set[int | None] = set()
 
         if self.query_count:
             connection.force_debug_cursor = True
@@ -473,8 +554,12 @@ class Command(BaseCommand):
                 except Exception as exc:
                     endpoint_id = getattr(endpoint, "id", None)
                     logger.exception("Failed to migrate endpoint id=%s; continuing", endpoint_id)
-                    self.failed_endpoints.append((endpoint_id, str(exc)))
-                    continue
+                    self._record_endpoint_failure(endpoint_id, exc)
+
+                # Flush independently of per-endpoint success so a failing
+                # endpoint at a batch boundary cannot leave the queue growing.
+                if i % self.batch_size == 0:
+                    self._flush_location_tags()
 
                 # Progress report every --progress-every endpoints
                 if i % self.progress_every == 0:
@@ -486,6 +571,9 @@ class Command(BaseCommand):
                         connection.queries_log.clear()
                         queries_at_chunk_start = 0
                     self._log_progress(i, endpoint_count, run_t0, queries_in_chunk)
+
+            # Persist the final partial batch before reporting completion.
+            self._flush_location_tags()
 
             elapsed = time.time() - run_t0
             successful = i - len(self.failed_endpoints)
@@ -506,7 +594,7 @@ class Command(BaseCommand):
             # product or system-wide) the migrated Locations would otherwise
             # not pick up inherited product tags. We grouped (product,
             # location) pairs during the main loop and now drive
-            # `LocationManager._bulk_inherit_tags` once per contributing
+            # `apply_inherited_tags_for_locations` once per contributing
             # product. The helper rediscovers each location's full product
             # set via LocationProductReference/LocationFindingReference and
             # diff-checks before writing, so revisits of shared locations

--- a/unittests/test_migrate_endpoints_to_locations.py
+++ b/unittests/test_migrate_endpoints_to_locations.py
@@ -31,14 +31,18 @@ class MigrateEndpointsToLocationsTest(TestCase):
         return endpoint
 
     def test_endpoint_tags_are_copied_in_deduplicated_batches(self):
-        # The first two legacy endpoints intentionally resolve to one Location.
-        # The batch accumulator must not create or count that relationship twice.
+        # Four legacy Endpoints resolve to one Location. With batches of three,
+        # at least one batch contains that Location more than once regardless of
+        # database row order, so this exercises in-batch deduplication without
+        # relying on an implicit queryset order.
         # Seed the Product tag before enabling propagation so setup does not
         # dispatch an unrelated asynchronous inheritance task.
         self.product.tags.add("product-inherited")
         self.product.enable_product_tag_inheritance = True
         self.product.save(update_fields=["enable_product_tag_inheritance"])
         self._make_endpoint("shared.example.com", ["shared", "secondary"])
+        self._make_endpoint("shared.example.com", ["shared"])
+        self._make_endpoint("shared.example.com", ["shared"])
         self._make_endpoint("shared.example.com", ["shared"])
         self._make_endpoint("unique.example.com", ["shared"])
 
@@ -48,14 +52,16 @@ class MigrateEndpointsToLocationsTest(TestCase):
         ) as bulk_add:
             call_command(
                 "migrate_endpoints_to_locations",
-                batch_size=2,
+                batch_size=3,
                 progress_every=100,
                 stdout=StringIO(),
             )
 
         self.assertEqual(bulk_add.call_count, 2)
-        first_mapping = bulk_add.call_args_list[0].args[0]
-        self.assertEqual(len(first_mapping["shared"]), 1)
+        shared_locations_written = sum(
+            len(call.args[0]["shared"]) for call in bulk_add.call_args_list
+        )
+        self.assertEqual(shared_locations_written, 3)
 
         shared_location = URL.objects.get(host="shared.example.com").location
         unique_location = URL.objects.get(host="unique.example.com").location
@@ -86,7 +92,7 @@ class MigrateEndpointsToLocationsTest(TestCase):
         # remain unchanged on a second pass.
         call_command(
             "migrate_endpoints_to_locations",
-            batch_size=2,
+            batch_size=3,
             progress_every=100,
             stdout=StringIO(),
         )

--- a/unittests/test_migrate_endpoints_to_locations.py
+++ b/unittests/test_migrate_endpoints_to_locations.py
@@ -1,0 +1,199 @@
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from dojo.location.models import Location
+from dojo.models import Endpoint, Product, Product_Type
+from dojo.tags.utils import bulk_add_tag_mapping
+from dojo.url.models import URL
+
+
+@override_settings(V3_FEATURE_LOCATIONS=True)
+class MigrateEndpointsToLocationsTest(TestCase):
+    def setUp(self):
+        product_type = Product_Type.objects.create(name="Endpoint migration product type")
+        self.product = Product.objects.create(
+            name="Endpoint migration product",
+            description="Test product",
+            prod_type=product_type,
+        )
+
+    def _make_endpoint(self, host, tags):
+        with Endpoint.allow_endpoint_init():
+            endpoint = Endpoint.objects.create(
+                protocol="https",
+                host=host,
+                product=self.product,
+            )
+        endpoint.tags.add(*tags)
+        return endpoint
+
+    def test_endpoint_tags_are_copied_in_deduplicated_batches(self):
+        # The first two legacy endpoints intentionally resolve to one Location.
+        # The batch accumulator must not create or count that relationship twice.
+        # Seed the Product tag before enabling propagation so setup does not
+        # dispatch an unrelated asynchronous inheritance task.
+        self.product.tags.add("product-inherited")
+        self.product.enable_product_tag_inheritance = True
+        self.product.save(update_fields=["enable_product_tag_inheritance"])
+        self._make_endpoint("shared.example.com", ["shared", "secondary"])
+        self._make_endpoint("shared.example.com", ["shared"])
+        self._make_endpoint("unique.example.com", ["shared"])
+
+        with patch(
+            "dojo.management.commands.migrate_endpoints_to_locations.bulk_add_tag_mapping",
+            wraps=bulk_add_tag_mapping,
+        ) as bulk_add:
+            call_command(
+                "migrate_endpoints_to_locations",
+                batch_size=2,
+                progress_every=100,
+                stdout=StringIO(),
+            )
+
+        self.assertEqual(bulk_add.call_count, 2)
+        first_mapping = bulk_add.call_args_list[0].args[0]
+        self.assertEqual(len(first_mapping["shared"]), 1)
+
+        shared_location = URL.objects.get(host="shared.example.com").location
+        unique_location = URL.objects.get(host="unique.example.com").location
+        self.assertCountEqual(
+            [tag.name for tag in shared_location.tags.all()],
+            ["shared", "secondary", "product-inherited"],
+        )
+        self.assertCountEqual(
+            [tag.name for tag in unique_location.tags.all()],
+            ["shared", "product-inherited"],
+        )
+        self.assertEqual(
+            [tag.name for tag in shared_location.inherited_tags.all()],
+            ["product-inherited"],
+        )
+        self.assertEqual(
+            [tag.name for tag in unique_location.inherited_tags.all()],
+            ["product-inherited"],
+        )
+
+        tag_model = Location.tags.tag_model
+        self.assertEqual(tag_model.objects.get(name="shared").count, 2)
+        self.assertEqual(tag_model.objects.get(name="secondary").count, 1)
+        self.assertEqual(tag_model.objects.get(name="product-inherited").count, 2)
+
+        # The management command is designed to be safely rerunnable after a
+        # partial migration. Existing relationships and Tagulous counts must
+        # remain unchanged on a second pass.
+        call_command(
+            "migrate_endpoints_to_locations",
+            batch_size=2,
+            progress_every=100,
+            stdout=StringIO(),
+        )
+
+        self.assertEqual(Location.tags.through.objects.count(), 5)
+        self.assertEqual(Location.inherited_tags.through.objects.count(), 2)
+        self.assertEqual(tag_model.objects.get(name="shared").count, 2)
+        self.assertEqual(tag_model.objects.get(name="secondary").count, 1)
+        self.assertEqual(tag_model.objects.get(name="product-inherited").count, 2)
+
+    def test_failed_batch_is_atomic_and_retried_per_endpoint(self):
+        self._make_endpoint("first.example.com", ["first-tag"])
+        self._make_endpoint("second.example.com", ["second-tag"])
+
+        through_model = Location.tags.through
+        rows_after_batch_write = []
+        rows_before_fallback = []
+        call_count = 0
+
+        def write_then_fail_once(tag_to_locations, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                bulk_add_tag_mapping(tag_to_locations, **kwargs)
+                rows_after_batch_write.append(through_model.objects.count())
+                msg = "simulated failure after the batch write"
+                raise RuntimeError(msg)
+            rows_before_fallback.append(through_model.objects.count())
+            return bulk_add_tag_mapping(tag_to_locations, **kwargs)
+
+        with (
+            patch(
+                "dojo.management.commands.migrate_endpoints_to_locations.bulk_add_tag_mapping",
+                side_effect=write_then_fail_once,
+            ),
+            self.assertLogs(
+                "dojo.management.commands.migrate_endpoints_to_locations",
+                level="ERROR",
+            ) as logs,
+        ):
+            call_command(
+                "migrate_endpoints_to_locations",
+                batch_size=2,
+                progress_every=100,
+                stdout=StringIO(),
+            )
+
+        # The outer transaction rolls back the completed batch before the
+        # command retries its two source Endpoints independently.
+        self.assertEqual(rows_after_batch_write, [2])
+        self.assertEqual(rows_before_fallback[0], 0)
+        self.assertEqual(through_model.objects.count(), 2)
+        self.assertTrue(any("retrying one endpoint at a time" in line for line in logs.output))
+
+        tag_model = Location.tags.tag_model
+        self.assertEqual(tag_model.objects.get(name="first-tag").count, 1)
+        self.assertEqual(tag_model.objects.get(name="second-tag").count, 1)
+
+    def test_failed_endpoint_tag_retry_is_reported_and_rerunnable(self):
+        failing_endpoint = self._make_endpoint("failing.example.com", ["failing-tag"])
+        self._make_endpoint("healthy.example.com", ["healthy-tag"])
+
+        def fail_one_tag(tag_to_locations, **kwargs):
+            if "failing-tag" in tag_to_locations:
+                msg = "simulated invalid endpoint tag"
+                raise RuntimeError(msg)
+            return bulk_add_tag_mapping(tag_to_locations, **kwargs)
+
+        stdout = StringIO()
+        with (
+            patch(
+                "dojo.management.commands.migrate_endpoints_to_locations.bulk_add_tag_mapping",
+                side_effect=fail_one_tag,
+            ),
+            self.assertLogs(
+                "dojo.management.commands.migrate_endpoints_to_locations",
+                level="ERROR",
+            ),
+        ):
+            call_command(
+                "migrate_endpoints_to_locations",
+                batch_size=2,
+                progress_every=100,
+                stdout=stdout,
+            )
+
+        self.assertIn("Migrated 1/2 endpoints", stdout.getvalue())
+        self.assertIn("1 endpoint(s) failed", stdout.getvalue())
+        self.assertIn(str(failing_endpoint.id), stdout.getvalue())
+
+        failing_location = URL.objects.get(host="failing.example.com").location
+        healthy_location = URL.objects.get(host="healthy.example.com").location
+        self.assertEqual([tag.name for tag in failing_location.tags.all()], [])
+        self.assertEqual([tag.name for tag in healthy_location.tags.all()], ["healthy-tag"])
+
+        # A clean rerun fills only the previously failed relationship and does
+        # not increment the existing healthy relationship's Tagulous count.
+        rerun_stdout = StringIO()
+        call_command(
+            "migrate_endpoints_to_locations",
+            batch_size=2,
+            progress_every=100,
+            stdout=rerun_stdout,
+        )
+
+        self.assertNotIn("endpoint(s) failed", rerun_stdout.getvalue())
+        self.assertEqual([tag.name for tag in failing_location.tags.all()], ["failing-tag"])
+        tag_model = Location.tags.tag_model
+        self.assertEqual(tag_model.objects.get(name="failing-tag").count, 1)
+        self.assertEqual(tag_model.objects.get(name="healthy-tag").count, 1)


### PR DESCRIPTION
## :warning: Pre-Approval check :warning:

This is a bug fix for #15124, not a new enhancement.

**Description**

The reporter's completed migration, whose progress output initially listed 65,194 Endpoints, attributed 115,317.36 seconds (99.8% of its measured phase time) to tags and required several restarts. The command copies tags separately for each tagged Endpoint; in a controlled rerun of the exact PR base, those writes also increased Tagulous counters without creating new relationships.

This PR:

- batches Endpoint tag writes and deduplicates Locations that normalize to the same URL;
- makes each batch atomic, falling back to per-Endpoint retries on failure; and
- replaces the stale `LocationManager._bulk_inherit_tags` call removed by #14877, restoring first-pass Product-tag inheritance when enabled.

**Tests**

Added focused coverage for full and partial batches, duplicate Locations, clean reruns, inherited tags, atomic rollback, and per-Endpoint recovery.

Local validation: 3 migration tests passed, 29 bulk-tag tests passed, and 39 inheritance tests completed (37 passed, 2 skipped). Django system and migration checks and Ruff also passed.

**Controlled comparison**

I compared the exact PR base (`22e2519`) and patch in two fresh databases inside the same PostgreSQL 18.4 container. The workload contained 1,000 Endpoints, five direct tags per Endpoint (14 unique direct tags), and one inherited Product tag. Both runs used `--batch-size 100 --progress-every 50 --benchmark --query-count`.

| Metric | Exact base | Patched |
| --- | ---: | ---: |
| First-pass main-loop time | 9.68 s | 4.33 s |
| First-pass tag phase | 5.34 s | 0.20 s |
| First-pass queries / Endpoint (50-Endpoint chunks) | 41.0-42.5 | 19.1-20.9 |
| Rerun main-loop time | 8.75 s | 1.15 s |
| Rerun tag phase | 7.95 s | 0.23 s |
| Rerun queries / Endpoint (50-Endpoint chunks) | 42.0-42.3 | 7.1 |

The patched runs had no tag or inheritance mismatches. After the rerun, all 6,000 `Location.tags` relationships, 1,000 `Location.inherited_tags` relationships, and all 15 counters remained correct.

This controlled workload is not a reproduction of the reporter's deployment and does not establish the same improvement for every tag distribution or at the full 65,194-Endpoint scale. The patch prevents new counter drift during this command; it does not repair counters that were already incorrect.

**Documentation**

No documentation change is needed because the command interface and workflow are unchanged.

**Checklist**

- [x] Targets the `bugfix` branch.
- [x] Uses a release-note-ready title.
- [x] Adds focused unit coverage.
- [x] Does not change models or require a migration.
- [ ] Maintainer label: `performance` / `bugfix`.
