### PR TITLE
fix(risk_acceptance): stop the expiration job aborting on an unattached risk acceptance

### DIFF
--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -18,20 +18,35 @@ logger = logging.getLogger(__name__)
 
 def engagement_to_notify_about(risk_acceptance: Risk_Acceptance) -> Engagement | None:
     """
-    Return the engagement backing a risk acceptance, or None when it has none.
+    Return an engagement to address a risk acceptance's expiration notification to.
 
-    `Risk_Acceptance.engagement` is a property over a many-to-many that is used as a
-    one-to-many, so it is None for a risk acceptance no engagement points at. Expiration
-    notifications are addressed to the engagement's product and link to a per-engagement
-    URL, so there is nothing to send when the engagement is missing.
+    `Risk_Acceptance.engagement` is a property over `Engagement.risk_acceptance`, a
+    many-to-many used as a one-to-many. It is empty for a risk acceptance that was not
+    created from an engagement page, which is a supported state rather than corrupt data:
+    `RiskAcceptanceSerializer.create` only attaches an engagement when the risk acceptance
+    already has findings, `_accept_risks` and the SonarQube status sync never attach one at
+    all, and the Pro plugin tracks the association on its own model instead of this relation.
+
+    So fall back to the engagement of an accepted finding - the same derivation
+    `RiskAcceptanceSerializer` uses both to attach an engagement on create and to repair an
+    orphan on update. Only a risk acceptance with neither an engagement nor any findings has
+    nothing to notify about; the notification names a product and links to a per-engagement
+    URL, and neither can be produced from an empty risk acceptance.
     """
     engagement = risk_acceptance.engagement
-    if engagement is None:
-        logger.warning(
-            "risk acceptance %i:%s is not attached to an engagement, skipping its expiration notification",
-            risk_acceptance.id, risk_acceptance,
-        )
-    return engagement
+    if engagement is not None:
+        return engagement
+
+    # iterate rather than .first(), to reuse the accepted_findings prefetch
+    accepted_finding = next(iter(risk_acceptance.accepted_findings.all()), None)
+    if accepted_finding is not None:
+        return accepted_finding.test.engagement
+
+    logger.warning(
+        "risk acceptance %i:%s has no engagement and no findings, skipping its expiration notification",
+        risk_acceptance.id, risk_acceptance,
+    )
+    return None
 
 
 def expire_now(risk_acceptance):

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -9,11 +9,29 @@ from django.utils import timezone
 
 from dojo.celery import app
 from dojo.jira import services as jira_services
-from dojo.models import Dojo_User, Finding, Notes, Risk_Acceptance, System_Settings
+from dojo.models import Dojo_User, Engagement, Finding, Notes, Risk_Acceptance, System_Settings
 from dojo.notifications.helper import create_notification
 from dojo.utils import get_full_url, get_system_setting
 
 logger = logging.getLogger(__name__)
+
+
+def engagement_to_notify_about(risk_acceptance: Risk_Acceptance) -> Engagement | None:
+    """
+    Return the engagement backing a risk acceptance, or None when it has none.
+
+    `Risk_Acceptance.engagement` is a property over a many-to-many that is used as a
+    one-to-many, so it is None for a risk acceptance no engagement points at. Expiration
+    notifications are addressed to the engagement's product and link to a per-engagement
+    URL, so there is nothing to send when the engagement is missing.
+    """
+    engagement = risk_acceptance.engagement
+    if engagement is None:
+        logger.warning(
+            "risk acceptance %i:%s is not attached to an engagement, skipping its expiration notification",
+            risk_acceptance.id, risk_acceptance,
+        )
+    return engagement
 
 
 def expire_now(risk_acceptance):
@@ -49,14 +67,19 @@ def expire_now(risk_acceptance):
     risk_acceptance.expiration_date_handled = timezone.now()
     risk_acceptance.save()
 
+    # the expiry above is the job here, the notification below is best effort
+    engagement = engagement_to_notify_about(risk_acceptance)
+    if engagement is None:
+        return
+
     accepted_findings = risk_acceptance.accepted_findings.all()
     title = "Risk acceptance with " + str(len(accepted_findings)) + " accepted findings has expired for " + \
-            str(risk_acceptance.engagement.product) + ": " + str(risk_acceptance.engagement.name)
+            str(engagement.product) + ": " + str(engagement.name)
 
     create_notification(event="risk_acceptance_expiration", title=title, risk_acceptance=risk_acceptance, accepted_findings=accepted_findings,
-                         reactivated_findings=reactivated_findings, engagement=risk_acceptance.engagement,
-                         product=risk_acceptance.engagement.product,
-                         url=reverse("view_risk_acceptance", args=(risk_acceptance.engagement.id, risk_acceptance.id)))
+                         reactivated_findings=reactivated_findings, engagement=engagement,
+                         product=engagement.product,
+                         url=reverse("view_risk_acceptance", args=(engagement.id, risk_acceptance.id)))
 
 
 def reinstate(risk_acceptance, old_expiration_date):
@@ -198,17 +221,21 @@ def expiration_handler(*args, **kwargs):
             for risk_acceptance in risk_acceptances:
                 logger.debug("notifying for risk acceptance %i:%s with %i findings", risk_acceptance.id, risk_acceptance, len(risk_acceptance.accepted_findings.all()))
 
-                notification_title = "Risk acceptance with " + str(len(risk_acceptance.accepted_findings.all())) + " accepted findings will expire on " + \
-                    timezone.localtime(risk_acceptance.expiration_date).strftime("%b %d, %Y") + " for " + \
-                    str(risk_acceptance.engagement.product) + ": " + str(risk_acceptance.engagement.name)
+                engagement = engagement_to_notify_about(risk_acceptance)
+                if engagement is not None:
+                    notification_title = "Risk acceptance with " + str(len(risk_acceptance.accepted_findings.all())) + " accepted findings will expire on " + \
+                        timezone.localtime(risk_acceptance.expiration_date).strftime("%b %d, %Y") + " for " + \
+                        str(engagement.product) + ": " + str(engagement.name)
 
-                create_notification(event="risk_acceptance_expiration", title=notification_title, risk_acceptance=risk_acceptance,
-                                    accepted_findings=risk_acceptance.accepted_findings.all(), engagement=risk_acceptance.engagement,
-                                    product=risk_acceptance.engagement.product,
-                                    url=reverse("view_risk_acceptance", args=(risk_acceptance.engagement.id, risk_acceptance.id)))
+                    create_notification(event="risk_acceptance_expiration", title=notification_title, risk_acceptance=risk_acceptance,
+                                        accepted_findings=risk_acceptance.accepted_findings.all(), engagement=engagement,
+                                        product=engagement.product,
+                                        url=reverse("view_risk_acceptance", args=(engagement.id, risk_acceptance.id)))
 
                 post_jira_comments(risk_acceptance, risk_acceptance.accepted_findings.all(), expiration_warning_message_creator, heads_up_days)
 
+                # marked as warned either way, so a risk acceptance nobody can be notified about
+                # is not re-selected on every subsequent run
                 risk_acceptance.expiration_date_warned = timezone.now()
                 risk_acceptance.save()
 

--- a/unittests/test_risk_acceptance.py
+++ b/unittests/test_risk_acceptance.py
@@ -302,17 +302,26 @@ class RiskAcceptanceTestUI(DojoTestCase):
         self.assertFalse(any(ra in to_expire for ra in [ra1, ra2, ra3]))
 
     def detach_from_engagements(self, ra):
-        """Leave a risk acceptance without an engagement, the state that triggers the regression below."""
+        """
+        Leave a risk acceptance without an engagement.
+
+        Not corrupt data: `RiskAcceptanceSerializer.create` only attaches an engagement when
+        the risk acceptance already has findings, and the Pro plugin tracks the association on
+        its own model rather than on `Engagement.risk_acceptance`.
+        """
         for engagement in ra.engagement_set.all():
             engagement.risk_acceptance.remove(ra)
         ra.refresh_from_db()
         self.assertIsNone(ra.engagement, msg="setup failed: risk acceptance is still attached to an engagement")
 
+    def notified_risk_acceptances(self, mock_create_notification):
+        return [call.kwargs.get("risk_acceptance") for call in mock_create_notification.call_args_list]
+
     # Regression: expiration_handler aborted the entire run with
     # "AttributeError: 'NoneType' object has no attribute 'product'" as soon as it reached a
-    # risk acceptance that is not attached to any engagement, so every remaining risk
-    # acceptance in the batch was left unhandled and the job failed again on every run.
-    def test_expiration_handler_warning_skips_risk_acceptance_without_engagement(self):
+    # risk acceptance not attached to any engagement, so every remaining risk acceptance in the
+    # batch was left unhandled and the job failed again on every subsequent run.
+    def test_expiration_handler_warns_via_findings_when_engagement_link_is_missing(self):
         ra1, ra2, ra3 = self.create_multiple_ras()
         system_settings = System_Settings.objects.get()
         system_settings.risk_acceptance_notify_before_expiration = 10
@@ -326,6 +335,7 @@ class RiskAcceptanceTestUI(DojoTestCase):
         ra1.save()
         ra2.save()
         ra3.save()
+        expected_engagement = ra1.accepted_findings.first().test.engagement
         self.detach_from_engagements(ra1)
 
         with patch("dojo.risk_acceptance.helper.create_notification") as mock_create_notification:
@@ -334,20 +344,72 @@ class RiskAcceptanceTestUI(DojoTestCase):
         ra1.refresh_from_db()
         ra2.refresh_from_db()
 
-        # the risk acceptance with an engagement is still notified about
-        notified_ras = [call.kwargs.get("risk_acceptance") for call in mock_create_notification.call_args_list]
-        self.assertIn(ra2, notified_ras, msg=f"expected a notification for the attached risk acceptance, got {notified_ras}")
-        self.assertNotIn(ra1, notified_ras, msg="a risk acceptance without an engagement has no product to notify about")
+        # the missing link is recovered from the accepted findings rather than dropping the notification
+        notified = self.notified_risk_acceptances(mock_create_notification)
+        self.assertIn(ra1, notified, msg=f"risk acceptance with findings but no engagement was not notified about, got {notified}")
+        self.assertIn(ra2, notified, msg=f"expected a notification for the attached risk acceptance, got {notified}")
 
-        # both are marked as warned, so neither is picked up again on the next run
-        self.assertIsNotNone(ra2.expiration_date_warned, msg="attached risk acceptance was never warned")
-        self.assertIsNotNone(
-            ra1.expiration_date_warned,
-            msg="risk acceptance without an engagement stays unwarned and fails the job again on every run",
+        ra1_call = next(c for c in mock_create_notification.call_args_list if c.kwargs.get("risk_acceptance") == ra1)
+        self.assertEqual(
+            ra1_call.kwargs.get("engagement"), expected_engagement,
+            msg=f"expected engagement={expected_engagement}, notified with {ra1_call.kwargs.get('engagement')}",
+        )
+        self.assertEqual(
+            ra1_call.kwargs.get("product"), expected_engagement.product,
+            msg=f"expected product={expected_engagement.product}, notified with {ra1_call.kwargs.get('product')}",
         )
 
-    # Regression: same root cause as above, on the expiry half of the job.
-    def test_expiration_handler_expires_risk_acceptance_without_engagement(self):
+        self.assertIsNotNone(ra1.expiration_date_warned, msg="risk acceptance with no engagement link was never warned")
+        self.assertIsNotNone(ra2.expiration_date_warned, msg="attached risk acceptance was never warned")
+
+    # Regression: the shape produced by the Pro standalone "New Risk Acceptance" page, which
+    # pre-fills an expiration date and posts no findings, so the risk acceptance is selected by
+    # the heads-up query while having neither an engagement nor anything to derive one from.
+    def test_expiration_handler_skips_risk_acceptance_with_no_engagement_and_no_findings(self):
+        ra1, ra2, ra3 = self.create_multiple_ras()
+        system_settings = System_Settings.objects.get()
+        system_settings.risk_acceptance_notify_before_expiration = 10
+        system_settings.save()
+        heads_up_days = system_settings.risk_acceptance_notify_before_expiration
+
+        for ra in (ra1, ra2, ra3):
+            ra.expiration_date = datetime.datetime.now(datetime.UTC) + relativedelta(days=heads_up_days + 1)
+            ra.save()
+
+        empty_ra = Risk_Acceptance.objects.create(
+            name="Accept: no findings, no engagement",
+            owner=self.get_test_admin(),
+            expiration_date=datetime.datetime.now(datetime.UTC) + relativedelta(days=heads_up_days - 1),
+        )
+        attached_ra = ra1
+        attached_ra.expiration_date = datetime.datetime.now(datetime.UTC) + relativedelta(days=heads_up_days - 1)
+        attached_ra.save()
+        self.assertIsNone(empty_ra.engagement, msg="setup failed: expected no engagement")
+        self.assertFalse(empty_ra.accepted_findings.exists(), msg="setup failed: expected no accepted findings")
+        self.assertIn(
+            empty_ra, ra_helper.get_almost_expired_risk_acceptances_to_handle(heads_up_days=heads_up_days),
+            msg="setup failed: the empty risk acceptance is not selected by the heads-up query",
+        )
+
+        with patch("dojo.risk_acceptance.helper.create_notification") as mock_create_notification:
+            ra_helper.expiration_handler()
+
+        empty_ra.refresh_from_db()
+        attached_ra.refresh_from_db()
+
+        # nothing to name a product with, so no notification - but the job must not die over it
+        notified = self.notified_risk_acceptances(mock_create_notification)
+        self.assertNotIn(empty_ra, notified, msg="a risk acceptance with no findings has no product to notify about")
+        self.assertIn(attached_ra, notified, msg=f"the rest of the batch was abandoned, notified: {notified}")
+
+        self.assertIsNotNone(
+            empty_ra.expiration_date_warned,
+            msg="empty risk acceptance stays unwarned and is re-selected, failing the job again on every run",
+        )
+        self.assertIsNotNone(attached_ra.expiration_date_warned, msg="attached risk acceptance was never warned")
+
+    # Regression: same root cause, on the expiry half of the job.
+    def test_expiration_handler_expires_risk_acceptance_without_engagement_link(self):
         ra1, ra2, ra3 = self.create_multiple_ras()
         system_settings = System_Settings.objects.get()
         system_settings.risk_acceptance_notify_before_expiration = 10
@@ -362,6 +424,7 @@ class RiskAcceptanceTestUI(DojoTestCase):
         ra2.save()
         ra3.save()
         findings = list(ra3.accepted_findings.all())
+        expected_engagement = ra3.accepted_findings.first().test.engagement
         self.detach_from_engagements(ra3)
 
         with patch("dojo.risk_acceptance.helper.create_notification") as mock_create_notification:
@@ -370,11 +433,17 @@ class RiskAcceptanceTestUI(DojoTestCase):
         ra1.refresh_from_db()
         ra3.refresh_from_db()
 
-        # the expiry itself still happens, only the notification is skipped
-        self.assertIsNotNone(ra3.expiration_date_handled, msg="risk acceptance without an engagement was never expired")
+        # the expiry happens and the notification still goes out, addressed via the findings
+        self.assertIsNotNone(ra3.expiration_date_handled, msg="risk acceptance with no engagement link was never expired")
         self.assert_all_active_not_risk_accepted(findings)
-        notified_ras = [call.kwargs.get("risk_acceptance") for call in mock_create_notification.call_args_list]
-        self.assertNotIn(ra3, notified_ras, msg="a risk acceptance without an engagement has no product to notify about")
+
+        notified = self.notified_risk_acceptances(mock_create_notification)
+        self.assertIn(ra3, notified, msg=f"expired risk acceptance with findings was not notified about, got {notified}")
+        ra3_call = next(c for c in mock_create_notification.call_args_list if c.kwargs.get("risk_acceptance") == ra3)
+        self.assertEqual(
+            ra3_call.kwargs.get("engagement"), expected_engagement,
+            msg=f"expected engagement={expected_engagement}, notified with {ra3_call.kwargs.get('engagement')}",
+        )
 
         # the rest of the batch is still processed instead of being abandoned mid-run
-        self.assertIsNotNone(ra1.expiration_date_warned, msg="the run stopped at the risk acceptance without an engagement")
+        self.assertIsNotNone(ra1.expiration_date_warned, msg="the run stopped at the risk acceptance with no engagement link")

--- a/unittests/test_risk_acceptance.py
+++ b/unittests/test_risk_acceptance.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import logging
+from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q
@@ -299,3 +300,81 @@ class RiskAcceptanceTestUI(DojoTestCase):
         # after handling no ra should be select for anything
         self.assertFalse(any(ra in to_warn for ra in [ra1, ra2, ra3]))
         self.assertFalse(any(ra in to_expire for ra in [ra1, ra2, ra3]))
+
+    def detach_from_engagements(self, ra):
+        """Leave a risk acceptance without an engagement, the state that triggers the regression below."""
+        for engagement in ra.engagement_set.all():
+            engagement.risk_acceptance.remove(ra)
+        ra.refresh_from_db()
+        self.assertIsNone(ra.engagement, msg="setup failed: risk acceptance is still attached to an engagement")
+
+    # Regression: expiration_handler aborted the entire run with
+    # "AttributeError: 'NoneType' object has no attribute 'product'" as soon as it reached a
+    # risk acceptance that is not attached to any engagement, so every remaining risk
+    # acceptance in the batch was left unhandled and the job failed again on every run.
+    def test_expiration_handler_warning_skips_risk_acceptance_without_engagement(self):
+        ra1, ra2, ra3 = self.create_multiple_ras()
+        system_settings = System_Settings.objects.get()
+        system_settings.risk_acceptance_notify_before_expiration = 10
+        system_settings.save()
+        heads_up_days = system_settings.risk_acceptance_notify_before_expiration
+
+        # both are inside the heads-up window, ra1 (created first, so handled first) has no engagement
+        ra1.expiration_date = datetime.datetime.now(datetime.UTC) + relativedelta(days=heads_up_days - 1)
+        ra2.expiration_date = datetime.datetime.now(datetime.UTC) + relativedelta(days=heads_up_days - 1)
+        ra3.expiration_date = datetime.datetime.now(datetime.UTC) + relativedelta(days=heads_up_days + 1)
+        ra1.save()
+        ra2.save()
+        ra3.save()
+        self.detach_from_engagements(ra1)
+
+        with patch("dojo.risk_acceptance.helper.create_notification") as mock_create_notification:
+            ra_helper.expiration_handler()
+
+        ra1.refresh_from_db()
+        ra2.refresh_from_db()
+
+        # the risk acceptance with an engagement is still notified about
+        notified_ras = [call.kwargs.get("risk_acceptance") for call in mock_create_notification.call_args_list]
+        self.assertIn(ra2, notified_ras, msg=f"expected a notification for the attached risk acceptance, got {notified_ras}")
+        self.assertNotIn(ra1, notified_ras, msg="a risk acceptance without an engagement has no product to notify about")
+
+        # both are marked as warned, so neither is picked up again on the next run
+        self.assertIsNotNone(ra2.expiration_date_warned, msg="attached risk acceptance was never warned")
+        self.assertIsNotNone(
+            ra1.expiration_date_warned,
+            msg="risk acceptance without an engagement stays unwarned and fails the job again on every run",
+        )
+
+    # Regression: same root cause as above, on the expiry half of the job.
+    def test_expiration_handler_expires_risk_acceptance_without_engagement(self):
+        ra1, ra2, ra3 = self.create_multiple_ras()
+        system_settings = System_Settings.objects.get()
+        system_settings.risk_acceptance_notify_before_expiration = 10
+        system_settings.save()
+        heads_up_days = system_settings.risk_acceptance_notify_before_expiration
+
+        # ra3 is past its expiration date and has no engagement, ra1 is only due a heads-up
+        ra1.expiration_date = datetime.datetime.now(datetime.UTC) + relativedelta(days=heads_up_days - 1)
+        ra2.expiration_date = datetime.datetime.now(datetime.UTC) + relativedelta(days=heads_up_days + 1)
+        ra3.expiration_date = datetime.datetime.now(datetime.UTC) - relativedelta(days=5)
+        ra1.save()
+        ra2.save()
+        ra3.save()
+        findings = list(ra3.accepted_findings.all())
+        self.detach_from_engagements(ra3)
+
+        with patch("dojo.risk_acceptance.helper.create_notification") as mock_create_notification:
+            ra_helper.expiration_handler()
+
+        ra1.refresh_from_db()
+        ra3.refresh_from_db()
+
+        # the expiry itself still happens, only the notification is skipped
+        self.assertIsNotNone(ra3.expiration_date_handled, msg="risk acceptance without an engagement was never expired")
+        self.assert_all_active_not_risk_accepted(findings)
+        notified_ras = [call.kwargs.get("risk_acceptance") for call in mock_create_notification.call_args_list]
+        self.assertNotIn(ra3, notified_ras, msg="a risk acceptance without an engagement has no product to notify about")
+
+        # the rest of the batch is still processed instead of being abandoned mid-run
+        self.assertIsNotNone(ra1.expiration_date_warned, msg="the run stopped at the risk acceptance without an engagement")


### PR DESCRIPTION
**Description**

The `dojo.risk_acceptance.helper.expiration_handler` Celery task aborts with:

```
File "dojo/risk_acceptance/helper.py", line 203, in expiration_handler
    str(risk_acceptance.engagement.product) + ": " + str(risk_acceptance.engagement.name)
AttributeError: 'NoneType' object has no attribute 'product'
```

Root cause: `Risk_Acceptance.engagement` (`dojo/risk_acceptance/models.py:90-96`) is a property over `engagement_set` — the reverse side of `Engagement.risk_acceptance`, a many-to-many used as a one-to-many. It returns `None` when no engagement points at the risk acceptance. Both halves of `expiration_handler` dereferenced it unconditionally while building the notification: `expire_now` at line 54, the heads-up loop at line 203.

**An empty engagement relation is a supported state, not corrupt data.** Several shipped paths produce one:

- `RiskAcceptanceSerializer.create` attaches an engagement **only if** `accepted_findings.exists()` (`dojo/risk_acceptance/api/serializer.py:36-40`). Create a risk acceptance with an expiration date and no findings and it is unattached from birth.
- `_accept_risks`, the bulk accept-risks API (`dojo/risk_acceptance/api/mixins.py:101`), and the SonarQube `WONTFIX` status sync (`dojo/tools/api_sonarqube/updater_from_source.py:101`) both create risk acceptances and never attach an engagement.
- `RiskAcceptanceSerializer.update` has an explicit repair branch for exactly this state, commented *"Handle orphaned risk acceptances"* (`serializer.py:66-70`).
- The same file notes twice that the relation is not the source of truth everywhere: *"This is fine as Pro has its own model + relationshop to track links with engagements."*

The module already concedes the point elsewhere: `get_view_risk_acceptance` (line 216) wraps the identical dereference in `contextlib.suppress(AttributeError)` with the comment *"it does not happen under most circumstances that a risk acceptance does not have engagement"*. The expiration paths never got the same treatment.

**Why the blast radius is larger than one row**

- The exception escapes the `for` loop, so **every risk acceptance later in the batch is left unhandled** — no expiry, no heads-up notification, for unrelated products.
- In the heads-up loop, `expiration_date_warned` is only set *after* `create_notification`, so the offending row is never marked handled. It is re-selected by `get_almost_expired_risk_acceptances_to_handle` and **fails the job again on every subsequent run** until its expiration date passes.
- In `expire_now`, the save at lines 48-50 happens *before* the crash, so the row is already marked expired when the task dies — the notification is silently lost.

**Fix**

Resolve the engagement through a new `engagement_to_notify_about()` helper:

1. Use `risk_acceptance.engagement` when the relation is populated — unchanged behaviour.
2. Otherwise fall back to the engagement of an accepted finding. This is the **same derivation** `RiskAcceptanceSerializer` already uses both to attach an engagement on create and to repair an orphan on update, so it introduces no new notion of ownership.
3. Only when there is neither an engagement nor any findings, log a warning and skip the notification. The notification names a product and reverses a per-engagement URL; neither can be produced from an empty risk acceptance, and a "0 accepted findings will expire" notice has no recipient worth naming.

Everything other than the notification is untouched — the expiry, the finding reactivation and the JIRA comments all still run. The heads-up loop now sets `expiration_date_warned` in every branch, so a risk acceptance that genuinely cannot be notified about stops being re-selected on each run instead of failing the job daily.

The fallback iterates the already-prefetched `accepted_findings` rather than calling `.first()`, so it costs no extra query on the common path.

*Known limitation, deliberately not solved here:* for a risk acceptance whose findings span several engagements, the notification is addressed to the first one. That matches what `RiskAcceptanceSerializer`'s orphan repair already does, and doing better requires ownership information this module does not have. Worth revisiting separately if multi-engagement risk acceptances should fan out notifications.

**Test results**

Three regression tests in `unittests/test_risk_acceptance.py`, one per distinct case. Each drives the real `expiration_handler` with a mix of attached and unattached risk acceptances, patches `create_notification`, and asserts exactly which ones are notified about — and for the fallback cases, that the notification carries the *derived* engagement and its product, not merely that it fired.

| Case | Against unmodified `bugfix` | With this PR |
|---|---|---|
| heads-up, engagement link missing, findings present | `AttributeError` at `helper.py:203` | notified via derived engagement |
| heads-up, no engagement and no findings | `AttributeError` at `helper.py:203` | skipped, still marked warned |
| expiry, engagement link missing, findings present | `AttributeError` at `helper.py:54` | expired + notified via derived engagement |
| `test_expiration_handler` (existing control — all attached) | passes | passes |

All three reproduce the reported traceback at the reported lines before the change. The existing control passing beforehand confirms the diagnosis is specific rather than a broad breakage. Each test also asserts the *rest* of the batch is still processed, which is the part the abort was destroying.

Run locally against PostgreSQL with `manage.py test`:

- `unittests.test_risk_acceptance` — 14 pass (11 existing + 3 new)
- with `test_risk_acceptance_api`, `test_bulk_risk_acceptance_api`, `test_notifications` — 78 pass, 24 skipped

`ruff check --config ruff.toml` clean on both changed files.

**Documentation**

No documentation changes needed — internal bug fix, no change to configuration, API surface, or user-facing behaviour. The reasoning is captured in the new helper's docstring and at the call sites.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.  *(bugfix — branched off current `bugfix` tip)*
- [ ] Features/Changes should be submitted against the `dev`.  *(n/a — bugfix)*
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs.  *(n/a — bugfix)*
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.  *(n/a — no model changes)*
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.