### PR TITLE
docs(connectors): Lacework / FortiCNAPP connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -879,6 +879,24 @@ You will need a Mend (service) user with a **User Key** (a personal access token
 4. Enter the Mend **User Key** in the **User Key** field.
 5. Optionally, set a **Minimum Severity** to limit which findings are imported.
 
+## **Lacework / FortiCNAPP**
+
+The Lacework / FortiCNAPP connector uses the Lacework v2 API to import **host and container vulnerabilities** for your whole Lacework account.
+
+#### Prerequisites
+
+You will need a Lacework **API key** — an API key id and secret, created in the Lacework console under **Settings → API keys**. The connector exchanges these for a short-lived access token on each sync; the key id, secret and token are never logged.
+
+#### Connector Mappings
+
+1. Enter your Lacework account URL in the **Location** field — for example `https://YOUR-ACCOUNT.lacework.net` (a bare account name is also accepted).
+2. Enter the **API Key ID** and **API Secret**.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo maps the Lacework **account** to a Record (the whole-account scope). Each **container** and **host** vulnerability becomes a finding: the severity comes from Lacework's own rating, the affected package and version become the component, the fix version becomes the mitigation, and the affected image/host is recorded as tags. Container vulnerabilities are recorded as static findings (image scans) and host vulnerabilities as dynamic findings (running-host scans).
+
+See the [Lacework API documentation](https://docs.lacework.net/api/v2/docs) for more information.
+
 ## **Microsoft Defender**
 
 The Microsoft Defender connector imports device vulnerability findings from **Microsoft Defender Vulnerability Management (MDVM)** — one finding per device / software version / CVE combination, including severity, CVSS score, exploitability level and recommended security updates. DefectDojo will discover your Defender **device groups** and create a Record for each one; devices that aren't assigned to any device group are collected under a synthetic **Unassigned** group.


### PR DESCRIPTION
Adds a **Lacework / FortiCNAPP** section to the Pro connectors tool reference.

Companion to [connectors#758](https://github.com/DefectDojo-Inc/connectors/pull/758) + [dojo-pro#2008](https://github.com/DefectDojo-Inc/dojo-pro/pull/2008). Story sc-13906.

Prerequisites (API key id + secret), the Location/Key-ID/Secret/Minimum-Severity mappings, and the whole-account model: the Lacework account → a Record, host + container vulnerabilities → findings (static container / dynamic host; severity, package, fix, image/host tags). Placed alphabetically between *Jira Service Management Assets* and *Microsoft Defender*. Draft until the connector lands.