### PR TITLE
docs(connectors): Socket.dev connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -1196,6 +1196,24 @@ The Snyk connector uses the Snyk REST API to fetch data.
 
 See the [Snyk API documentation](https://docs.snyk.io/snyk-api) for more info.
 
+## **Socket**
+
+The Socket connector uses the [Socket.dev](https://socket.dev) API to import **software supply-chain findings** — Socket's alerts on your dependencies (malware, typosquats, install scripts, known vulnerabilities and 70+ other categories). DefectDojo discovers every repository across the organizations your token can access and creates a Record for each, then imports the alerts from that repository's latest full scan.
+
+#### Prerequisites
+
+You will need a Socket **API token** — an organization token created in the Socket dashboard under **Settings → API Tokens** (with the `repo:list` and full-scan read scopes). The token is sent as a bearer token and is never logged.
+
+#### Connector Mappings
+
+1. Leave the **Location** field blank to use `https://api.socket.dev/v0`, or enter it explicitly.
+2. Enter the Socket API token in the **Secret** field.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo maps each **repository** to a Record and imports the alerts from its most recent full scan. Each alert becomes a finding: the severity comes from Socket's own rating (low, medium, high, critical), the affected package becomes the component and a PURL, the alert category (supply-chain risk, quality, maintenance, vulnerability, license) is recorded as tags, and the alert details are carried into the description. Findings are recorded as static findings and de-duplicated on Socket's alert key.
+
+See the [Socket API documentation](https://docs.socket.dev/reference) for more information.
+
 ## **Sonatype IQ**
 
 The Sonatype IQ connector uses the Sonatype IQ Server (Nexus Lifecycle) REST API to import open\-source component vulnerabilities. It enumerates every application in your IQ organization and, for each one, imports the component vulnerabilities from that application's latest report at the lifecycle stage you configure. DefectDojo creates a Record for each application automatically — there is no per\-application configuration.


### PR DESCRIPTION
Adds a **Socket** section to the Pro connectors tool reference. Companion to [connectors#759](https://github.com/DefectDojo-Inc/connectors/pull/759) + [dojo-pro#2009](https://github.com/DefectDojo-Inc/dojo-pro/pull/2009). Story sc-13907.

Prerequisites (org API token), the Location/Secret/Minimum-Severity mappings, and the whole-account model: each repository → a Record, each full-scan alert → a finding (severity, package + PURL, category tags, static, dedupe on alert key). Placed alphabetically between *Snyk* and *Tenable*. Draft until the connector lands.