### PR TITLE
docs(connectors): document Bugcrowd, ServiceNow CMDB, and Linear

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -26,7 +26,7 @@ Most Connectors import **findings** from a security tool. **Asset Connectors** w
 * **Discover** and **Sync** both reconcile the asset list. New assets appear as `NEW` Records; once mapped (automatically, if auto-mapping is enabled), DefectDojo creates the Product and groups it under a Product Type derived from the tool — for example, the GitLab namespace or the Azure DevOps project.
 * If an asset is later removed upstream (for example, a repository is deleted), its mapped Record is flagged `MISSING` on the next Sync so your team can triage it. DefectDojo never silently deletes a Product.
 
-Azure DevOps, Bitbucket, GitHub, GitLab, and Jira Service Management Assets are Asset Connectors. All other Connectors listed below import findings.
+Azure DevOps, Bitbucket, GitHub, GitLab, Jira Service Management Assets, and ServiceNow CMDB are Asset Connectors. All other Connectors listed below import findings.
 
 # **Supported Connectors**
 
@@ -207,6 +207,22 @@ Only Bitbucket Cloud (bitbucket.org) is supported. Bitbucket Server reached end 
 4. Enter one or more workspace slugs (comma-separated) in the **Workspace Slugs** field. This field is required: Bitbucket's scoped API tokens cannot list workspaces automatically, so DefectDojo needs to be told which workspaces to read.
 
 Each repository becomes a Record named after the repository, grouped by its Bitbucket **project**.
+
+## **Bugcrowd**
+
+The Bugcrowd connector uses the Bugcrowd REST API to import submissions from your bug bounty and vulnerability disclosure programs. DefectDojo discovers the programs your API token can access and creates a Record for each one, importing that program's submissions as findings.
+
+#### Prerequisites
+
+You will need a Bugcrowd **API token** with access to the programs you want to import. We recommend creating a dedicated service account for DefectDojo so automated activity is easy to distinguish from manual team actions. Generate the token in Bugcrowd under **Organization settings \> API credentials**; read access to submissions, programs, and targets is sufficient.
+
+#### Connector Mappings
+
+1. Enter `https://api.bugcrowd.com` in the **Location** field.
+2. Enter your Bugcrowd API token in the **Secret** field. It is sent as an `Authorization: Token` header.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each Bugcrowd **program** becomes a Record, and its submissions are imported as findings with the Bugcrowd severity preserved. Duplicate submissions are excluded, so reimport does not create repeated findings for the same issue.
 
 ## **BurpSuite**
 
@@ -829,6 +845,21 @@ Enter `https://semgrep.dev/api/v1/` in the **Location** field.
 "Settings" in the left navbar \> Tokens \> Create new token ([https://semgrep.dev/orgs/\-/settings/tokens](https://semgrep.dev/orgs/-/settings/tokens))
 
 See [Semgrep documentation](https://semgrep.dev/docs/semgrep-cloud-platform/semgrep-api/#tag__badge-list) for more info.
+
+## **ServiceNow CMDB**
+
+The ServiceNow CMDB connector is an **Asset Connector**: instead of importing findings, it reads Configuration Items (CIs) from your ServiceNow Configuration Management Database and creates a DefectDojo Asset for each CI, grouped into Organizations by CI class. No findings are imported.
+
+#### Prerequisites
+
+You will need a ServiceNow instance and an account that can read the CMDB tables over the ServiceNow Table API. We recommend a dedicated, read-only service account for DefectDojo. The account needs read access to the `cmdb_ci` tables you want to import.
+
+#### Connector Mappings
+
+1. Enter your ServiceNow instance URL in the **Location** field: `https://{your-instance}.service-now.com`.
+2. Select or create a ServiceNow **Tool Configuration** holding the instance credentials (the ServiceNow username and password).
+
+Each Configuration Item becomes a Record named after the CI, grouped by its **CI class** (for example, application, server, or business service). Discovery and Sync reconcile the CI list: new CIs appear as `NEW` Records, and a CI removed from the CMDB is flagged `MISSING` on the next Sync so your team can triage it. DefectDojo never silently deletes a Product.
 
 ## **Shodan**
 

--- a/docs/content/issue_tracking/pro_integration/integrations.md
+++ b/docs/content/issue_tracking/pro_integration/integrations.md
@@ -18,6 +18,7 @@ Supported Integrations:
 - GitHub
 - GitLab Boards
 - Jira
+- Linear
 - PagerDuty
 - ServiceDesk Plus
 - ServiceNow
@@ -96,6 +97,7 @@ For the complete list of requirements, please open the vendor specific pages bel
 - [GitHub](/issue_tracking/pro_integration/integrations_toolreference/#github)
 - [GitLab Boards](/issue_tracking/pro_integration/integrations_toolreference/#gitlab)
 - [Jira](/issue_tracking/pro_integration/integrations_toolreference/#jira)
+- [Linear](/issue_tracking/pro_integration/integrations_toolreference/#linear)
 - [PagerDuty](/issue_tracking/pro_integration/integrations_toolreference/#pagerduty)
 - [ServiceDesk Plus](/issue_tracking/pro_integration/integrations_toolreference/#servicedesk-plus)
 - [ServiceNow](/issue_tracking/pro_integration/integrations_toolreference/#servicenow)

--- a/docs/content/issue_tracking/pro_integration/integrations_toolreference.md
+++ b/docs/content/issue_tracking/pro_integration/integrations_toolreference.md
@@ -286,6 +286,49 @@ By default Jira issues use DefectDojo's built-in title and body. To customize th
 - **Token lifecycle (OAuth):** DefectDojo owns the whole flow — it performs the authorization-code exchange, stores the access and refresh tokens, and refreshes on demand before a push, persisting the new refresh token each time (Atlassian rotates it on every refresh).
 - **Credential storage:** all connection credentials (passwords, tokens, client secrets, OAuth tokens) are encrypted at rest and are never returned through the API — editing a connection shows a "leave blank to keep" placeholder for stored secrets.
 
+## Linear
+
+The Linear integration allows you to push DefectDojo Findings as [Linear](https://linear.app/) Issues. Issues are created in a Team in your Linear workspace.
+
+### Instance Setup
+
+- **Label** should be the label that you want to use to identify this integration.
+- **Location** should be set to `https://api.linear.app/graphql`.
+- **API Key** should be set to a Linear personal API key. Keys can be generated in Linear under Settings, then Security & access, then [API](https://linear.app/settings/account/security). The key is sent to Linear's GraphQL API in the `Authorization` header.
+
+### Issue Tracker Mapping
+
+- **Team (Group) ID** should be set to the ID of the Linear Team that Issues will be created for. You can list your Teams and their IDs by calling the Linear GraphQL API:
+
+```
+curl -H "Authorization: {{API_KEY}}" -H "Content-Type: application/json" \
+  -d '{"query":"{ teams { nodes { id name key } } }"}' https://api.linear.app/graphql
+```
+
+### Severity Mapping Details
+
+A Linear Issue carries a numeric **priority** rather than a severity field. Each DefectDojo severity maps to a Linear priority, where `1` is Urgent and `4` is Low:
+
+- **Severity Field Name**: `Priority`
+- **Info Mapping**: `4`
+- **Low Mapping**: `4`
+- **Medium Mapping**: `3`
+- **High Mapping**: `2`
+- **Critical Mapping**: `1`
+
+### Status Mapping Details
+
+Each status value must be set to the ID of a Workflow State in your Linear Team. Workflow State IDs are unique to each workspace, so there are no default values. You can list the Workflow States and their IDs by calling the Linear GraphQL API:
+
+```
+curl -H "Authorization: {{API_KEY}}" -H "Content-Type: application/json" \
+  -d '{"query":"{ workflowStates { nodes { id name type team { key } } } }"}' https://api.linear.app/graphql
+```
+
+- **Status Field Name**: `Workflow State ID`
+- **Active Mapping**: the ID of a started or unstarted state, for example `Todo` or `In Progress`.
+- **Closed Mapping**: the ID of a completed state, for example `Done`. When a Finding is deleted in DefectDojo, its Issue is moved to this state.
+
 ## PagerDuty
 
 The PagerDuty Integration allows you to push DefectDojo Findings and Finding Groups as PagerDuty Incidents, opened on a PagerDuty Service of your choice.


### PR DESCRIPTION
## What

Documentation for three connectors/integrations that are **live in the production Pro catalog** but had no published reference docs:

- **Bugcrowd** — finding connector (`connectors_tool_reference.md`)
- **ServiceNow CMDB** — asset connector (`connectors_tool_reference.md`, added to the asset-connector list)
- **Linear** — downstream integrator (`integrations_toolreference.md` + both index lists in `integrations.md`)

These surfaced from a diff of the live connector catalog against the deployed docs: the connectors exist in production but nothing documented them and no PR was open for them.

## Sourcing / notes for reviewer

- **Bugcrowd** is derived from the in-repo API client (`dojo/tools/api_bugcrowd/`): base URL `https://api.bugcrowd.com`, `Authorization: Token` header, submissions filtered per program with duplicates excluded. Should be accurate.
- **ServiceNow CMDB** and **Linear** are Pro/closed-source and not present in this OSS repo, so their field details were taken from the live Pro "Add Configuration" / "New Integration" forms plus each vendor's public API. **Please verify the specifics before merge**, in particular:
  - ServiceNow CMDB: exact credential mechanism (Tool Configuration vs. inline) and how CI class maps to Organization.
  - Linear: the Issue Tracker Mapping fields (Team ID, priority mapping, workflow-state status mapping) are modeled on the Shortcut integrator and inferred from Linear's GraphQL API; confirm they match the actual mapping form.

## Milestone
3.1.300
