### PR TITLE
docs(connectors): Fortify connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -548,6 +548,29 @@ DefectDojo maps each active **cluster** to a Record and each Security **action i
 
 See the [Fairwinds Insights API documentation](https://insights.docs.fairwinds.com/technical-details/api/) for more information.
 
+## **Fortify**
+
+The Fortify connector imports SAST/DAST results from Fortify (OpenText/Micro Focus), covering both editions that share the platform: **SSC** (Software Security Center, self-hosted) and **Fortify on Demand (FoD)** (SaaS). It syncs the whole account: DefectDojo discovers every application (SSC project version / FoD release) and creates a Record for each, then imports that application's issues as findings.
+
+#### Prerequisites
+
+- **SSC**: a **FortifyToken** — create one in the SSC UI under **Administration → Token Management** (a CIToken/UnifiedLoginToken).
+- **FoD**: an **OAuth2 API key** — a Client ID and Client Secret from **Settings → API** (with the `api-tenant` scope).
+
+The token and OAuth secret are never logged.
+
+#### Connector Mappings
+
+1. Enter the Fortify base URL in the **Location** field: for SSC your server host (the connector adds `/ssc/api/v1`); for FoD the API host for your region, e.g. `https://api.ams.fortify.com`.
+2. Set **Edition** to `SSC` or `FoD`.
+3. For **FoD**, enter the OAuth **Client ID**; leave it blank for SSC.
+4. In **Token / Client Secret**, enter the SSC FortifyToken or the FoD OAuth client secret.
+5. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo maps each Fortify **application** to a Record and each **issue** to a finding: the severity comes from Fortify's own **friority** rating (Critical/High/Medium/Low), the title combines the issue category with its file and line, and the file path, line, kingdom, analyzer and engine type are carried over. Issues from static-analysis engines (SCA) are recorded as static findings and WebInspect (DAST) issues as dynamic findings; suppressed, removed and hidden issues are skipped, issues audited "Not an Issue" are marked false positive, and "Exploitable"/reviewed issues are marked verified.
+
+See the [Fortify SSC](https://www.microfocus.com/documentation/fortify-software-security-center/) and [Fortify on Demand](https://api.ams.fortify.com/swagger/ui) API documentation for more information.
+
 ## **GitGuardian**
 
 The GitGuardian connector uses the GitGuardian REST API to import **secret incidents** — exposed credentials GitGuardian has detected across your monitored sources. DefectDojo creates a Record for each monitored source (repository or perimeter) that currently has open incidents, and imports each open incident as a finding.


### PR DESCRIPTION
## What

Adds the **Fortify** connector to the Pro connector tool reference. Fortify (OpenText/Micro Focus) is an enterprise SAST/DAST platform; the connector imports issues from both editions — **SSC** (self-hosted) and **Fortify on Demand** (SaaS) — mapping each application (project version / release) to a product and each issue to a finding.

Companion to:
- DefectDojo-Inc/connectors#751 (the Go connector)
- DefectDojo-Inc/dojo-pro#1996 (Pro-UI registration)

## Section covers

- Prerequisites: an SSC FortifyToken, or an FoD OAuth Client ID + Secret.
- Connector mappings: **Location** (SSC host / FoD region host), **Edition** `SSC`/`FoD`, **FoD Client ID**, **Token / Client Secret**, optional **Minimum Severity**.
- Mapping model: application → Record; issue → finding — **severity from Fortify's friority**, title (category + file:line), file/line, kingdom/analyzer/engine, static vs dynamic by engine, suppressed/removed/hidden skipped, "Not an Issue" → false positive, "Exploitable"/reviewed → verified.

Live validation needs an SSC or FoD instance (NFR/eval, no free tier); details in connectors#751 (outstanding follow-up).

Base: `bugfix`.
