### PR TITLE
docs(connectors): HCL AppScan connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -813,6 +813,25 @@ DefectDojo creates a separate Record for each domain you have verified with HIBP
 
 See the [Have I Been Pwned API documentation](https://haveibeenpwned.com/API/v3) for more information.
 
+## **HCL AppScan**
+
+The HCL AppScan connector uses the AppScan v4 REST API to import issues from **AppScan on Cloud (ASoC)** or a self-hosted **AppScan 360°** (both share the API). It syncs the whole account: DefectDojo discovers every application and creates a Record for each, then imports that application's issues (DAST, SAST and IAST) as findings.
+
+#### Prerequisites
+
+You will need an AppScan **API key** — a Key ID and Key Secret generated under your AppScan account settings (API Key). The connector exchanges them for a short-lived session token on each run; the Key ID, Key Secret and token are never logged.
+
+#### Connector Mappings
+
+1. Enter the AppScan console URL in the **Location** field: for ASoC use `https://cloud.appscan.com` (or `https://eu.cloud.appscan.com` for the EU region); for AppScan 360° use your instance host.
+2. Set **Provider** to `ASOC` for AppScan on Cloud, or `A360` for a self-hosted AppScan 360°.
+3. Enter the **API Key ID** and **API Key Secret**.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo maps each AppScan **application** to a Record (VEP) and each **issue** to a finding: the title is the issue type with its domain / entity / cause-id / URL / path appended; the severity maps Informational → Info (Low/Medium/High/Critical pass through); the CWE, a labeled description, the remediation and advisory, and the host/port endpoint are carried over. Issues from static analysis are recorded as static findings and dynamic/interactive issues as dynamic findings; open issues are active and fixed/passed issues are mitigated.
+
+See the [AppScan REST API documentation](https://help.hcl-software.com/appscan/ASoC/appseccloud_rest_apis.html) for more information.
+
 ## **Intigriti**
 
 The Intigriti connector uses the Intigriti company API to import submissions as findings. DefectDojo creates a Record for each **program**.


### PR DESCRIPTION
## What

Adds the **HCL AppScan** connector to the Pro connector tool reference. AppScan (AppScan on Cloud + self-hosted AppScan 360°, sharing the v4 REST API) is a DAST/SAST/IAST application-security platform; the connector syncs the whole account — application → Record, issue → finding.

Companion to:
- DefectDojo-Inc/connectors#749 (the Go connector)
- DefectDojo-Inc/dojo-pro#1990 (Pro-UI registration)

## Section covers

- Prerequisites: an AppScan API Key ID + Key Secret (exchanged for a short-lived session token; never logged).
- Connector mappings: **Location** (ASoC `https://cloud.appscan.com` / EU host, or the A360 instance host), **Provider** `ASOC`/`A360`, **API Key ID** + **API Key Secret**, optional **Minimum Severity**.
- Mapping model: application → Record; issue → finding (title suffix chain, severity Informational→Info, CWE, remediation/advisory, host:port endpoint, static/dynamic by scan technology, open→active / fixed→mitigated).

Live validation needs an ASoC trial tenant or an AppScan 360° instance; details in connectors#749 (outstanding follow-up).

Base: `bugfix`.
