### PR TITLE
fix: restore IPv6 dual-stack support for nginx and uWSGI probes

### DIFF
--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -34,6 +34,10 @@ if [ -n "${DD_UWSGI_MAX_FD}" ]; then
     DD_UWSGI_EXTRA_ARGS="${DD_UWSGI_EXTRA_ARGS} --max-fd ${DD_UWSGI_MAX_FD}"
 fi
 
+# HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.
+# Override with DD_UWSGI_HTTP (e.g. "[::]:8081") for IPv6-only / dual-stack clusters.
+DD_UWSGI_HTTP="${DD_UWSGI_HTTP:-0.0.0.0:8081}"
+
 exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
@@ -42,7 +46,6 @@ exec uwsgi \
   --threads "${DD_UWSGI_NUM_OF_THREADS:-4}" \
   --wsgi dojo.wsgi:application \
   --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
-  --http 0.0.0.0:8081 --http-to "${DD_UWSGI_ENDPOINT}" \
+  --http "${DD_UWSGI_HTTP}" --http-to "${DD_UWSGI_ENDPOINT}" \
   --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}" \
   $DD_UWSGI_EXTRA_ARGS
-  # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.

--- a/docs/content/get_started/open_source/running-in-production.md
+++ b/docs/content/get_started/open_source/running-in-production.md
@@ -63,6 +63,9 @@ Based on your resource settings, you can tweak:
     (default 4)
 -   `DD_UWSGI_NUM_OF_THREADS` for the number of threads in these
     processes. (default 4)
+-   `DD_UWSGI_HTTP` for the HTTP bind address used by Kubernetes
+    liveness probes. (default `0.0.0.0:8081`; use `[::]:8081` on
+    IPv6-only / dual-stack clusters)
 
 For example, you may have 4 processes with 6 threads each, yielding 24
 concurrent connections.

--- a/helm/defectdojo/README.md
+++ b/helm/defectdojo/README.md
@@ -649,6 +649,7 @@ A Helm chart for Kubernetes to install DefectDojo
 | django.strategy | object | `{}` |  |
 | django.terminationGracePeriodSeconds | int | `60` |  |
 | django.tolerations | list | `[]` |  |
+| django.uwsgi.appSettings.http | string | `"0.0.0.0:8081"` | uWSGI HTTP bind for Kubernetes liveness probes (DD_UWSGI_HTTP). Use "[::]:8081" on IPv6-only / dual-stack clusters so kubelet can reach the probe listener. |
 | django.uwsgi.appSettings.maxFd | int | `0` | Use this value to set the maximum number of file descriptors. If set to 0 will be detected by uwsgi e.g. 102400 |
 | django.uwsgi.appSettings.processes | int | `4` |  |
 | django.uwsgi.appSettings.threads | int | `4` |  |

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -48,6 +48,7 @@ data:
   DD_UWSGI_ENDPOINT: /run/defectdojo/uwsgi.sock
   DD_UWSGI_HOST: localhost
   DD_UWSGI_PASS: unix:///run/defectdojo/uwsgi.sock
+  DD_UWSGI_HTTP: '{{ .Values.django.uwsgi.appSettings.http | default "0.0.0.0:8081" }}'
   DD_UWSGI_NUM_OF_PROCESSES: '{{ .Values.django.uwsgi.appSettings.processes | default 4 }}'
   DD_UWSGI_NUM_OF_THREADS: '{{ .Values.django.uwsgi.appSettings.threads | default 4 }}'
   {{- if  .Values.django.uwsgi.appSettings.maxFd }}

--- a/helm/defectdojo/values.schema.json
+++ b/helm/defectdojo/values.schema.json
@@ -711,6 +711,10 @@
                         "appSettings": {
                             "type": "object",
                             "properties": {
+                                "http": {
+                                    "description": "uWSGI HTTP bind for Kubernetes liveness probes (DD_UWSGI_HTTP). Use \"[::]:8081\" on IPv6-only / dual-stack clusters so kubelet can reach the probe listener.",
+                                    "type": "string"
+                                },
                                 "maxFd": {
                                     "description": "Use this value to set the maximum number of file descriptors. If set to 0 will be detected by uwsgi e.g. 102400",
                                     "type": "integer"

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -469,6 +469,9 @@ django:
     appSettings:
       processes: 4
       threads: 4
+      # -- uWSGI HTTP bind for Kubernetes liveness probes (DD_UWSGI_HTTP).
+      # Use "[::]:8081" on IPv6-only / dual-stack clusters so kubelet can reach the probe listener.
+      http: "0.0.0.0:8081"
       # -- Use this value to set the maximum number of file descriptors. If set to 0 will be detected by uwsgi
       # e.g. 102400
       maxFd: 0

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,11 +20,13 @@ http {
   # Disable metrics auth for localhost (for nginx prometheus exporter)
   geo $metrics_auth_bypass {
     127.0.0.1/32 "off";
+    ::1/128 "off";
     default "Metrics";
   }
   server {
     server_tokens off;
     listen 8080;
+    listen [::]:8080;
 
     gzip on;
     gzip_types      application/atom+xml  application/geo+json  application/javascript  application/x-javascript  application/json  application/ld+json  application/manifest+json  application/rdf+xml  application/rss+xml  application/xhtml+xml  application/xml  font/eot  font/otf  font/ttf  image/svg+xml  text/css  text/javascript text/plain  text/xml;

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -20,6 +20,7 @@ http {
   }
   server {
       listen 8080;
+      listen [::]:8080;
       location / {
           return 301 https://$host:8443$request_uri;
       }
@@ -27,11 +28,13 @@ http {
   # Disable metrics auth for localhost (for nginx prometheus exporter)
   geo $metrics_auth_bypass {
     127.0.0.1/32 "off";
+    ::1/128 "off";
     default "Metrics";
   }
   server {
     server_tokens off;
     listen 8443 ssl;
+    listen [::]:8443 ssl;
     server_name your.servername.com;
     ssl_certificate /etc/nginx/ssl/nginx.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx.key;


### PR DESCRIPTION
## Summary
- Restore nginx dual-stack `listen [::]:...` directives (and `::1/128` metrics bypass) that were added in #12710, reverted in #12916, and never put back (entrypoint already strips IPv6 listens on IPv4-only hosts).
- Make the uWSGI Kubernetes probe HTTP bind configurable via `DD_UWSGI_HTTP` (default remains `0.0.0.0:8081`).
- Expose it in the Helm chart as `django.uwsgi.appSettings.http` so IPv6-only / dual-stack clusters can set `[::]:8081` without rebuilding images.

Related: #12695, #12710, #12916, #12938.

### Helm usage (IPv6-only)
```yaml
django:
  uwsgi:
    appSettings:
      http: "[::]:8081"
```

## Test plan
- [x] `helm template` renders `DD_UWSGI_HTTP: '0.0.0.0:8081'` by default
- [x] `helm template --set django.uwsgi.appSettings.http=[::]:8081` renders `DD_UWSGI_HTTP: '[::]:8081'`
- [x] `nginx -t` succeeds for dual-stack `nginx.conf` / `nginx_TLS.conf`
- [x] `nginx -t` still succeeds after entrypoint IPv4-only strip of `listen [::]:`
- [x] Live nginx listens on both IPv4 and IPv6 `:8080`; `/nginx_health` returns 200 on `127.0.0.1` and `[::1]`
- [x] uWSGI `--http 0.0.0.0:8081` and `--http [::]:8081` both answer probes
- [ ] Reviewers: deploy Helm chart on an IPv6-only cluster with `django.uwsgi.appSettings.http: "[::]:8081"` and confirm uwsgi/nginx probes pass.