### PR TITLE
fix: map KICS critical severity

### DIFF
--- a/dojo/tools/kics/parser.py
+++ b/dojo/tools/kics/parser.py
@@ -13,6 +13,7 @@ class KICSParser:
 
     # table to match KICS severity to DefectDojo severity
     SEVERITY = {
+        "CRITICAL": "Critical",
         "HIGH": "High",
         "MEDIUM": "Medium",
         "LOW": "Low",

--- a/unittests/tools/test_kics_parser.py
+++ b/unittests/tools/test_kics_parser.py
@@ -1,3 +1,6 @@
+import io
+import json
+
 from dojo.models import Test
 from dojo.tools.kics.parser import KICSParser
 from unittests.dojo_test_case import DojoTestCase, get_unit_tests_scans_path
@@ -10,6 +13,34 @@ class TestKICSParser(DojoTestCase):
             parser = KICSParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(0, len(findings))
+
+    def test_parse_critical_severity(self):
+        payload = {
+            "queries": [
+                {
+                    "query_name": "Critical IaC Issue",
+                    "query_url": "https://kics.io/",
+                    "severity": "CRITICAL",
+                    "platform": "Terraform",
+                    "category": "Access Control",
+                    "description": "Critical issue description.",
+                    "files": [
+                        {
+                            "file_name": "main.tf",
+                            "line": 7,
+                            "issue_type": "IncorrectValue",
+                            "expected_value": "secure value",
+                            "actual_value": "insecure value",
+                        },
+                    ],
+                },
+            ],
+        }
+        parser = KICSParser()
+        findings = parser.get_findings(io.StringIO(json.dumps(payload)), Test())
+
+        self.assertEqual(1, len(findings))
+        self.assertEqual("Critical", findings[0].severity)
 
     def test_parse_many_findings(self):
         with (get_unit_tests_scans_path("kics") / "many_findings.json").open(encoding="utf-8") as testfile:


### PR DESCRIPTION
## Summary
- Preserve KICS `CRITICAL` findings as DefectDojo `Critical` instead of falling through to the `Medium` default.
- Add a focused parser regression test for KICS critical severity mapping.

## Why
The KICS parser severity map did not include `CRITICAL`, so KICS reports with `"severity": "CRITICAL"` were imported as Medium findings. This can understate IaC risk in dashboards, filters, reports, and SLA workflows.

Fixes #15345.

## Test plan
- [x] `python3 -m py_compile dojo/tools/kics/parser.py unittests/tools/test_kics_parser.py`
- [x] Lightweight parser harness with stubbed `Finding`/settings confirmed `CRITICAL` maps to `Critical`
- [x] `git diff --check`

I did not run the full Docker-backed unit test suite in this local environment.
