### PR TITLE
fix(finding): clear dangling duplicate_finding refs during bulk delete

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -819,6 +819,34 @@ def bulk_clear_finding_m2m(finding_qs):
         Notes.objects.filter(id__in=note_ids).delete()
 
 
+def _clear_dangling_duplicate_finding_refs(chunk_ids):
+    """
+    Unlink findings that point at this chunk via duplicate_finding but survive it.
+
+    Finding.duplicate_finding is a self-FK with on_delete=DO_NOTHING, so Django
+    performs no cleanup and Postgres enforces the constraint at COMMIT. The
+    cascade walker is called with skip_relations={Finding}, so nothing else
+    clears the pointer.
+
+    Ordering alone cannot prevent the violation: the referrer is frequently not
+    in the deletion set at all (transitive duplicate chains, or a caller that
+    deletes only part of a cluster - e.g. async_dupe_delete trimming excess
+    duplicates). This mirrors what prepare_duplicates_for_delete already does
+    for scope-based deletes, and is a no-op when that ran first.
+    """
+    unlinked = Finding.objects.filter(
+        duplicate_finding_id__in=chunk_ids,
+    ).exclude(
+        id__in=chunk_ids,
+    ).update(duplicate_finding=None, duplicate=False)
+    if unlinked:
+        logger.debug(
+            "bulk_delete_findings: unlinked %d surviving duplicate_finding references",
+            unlinked,
+        )
+    return unlinked
+
+
 def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=False):
     """
     Delete findings and all related objects efficiently. Including any related object in Dojo-Pro
@@ -831,6 +859,9 @@ def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=Fa
     When order_desc is True, findings are processed highest id first (matches
     finding_delete: duplicate_cluster.order_by("-id").delete()) so self-FK
     duplicate chains delete children before parents.
+
+    Before each chunk is deleted, surviving findings that still point at it via
+    duplicate_finding are unlinked; see _clear_dangling_duplicate_finding_refs.
     """
     from dojo.signals import pre_bulk_delete_findings  # noqa: PLC0415 circular import
     from dojo.utils_cascade_delete import (  # noqa: PLC0415 circular import
@@ -851,6 +882,7 @@ def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=Fa
     ):
         chunk_qs = Finding.objects.filter(id__in=chunk_ids)
         with transaction.atomic():
+            _clear_dangling_duplicate_finding_refs(chunk_ids)
             cascade_delete_related_objects(Finding, chunk_qs, skip_relations={Finding}, skip_m2m_for={Finding})
             execute_delete_sql(chunk_qs)
         logger.info(

--- a/unittests/test_bulk_delete_duplicate_fk.py
+++ b/unittests/test_bulk_delete_duplicate_fk.py
@@ -1,0 +1,174 @@
+"""
+Regression: bulk_delete_findings raised IntegrityError on the self-referential
+dojo_finding.duplicate_finding_id FK when a surviving finding still pointed at a
+deleted one (seen in production via dojo.tasks.async_dupe_delete).
+"""
+
+import logging
+
+from django.db import IntegrityError, connection
+from django.utils import timezone
+from parameterized import parameterized
+
+from dojo.finding.helper import bulk_delete_findings
+from dojo.models import (
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+    User,
+    UserContactInfo,
+)
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+class TestBulkDeleteDuplicateFindingFK(DojoTestCase):
+
+    """
+    bulk_delete_findings must never leave a dangling duplicate_finding_id.
+
+    ``Finding.duplicate_finding`` is a self-FK with ``on_delete=DO_NOTHING``, so
+    Django performs no cleanup and Postgres enforces the constraint at COMMIT.
+    ``_bulk_delete_findings_internal`` passes ``skip_relations={Finding}`` to the
+    cascade walker, so nothing clears the pointer for findings that survive the
+    delete.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.testuser = User.objects.create(
+            username="bulk_delete_dupe_fk_user",
+            is_staff=True,
+            is_superuser=True,
+        )
+        UserContactInfo.objects.create(user=self.testuser, block_execution=True)
+        self.system_settings(enable_deduplication=False)
+        self.system_settings(enable_product_grade=False)
+
+        self.product_type = Product_Type.objects.create(name="Bulk Delete Dupe FK PT")
+        self.product = Product.objects.create(
+            name="Bulk Delete Dupe FK Product",
+            description="Test",
+            prod_type=self.product_type,
+        )
+        self.test_type = Test_Type.objects.get_or_create(name="Manual Test")[0]
+        self.engagement = Engagement.objects.create(
+            name="Bulk Delete Dupe FK Engagement",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        self.test = Test.objects.create(
+            engagement=self.engagement,
+            test_type=self.test_type,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+
+    def _create_finding(self, title, *, duplicate_of=None):
+        return Finding.objects.create(
+            test=self.test,
+            title=title,
+            severity="High",
+            description="Test",
+            mitigation="Test",
+            impact="Test",
+            reporter=self.testuser,
+            duplicate=duplicate_of is not None,
+            duplicate_finding=duplicate_of,
+        )
+
+    @staticmethod
+    def _assert_no_deferred_fk_violation():
+        """Force Postgres to validate the deferred FKs the way COMMIT would."""
+        try:
+            connection.check_constraints()
+        except IntegrityError as exc:  # pragma: no cover - only on regression
+            msg = f"bulk_delete_findings left a dangling duplicate_finding_id: {exc}"
+            raise AssertionError(msg) from exc
+
+    @parameterized.expand([
+        # (scenario, referrer_is_in_delete_set)
+        ("referrer_outside_delete_set", False),
+        ("referrer_inside_delete_set", True),
+    ])
+    def test_bulk_delete_clears_dangling_duplicate_finding(self, scenario, referrer_in_delete_set):
+        """
+        Deleting a finding that is itself an original must not orphan its cluster.
+
+        The failing case is a transitive duplicate chain (original <- middle <- tail)
+        where only ``middle`` is selected for deletion, exactly what
+        ``async_dupe_delete`` does when it deletes excess duplicates: ``tail``
+        survives and still references the deleted ``middle``.
+
+        The control case deletes both, which already worked, so the fix is locked
+        in both directions.
+        """
+        original = self._create_finding("original")
+        middle = self._create_finding("middle", duplicate_of=original)
+        tail = self._create_finding("tail", duplicate_of=middle)
+
+        delete_ids = [middle.id, tail.id] if referrer_in_delete_set else [middle.id]
+
+        bulk_delete_findings(Finding.objects.filter(id__in=delete_ids), order_desc=True)
+        self._assert_no_deferred_fk_violation()
+
+        self.assertFalse(
+            Finding.objects.filter(id__in=delete_ids).exists(),
+            msg=f"[{scenario}] expected findings {delete_ids} to be deleted",
+        )
+        self.assertFalse(
+            Finding.objects.filter(duplicate_finding_id=middle.id).exists(),
+            msg=(
+                "expected no surviving finding to reference deleted finding "
+                f"{middle.id}, found "
+                f"{list(Finding.objects.filter(duplicate_finding_id=middle.id).values_list('id', flat=True))}"
+            ),
+        )
+
+        if not referrer_in_delete_set:
+            tail.refresh_from_db()
+            self.assertIsNone(
+                tail.duplicate_finding_id,
+                msg=f"expected tail.duplicate_finding_id=None, persisted={tail.duplicate_finding_id}",
+            )
+            self.assertFalse(
+                tail.duplicate,
+                msg=f"expected tail.duplicate=False, persisted={tail.duplicate}",
+            )
+
+    def test_bulk_delete_clears_dangling_references_in_every_chunk(self):
+        """
+        Every chunk must clean up its own referrers, not just the first one.
+
+        Each chunk commits separately in production, so a chunk that leaves a
+        dangling pointer fails on its own COMMIT. Two originals are deleted with
+        chunk_size=1 (one chunk each), each with a surviving duplicate outside the
+        deletion set.
+        """
+        original_a = self._create_finding("chunked original A")
+        original_b = self._create_finding("chunked original B")
+        survivor_a = self._create_finding("survivor A", duplicate_of=original_a)
+        survivor_b = self._create_finding("survivor B", duplicate_of=original_b)
+
+        bulk_delete_findings(
+            Finding.objects.filter(id__in=[original_a.id, original_b.id]),
+            chunk_size=1,
+            order_desc=True,
+        )
+        self._assert_no_deferred_fk_violation()
+
+        for survivor in (survivor_a, survivor_b):
+            survivor.refresh_from_db()
+            self.assertIsNone(
+                survivor.duplicate_finding_id,
+                msg=(
+                    f"expected {survivor.title}.duplicate_finding_id=None, "
+                    f"persisted={survivor.duplicate_finding_id}"
+                ),
+            )


### PR DESCRIPTION
**Description**

`bulk_delete_findings` fails at COMMIT whenever a finding that survives the delete still points at one that was deleted:

```
django.db.utils.IntegrityError: update or delete on table "dojo_finding" violates foreign key
constraint "dojo_finding_duplicate_finding_id_9ff391c5_fk_dojo_finding_id" on table "dojo_finding"
DETAIL:  Key (id)=(...) is still referenced from table "dojo_finding".
```

Root cause: `Finding.duplicate_finding` is a self-FK with `on_delete=DO_NOTHING` (`dojo/finding/models.py:221`), so Django performs no cleanup and Postgres enforces the constraint at COMMIT. `_bulk_delete_findings_internal` calls the cascade walker with `skip_relations={Finding}`, so nothing clears the pointer.

The existing `order_desc=True` ordering only helps when the referrer is inside the deletion set. In practice it often is not:

- transitive duplicate chains (`A → B → C`) — the condition `fix_loop_duplicates` exists to repair. Deleting `B` leaves `C` pointing at it.
- a caller that deletes only part of a cluster — e.g. `async_dupe_delete` trimming excess duplicates, where the `[:DUPE_DELETE_MAX_PER_RUN]` slice in `dojo/tasks.py` can cut a cluster in half.

The scope-based delete path already handles this: `prepare_duplicates_for_delete` nulls outside-scope references with the comment *"prevent FK violation"*. The bare-queryset path never got the same treatment.

**Fix**

Unlink surviving referrers inside each chunk's own transaction, before the chunk is deleted:

```python
 chunk_qs = Finding.objects.filter(id__in=chunk_ids)
 with transaction.atomic():
+    _clear_dangling_duplicate_finding_refs(chunk_ids)
     cascade_delete_related_objects(Finding, chunk_qs, skip_relations={Finding}, skip_m2m_for={Finding})
     execute_delete_sql(chunk_qs)
```

The new helper runs `Finding.objects.filter(duplicate_finding_id__in=chunk_ids).exclude(id__in=chunk_ids).update(duplicate_finding=None, duplicate=False)`. Per chunk rather than once up front, because each chunk commits separately — a single pre-pass would leave later chunks exposed. It is a no-op for callers that already ran `prepare_duplicates_for_delete`, so those paths are unchanged.

The filter is served by the existing `models.Index(fields=["duplicate_finding", "id"])`.

**Test results**

New file `unittests/test_bulk_delete_duplicate_fk.py`, 3 cases. Deferred FKs are validated the way COMMIT would via `connection.check_constraints()`, so the test reproduces the real failure rather than only asserting on resulting state.

| Case | Before | After |
|---|---|---|
| referrer outside the deletion set (transitive chain) | fails with the exact constraint error | passes |
| referrer inside the deletion set (control — already worked) | passes | passes |
| referrers spread across chunks (`chunk_size=1`) | fails with the exact constraint error | passes |

The control case passing before the fix confirms the diagnosis is specific rather than a broad breakage.

No collateral damage, run locally against PostgreSQL:

- `test_duplication_loops`, `test_cascade_delete`, `test_async_delete`, `test_deduplication_logic` — 107 pass, 2 skipped
- `test_prepare_duplicates_for_delete`, `test_finding_helper`, `test_finding_model`, `test_delete_with_endpoints_v3`, `test_importers_deduplication`, `test_utils_deduplication_reopen` — 186 pass, 29 skipped

**Documentation**

No documentation changes needed — this is an internal bug fix with no change to configuration, API surface, or user-facing behaviour. The reasoning is captured in the new helper's docstring and in `_bulk_delete_findings_internal`'s.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.  *(bugfix — branched off current `bugfix` tip)*
- [ ] Features/Changes should be submitted against the `dev`.  *(n/a — bugfix)*
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs.  *(n/a — bugfix)*
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.  *(n/a — no model changes)*
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.  *(suggested: `bugfix`)*