### PR TITLE
fix(finding): carry locations across a finding merge

### DIFF
--- a/dojo/finding/ui/forms.py
+++ b/dojo/finding/ui/forms.py
@@ -124,8 +124,8 @@ class MergeFindings(forms.ModelForm):
     append_description = forms.BooleanField(label="Append Description", initial=True, required=False,
                                             help_text="Description in all findings will be appended into the merged finding.")
 
-    add_endpoints = forms.BooleanField(label="Add Endpoints", initial=True, required=False,
-                                           help_text="Endpoints in all findings will be merged into the merged finding.")
+    add_endpoints = forms.BooleanField(label="Add Endpoints and Locations", initial=True, required=False,
+                                           help_text="Endpoints and locations in all findings will be merged into the merged finding.")
 
     dynamic_raw = forms.BooleanField(label="Dynamic Scanner Raw Requests", initial=True, required=False,
                                            help_text="Dynamic scanner raw requests in all findings will be merged into the merged finding.")

--- a/dojo/finding/ui/views.py
+++ b/dojo/finding/ui/views.py
@@ -73,6 +73,7 @@ from dojo.forms import (
 from dojo.jira import services as jira_services
 from dojo.location.queries import get_authorized_locations
 from dojo.location.status import FindingLocationStatus
+from dojo.location.utils import copy_location_references
 from dojo.models import (
     IMPORT_UNTOUCHED_FINDING,
     BurpRawRequestResponse,
@@ -2338,12 +2339,14 @@ def merge_finding_product(request, pid):
                         ):
                             finding_references = f"{finding_references}\n{finding.references}"
 
-                        # if checked merge the endpoints
+                        # if checked merge the endpoints and locations
                         if form.cleaned_data["add_endpoints"]:
                             with Endpoint.allow_endpoint_init():  # TODO: Delete this after the move to Locations
                                 finding_to_merge_into.endpoints.add(
                                     *finding.endpoints.all(),
                                 )
+                            if settings.V3_FEATURE_LOCATIONS:
+                                copy_location_references(finding, finding_to_merge_into)
 
                         # if checked merge the tags
                         if form.cleaned_data["tag_finding"]:

--- a/dojo/location/utils.py
+++ b/dojo/location/utils.py
@@ -3,11 +3,37 @@ import logging
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 
-from dojo.location.models import AbstractLocation
+from dojo.location.models import AbstractLocation, LocationFindingReference
+from dojo.models import Finding
 from dojo.url.models import URL
 from dojo.url.validators import DEFAULT_PORTS
 
 logger = logging.getLogger(__name__)
+
+
+def copy_location_references(source_finding: Finding, destination_finding: Finding) -> int:
+    """
+    Copy the source finding's location references onto the destination finding.
+
+    Used when consolidating findings, so the destination ends up covering every location the
+    source findings did. Locations the destination already references are skipped: its own
+    status and relationship data win, and the unique (location, finding) constraint holds.
+    The source finding keeps its references; they are copied, not moved.
+
+    Returns the number of references created.
+    """
+    already_referenced = LocationFindingReference.objects.filter(
+        finding=destination_finding,
+    ).values_list("location_id", flat=True)
+    references_to_copy = LocationFindingReference.objects.filter(
+        finding=source_finding,
+    ).exclude(location_id__in=already_referenced)
+
+    copied = 0
+    for reference in references_to_copy:
+        reference.copy(destination_finding)
+        copied += 1
+    return copied
 
 
 def save_location(unsaved_location: AbstractLocation) -> AbstractLocation:

--- a/unittests/test_merge_findings_locations.py
+++ b/unittests/test_merge_findings_locations.py
@@ -1,0 +1,177 @@
+"""
+Regression: merging findings copies endpoints onto the destination finding but drops locations.
+
+Reported as issue #15377. ``merge_finding_product`` (``dojo/finding/ui/views.py``) only copied the
+legacy ``Endpoint`` m2m when "Add Endpoints" was checked, so under ``V3_FEATURE_LOCATIONS`` the
+destination finding came out of the merge with none of the source findings' locations.
+"""
+
+import logging
+
+from django.contrib.auth.models import User
+from django.test import Client, override_settings
+from django.urls import reverse
+from django.utils import timezone
+from parameterized import parameterized
+
+from dojo.location.models import LocationFindingReference
+from dojo.location.status import FindingLocationStatus
+from dojo.models import (
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+    UserContactInfo,
+)
+from dojo.url.models import URL
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+@override_settings(V3_FEATURE_LOCATIONS=True, SECURE_SSL_REDIRECT=False)
+class TestMergeFindingsLocations(DojoTestCase):
+
+    """Locations of the merged findings must land on the destination finding."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.admin = User.objects.create(
+            username="test_merge_locations_admin",
+            is_staff=True,
+            is_superuser=True,
+        )
+        UserContactInfo.objects.create(user=self.admin, block_execution=True)
+
+        self.ui_client = Client()
+        self.ui_client.force_login(self.admin)
+
+        self.system_settings(enable_jira=False)
+        self.system_settings(enable_github=False)
+
+        now = timezone.now()
+        test_type = Test_Type.objects.get_or_create(name="Manual Test")[0]
+        product_type = Product_Type.objects.create(name="Org for merge locations")
+        self.product = Product.objects.create(
+            name="Product for merge locations",
+            description="regression fixture",
+            prod_type=product_type,
+        )
+        engagement = Engagement.objects.create(
+            name="Engagement for merge locations",
+            product=self.product,
+            target_start=now,
+            target_end=now,
+        )
+        self.test = Test.objects.create(
+            engagement=engagement,
+            test_type=test_type,
+            target_start=now,
+            target_end=now,
+        )
+
+    def _make_finding(self, title):
+        return Finding.objects.create(
+            test=self.test,
+            title=title,
+            severity="High",
+            description="regression fixture",
+            mitigation="n/a",
+            impact="n/a",
+            reporter=self.admin,
+        )
+
+    def _add_location(self, finding, host, *, status=FindingLocationStatus.Active):
+        url = URL(protocol="https", host=host)
+        url.clean()
+        url = URL.get_or_create_from_object(url)
+        LocationFindingReference.objects.create(
+            location=url.location,
+            finding=finding,
+            status=status,
+        )
+        return url.location
+
+    def _merge(self, destination, sources, *, add_endpoints):
+        finding_ids = [destination.id, *[f.id for f in sources]]
+        query = "&".join(f"finding_to_update={fid}" for fid in finding_ids)
+        payload = {
+            "finding_to_merge_into": destination.id,
+            "findings_to_merge": [f.id for f in sources],
+            "append_description": "on",
+            "finding_action": "inactive",
+        }
+        if add_endpoints:
+            payload["add_endpoints"] = "on"
+        return self.ui_client.post(
+            f"{reverse('merge_finding_product', kwargs={'pid': self.product.id})}?{query}",
+            payload,
+        )
+
+    @parameterized.expand([(True,), (False,)])
+    def test_merge_copies_locations_when_requested(self, add_endpoints):
+        """Locations follow the "Add Endpoints" choice: copied when checked, left alone when not."""
+        destination = self._make_finding("Merge locations destination")
+        source = self._make_finding("Merge locations source")
+        source_location = self._add_location(source, "merge-source.example.com")
+
+        response = self._merge(destination, [source], add_endpoints=add_endpoints)
+        self.assertEqual(response.status_code, 302)
+
+        persisted = list(
+            LocationFindingReference.objects.filter(finding=destination).values_list(
+                "location__location_value", flat=True,
+            ),
+        )
+        expected = ["https://merge-source.example.com"] if add_endpoints else []
+        self.assertEqual(
+            sorted(persisted), expected,
+            msg=f"add_endpoints={add_endpoints}: expected {expected}, destination has {persisted}",
+        )
+        # The source finding keeps its own location reference; locations are copied, not moved.
+        self.assertTrue(
+            LocationFindingReference.objects.filter(finding=source, location=source_location).exists(),
+            msg="the source finding lost its location reference during the merge",
+        )
+
+    def test_merge_keeps_destination_reference_for_shared_location(self):
+        """A location on both findings must not raise on the unique (location, finding) constraint."""
+        destination = self._make_finding("Merge shared location destination")
+        source = self._make_finding("Merge shared location source")
+        shared = self._add_location(destination, "merge-shared.example.com")
+        self._add_location(source, "merge-shared.example.com", status=FindingLocationStatus.Mitigated)
+
+        response = self._merge(destination, [source], add_endpoints=True)
+        self.assertEqual(response.status_code, 302)
+
+        references = LocationFindingReference.objects.filter(finding=destination, location=shared)
+        self.assertEqual(
+            references.count(), 1,
+            msg=f"expected a single reference to the shared location, found {references.count()}",
+        )
+        self.assertEqual(
+            references.first().status, FindingLocationStatus.Active,
+            msg="the destination finding's own status must win over the merged finding's status",
+        )
+
+    def test_merge_copies_locations_from_every_source_finding(self):
+        destination = self._make_finding("Merge multi destination")
+        source_a = self._make_finding("Merge multi source A")
+        source_b = self._make_finding("Merge multi source B")
+        self._add_location(source_a, "merge-multi-a.example.com")
+        self._add_location(source_b, "merge-multi-b.example.com")
+
+        response = self._merge(destination, [source_a, source_b], add_endpoints=True)
+        self.assertEqual(response.status_code, 302)
+
+        persisted = sorted(
+            LocationFindingReference.objects.filter(finding=destination).values_list(
+                "location__location_value", flat=True,
+            ),
+        )
+        expected = ["https://merge-multi-a.example.com", "https://merge-multi-b.example.com"]
+        self.assertEqual(persisted, expected, msg=f"expected {expected}, destination has {persisted}")


### PR DESCRIPTION
[sc-14015]

Fixes #15377

## Problem

Merging findings copied the legacy `Endpoint` m2m onto the destination finding but never copied its location references. With `V3_FEATURE_LOCATIONS` enabled (the default), findings carry `LocationFindingReference` rows instead of endpoints, so merging a finding that has locations into one that doesn't left the destination with no locations at all.

Reproduction from the issue:
1. Create two findings, one with locations and one without.
2. Merge the one with locations into the one without.
3. The destination finding still has no locations.

The gap is in `merge_finding_product` (`dojo/finding/ui/views.py`), where the `add_endpoints` branch only ever touched the endpoint m2m — the same block that already carries a `TODO: Delete this after the move to Locations`.

## Fix

Add `copy_location_references(source_finding, destination_finding)` to `dojo/location/utils.py` and call it from `merge_finding_product` alongside the existing endpoint copy, gated on the same "Add Endpoints" choice.

Behaviour:
- Locations the destination already references are skipped, so the destination's own status and relationship data win and the unique `(location, finding)` constraint holds.
- References are copied, not moved — the source finding keeps its own, matching how vulnerability IDs already behave in this view.

The checkbox label and help text now read "Add Endpoints and Locations".

### A note on the flag

Locations are folded into the existing `add_endpoints` field rather than getting a separate `add_locations` checkbox. Locations are the replacement for endpoints, and the endpoint copy in this block is already marked for deletion, so a second knob would ship something due for removal almost immediately. Happy to split it into its own field if maintainers would rather have the two independent.

## Tests

New `unittests/test_merge_findings_locations.py`:
- `test_merge_copies_locations_when_requested` — parameterized on the `add_endpoints` choice: locations are copied when checked, left alone when not.
- `test_merge_keeps_destination_reference_for_shared_location` — a location present on both findings does not trip the unique constraint, and the destination's own status is preserved.
- `test_merge_copies_locations_from_every_source_finding` — locations from every merged finding land on the destination.

Assertions read the persisted `LocationFindingReference` rows rather than the response, and include the persisted value in the failure message.

Before the fix, 2 of the 4 cases fail:

```
FAIL: test_merge_copies_locations_when_requested_0 [with add_endpoints=True]
AssertionError: Lists differ: [] != ['https://merge-source.example.com']

FAIL: test_merge_copies_locations_from_every_source_finding
AssertionError: [] != ['https://merge-multi-a.example.com', 'https://merge-multi-b.example.com']
```

After the fix:

```
unittests.test_merge_findings_locations ........................ Ran 4 tests, OK
unittests.test_finding_template_merge_endpoints_v3 ............. Ran 2 tests, OK
unittests.test_bulk_locations .................................. OK
```

`test_finding_template_merge_endpoints_v3` covers the same merge code path with legacy endpoint rows and still passes, so the endpoint behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
