### PR TITLE
docs(connectors): Bright Security connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -271,6 +271,24 @@ You will need a Bugcrowd **API token** with access to the programs you want to i
 
 Each Bugcrowd **program** becomes a Record, and its submissions are imported as findings with the Bugcrowd severity preserved. Duplicate submissions are excluded, so reimport does not create repeated findings for the same issue.
 
+## **Bright Security**
+
+The Bright Security connector uses the [Bright](https://brightsec.com) (formerly NeuraLegion) API to import **DAST findings**. DefectDojo discovers every scan the token can access and creates a Record for each completed scan, then imports that scan's issues as findings.
+
+#### Prerequisites
+
+You will need a Bright **API key**, created in the Bright app under **User settings → API keys** (an `Org` or personal key). The key is sent in the `Authorization: Api-Key` header and is never logged.
+
+#### Connector Mappings
+
+1. Leave the **Location** field blank to use `https://app.brightsec.com`, or enter your Bright host explicitly.
+2. Enter the Bright API key in the **Secret** field.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo maps each completed **scan** to a Record and each **issue** to a finding: the severity comes from Bright's own rating (Critical/High/Medium/Low), the CVSS score, CWE and remediation are carried over, the affected entry point becomes the endpoint, and the request/response evidence is included in the description. Findings are recorded as dynamic findings and de-duplicated on Bright's issue id.
+
+See the [Bright API documentation](https://docs.brightsec.com/) for more information.
+
 ## **BurpSuite**
 
 DefectDojo’s Burp connector calls Burp’s GraphQL API to fetch data. 


### PR DESCRIPTION
Adds a **Bright Security** section to the Pro connectors tool reference. Companion to [connectors#760](https://github.com/DefectDojo-Inc/connectors/pull/760) + [dojo-pro#2010](https://github.com/DefectDojo-Inc/dojo-pro/pull/2010). Story sc-13908.

Prerequisites (API key), the Location/Secret/Minimum-Severity mappings, and the whole-account model: each completed scan → a Record, each issue → a finding (severity/CVSS/CWE/remediation/endpoint/request-response, dynamic, dedupe on issue id). Placed alphabetically between *Bitbucket* and *BurpSuite*. Draft until the connector lands.