### PR TITLE
docs(connectors): NeuVector connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -697,6 +697,25 @@ Unlike the device\-based Microsoft Defender connector, no API permissions or adm
 
 Each enabled Azure subscription becomes a Record. Findings are read through Azure Resource Graph, so they surface promptly once Defender for Cloud has scanned your resources — but the scans themselves run on Microsoft's schedule: container\-registry images are usually scanned within an hour of being pushed, while a VM's first agentless vulnerability scan can take several hours. A newly enabled subscription will legitimately Sync zero findings until its resources have been scanned.
 
+## **NeuVector**
+
+The NeuVector connector uses the [NeuVector](https://github.com/neuvector/neuvector) controller REST API to import container **image vulnerability scans**. DefectDojo discovers every image NeuVector has scanned and creates a Record for each, then imports that image's scan report as findings.
+
+#### Prerequisites
+
+You will need a NeuVector **username and password** for a controller account with permission to read scan results. The connector logs in with these credentials to obtain a session token; the password and token are never logged.
+
+#### Connector Mappings
+
+1. Enter your NeuVector controller URL in the **Location** field, including the REST API port — for example `https://neuvector.example.com:10443`.
+2. Enter the controller **Username** and **Password**.
+3. If your controller uses a self-signed certificate, set **Skip TLS Verification** to `true`.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo maps each scanned **image** to a Record and each **CVE** in its scan report to a finding. The severity comes from NeuVector's own rating, and the affected package and version, CVSSv3 score and vector, fix version (as mitigation) and reference link are carried over. Findings are de-duplicated on the image, CVE, package, version and severity.
+
+See the [NeuVector API documentation](https://open-docs.neuvector.com/automation/automation) for more information.
+
 ## **Nuclei (ProjectDiscovery Cloud)**
 
 The Nuclei connector uses the ProjectDiscovery Cloud Platform (PDCP) REST API to pull [nuclei](https://github.com/projectdiscovery/nuclei) scan results from your PDCP account. DefectDojo discovers every scan in the account and creates a separate Record for each **scan**.


### PR DESCRIPTION
## What

Adds a **NeuVector** section to the Pro connectors tool reference, documenting the new connector.

Companion to:
- Connector: [DefectDojo-Inc/connectors#757](https://github.com/DefectDojo-Inc/connectors/pull/757)
- Pro UI registration: [DefectDojo-Inc/dojo-pro#2007](https://github.com/DefectDojo-Inc/dojo-pro/pull/2007)

Story: sc-13905

## Content

Prerequisites (a controller username/password), the Location/Username/Password/Skip-TLS/Minimum-Severity connector mappings, and the whole-controller model: each scanned image → a Record, and each CVE in its scan report → a finding (severity from NeuVector, package/version, CVSSv3 score + vector, fix as mitigation, deduped on image + CVE + package + version + severity).

Placed alphabetically between *Microsoft Defender for Cloud* and *Nuclei*.

Draft until the connector lands.