### PR TITLE
fix(ui): style OS promo banner dismiss button in classic UI

### DIFF
--- a/dojo/static/dojo/css/classic/dojo.css
+++ b/dojo/static/dojo/css/classic/dojo.css
@@ -1161,6 +1161,51 @@ div.custom-search-form {
     margin-top: 8px;
 }
 
+/* OS message banner dismiss (×): inline, grouped with the headline/caret
+   (not floated into the empty right side). Scoped so it only affects the
+   OS promo banner, which is the only banner carrying these classes. */
+/* Lay out the OS promo banner as a single centered row so the dismiss button,
+   headline, and expand caret line up vertically. Scoped to data-source="os"
+   so the other banners are untouched. */
+.announcement-banner[data-source="os"] {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.announcement-banner[data-source="os"] .banner-expanded {
+    flex-basis: 100%;  /* expanded text drops to its own row */
+}
+
+.announcement-banner .os-message-dismiss-form {
+    display: inline-flex;
+    margin-right: 10px;
+}
+
+.announcement-banner .os-message-dismiss {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    background: transparent;
+    border: 1px solid rgba(0, 0, 0, 0.3);
+    border-radius: 3px;
+    color: inherit;
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 1;
+    opacity: 0.7;
+}
+
+.announcement-banner .os-message-dismiss:hover,
+.announcement-banner .os-message-dismiss:focus {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.06);
+    outline: none;
+}
+
 @media (min-width: 795px) {
     div.custom-search-form {
         height: 21px;


### PR DESCRIPTION
[sc-13889]

## Summary

The open-source "Go Pro" promo banner (`data-source="os"`) is rendered from **identical markup** in both base templates (`templates_classic/base.html` and `templates/base.html`), but the two stylesheets were out of sync: `dojo/static/dojo/css/dojo.css` (Tailwind UI) had a dedicated OS-banner block while `dojo/static/dojo/css/classic/dojo.css` (classic Bootstrap UI) did not.

Without those rules the classic UI's dismiss control fell back to a bulky default browser button and the banner row layout was inconsistent, degrading the look of the promo banner (reported from the Community demo via an internal Slack thread).

This PR ports the same OS-banner block into the classic stylesheet so both UIs render the banner identically.

## Changes

- Add to `classic/dojo.css` (byte-identical to the block already in `dojo.css`):
  - `.announcement-banner[data-source="os"]` — flex row so dismiss ×, headline, and expand caret align
  - `.announcement-banner[data-source="os"] .banner-expanded` — expanded text drops to its own row
  - `.os-message-dismiss-form` / `.os-message-dismiss` (+ `:hover`/`:focus`) — compact 18×18 bordered × button

CSS-only; no markup or behavior changes. The collapse-by-default behavior is unchanged.

## Testing

Verified live against the running dev server:
- Classic UI (`/product`): banner renders correctly collapsed and expanded, with the styled dismiss button.
- Confirmed the OS-banner rules are now identical between `classic/dojo.css` and `dojo.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
