### PR TITLE
fix(api): return a validation error instead of 500 when environment is omitted

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -620,7 +620,7 @@ class CommonImportScanSerializer(serializers.Serializer):
             try:
                 environment = Development_Environment.objects.get(name=data.get("environment", "Development"))
             except:
-                msg = "Environment named " + data.get("environment") + " does not exist."
+                msg = "Environment named " + data.get("environment", "Development") + " does not exist."
                 raise ValidationError(msg)
 
         context["environment"] = environment


### PR DESCRIPTION
## Bug

`CommonImportScanSerializer.setup_common_context` looks the environment up with a default, but builds the failure message without one:

```python
environment = Development_Environment.objects.get(name=data.get("environment", "Development"))
except:
    msg = "Environment named " + data.get("environment") + " does not exist."
```

When a request to `/api/v2/import-scan/` (or `reimport-scan`) omits `environment` **and** no `Development` environment exists, the lookup raises, and the `except` branch concatenates `None` to a string:

```
TypeError: can only concatenate str (not "NoneType") to str
```

The `TypeError` replaces the intended `ValidationError`, so the API responds with an opaque **HTTP 500 / "Internal server error, check logs for details"** instead of a 400 naming the missing environment. The failure is in the error handler itself, which also makes it harder to diagnose from the client side.

## Reproduction

On an instance without the default `Development` environment (e.g. a database migrated without loading the initial fixtures), POST to `/api/v2/import-scan/` with a valid engagement, `scan_type`, and file, but no `environment` field.

- Before: HTTP 500, `TypeError` in the log.
- After: HTTP 400, `Environment named Development does not exist.`

## Fix

Use the same default in the message as in the lookup — one line.
