### PR TITLE
deprecate: API-based pull parsers, Tool Type/Configuration, and dbbackup (3.2.0 → 3.5.0 EOL)

### DIFF
--- a/docs/content/en/open_source/upgrading/3.2.md
+++ b/docs/content/en/open_source/upgrading/3.2.md
@@ -4,4 +4,4 @@ toc_hide: true
 weight: -20260706
 description: Deprecations of the API-based (pull) parsers, Tool Type / Tool Configuration, and django-dbbackup (removal in 3.5.0); plus vulnerability-id type and multiple-CWE migrations.
 ---
-3.2.x deprecates the API-based (pull) parsers, the Tool Type / Tool Configuration feature, and the `django-dbbackup` integration (all scheduled for removal in 3.5.0), and adds the vulnerability-id type and multiple-CWE migrations. See the full [Upgrading to DefectDojo Version 3.2.x](../../../releases/os_upgrading/3.2/) notes and the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.2.0).
+3.2.x deprecates the API-based (pull) parsers, the Tool Type / Tool Configuration feature, and the `django-dbbackup` integration (all scheduled for removal in 3.5.0), and adds the vulnerability-id type and multiple-CWE migrations. See the full [Upgrading to DefectDojo Version 3.2.x](../../../../releases/os_upgrading/3.2/) notes and the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.2.0).

--- a/docs/content/en/open_source/upgrading/3.2.md
+++ b/docs/content/en/open_source/upgrading/3.2.md
@@ -2,6 +2,6 @@
 title: 'Upgrading to DefectDojo Version 3.2.x'
 toc_hide: true
 weight: -20260706
-description: No special instructions.
+description: Deprecations of the API-based (pull) parsers, Tool Type / Tool Configuration, and django-dbbackup (removal in 3.5.0); plus vulnerability-id type and multiple-CWE migrations.
 ---
-There are no special instructions for upgrading to 3.2.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.2.0) for the contents of the release.
+3.2.x deprecates the API-based (pull) parsers, the Tool Type / Tool Configuration feature, and the `django-dbbackup` integration (all scheduled for removal in 3.5.0), and adds the vulnerability-id type and multiple-CWE migrations. See the full [Upgrading to DefectDojo Version 3.2.x](../../../releases/os_upgrading/3.2/) notes and the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.2.0).

--- a/docs/content/releases/os_upgrading/3.2.md
+++ b/docs/content/releases/os_upgrading/3.2.md
@@ -2,7 +2,7 @@
 title: 'Upgrading to DefectDojo Version 3.2.x'
 toc_hide: true
 weight: -20260701
-description: Vulnerability ids gain an autodetected type and a uniqueness constraint; findings can now carry multiple CWEs via a new Finding_CWE relationship. Migrations add the type column, de-duplicate vulnerability-id rows, add the uniqueness constraint, create the CWE table, and backfill it. Existing hash codes are unaffected.
+description: Vulnerability ids gain an autodetected type and a uniqueness constraint; findings can now carry multiple CWEs via a new Finding_CWE relationship. Migrations add the type column, de-duplicate vulnerability-id rows, add the uniqueness constraint, create the CWE table, and backfill it. Existing hash codes are unaffected. This release also deprecates the API-based (pull) parsers, the Tool Type / Tool Configuration feature, and the django-dbbackup integration, all scheduled for removal in 3.5.0.
 ---
 
 ## Vulnerability id type
@@ -55,5 +55,65 @@ The `manage.py migrate_cwe` management command is **optional** and is *not* requ
 (it would repeat the work `0284` already did). It exists only as an idempotent re-scan you can run
 later — for example after a parser upgrade changes how a scan's CWEs are derived — to reconcile
 `Finding_CWE` rows from the current `Finding.cwe` values.
+
+## Deprecation: API-based (pull) parsers
+
+The following **API-based (pull) parsers** — which fetch findings directly from a vendor API using
+a **Tool Configuration** and a **Product API Scan Configuration**, rather than parsing an uploaded
+report file — are being deprecated and will be removed in **DefectDojo 3.5.0 (November 2026)**.
+These pull integrations are being consolidated into DefectDojo Pro's no-code
+[connectors](https://docs.defectdojo.com/import_data/pro/connectors/about_connectors/).
+
+- BlackDuck API
+- Bugcrowd API Import
+- Cobalt.io API Import
+- Edgescan Scan
+- SonarQube API Import
+- Vulners
+
+### What you need to do
+
+If you use any of these parsers to pull findings directly from a vendor API, plan to migrate to a
+DefectDojo Pro connector before 3.5.0. After 3.5.0, these parsers and their API-pull import path
+are removed, and imports that rely on a Tool Configuration will no longer function.
+
+## Deprecation: Tool Type and Tool Configuration
+
+The **Tool Type** and **Tool Configuration** features exist to configure the API-based pull
+parsers listed above. They are being deprecated and will be removed in **DefectDojo 3.5.0
+(November 2026)**, at the same time as the parsers they serve, so that no configuration tables
+remain that do nothing. (CI/CD engagement data entry no longer depends on Tool Configuration as of
+the CI/CD infrastructure split in this release.)
+
+The following UI pages and API endpoints are affected:
+
+- **UI:** Tool Type, Tool Configuration, and per-product API Scan Configuration pages
+- **API:** `/api/v2/tool_types/`, `/api/v2/tool_configurations/`, `/api/v2/product_api_scan_configurations/`
+
+### What you need to do
+
+If you manage Tool Types or Tool Configurations via the UI or API, migrate the corresponding
+integrations to DefectDojo Pro connectors before 3.5.0. From 3.2.0 onward these pages display a
+deprecation warning and the API endpoints return an `X-Deprecated` response header.
+
+## Deprecation: `manage.py dbbackup`
+
+The bundled [`django-dbbackup`](https://pypi.org/project/django-dbbackup/) integration (the
+`manage.py dbbackup` / `dbrestore` commands) is being deprecated and will be removed in
+**DefectDojo 3.5.0 (November 2026)**. It is minimally integrated, and its `pg_dump`-based backup
+fails when the PostgreSQL client and server versions differ (see
+[#15301](https://github.com/DefectDojo/django-DefectDojo/issues/15301)).
+
+### What you need to do
+
+For database backups, use your database's native tooling — for example `pg_dump`/`pg_restore`
+matched to your PostgreSQL server version, or your managed database provider's backup features.
+
+## Deprecation timeline
+
+- **3.2.x onwards:** the features above are deprecated. UI pages display a warning banner and
+  affected API endpoints return an `X-Deprecated` header.
+- **3.5.0 (November 2026):** the API-based pull parsers, Tool Type / Tool Configuration, and the
+  `django-dbbackup` integration are removed.
 
 For more information, check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.2.0).

--- a/dojo/asset/api/views.py
+++ b/dojo/asset/api/views.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
@@ -8,7 +10,7 @@ from rest_framework.response import Response
 import dojo.api_v2.mixins as dojo_mixins
 from dojo.api_v2 import prefetch
 from dojo.api_v2.serializers import ReportGenerateOptionSerializer, ReportGenerateSerializer
-from dojo.api_v2.views import PrefetchDojoModelViewSet, report_generate, schema_with_prefetch
+from dojo.api_v2.views import DeprecationNoticeMixin, PrefetchDojoModelViewSet, report_generate, schema_with_prefetch
 from dojo.asset.api import serializers
 from dojo.asset.api.filters import (
     ApiAssetFilter,
@@ -27,10 +29,14 @@ from dojo.utils import async_delete, get_setting
 
 
 # Authorization: object-based
+# Deprecated in 3.2.0, removal planned for 3.5.0 (serves the API-based pull parsers).
 @extend_schema_view(**schema_with_prefetch())
 class AssetAPIScanConfigurationViewSet(
+    DeprecationNoticeMixin,
     PrefetchDojoModelViewSet,
 ):
+    deprecated = True
+    end_of_life_date = datetime(2026, 11, 1)
     serializer_class = serializers.AssetAPIScanConfigurationSerializer
     queryset = Product_API_Scan_Configuration.objects.none()
     filter_backends = (DjangoFilterBackend,)

--- a/dojo/product/api/views.py
+++ b/dojo/product/api/views.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, status, viewsets
@@ -8,7 +10,7 @@ from rest_framework.response import Response
 import dojo.api_v2.mixins as dojo_mixins
 from dojo.api_v2 import prefetch
 from dojo.api_v2 import serializers as api_v2_serializers
-from dojo.api_v2.views import PrefetchDojoModelViewSet, report_generate_response, schema_with_prefetch
+from dojo.api_v2.views import DeprecationNoticeMixin, PrefetchDojoModelViewSet, report_generate_response, schema_with_prefetch
 from dojo.authorization import api_permissions as permissions
 from dojo.models import Endpoint, Product, Product_API_Scan_Configuration
 from dojo.product.api.filters import ApiProductFilter
@@ -24,10 +26,14 @@ from dojo.utils import async_delete, get_setting
 
 
 # Authorization: object-based
+# Deprecated in 3.2.0, removal planned for 3.5.0 (serves the API-based pull parsers).
 @extend_schema_view(**schema_with_prefetch())
 class ProductAPIScanConfigurationViewSet(
+    DeprecationNoticeMixin,
     PrefetchDojoModelViewSet,
 ):
+    deprecated = True
+    end_of_life_date = datetime(2026, 11, 1)
     serializer_class = ProductAPIScanConfigurationSerializer
     queryset = Product_API_Scan_Configuration.objects.none()
     filter_backends = (DjangoFilterBackend,)

--- a/dojo/product/api/views.py
+++ b/dojo/product/api/views.py
@@ -10,7 +10,12 @@ from rest_framework.response import Response
 import dojo.api_v2.mixins as dojo_mixins
 from dojo.api_v2 import prefetch
 from dojo.api_v2 import serializers as api_v2_serializers
-from dojo.api_v2.views import DeprecationNoticeMixin, PrefetchDojoModelViewSet, report_generate_response, schema_with_prefetch
+from dojo.api_v2.views import (
+    DeprecationNoticeMixin,
+    PrefetchDojoModelViewSet,
+    report_generate_response,
+    schema_with_prefetch,
+)
 from dojo.authorization import api_permissions as permissions
 from dojo.models import Endpoint, Product, Product_API_Scan_Configuration
 from dojo.product.api.filters import ApiProductFilter

--- a/dojo/product/ui/views.py
+++ b/dojo/product/ui/views.py
@@ -29,6 +29,7 @@ import dojo.finding.helper as finding_helper
 from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.authorization.roles_permissions import Permissions
 from dojo.components.sql_group_concat import Sql_GroupConcat
+from dojo.decorators import deprecated_view
 from dojo.engagement.ui.filters import (
     EngagementFilter,
     EngagementFilterWithoutObjectLookups,
@@ -1704,6 +1705,7 @@ def delete_product_authorized_user(request, pid, user_id):
     return HttpResponseRedirect(reverse("view_product", args=(pid,)))
 
 
+@deprecated_view("API Scan Configuration", removal_version="3.5.0", removal_date="November 2026")
 def add_api_scan_configuration(request, pid):
     product = get_object_or_404(Product, id=pid)
     if request.method == "POST":
@@ -1747,6 +1749,7 @@ def add_api_scan_configuration(request, pid):
                    })
 
 
+@deprecated_view("API Scan Configuration", removal_version="3.5.0", removal_date="November 2026")
 def view_api_scan_configurations(request, pid):
     product_api_scan_configurations = Product_API_Scan_Configuration.objects.filter(product=pid)
 
@@ -1760,6 +1763,7 @@ def view_api_scan_configurations(request, pid):
                   })
 
 
+@deprecated_view("API Scan Configuration", removal_version="3.5.0", removal_date="November 2026")
 def edit_api_scan_configuration(request, pid, pascid):
     product_api_scan_configuration = get_object_or_404(Product_API_Scan_Configuration, id=pascid)
 
@@ -1805,6 +1809,7 @@ def edit_api_scan_configuration(request, pid, pascid):
                   })
 
 
+@deprecated_view("API Scan Configuration", removal_version="3.5.0", removal_date="November 2026")
 def delete_api_scan_configuration(request, pid, pascid):
     product_api_scan_configuration = get_object_or_404(Product_API_Scan_Configuration, id=pascid)
 

--- a/dojo/tool_config/api/views.py
+++ b/dojo/tool_config/api/views.py
@@ -1,9 +1,10 @@
 import logging
+from datetime import datetime
 
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema_view
 
-from dojo.api_v2.views import PrefetchDojoModelViewSet, schema_with_prefetch
+from dojo.api_v2.views import DeprecationNoticeMixin, PrefetchDojoModelViewSet, schema_with_prefetch
 from dojo.authorization import api_permissions as permissions
 from dojo.tool_config.api.serializer import ToolConfigurationSerializer
 from dojo.tool_config.models import Tool_Configuration
@@ -12,10 +13,14 @@ logger = logging.getLogger(__name__)
 
 
 # Authorization: configurations
+# Deprecated in 3.2.0, removal planned for 3.5.0 (serves the API-based pull parsers).
 @extend_schema_view(**schema_with_prefetch())
 class ToolConfigurationsViewSet(
+    DeprecationNoticeMixin,
     PrefetchDojoModelViewSet,
 ):
+    deprecated = True
+    end_of_life_date = datetime(2026, 11, 1)
     serializer_class = ToolConfigurationSerializer
     queryset = Tool_Configuration.objects.none()
     filter_backends = (DjangoFilterBackend,)

--- a/dojo/tool_config/ui/views.py
+++ b/dojo/tool_config/ui/views.py
@@ -6,6 +6,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 
+from dojo.decorators import deprecated_view
 from dojo.tool_config.factory import create_API
 from dojo.tool_config.models import Tool_Configuration
 from dojo.tool_config.ui.forms import ToolConfigForm
@@ -14,6 +15,7 @@ from dojo.utils import add_breadcrumb, dojo_crypto_encrypt, prepare_for_view
 logger = logging.getLogger(__name__)
 
 
+@deprecated_view("Tool Configuration", removal_version="3.5.0", removal_date="November 2026")
 def new_tool_config(request):
     if request.method == "POST":
         tform = ToolConfigForm(request.POST)
@@ -48,6 +50,7 @@ def new_tool_config(request):
                   {"tform": tform})
 
 
+@deprecated_view("Tool Configuration", removal_version="3.5.0", removal_date="November 2026")
 def edit_tool_config(request, ttid):
     tool_config = Tool_Configuration.objects.get(pk=ttid)
     if request.method == "POST":
@@ -89,6 +92,7 @@ def edit_tool_config(request, ttid):
                   })
 
 
+@deprecated_view("Tool Configuration", removal_version="3.5.0", removal_date="November 2026")
 def tool_config(request):
     confs = Tool_Configuration.objects.all().order_by("name")
     add_breadcrumb(title="Tool Configuration List", top_level=not len(request.GET), request=request)

--- a/dojo/tool_type/api/views.py
+++ b/dojo/tool_type/api/views.py
@@ -1,8 +1,9 @@
 import logging
+from datetime import datetime
 
 from django_filters.rest_framework import DjangoFilterBackend
 
-from dojo.api_v2.views import DojoModelViewSet
+from dojo.api_v2.views import DeprecationNoticeMixin, DojoModelViewSet
 from dojo.authorization import api_permissions as permissions
 from dojo.tool_type.api.serializer import ToolTypeSerializer
 from dojo.tool_type.models import Tool_Type
@@ -11,9 +12,13 @@ logger = logging.getLogger(__name__)
 
 
 # Authorization: configuration
+# Deprecated in 3.2.0, removal planned for 3.5.0 (serves the API-based pull parsers).
 class ToolTypesViewSet(
+    DeprecationNoticeMixin,
     DojoModelViewSet,
 ):
+    deprecated = True
+    end_of_life_date = datetime(2026, 11, 1)
     serializer_class = ToolTypeSerializer
     queryset = Tool_Type.objects.none()
     filter_backends = (DjangoFilterBackend,)

--- a/dojo/tool_type/ui/views.py
+++ b/dojo/tool_type/ui/views.py
@@ -7,6 +7,7 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.utils.translation import gettext as _
 
+from dojo.decorators import deprecated_view
 from dojo.tool_type.models import Tool_Type
 from dojo.tool_type.ui.forms import ToolTypeForm
 from dojo.utils import add_breadcrumb
@@ -14,6 +15,7 @@ from dojo.utils import add_breadcrumb
 logger = logging.getLogger(__name__)
 
 
+@deprecated_view("Tool Type", removal_version="3.5.0", removal_date="November 2026")
 def new_tool_type(request):
     if request.method == "POST":
         tform = ToolTypeForm(request.POST, instance=Tool_Type())
@@ -33,6 +35,7 @@ def new_tool_type(request):
     return render(request, "dojo/new_tool_type.html", {"tform": tform})
 
 
+@deprecated_view("Tool Type", removal_version="3.5.0", removal_date="November 2026")
 def edit_tool_type(request, ttid):
     tool_type = Tool_Type.objects.get(pk=ttid)
     if request.method == "POST":
@@ -52,6 +55,7 @@ def edit_tool_type(request, ttid):
     return render(request, "dojo/edit_tool_type.html", {"tform": tform})
 
 
+@deprecated_view("Tool Type", removal_version="3.5.0", removal_date="November 2026")
 def tool_type(request):
     confs = Tool_Type.objects.all().order_by("name")
     add_breadcrumb(title=_("Tool Type List"), top_level=not len(request.GET), request=request)

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -2677,6 +2677,15 @@ class Product_API_Scan_ConfigurationTest(BaseClass.BaseClassTest):
         self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
+    def test_deprecation_notice_header(self):
+        # Deprecated in 3.2.0, removal planned for 3.5.0 (serves the API-based pull parsers).
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(200, response.status_code, response.content[:1000])
+        self.assertTrue(response.has_header("X-Deprecated"))
+        self.assertEqual("True", str(response["X-Deprecated"]))
+        self.assertTrue(response.has_header("X-End-Of-Life-Date"))
+        self.assertTrue(str(response["X-End-Of-Life-Date"]).startswith("2026-11-01"))
+
 
 @versioned_fixtures
 class Asset_API_Scan_ConfigurationTest(BaseClass.BaseClassTest):
@@ -2700,6 +2709,15 @@ class Asset_API_Scan_ConfigurationTest(BaseClass.BaseClassTest):
         self.permission_delete = Permissions.Product_API_Scan_Configuration_Delete
         self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+    def test_deprecation_notice_header(self):
+        # Deprecated in 3.2.0, removal planned for 3.5.0 (serves the API-based pull parsers).
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(200, response.status_code, response.content[:1000])
+        self.assertTrue(response.has_header("X-Deprecated"))
+        self.assertEqual("True", str(response["X-Deprecated"]))
+        self.assertTrue(response.has_header("X-End-Of-Life-Date"))
+        self.assertTrue(str(response["X-End-Of-Life-Date"]).startswith("2026-11-01"))
 
 
 @versioned_fixtures
@@ -2818,6 +2836,17 @@ class ToolConfigurationsTest(BaseClass.BaseClassTest):
         self.deleted_objects = 2
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
+    def test_deprecation_notice_header(self):
+        # Deprecated in 3.2.0, removal planned for 3.5.0. The DeprecationNoticeMixin
+        # must run in finalize_response, which only happens if it precedes the base
+        # viewset in the MRO (see dojo/api_v2/views.py:DeprecationNoticeMixin).
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(200, response.status_code, response.content[:1000])
+        self.assertTrue(response.has_header("X-Deprecated"))
+        self.assertEqual("True", str(response["X-Deprecated"]))
+        self.assertTrue(response.has_header("X-End-Of-Life-Date"))
+        self.assertTrue(str(response["X-End-Of-Life-Date"]).startswith("2026-11-01"))
+
 
 @versioned_fixtures
 class ToolProductSettingsTest(BaseClass.BaseClassTest):
@@ -2863,6 +2892,15 @@ class ToolTypesTest(BaseClass.BaseClassTest):
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
         self.deleted_objects = 3
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+    def test_deprecation_notice_header(self):
+        # Deprecated in 3.2.0, removal planned for 3.5.0 (serves the API-based pull parsers).
+        response = self.client.get(self.url, format="json")
+        self.assertEqual(200, response.status_code, response.content[:1000])
+        self.assertTrue(response.has_header("X-Deprecated"))
+        self.assertEqual("True", str(response["X-Deprecated"]))
+        self.assertTrue(response.has_header("X-End-Of-Life-Date"))
+        self.assertTrue(str(response["X-End-Of-Life-Date"]).startswith("2026-11-01"))
 
 
 @versioned_fixtures


### PR DESCRIPTION
Shortcut: [sc-13944](https://app.shortcut.com/defectdojo/story/13944)

## Description

Formally deprecates the **API-based (pull) parsers**, the **Tool Type / Tool Configuration** feature, and the **`django-dbbackup`** integration in **3.2.0**, with planned removal in **3.5.0 (November 2026)** — a full quarter of deprecation runway. Based on the maintainer decision thread.

### Rationale
- API-pull integrations (the 6 `api_*` parsers: BlackDuck, Bugcrowd, Cobalt.io, Edgescan, SonarQube, Vulners) are being consolidated into DefectDojo Pro's no-code connectors.
- Tool Type / Tool Configuration exist only to configure those pull parsers; after the CI/CD infrastructure split (#15002) they have no other consumers, so they are removed at the same time as the parsers.
- `django-dbbackup` is minimally integrated and its `pg_dump`-based backup fails on PostgreSQL client/server version skew (see #15301).

### Changes
- **Docs:** deprecation notices + timeline in `docs/content/releases/os_upgrading/3.2.md`; legacy upgrade stub repointed.
- **API:** `X-Deprecated` / `X-End-Of-Life-Date` response headers on the Tool Configuration, Tool Type, and Product/Asset API Scan Configuration viewsets via `DeprecationNoticeMixin`. The mixin is placed **first** in the MRO so `finalize_response` actually runs (listing it last makes it dead code).
- **UI:** deprecation banners on the Tool Configuration, Tool Type, and per-product API Scan Configuration pages — rendering on **both** the new and classic UIs via the messages framework.
- **Tests:** assert the deprecation headers on the affected endpoints.

Nothing is removed in this PR — removal is tracked for 3.5.0 (state-only migrations, following the stub-finding / credential-manager pattern).

### Open items to reconcile (non-blocking)
- "Coverity API" is a *file* parser (not one of the 6 pull parsers) — kept out of scope; reconcile the customer list with the Pro migration.
- Edgescan/Vulners also accept an uploaded file; the file-import path's fate at 3.5.0 to be confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)