### PR TITLE
docs(feature-flags): correct Organization / Asset relabeling controls

### DIFF
--- a/docs/content/admin/feature_flags/PRO__feature_flags.md
+++ b/docs/content/admin/feature_flags/PRO__feature_flags.md
@@ -26,11 +26,22 @@ Use the search box to filter the list by feature name or description.
 
 1. Find the feature in the list.
 2. Click its toggle.
-3. The change takes effect immediately. You do not need to restart anything, and other users pick the change up on their next page load.
+3. The change takes effect immediately. Other users pick the change up on their next page load.
 
 Some features show a confirmation dialog before the change is applied. This happens when enabling a feature that carries a warning (for example one that requires a restart or may affect existing data), or one that cannot be turned back off.
 
-Turning a feature off is normally just the reverse of turning it on. The exceptions are called out in the next section.
+Turning a feature off is normally just the reverse of turning it on. The exceptions are called out in [When a toggle is locked](#when-a-toggle-is-locked).
+
+### Organization / Asset Relabeling
+
+**Organization / Asset Relabeling** renames "Product Type" to "Organization" and "Product" to "Asset". It is on by default and toggles from this page like any other feature, but it is worth knowing which parts of DefectDojo it governs:
+
+* The **Pro UI** follows this toggle. The new labels appear on your next page load.
+* The **Classic UI** pages, their URLs, and generated reports take their naming from the `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL` deployment setting (also on by default), which is read when DefectDojo starts. This toggle does not change them, and restarting does not make it change them.
+
+The stored toggle was seeded from that deployment setting, so the two agree until you change one of them. If you turn relabeling off here and you also use the Classic UI, set `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL=False` on your deployment and restart so both surfaces match. On [DefectDojo Pro (Cloud)](/get_started/pro/cloud/), contact [DefectDojo Support](mailto:support@defectdojo.com) to have the deployment setting changed.
+
+The feature carries a **Restart Recommended** tag on the Feature Flags page for this reason: the naming used outside the Pro UI is fixed when the process starts. Relabeling is cosmetic either way. Database models, field names, and API endpoints are unchanged, so existing automation keeps working. See [Asset Hierarchy](/asset_modelling/pro_hierarchy/asset_hierarchy/).
 
 ## When a toggle is locked
 
@@ -58,7 +69,7 @@ Cloud instances also have access to features that are not offered on-premise. Se
 
 On [DefectDojo Pro (On-Premise)](/get_started/pro/onprem/), most features work exactly as they do on Cloud: open **Settings > Feature Flags** and toggle them.
 
-A small number of features are read from your deployment configuration instead — they change how the application starts, so they cannot be flipped at runtime. These appear on the page as read-only, labeled **Managed by deployment**, and name the environment variable that controls them, for example `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL`.
+A small number of features are read from your deployment configuration instead. They change how the application starts, so they cannot be flipped at runtime. These appear on the page as read-only, labeled **Managed by deployment**, and name the environment variable that controls them, for example `DD_V3_FEATURE_LOCATIONS` for [Locations](/asset_modelling/locations/pro__locations_overview/).
 
 Because these features require a restart, and some of them cannot be reversed once enabled, check the feature's own documentation before changing one. Several are best enabled with help from [DefectDojo Support](mailto:support@defectdojo.com).
 
@@ -81,7 +92,6 @@ Most features are available on both installation types. The exceptions are:
 | Downstream Connections | [DefectDojo Pro (Cloud)](/get_started/pro/cloud/) only | Feature Flags page. Shown as **Unavailable on This Deployment** on-premise, which does not run the required infrastructure. See [Pro Integrations](/issue_tracking/pro_integration/integrations/). |
 | Request a New Connector | [DefectDojo Pro (Cloud)](/get_started/pro/cloud/) only | Feature Flags page. Shown as **Unavailable on This Deployment** on-premise. |
 | Locations | Both | Deployment configuration. Locations is in Beta and cannot be turned back off once enabled, so contact [DefectDojo Support](mailto:support@defectdojo.com) to have it enabled. See [Locations Overview](/asset_modelling/locations/pro__locations_overview/). |
-| Organization / Asset Relabeling | Both | Deployment configuration: `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL`. |
 
 Every other optional feature is toggled directly on the Feature Flags page on both Cloud and On-Premise instances.
 

--- a/docs/content/asset_modelling/PRO_hierarchy/asset_hierarchy.md
+++ b/docs/content/asset_modelling/PRO_hierarchy/asset_hierarchy.md
@@ -27,16 +27,18 @@ A superuser can turn it on from **Settings > Feature Flags**, on both Cloud and 
 
 **Label Changes** renames "Product Type" to "Organization" and "Product" to "Asset" throughout the UI. This is a separate step from enabling the hierarchy and can be done at the same time or later.
 
-Label changes are read from your deployment configuration when DefectDojo starts, so they are not toggled from the Feature Flags page:
+Label changes are on by default as of 3.0. There are two controls, covering different parts of the application:
 
-* **[DefectDojo Pro (Cloud)](/get_started/pro/cloud/)** — email [support@defectdojo.com](mailto:support@defectdojo.com) with your instance URL.
-* **[DefectDojo Pro (On-Premise)](/get_started/pro/onprem/)** — set `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL` and restart DefectDojo. Contact Support if you would like guidance before making the change.
+* **Pro UI** (the default UI): a superuser toggles "Organization / Asset Relabeling" at **Settings > Feature Flags**, on both Cloud and On-Premise instances. The new labels appear on the next page load. See [Feature Flags](/admin/feature_flags/pro__feature_flags/).
+* **Classic UI pages and generated reports**: their labels and URLs come from the `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL` deployment setting, which is read when DefectDojo starts. On-premise, set it and restart DefectDojo. On [DefectDojo Pro (Cloud)](/get_started/pro/cloud/), email [support@defectdojo.com](mailto:support@defectdojo.com) with your instance URL.
+
+Both default to on, and the Feature Flags value was seeded from the deployment setting, so the two agree unless you change one of them. Keep them in sync if you use the Classic UI as well as the Pro UI.
 
 Note that label changes are cosmetic only: API endpoints and field names remain unchanged, so existing automation will continue to work.
 
 ## Significant Changes
 
-* **Product Types** have been renamed to "Organizations", and **Products** have been renamed to "Assets".  Currently, this name change is opt-in for existing DefectDojo Pro subscriptions.
+* **Product Types** have been renamed to "Organizations", and **Products** have been renamed to "Assets".  As of 3.0 this name change is on by default. See [Label Changes](#label-changes-optional) for the controls that turn it off.
 * **Assets** can now have parent/child relationships with one another to further sub-categorize Organizational components. 
 
 ### Organizations


### PR DESCRIPTION
The `v3_relabel` feature (Organization / Asset relabeling) moved from
environment-driven to DB-backed and self-serve, but the docs still described the
old behavior. This corrects the three stale places.

### Changes

**`admin/feature_flags/PRO__feature_flags.md`**

- Removed the `Organization / Asset Relabeling` row from the "Feature
  availability" table. That table lists exceptions to the self-serve rule, and
  relabeling is no longer one of them.
- Added an `Organization / Asset Relabeling` subsection next to the toggle
  instructions, carrying the facts the removed row was holding: on by default,
  and which surfaces the toggle actually governs.
- Replaced the "Managed by deployment" example. It used
  `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL`, which is no longer env-managed.
  Now uses `DD_V3_FEATURE_LOCATIONS`, which genuinely is, with the `DD_` prefix
  matching what the Feature Flags page renders.

**`asset_modelling/PRO_hierarchy/asset_hierarchy.md`**

- "Label Changes" no longer tells on-premise users to set the env var and
  restart, or Cloud users to email Support. It documents both controls and what
  each covers.
- Two adjacent stale claims fixed: the name change is on by default as of 3.0
  rather than opt-in for existing subscriptions, and the pointer for turning it
  off now goes to the section that explains the controls.

### The behavior being documented

The toggle governs the **Pro UI only**. The Classic UI labels, its URLs, and
generated reports read `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL` at process
start, and no restart makes the toggle reach them. Those branches are in
`dojo/asset/labels.py`, `dojo/organization/labels.py`, `dojo/asset/urls.py`,
`dojo/organization/urls.py`, `dojo/metrics/urls.py`,
`dojo/system_settings/labels.py`, and `dojo/reports/ui/urls.py`, and the setting
is only ever assigned from the environment in `settings.dist.py`.

Verified by forcing the env var and the DB flag to disagree in a running
instance: the OSS labels returned `Asset` / `Organization` (following the
environment) while only Pro's overlay followed the database.

Since both default to on and the stored value was seeded from the env var, they
agree until someone changes one, so the docs tell readers to keep them in sync
if they use both UIs.

Docs only. No code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
