### PR TITLE
Docs: clarify that the Jira webhook secret authenticates incoming requests

### DIFF
--- a/docs/content/issue_tracking/jira/OS__jira_guide.md
+++ b/docs/content/issue_tracking/jira/OS__jira_guide.md
@@ -256,7 +256,7 @@ Your Jira Webhook is located on the System Settings form under **Jira Integratio
 
 Note that you do not need to create a Secret within Jira to use this webhook. The Secret is built into DefectDojo's URL, so simply adding the complete URL to the Jira Webhook form is sufficient.
 
-DefectDojo's Jira Webhook only accepts requests from the Jira API.
+Incoming webhook requests are authenticated by the secret in that URL, so treat the full URL as a credential and keep it private.
 
 #### Testing the Webhook
 

--- a/docs/content/issue_tracking/jira/PRO__jira_guide.md
+++ b/docs/content/issue_tracking/jira/PRO__jira_guide.md
@@ -255,7 +255,7 @@ Your Jira Webhook is located on the System Settings form under **Jira Integratio
 
 Note that you do not need to create a Secret within Jira to use this webhook. The Secret is built into DefectDojo's URL, so simply adding the complete URL to the Jira Webhook form is sufficient.
 
-DefectDojo's Jira Webhook only accepts requests from the Jira API.
+Incoming webhook requests are authenticated by the secret in that URL, so treat the full URL as a credential and keep it private.
 
 #### Testing the Webhook
 


### PR DESCRIPTION
The OS and Pro Jira integration guides stated that the incoming webhook "only accepts requests from the Jira API." That is not accurate: incoming requests are authenticated by the secret embedded in the webhook URL. Updated both guides to say the secret is what authenticates incoming requests and that the full URL should be treated as a credential.

Docs-only change.