### PR TITLE
Apply the member-management check on every serializer exposing the field

### DIFF
--- a/dojo/asset/api/serializers.py
+++ b/dojo/asset/api/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from dojo.api_v2.serializers import ProductMetaSerializer, TagListSerializerField
+from dojo.authorization.serializer_guards import AuthorizedUsersMemberGuardMixin
 from dojo.models import (
     Dojo_User,
     Product,
@@ -23,7 +24,7 @@ class AssetAPIScanConfigurationSerializer(serializers.ModelSerializer):
         exclude = ("product",)
 
 
-class AssetSerializer(serializers.ModelSerializer):
+class AssetSerializer(AuthorizedUsersMemberGuardMixin, serializers.ModelSerializer):
     findings_count = serializers.SerializerMethodField()
     findings_list = serializers.SerializerMethodField()
 

--- a/dojo/authorization/serializer_guards.py
+++ b/dojo/authorization/serializer_guards.py
@@ -1,0 +1,78 @@
+from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
+
+# Keyed by model name so this module stays import-light and free of cycles.
+# Value is (Permissions attribute name, noun used in the error message).
+_MANAGE_MEMBERS = {
+    "Product": ("Product_Manage_Members", "product"),
+    "Product_Type": ("Product_Type_Manage_Members", "product type"),
+}
+
+
+class AuthorizedUsersMemberGuardMixin:
+
+    """
+    Enforce the member-management permission on ``authorized_users`` writes.
+
+    ``authorized_users`` is a writable M2M on ``Product`` and ``Product_Type``, so
+    every ``ModelSerializer`` over those models picks it up unless it is explicitly
+    excluded. Object access is derived from that list, which makes writing it a
+    member-management operation rather than an ordinary edit: it is gated behind
+    ``Product_Manage_Members`` / ``Product_Type_Manage_Members``, the same
+    permissions the web UI requires (dojo.product.ui.views.add_product_authorized_users).
+    The rest of these endpoints is governed by the corresponding ``_Edit`` permission.
+
+    Mix this into *every* serializer exposing the field, including alias
+    serializers over the same models, so the rule holds wherever the field is
+    reachable. The permission is derived from ``Meta.model``, so there is nothing
+    per-serializer to configure or forget.
+
+    The check hangs off ``run_validation`` rather than ``validate`` on purpose: a
+    subclass that defines its own ``validate`` would otherwise shadow the mixin's
+    and silently drop the guard.
+
+    No-ops when the field is absent or unchanged (replay-safe), mirroring
+    dojo.authorization.api_permissions.check_update_permission.
+    """
+
+    def run_validation(self, data=serializers.empty):
+        value = super().run_validation(data)
+        self._validate_authorized_users_change(value)
+        return value
+
+    def _validate_authorized_users_change(self, data):
+        if "authorized_users" not in data:
+            return
+
+        # Field-level validation has already resolved the payload to Dojo_User
+        # instances at this point.
+        from dojo.authorization.authorization import (  # noqa: PLC0415 -- lazy import, avoids circular dependency
+            user_has_permission,
+        )
+        from dojo.authorization.roles_permissions import (  # noqa: PLC0415 -- lazy import, avoids circular dependency
+            Permissions,
+        )
+
+        model_name = self.Meta.model.__name__
+        if model_name not in _MANAGE_MEMBERS:
+            # Fail closed: a model we have no member-management permission for
+            # must not get a free pass on the membership list.
+            msg = f"No member-management permission is defined for {model_name}."
+            raise PermissionDenied(msg)
+        permission_name, label = _MANAGE_MEMBERS[model_name]
+
+        new_ids = sorted(user.pk for user in (data.get("authorized_users") or []))
+        current_ids = (
+            sorted(self.instance.authorized_users.values_list("pk", flat=True))
+            if self.instance is not None
+            else []
+        )
+        if new_ids == current_ids:
+            return
+
+        request = self.context.get("request")
+        request_user = getattr(request, "user", None)
+        permission = getattr(Permissions, permission_name)
+        if not (request_user and user_has_permission(request_user, self.instance, permission)):
+            msg = f"You do not have permission to manage authorized users for this {label}."
+            raise PermissionDenied(msg)

--- a/dojo/organization/api/serializers.py
+++ b/dojo/organization/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from dojo.authorization.serializer_guards import AuthorizedUsersMemberGuardMixin
 from dojo.models import Product_Type
 from dojo.product_type.queries import get_authorized_product_types
 
@@ -9,7 +10,7 @@ class RelatedOrganizationField(serializers.PrimaryKeyRelatedField):
         return get_authorized_product_types("view")
 
 
-class OrganizationSerializer(serializers.ModelSerializer):
+class OrganizationSerializer(AuthorizedUsersMemberGuardMixin, serializers.ModelSerializer):
     critical_asset = serializers.BooleanField(source="critical_product", default=False)
     key_asset = serializers.BooleanField(source="key_product", default=False)
 

--- a/dojo/product/api/serializer.py
+++ b/dojo/product/api/serializer.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
 
+from dojo.authorization.serializer_guards import AuthorizedUsersMemberGuardMixin
 from dojo.models import DojoMeta, Product, Product_API_Scan_Configuration
 
 
@@ -16,7 +16,7 @@ class ProductAPIScanConfigurationSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
-class ProductSerializer(serializers.ModelSerializer):
+class ProductSerializer(AuthorizedUsersMemberGuardMixin, serializers.ModelSerializer):
     findings_count = serializers.SerializerMethodField()
     findings_list = serializers.SerializerMethodField()
 
@@ -51,47 +51,7 @@ class ProductSerializer(serializers.ModelSerializer):
             if new_sla_config and old_sla_config and new_sla_config != old_sla_config:
                 msg = "Finding SLA expiration dates are currently being recalculated. The SLA configuration for this product cannot be changed until the calculation is complete."
                 raise serializers.ValidationError(msg)
-        self._validate_authorized_users_change(data)
         return data
-
-    def _validate_authorized_users_change(self, data):
-        """
-        Writing ``authorized_users`` is a member-management operation and is
-        gated behind ``Product_Manage_Members`` -- the same permission the web
-        UI requires (dojo.product.ui.views.add_product_authorized_users). The
-        rest of this endpoint is governed by ``Product_Edit``, so this keeps
-        changes to the membership list aligned with the dedicated
-        member-management permission.
-
-        No-ops when the field is absent or unchanged (replay-safe), mirroring
-        dojo.authorization.api_permissions.check_update_permission.
-        """
-        if "authorized_users" not in data:
-            return
-
-        # Field-level validation has already resolved the payload to Dojo_User
-        # instances at this point.
-        from dojo.authorization.authorization import (  # noqa: PLC0415 -- lazy import, avoids circular dependency
-            user_has_permission,
-        )
-        from dojo.authorization.roles_permissions import (  # noqa: PLC0415 -- lazy import, avoids circular dependency
-            Permissions,
-        )
-
-        new_ids = sorted(user.pk for user in (data.get("authorized_users") or []))
-        current_ids = (
-            sorted(self.instance.authorized_users.values_list("pk", flat=True))
-            if self.instance is not None
-            else []
-        )
-        if new_ids == current_ids:
-            return
-
-        request = self.context.get("request")
-        request_user = getattr(request, "user", None)
-        if not (request_user and user_has_permission(request_user, self.instance, Permissions.Product_Manage_Members)):
-            msg = "You do not have permission to manage authorized users for this product."
-            raise PermissionDenied(msg)
 
     def get_findings_count(self, obj) -> int:
         return obj.findings_count

--- a/dojo/product_type/api/serializer.py
+++ b/dojo/product_type/api/serializer.py
@@ -1,51 +1,10 @@
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
 
+from dojo.authorization.serializer_guards import AuthorizedUsersMemberGuardMixin
 from dojo.product_type.models import Product_Type
 
 
-class ProductTypeSerializer(serializers.ModelSerializer):
+class ProductTypeSerializer(AuthorizedUsersMemberGuardMixin, serializers.ModelSerializer):
     class Meta:
         model = Product_Type
         fields = "__all__"
-
-    def validate(self, data):
-        self._validate_authorized_users_change(data)
-        return data
-
-    def _validate_authorized_users_change(self, data):
-        """
-        Changing ``authorized_users`` requires ``Product_Type_Manage_Members``;
-        all other fields on this serializer require ``Product_Type_Edit``. No-op
-        when the field is absent or unchanged (replay-safe). Mirrors
-        dojo.product.api.serializer.ProductSerializer.
-        """
-        if "authorized_users" not in data:
-            return
-
-        # Field-level validation has already resolved the payload to Dojo_User
-        # instances at this point.
-        from dojo.authorization.authorization import (  # noqa: PLC0415 -- lazy import, avoids circular dependency
-            user_has_permission,
-        )
-        from dojo.authorization.roles_permissions import (  # noqa: PLC0415 -- lazy import, avoids circular dependency
-            Permissions,
-        )
-
-        new_ids = sorted(user.pk for user in (data.get("authorized_users") or []))
-        current_ids = (
-            sorted(self.instance.authorized_users.values_list("pk", flat=True))
-            if self.instance is not None
-            else []
-        )
-        if new_ids == current_ids:
-            return
-
-        request = self.context.get("request")
-        request_user = getattr(request, "user", None)
-        if not (
-            request_user
-            and user_has_permission(request_user, self.instance, Permissions.Product_Type_Manage_Members)
-        ):
-            msg = "You do not have permission to manage authorized users for this product type."
-            raise PermissionDenied(msg)

--- a/unittests/test_v3_alias_authorized_users_api_authz.py
+++ b/unittests/test_v3_alias_authorized_users_api_authz.py
@@ -1,0 +1,155 @@
+from django.urls import reverse
+from rest_framework import serializers
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from dojo.authorization.authorization import user_has_permission
+from dojo.authorization.roles_permissions import Permissions
+from dojo.authorization.serializer_guards import AuthorizedUsersMemberGuardMixin
+from dojo.models import Dojo_User, Product, Product_Type, User
+from unittests.dojo_test_case import DojoAPITestCase, versioned_fixtures
+
+
+def _all_model_serializers():
+    found, stack = set(), [serializers.ModelSerializer]
+    while stack:
+        for sub in stack.pop().__subclasses__():
+            if sub not in found:
+                found.add(sub)
+                stack.append(sub)
+    return found
+
+
+@versioned_fixtures
+class V3AliasAuthorizedUsersApiPermissionTest(DojoAPITestCase):
+
+    """
+    The asset and organization endpoints are aliases over the same Product and
+    Product_Type objects as the product and product_type endpoints, and expose the
+    same ``authorized_users`` membership field. Changing that list is a
+    member-management operation wherever it is reached, so these pin that the alias
+    endpoints require the member-management permission exactly as their
+    counterparts do in test_product_authorized_users_api_authz.py.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.prod_type = Product_Type.objects.create(name="V3A-Perm PT")
+        cls.product = Product.objects.create(
+            name="V3A-Perm Product",
+            description="product for alias authorized_users permission tests",
+            prod_type=cls.prod_type,
+        )
+
+        # Alice holds edit on both objects, via authorized_users membership.
+        cls.alice = User.objects.create_user(
+            username="v3a_alice",
+            password="not-a-real-secret",  # noqa: S106 - test fixture user
+            is_staff=False,
+        )
+        cls.product.authorized_users.add(Dojo_User.objects.get(pk=cls.alice.pk))
+        cls.prod_type.authorized_users.add(Dojo_User.objects.get(pk=cls.alice.pk))
+
+        # Bob is not a member of either.
+        cls.bob = User.objects.create_user(
+            username="v3a_bob",
+            password="not-a-real-secret",  # noqa: S106 - test fixture user
+            is_staff=False,
+        )
+
+        # Staff user, who holds the member-management permissions.
+        cls.admin = User.objects.create_user(
+            username="v3a_admin",
+            password="not-a-real-secret",  # noqa: S106 - test fixture user
+            is_staff=True,
+        )
+
+        cls.asset_url = reverse("asset-detail", args=[cls.product.id])
+        cls.organization_url = reverse("organization-detail", args=[cls.prod_type.id])
+
+    def _client_for(self, user):
+        token, _ = Token.objects.get_or_create(user=user)
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+        return client
+
+    def _assert_denied(self, url, obj, edit_permission):
+        client = self._client_for(self.alice)
+        bob = Dojo_User.objects.get(pk=self.bob.pk)
+
+        self.assertFalse(obj.authorized_users.filter(pk=bob.pk).exists())
+        self.assertTrue(
+            user_has_permission(Dojo_User.objects.get(pk=self.alice.pk), obj, edit_permission),
+        )
+
+        response = client.patch(
+            url, {"authorized_users": [self.alice.pk, self.bob.pk]}, format="json",
+        )
+        self.assertEqual(403, response.status_code, response.content[:400])
+
+        obj.refresh_from_db()
+        self.assertFalse(obj.authorized_users.filter(pk=bob.pk).exists())
+        self.assertFalse(user_has_permission(bob, obj, edit_permission))
+
+    def test_asset_edit_cannot_add_authorized_users(self):
+        self._assert_denied(self.asset_url, self.product, Permissions.Product_Edit)
+
+    def test_organization_edit_cannot_add_authorized_users(self):
+        self._assert_denied(self.organization_url, self.prod_type, Permissions.Product_Type_Edit)
+
+    def test_asset_edit_unchanged_authorized_users_is_allowed(self):
+        # Replay-safe: resubmitting the current membership set is not a change.
+        client = self._client_for(self.alice)
+        response = client.patch(
+            self.asset_url, {"authorized_users": [self.alice.pk]}, format="json",
+        )
+        self.assertEqual(200, response.status_code, response.content[:400])
+
+    def test_asset_ordinary_edit_still_works(self):
+        # The endpoint stays usable for an edit-level user; only the membership
+        # list is gated.
+        client = self._client_for(self.alice)
+        response = client.patch(
+            self.asset_url, {"description": "edited via alias"}, format="json",
+        )
+        self.assertEqual(200, response.status_code, response.content[:400])
+
+    def test_manage_members_permission_can_change_authorized_users(self):
+        client = self._client_for(self.admin)
+        response = client.patch(
+            self.asset_url, {"authorized_users": [self.alice.pk, self.bob.pk]}, format="json",
+        )
+        self.assertEqual(200, response.status_code, response.content[:400])
+
+        self.product.refresh_from_db()
+        self.assertTrue(self.product.authorized_users.filter(pk=self.bob.pk).exists())
+
+    def test_every_serializer_exposing_authorized_users_carries_the_guard(self):
+        """
+        Any serializer over Product / Product_Type picks up ``authorized_users``
+        unless it excludes it, so each one has to carry the guard. This fails on a
+        newly added serializer that forgets it, rather than leaving a gap for a
+        report to find.
+        """
+        reverse("asset-detail", args=[self.product.id])  # force the URLconf, and so every viewset module, to load
+
+        unguarded = []
+        for ser in _all_model_serializers():
+            meta = getattr(ser, "Meta", None)
+            if getattr(meta, "model", None) not in {Product, Product_Type}:
+                continue
+            declared = getattr(meta, "fields", None)
+            excluded = tuple(getattr(meta, "exclude", ()) or ())
+            exposed = "authorized_users" not in excluded and (
+                declared is None or declared == "__all__" or "authorized_users" in declared
+            )
+            if exposed and not issubclass(ser, AuthorizedUsersMemberGuardMixin):
+                unguarded.append(f"{ser.__module__}.{ser.__name__}")
+
+        self.assertEqual(
+            [], sorted(unguarded),
+            "these serializers expose authorized_users without the member-management guard; "
+            "add AuthorizedUsersMemberGuardMixin, or exclude the field",
+        )


### PR DESCRIPTION
The member-management check on the membership field was implemented separately in the product and product type serializers. That field is a writable M2M on both models, so any ModelSerializer over them picks it up unless it explicitly excludes it, which means a per-serializer check is something each new serializer has to remember.

This pulls the check into one shared mixin and routes every serializer over those models through it, including the alias serializers. The permission is derived from `Meta.model` so there is nothing per-serializer to configure, and the check hangs off `run_validation` rather than `validate` so a subclass defining its own `validate` cannot shadow it.

Also adds a test that fails if a serializer exposes the field without the guard, so this stays consistent as serializers get added.

Net effect is less duplicated authorization code than before, and no functional change for correctly-permissioned users. Tests pass on both legs of the `DD_V3_FEATURE_LOCATIONS` matrix.