### PR TITLE
docs(connectors): Deepfence ThreatMapper connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -338,6 +338,25 @@ A Falcon **API client** (Client ID and secret), created in the Falcon console un
 
 Each Falcon host becomes a Record, named for its hostname, OS, and type. Only **open** and **reopened** Spotlight vulnerabilities are imported, so reimport closes remediated findings.
 
+## **Deepfence ThreatMapper**
+
+The Deepfence ThreatMapper connector uses the [ThreatMapper](https://github.com/deepfence/ThreatMapper) management-console REST API to import **vulnerability scan** results. DefectDojo discovers every node ThreatMapper has scanned — a container image, host, or container — and creates a Record for each, then imports that node's most recent completed scan as findings.
+
+#### Prerequisites
+
+You will need a ThreatMapper **API token**, found in the console under **Settings → User Management** (your user's API key). The connector exchanges it for a short-lived access token on each sync; the API token is never logged.
+
+#### Connector Mappings
+
+1. Enter your ThreatMapper console URL in the **Location** field (for example `https://threatmapper.example.com`).
+2. In the **Secret** field, enter the ThreatMapper API token.
+3. If your console uses a self-signed certificate, set **Skip TLS Verification** to `true`.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo maps each scanned **node** to a Record and each **CVE** in its latest completed vulnerability scan to a finding. The severity comes from ThreatMapper's own rating, and the affected package, CVSS score, fix version (as mitigation), reference links, and a details block are carried over. Findings are recorded as dynamic findings and de-duplicated on the node, CVE, package and package path.
+
+See the [ThreatMapper documentation](https://community.deepfence.io/threatmapper/docs/v2.5/) for more information.
+
 ## Dependency\-Track
 
 This connector fetches data from a on\-premise Dependency\-Track instance, via REST API.


### PR DESCRIPTION
## What

Adds a **Deepfence ThreatMapper** section to the Pro connectors tool reference, documenting the new connector.

Companion to:
- Connector: [DefectDojo-Inc/connectors#755](https://github.com/DefectDojo-Inc/connectors/pull/755)
- Pro UI registration: [DefectDojo-Inc/dojo-pro#2005](https://github.com/DefectDojo-Inc/dojo-pro/pull/2005)

Story: sc-13884

## Content

Prerequisites (the ThreatMapper console API token), the Location/Secret/Skip-TLS/Minimum-Severity connector mappings, and the whole-console model: each scanned node (container image / host / container) → a Record, and each CVE in its latest completed vulnerability scan → a finding (dynamic finding, severity from ThreatMapper, package/CVSS/fix/references carried over, deduped on node + CVE + package + path).

Placed alphabetically between *CrowdStrike Falcon* and *Dependency-Track*.

Draft until the connector lands.