### PR TITLE
docs(connectors): Fairwinds Insights connector reference

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -452,6 +452,25 @@ You will need an Edgescan API token. Create one from your Edgescan account under
 
 Each Edgescan asset becomes a Record, and each open vulnerability on that asset is imported as a finding. Severity is mapped from Edgescan's numeric scale (1–5) to DefectDojo's Info–Critical, and CVE references, the CWE, and a CVSS v3 vector are included where Edgescan provides them.
 
+## **Fairwinds Insights**
+
+The Fairwinds Insights connector uses the [Fairwinds Insights](https://insights.fairwinds.com) REST API to import **Kubernetes security findings** across your whole organization. DefectDojo enumerates every active **cluster** and creates a Record for each one, then imports that cluster's Security **action items** \(from Polaris, Trivy, Kube\-bench, OPA and the other Insights reports\) as findings — there is no per\-cluster configuration.
+
+#### Prerequisites
+
+You will need a Fairwinds Insights **organization** name and an **API token**. Create the token in the Insights app under **Organization Settings \> Tokens**; a `read_only` token is sufficient. The token is org\-scoped and is sent as a bearer token; it is never logged.
+
+#### Connector Mappings
+
+1. Leave the **Location** field blank to use `https://insights.fairwinds.com`, or enter your Insights host explicitly.
+2. Enter your Insights **Organization** name (the slug shown in your dashboard URL).
+3. Enter the Insights API token in the **Secret** field.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+DefectDojo maps each active **cluster** to a Record and each Security **action item** to a finding: severity comes from Fairwinds' numeric score \(mapped to DefectDojo's Info–Critical\), the Fairwinds report that produced the item \(`polaris`, `trivy`, `kube-bench`, ...\) becomes a tool tag, the affected Kubernetes resource and container image are included, and any CVE identifiers are extracted. Findings are recorded as static findings and de\-duplicated on the Fairwinds action\-item id.
+
+See the [Fairwinds Insights API documentation](https://insights.docs.fairwinds.com/technical-details/api/) for more information.
+
 ## **GitGuardian**
 
 The GitGuardian connector uses the GitGuardian REST API to import **secret incidents** — exposed credentials GitGuardian has detected across your monitored sources. DefectDojo creates a Record for each monitored source (repository or perimeter) that currently has open incidents, and imports each open incident as a finding.


### PR DESCRIPTION
## Fairwinds Insights connector reference

Adds the connector reference entry for the new **Fairwinds Insights** connector
(DefectDojo-Inc/connectors#764, dojo-pro#2018). Fairwinds Insights is a
Kubernetes governance/security platform.

Documents:
- The **organization** + **API token** prerequisite (org-scoped bearer token,
  `read_only` is sufficient; never logged).
- The **Location** (defaults to `https://insights.fairwinds.com`),
  **Organization**, **Secret**, and optional **Minimum Severity** field mappings.
- The whole-account model: every active **cluster** → a Record; each Security
  **action item** → a finding (numeric severity → Info–Critical, reportType
  tool tag, resource/image context, CVE extraction), recorded as a static
  finding and de-duplicated on the action-item id.

sc-13911

🤖 Generated with [Claude Code](https://claude.com/claude-code)
