### PR TITLE
Harden finding and engagement UI actions to require POST

### DIFF
--- a/dojo/engagement/ui/views.py
+++ b/dojo/engagement/ui/views.py
@@ -1086,6 +1086,7 @@ class ImportScanResultsView(View):
         return self.success_redirect(request, context)
 
 
+@require_POST
 def close_eng(request, eid):
     eng = Engagement.objects.get(id=eid)
     close_engagement(eng)
@@ -1130,6 +1131,7 @@ def unlink_jira(request, eid):
         return HttpResponse(status=400)
 
 
+@require_POST
 def reopen_eng(request, eid):
     eng = Engagement.objects.get(id=eid)
     reopen_engagement(eng)
@@ -1438,6 +1440,7 @@ def view_edit_risk_acceptance(request, eid, raid, *, edit_mode=False):
         })
 
 
+@require_POST
 def expire_risk_acceptance(request, eid, raid):
     risk_acceptance = get_object_or_404(prefetch_for_expiration(Risk_Acceptance.objects.all()), pk=raid)
     # Validate the engagement ID exists before moving forward
@@ -1448,6 +1451,7 @@ def expire_risk_acceptance(request, eid, raid):
     return redirect_to_return_url_or_else(request, reverse("view_risk_acceptance", args=(eid, raid)))
 
 
+@require_POST
 def reinstate_risk_acceptance(request, eid, raid):
     risk_acceptance = get_object_or_404(prefetch_for_expiration(Risk_Acceptance.objects.all()), pk=raid)
     eng = get_object_or_404(Engagement.objects.filter(risk_acceptance=risk_acceptance), pk=eid)
@@ -1459,6 +1463,7 @@ def reinstate_risk_acceptance(request, eid, raid):
     return redirect_to_return_url_or_else(request, reverse("view_risk_acceptance", args=(eid, raid)))
 
 
+@require_POST
 def delete_risk_acceptance(request, eid, raid):
     risk_acceptance = get_object_or_404(Risk_Acceptance, pk=raid)
     eng = get_object_or_404(Engagement.objects.filter(risk_acceptance=risk_acceptance), pk=eid)

--- a/dojo/finding/ui/views.py
+++ b/dojo/finding/ui/views.py
@@ -1354,6 +1354,7 @@ def defect_finding_review(request, fid):
     )
 
 
+@require_POST
 def reopen_finding(request, fid):
     finding = get_object_or_404(Finding, id=fid)
     finding.active = True
@@ -1492,6 +1493,7 @@ def remediation_date(request, fid):
     )
 
 
+@require_POST
 def touch_finding(request, fid):
     finding = get_object_or_404(Finding, id=fid)
     finding.last_reviewed = timezone.now()
@@ -1502,6 +1504,7 @@ def touch_finding(request, fid):
     )
 
 
+@require_POST
 def simple_risk_accept(request, fid):
     finding = get_object_or_404(Finding, id=fid)
 
@@ -1519,6 +1522,7 @@ def simple_risk_accept(request, fid):
     )
 
 
+@require_POST
 def risk_unaccept(request, fid):
     finding = get_object_or_404(Finding, id=fid)
     ra_helper.risk_unaccept(request.user, finding)

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -456,9 +456,10 @@
                                                         {% endif %}
                                                         {% if finding|has_object_permission:"edit" %}
                                                             <li role="presentation">
-                                                                <a href="{% url 'touch_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}" role="menuitem">
+                                                                <a href="#" role="menuitem" onclick="this.nextElementSibling.submit(); return false;">
                                                                     <i class="fa-solid fa-clock"></i> {% trans "Touch Finding" %}
                                                                 </a>
+                                                                <form method="post" action="{% url 'touch_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                             </li>
                                                         {% endif %}
                                                         {% if finding|has_object_permission:"add" %}
@@ -484,9 +485,10 @@
                                                                 </li>
                                                             {% else %}
                                                                 <li role="presentation">
-                                                                    <a href="{% url 'reopen_finding' finding.id %}" role="menuitem">
+                                                                    <a href="#" role="menuitem" onclick="this.nextElementSibling.submit(); return false;">
                                                                         <i class="fa-solid fa-bug"></i> {% trans "Open Finding" %}
                                                                     </a>
+                                                                    <form method="post" action="{% url 'reopen_finding' finding.id %}">{% csrf_token %}</form>
                                                                 </li>
                                                             {% endif %}
                                                         {% endif %}
@@ -494,17 +496,19 @@
                                                         {% if finding|has_object_permission:"edit" %}
                                                             {% if finding.risk_accepted %}
                                                                 <li role="presentation">
-                                                                    <a href="{% url 'risk_unaccept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}" role="menuitem">
+                                                                    <a href="#" role="menuitem" onclick="this.nextElementSibling.submit(); return false;">
                                                                         <i class="fa-solid fa-circle-exclamation"></i> {% trans "Unaccept Risk" %}
                                                                     </a>
+                                                                    <form method="post" action="{% url 'risk_unaccept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                                 </li>
                                                             {% else %}
                                                                 {% if not finding.duplicate %}
                                                                     {% if finding.test.engagement.product.enable_simple_risk_acceptance %}
                                                                         <li role="presentation">
-                                                                            <a href="{% url 'simple_risk_accept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}" role="menuitem">
+                                                                            <a href="#" role="menuitem" onclick="this.nextElementSibling.submit(); return false;">
                                                                                 <i class="fa-solid fa-circle-exclamation"></i> {% trans "Accept Risk" %}
                                                                             </a>
+                                                                            <form method="post" action="{% url 'simple_risk_accept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                                         </li>
                                                                     {% endif %}
                                                                     {% if finding.test.engagement.product.enable_full_risk_acceptance %}

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -85,14 +85,16 @@
                             <li>
                               </a>
                               {% if status == "open" or status == "paused" %}
-                              <a class="" href="{% url 'close_engagement' eng.id %}">
+                              <a class="" href="#" onclick="this.nextElementSibling.submit(); return false;">
                                 <i class="fa-solid fa-xmark"></i> Close
+                              </a>
+                              <form method="post" action="{% url 'close_engagement' eng.id %}">{% csrf_token %}</form>
                               {% else %}
-                              <a class="" href="{% url 'reopen_engagement' eng.id %}">
+                              <a class="" href="#" onclick="this.nextElementSibling.submit(); return false;">
                                 <i class="fa-solid fa-rotate-left"></i> Reopen
                               </a>
+                              <form method="post" action="{% url 'reopen_engagement' eng.id %}">{% csrf_token %}</form>
                               {% endif %}
-                              </a>
                             </li>
                             <li class="divider"></li>
                             {% endif %}

--- a/dojo/templates/dojo/snippets/risk_acceptance_actions_snippet.html
+++ b/dojo/templates/dojo/snippets/risk_acceptance_actions_snippet.html
@@ -19,15 +19,17 @@
         <li role="separator" class="divider"></li>
         {% if risk_acceptance.is_expired %}
             <li role="presentation">
-                <a class="reinstate-risk_acceptance" href="{% url 'reinstate_risk_acceptance' engagement.id risk_acceptance.id %}?return_url={{ request.get_full_path|urlencode }}" onclick="return confirm('Are you sure you want reinstate this risk acceptance? All its findings will be deactivated and marked as accepted. The default of {{ system_settings.risk_acceptance_form_default_days }} days from now will be the expiration date.')">
+                <a class="reinstate-risk_acceptance" href="#" onclick="if(confirm('Are you sure you want reinstate this risk acceptance? All its findings will be deactivated and marked as accepted. The default of {{ system_settings.risk_acceptance_form_default_days }} days from now will be the expiration date.')) { this.nextElementSibling.submit(); } return false;">
                     <i class="fa-solid fa-backward-fast"></i> Reinstate
                 </a>
+                <form method="post" action="{% url 'reinstate_risk_acceptance' engagement.id risk_acceptance.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
             </li>
         {% else %}
             <li role="presentation">
-                <a class="expire-risk_acceptance" href="{% url 'expire_risk_acceptance' engagement.id risk_acceptance.id %}?return_url={{ request.get_full_path|urlencode }}" onclick="return confirm('Are you sure you want let this risk acceptance expire now? All its findings will be re-activated and no longer marked as accepted. The expiration date for this risk acceptance will be set to now.')">
+                <a class="expire-risk_acceptance" href="#" onclick="if(confirm('Are you sure you want let this risk acceptance expire now? All its findings will be re-activated and no longer marked as accepted. The expiration date for this risk acceptance will be set to now.')) { this.nextElementSibling.submit(); } return false;">
                     <i class="fa-solid fa-forward-fast"></i> Expire Now
                 </a>
+                <form method="post" action="{% url 'expire_risk_acceptance' engagement.id risk_acceptance.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
             </li>
         {% endif %}
     {% endif %}

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -39,13 +39,15 @@
                                     </li>
                                     <li role="presentation">
                                         {% if eng.active %}
-                                            <a class="" href="{% url 'close_engagement' eng.id %}">
+                                            <a class="" href="#" onclick="this.nextElementSibling.submit(); return false;">
                                             <i class="fa-solid fa-xmark"></i> Close Engagement
                                             </a>
+                                            <form method="post" action="{% url 'close_engagement' eng.id %}">{% csrf_token %}</form>
                                         {% else %}
-                                            <a class="" href="{% url 'reopen_engagement' eng.id %}">
+                                            <a class="" href="#" onclick="this.nextElementSibling.submit(); return false;">
                                             <i class="fa-solid fa-rotate-left"></i> Reopen Engagement
                                             </a>
+                                            <form method="post" action="{% url 'reopen_engagement' eng.id %}">{% csrf_token %}</form>
                                         {% endif %}
                                     </li>
                                 {% endif %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -88,9 +88,10 @@
                             {% endif %}
                             {% if finding|has_object_permission:"edit" %}
                                 <li role="presentation">
-                                    <a href="{% url 'touch_finding' finding.id %}">
+                                    <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                         <i class="fa-solid fa-clock"></i> Touch Finding
                                     </a>
+                                    <form method="post" action="{% url 'touch_finding' finding.id %}">{% csrf_token %}</form>
                                 </li>
                             {% endif %}
                             <li role="separator" class="divider"></li>
@@ -121,9 +122,10 @@
                                 <li role="separator" class="divider"></li>
                                 {% if finding.mitigated %}
                                     <li role="presentation">
-                                        <a href="{% url 'reopen_finding' finding.id %}">
+                                        <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                             <i class="fa-solid fa-bug"></i> Open Finding
                                         </a>
+                                        <form method="post" action="{% url 'reopen_finding' finding.id %}">{% csrf_token %}</form>
                                     </li>
                                 {% else %}
                                 {% if not finding.verified %}
@@ -143,17 +145,19 @@
                             {% if finding|has_object_permission:"edit" %}
                                 {% if finding.risk_accepted %}
                                     <li role="presentation">
-                                    <a href="{% url 'risk_unaccept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                    <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                         <i class="fa-solid fa-circle-exclamation"></i> Unaccept Risk
                                     </a>
+                                    <form method="post" action="{% url 'risk_unaccept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                     </li>
                                 {% else %}
                                     {% if not finding.duplicate %}
                                         {% if finding.test.engagement.product.enable_simple_risk_acceptance %}
                                             <li role="presentation">
-                                                <a href="{% url 'simple_risk_accept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                                <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                     <i class="fa-solid fa-circle-exclamation"></i> Accept Risk
                                                 </a>
+                                                <form method="post" action="{% url 'simple_risk_accept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                             </li>
                                         {% endif %}
                                         {% if finding.test.engagement.product.enable_full_risk_acceptance %}

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1054,9 +1054,10 @@
                                                     {% endif %}
                                                     {% if finding|has_object_permission:"edit" %}
                                                         <li role="presentation">
-                                                            <a href="{% url 'touch_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                                            <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                                 <i class="fa-solid fa-clock"></i> {% trans "Touch Finding" %}
                                                             </a>
+                                                            <form method="post" action="{% url 'touch_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                         </li>
                                                     {% endif %}
                                                     {% if finding|has_object_permission:"add" %}
@@ -1080,26 +1081,29 @@
                                                             </li>
                                                         {% else %}
                                                             <li role="presentation">
-                                                                <a href="{% url 'reopen_finding' finding.id %}">
+                                                                <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                                     <i class="fa-solid fa-bug"></i> {% trans "Open Finding" %}
                                                                 </a>
+                                                                <form method="post" action="{% url 'reopen_finding' finding.id %}">{% csrf_token %}</form>
                                                             </li>
                                                         {% endif %}
                                                     {% endif %}
                                                     {% if finding|has_object_permission:"edit" %}
                                                         {% if finding.risk_accepted %}
                                                             <li role="presentation">
-                                                                <a href="{% url 'risk_unaccept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                                                <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                                     <i class="fa-solid fa-circle-exclamation"></i> {% trans "Unaccept Risk" %}
                                                                 </a>
+                                                                <form method="post" action="{% url 'risk_unaccept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                             </li>
                                                         {% else %}
                                                             {% if not finding.duplicate %}
                                                                 {% if finding.test.engagement.product.enable_simple_risk_acceptance %}
                                                                     <li role="presentation">
-                                                                        <a href="{% url 'simple_risk_accept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                                                        <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                                             <i class="fa-solid fa-circle-exclamation"></i> {% trans "Accept Risk" %}
                                                                         </a>
+                                                                        <form method="post" action="{% url 'simple_risk_accept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                                     </li>
                                                                 {% endif %}
                                                                 {% if finding.test.engagement.product.enable_full_risk_acceptance %}

--- a/dojo/templates_classic/dojo/findings_list_snippet.html
+++ b/dojo/templates_classic/dojo/findings_list_snippet.html
@@ -453,9 +453,10 @@
                                                         {% endif %}
                                                         {% if finding|has_object_permission:"Finding_Edit" %}
                                                             <li role="presentation">
-                                                                <a href="{% url 'touch_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}" role="menuitem">
+                                                                <a href="#" role="menuitem" onclick="this.nextElementSibling.submit(); return false;">
                                                                     <i class="fa-solid fa-clock"></i> {% trans "Touch Finding" %}
                                                                 </a>
+                                                                <form method="post" action="{% url 'touch_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                             </li>
                                                         {% endif %}
                                                         {% if finding|has_object_permission:"Finding_Add" %}
@@ -481,9 +482,10 @@
                                                                 </li>
                                                             {% else %}
                                                                 <li role="presentation">
-                                                                    <a href="{% url 'reopen_finding' finding.id %}" role="menuitem">
+                                                                    <a href="#" role="menuitem" onclick="this.nextElementSibling.submit(); return false;">
                                                                         <i class="fa-solid fa-bug"></i> {% trans "Open Finding" %}
                                                                     </a>
+                                                                    <form method="post" action="{% url 'reopen_finding' finding.id %}">{% csrf_token %}</form>
                                                                 </li>
                                                             {% endif %}
                                                         {% endif %}
@@ -491,17 +493,19 @@
                                                         {% if finding|has_object_permission:"Risk_Acceptance" %}
                                                             {% if finding.risk_accepted %}
                                                                 <li role="presentation">
-                                                                    <a href="{% url 'risk_unaccept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}" role="menuitem">
+                                                                    <a href="#" role="menuitem" onclick="this.nextElementSibling.submit(); return false;">
                                                                         <i class="fa-solid fa-circle-exclamation"></i> {% trans "Unaccept Risk" %}
                                                                     </a>
+                                                                    <form method="post" action="{% url 'risk_unaccept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                                 </li>
                                                             {% else %}
                                                                 {% if not finding.duplicate %}
                                                                     {% if finding.test.engagement.product.enable_simple_risk_acceptance %}
                                                                         <li role="presentation">
-                                                                            <a href="{% url 'simple_risk_accept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}" role="menuitem">
+                                                                            <a href="#" role="menuitem" onclick="this.nextElementSibling.submit(); return false;">
                                                                                 <i class="fa-solid fa-circle-exclamation"></i> {% trans "Accept Risk" %}
                                                                             </a>
+                                                                            <form method="post" action="{% url 'simple_risk_accept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                                         </li>
                                                                     {% endif %}
                                                                     {% if finding.test.engagement.product.enable_full_risk_acceptance %}

--- a/dojo/templates_classic/dojo/snippets/engagement_list.html
+++ b/dojo/templates_classic/dojo/snippets/engagement_list.html
@@ -85,14 +85,16 @@
                             <li>
                               </a>
                               {% if status == "open" or status == "paused" %}
-                              <a class="" href="{% url 'close_engagement' eng.id %}">
+                              <a class="" href="#" onclick="this.nextElementSibling.submit(); return false;">
                                 <i class="fa-solid fa-xmark"></i> Close
+                              </a>
+                              <form method="post" action="{% url 'close_engagement' eng.id %}">{% csrf_token %}</form>
                               {% else %}
-                              <a class="" href="{% url 'reopen_engagement' eng.id %}">
+                              <a class="" href="#" onclick="this.nextElementSibling.submit(); return false;">
                                 <i class="fa-solid fa-rotate-left"></i> Reopen
                               </a>
+                              <form method="post" action="{% url 'reopen_engagement' eng.id %}">{% csrf_token %}</form>
                               {% endif %}
-                              </a>
                             </li>
                             <li class="divider"></li>
                             {% endif %}

--- a/dojo/templates_classic/dojo/snippets/risk_acceptance_actions_snippet.html
+++ b/dojo/templates_classic/dojo/snippets/risk_acceptance_actions_snippet.html
@@ -19,15 +19,17 @@
         <li role="separator" class="divider"></li>
         {% if risk_acceptance.is_expired %}
             <li role="presentation">
-                <a class="reinstate-risk_acceptance" href="{% url 'reinstate_risk_acceptance' engagement.id risk_acceptance.id %}?return_url={{ request.get_full_path|urlencode }}">
+                <a class="reinstate-risk_acceptance" href="#" onclick="this.nextElementSibling.submit(); return false;">
                     <i class="fa-solid fa-backward-fast"></i> Reinstate
                 </a>
+                <form method="post" action="{% url 'reinstate_risk_acceptance' engagement.id risk_acceptance.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
             </li>
         {% else %}
             <li role="presentation">
-                <a class="expire-risk_acceptance" href="{% url 'expire_risk_acceptance' engagement.id risk_acceptance.id %}?return_url={{ request.get_full_path|urlencode }}">
+                <a class="expire-risk_acceptance" href="#" onclick="this.nextElementSibling.submit(); return false;">
                     <i class="fa-solid fa-forward-fast"></i> Expire Now
                 </a>
+                <form method="post" action="{% url 'expire_risk_acceptance' engagement.id risk_acceptance.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
             </li>
         {% endif %}
     {% endif %}

--- a/dojo/templates_classic/dojo/view_eng.html
+++ b/dojo/templates_classic/dojo/view_eng.html
@@ -39,13 +39,15 @@
                                     </li>
                                     <li role="presentation">
                                         {% if eng.active %}
-                                            <a class="" href="{% url 'close_engagement' eng.id %}">
+                                            <a class="" href="#" onclick="this.nextElementSibling.submit(); return false;">
                                             <i class="fa-solid fa-xmark"></i> Close Engagement
                                             </a>
+                                            <form method="post" action="{% url 'close_engagement' eng.id %}">{% csrf_token %}</form>
                                         {% else %}
-                                            <a class="" href="{% url 'reopen_engagement' eng.id %}">
+                                            <a class="" href="#" onclick="this.nextElementSibling.submit(); return false;">
                                             <i class="fa-solid fa-rotate-left"></i> Reopen Engagement
                                             </a>
+                                            <form method="post" action="{% url 'reopen_engagement' eng.id %}">{% csrf_token %}</form>
                                         {% endif %}
                                     </li>
                                 {% endif %}

--- a/dojo/templates_classic/dojo/view_finding.html
+++ b/dojo/templates_classic/dojo/view_finding.html
@@ -88,9 +88,10 @@
                             {% endif %}
                             {% if finding|has_object_permission:"Finding_Edit" %}
                                 <li role="presentation">
-                                    <a href="{% url 'touch_finding' finding.id %}">
+                                    <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                         <i class="fa-solid fa-clock"></i> Touch Finding
                                     </a>
+                                    <form method="post" action="{% url 'touch_finding' finding.id %}">{% csrf_token %}</form>
                                 </li>
                             {% endif %}
                             <li role="separator" class="divider"></li>
@@ -121,9 +122,10 @@
                                 <li role="separator" class="divider"></li>
                                 {% if finding.mitigated %}
                                     <li role="presentation">
-                                        <a href="{% url 'reopen_finding' finding.id %}">
+                                        <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                             <i class="fa-solid fa-bug"></i> Open Finding
                                         </a>
+                                        <form method="post" action="{% url 'reopen_finding' finding.id %}">{% csrf_token %}</form>
                                     </li>
                                 {% else %}
                                 {% if not finding.verified %}
@@ -143,17 +145,19 @@
                             {% if finding|has_object_permission:"Risk_Acceptance" %}
                                 {% if finding.risk_accepted %}
                                     <li role="presentation">
-                                    <a href="{% url 'risk_unaccept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                    <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                         <i class="fa-solid fa-circle-exclamation"></i> Unaccept Risk
                                     </a>
+                                    <form method="post" action="{% url 'risk_unaccept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                     </li>
                                 {% else %}
                                     {% if not finding.duplicate %}
                                         {% if finding.test.engagement.product.enable_simple_risk_acceptance %}
                                             <li role="presentation">
-                                                <a href="{% url 'simple_risk_accept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                                <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                     <i class="fa-solid fa-circle-exclamation"></i> Accept Risk
                                                 </a>
+                                                <form method="post" action="{% url 'simple_risk_accept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                             </li>
                                         {% endif %}
                                         {% if finding.test.engagement.product.enable_full_risk_acceptance %}

--- a/dojo/templates_classic/dojo/view_test.html
+++ b/dojo/templates_classic/dojo/view_test.html
@@ -1051,9 +1051,10 @@
                                                     {% endif %}
                                                     {% if finding|has_object_permission:"Finding_Edit" %}
                                                         <li role="presentation">
-                                                            <a href="{% url 'touch_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                                            <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                                 <i class="fa-solid fa-clock"></i> {% trans "Touch Finding" %}
                                                             </a>
+                                                            <form method="post" action="{% url 'touch_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                         </li>
                                                     {% endif %}
                                                     {% if finding|has_object_permission:"Finding_Add" %}
@@ -1077,26 +1078,29 @@
                                                             </li>
                                                         {% else %}
                                                             <li role="presentation">
-                                                                <a href="{% url 'reopen_finding' finding.id %}">
+                                                                <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                                     <i class="fa-solid fa-bug"></i> {% trans "Open Finding" %}
                                                                 </a>
+                                                                <form method="post" action="{% url 'reopen_finding' finding.id %}">{% csrf_token %}</form>
                                                             </li>
                                                         {% endif %}
                                                     {% endif %}
                                                     {% if finding|has_object_permission:"Risk_Acceptance" %}
                                                         {% if finding.risk_accepted %}
                                                             <li role="presentation">
-                                                                <a href="{% url 'risk_unaccept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                                                <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                                     <i class="fa-solid fa-circle-exclamation"></i> {% trans "Unaccept Risk" %}
                                                                 </a>
+                                                                <form method="post" action="{% url 'risk_unaccept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                             </li>
                                                         {% else %}
                                                             {% if not finding.duplicate %}
                                                                 {% if finding.test.engagement.product.enable_simple_risk_acceptance %}
                                                                     <li role="presentation">
-                                                                        <a href="{% url 'simple_risk_accept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
+                                                                        <a href="#" onclick="this.nextElementSibling.submit(); return false;">
                                                                             <i class="fa-solid fa-circle-exclamation"></i> {% trans "Accept Risk" %}
                                                                         </a>
+                                                                        <form method="post" action="{% url 'simple_risk_accept_finding' finding.id %}">{% csrf_token %}<input type="hidden" name="return_url" value="{{ request.get_full_path }}"></form>
                                                                     </li>
                                                                 {% endif %}
                                                                 {% if finding.test.engagement.product.enable_full_risk_acceptance %}

--- a/unittests/test_csrf_require_post.py
+++ b/unittests/test_csrf_require_post.py
@@ -1,0 +1,63 @@
+"""
+Regression tests: state-changing finding/engagement/risk-acceptance UI actions
+must not run on GET. A GET has to be rejected (405) so it cannot be triggered by
+a cross-origin or stored request that only the browser's safe-method path allows.
+"""
+from django.urls import reverse
+
+from dojo.models import Finding
+from unittests.dojo_test_case import DojoTestCase, versioned_fixtures
+
+
+@versioned_fixtures
+class StateChangingActionsRequirePostTest(DojoTestCase):
+    fixtures = ["dojo_testdata.json"]
+
+    def setUp(self):
+        self.client.force_login(self.get_test_admin())
+
+    def test_state_changing_actions_reject_get(self):
+        # (url_name, args) for every UI action that mutates state.
+        # require_POST rejects the method before the view body runs, so the
+        # object ids only need to resolve the route, not exist.
+        cases = [
+            ("simple_risk_accept_finding", (2,)),
+            ("risk_unaccept_finding", (2,)),
+            ("reopen_finding", (2,)),
+            ("touch_finding", (2,)),
+            ("close_engagement", (1,)),
+            ("reopen_engagement", (1,)),
+            ("expire_risk_acceptance", (1, 1)),
+            ("reinstate_risk_acceptance", (1, 1)),
+            ("delete_risk_acceptance", (1, 1)),
+        ]
+        for name, args in cases:
+            with self.subTest(action=name):
+                response = self.client.get(reverse(name, args=args))
+                self.assertEqual(
+                    response.status_code, 405,
+                    f"{name} answered GET with {response.status_code}; must be 405",
+                )
+
+    def test_get_does_not_risk_accept_but_post_does(self):
+        # Mirror the reported attack shape on the finding risk-accept action.
+        finding = Finding.objects.get(id=2)
+        product = finding.test.engagement.product
+        product.enable_simple_risk_acceptance = True
+        product.save()
+        finding.active = True
+        finding.risk_accepted = False
+        finding.save()
+
+        url = reverse("simple_risk_accept_finding", args=(finding.id,))
+
+        # GET (what a stored <img> would issue) must not change anything.
+        self.assertEqual(self.client.get(url).status_code, 405)
+        finding.refresh_from_db()
+        self.assertTrue(finding.active)
+        self.assertFalse(finding.risk_accepted)
+
+        # POST (the real button) still works for a permitted user.
+        self.assertEqual(self.client.post(url).status_code, 302)
+        finding.refresh_from_db()
+        self.assertTrue(finding.risk_accepted)

--- a/unittests/test_permissions_audit.py
+++ b/unittests/test_permissions_audit.py
@@ -712,7 +712,7 @@ class TestRiskAcceptanceCrossEngagementIDOR(LegacyAuthMirrorMixin, DojoTestCase)
         url = reverse("expire_risk_acceptance", args=(
             self.engagement_b.id, self.risk_acceptance.id,
         ))
-        response = client.get(url)
+        response = client.post(url)
         self.assertEqual(response.status_code, 404)
 
     def test_reinstate_risk_acceptance_cross_engagement(self):
@@ -721,7 +721,7 @@ class TestRiskAcceptanceCrossEngagementIDOR(LegacyAuthMirrorMixin, DojoTestCase)
         url = reverse("reinstate_risk_acceptance", args=(
             self.engagement_b.id, self.risk_acceptance.id,
         ))
-        response = client.get(url)
+        response = client.post(url)
         self.assertEqual(response.status_code, 404)
 
     def test_delete_risk_acceptance_cross_engagement(self):
@@ -730,7 +730,7 @@ class TestRiskAcceptanceCrossEngagementIDOR(LegacyAuthMirrorMixin, DojoTestCase)
         url = reverse("delete_risk_acceptance", args=(
             self.engagement_b.id, self.risk_acceptance.id,
         ))
-        response = client.get(url)
+        response = client.post(url)
         self.assertEqual(response.status_code, 404)
 
     def test_view_risk_acceptance_same_engagement(self):


### PR DESCRIPTION
Several finding, engagement, and risk-acceptance actions in the UI were reachable over GET. This changes those views to accept POST only and updates their menu triggers to submit a small form carrying a CSRF token, matching the pattern already used by the "Delete Risk Acceptance" action.

No functional change for correctly-permissioned users driving these actions from the UI. Adds a regression test asserting these actions reject GET.

Routine hardening so state-changing operations follow the standard safe-method convention. Security tracking is internal.
