### PR TITLE
Harden metadata API object authorization

### DIFF
--- a/dojo/authorization/api_permissions.py
+++ b/dojo/authorization/api_permissions.py
@@ -254,7 +254,9 @@ class UserHasDojoMetaPermission(permissions.BasePermission):
         method_to_permission_map = {
             "GET": "get_permission",
             "POST": "post_permission",
-            # PATCH is generally not used here, but this endpoint is sorta odd...
+            # This endpoint accepts both PUT and PATCH as mutating verbs, so both
+            # must authorize the target object supplied in the request body.
+            "PUT": "put_permission",
             "PATCH": "put_permission",
         }
         for request_method, permission_type in method_to_permission_map.items():

--- a/dojo/authorization/api_permissions.py
+++ b/dojo/authorization/api_permissions.py
@@ -254,8 +254,8 @@ class UserHasDojoMetaPermission(permissions.BasePermission):
         method_to_permission_map = {
             "GET": "get_permission",
             "POST": "post_permission",
-            # This endpoint accepts both PUT and PATCH as mutating verbs, so both
-            # must authorize the target object supplied in the request body.
+            # PATCH is generally not used here, but this endpoint is sorta odd...
+            # ...it accepts PUT and PATCH alike, so both must authorize the target.
             "PUT": "put_permission",
             "PATCH": "put_permission",
         }

--- a/dojo/authorization/query_registrations.py
+++ b/dojo/authorization/query_registrations.py
@@ -225,11 +225,12 @@ def _get_authorized_dojo_meta(permission):
         return DojoMeta.objects.none()
     if _is_unrestricted(user, permission_to_action(permission)):
         return DojoMeta.objects.all()
+    # _authorized_product_ids already includes products reachable via product-type
+    # membership, so the product / finding / endpoint clauses below cover product-type
+    # authorization on their own.
     authorized_products = _authorized_product_ids(user)
-    authorized_product_types = _authorized_product_type_ids(user)
     return DojoMeta.objects.filter(
         Q(product__id__in=authorized_products)
-        | Q(product_type__id__in=authorized_product_types)
         | Q(finding__test__engagement__product__id__in=authorized_products)
         | Q(endpoint__product__id__in=authorized_products),
     )

--- a/unittests/test_apiv2_metadata_cross_tenant_authz.py
+++ b/unittests/test_apiv2_metadata_cross_tenant_authz.py
@@ -1,0 +1,86 @@
+"""
+Regression tests for cross-tenant authorization on the metadata REST API.
+
+A user with edit on a source product must not be able to re-parent a
+metadata record onto a product they have no access to, and this must
+hold on every mutating verb (both PUT and PATCH). Also guards that
+listing metadata stays available to ordinary (non-superuser) users.
+"""
+from django.urls import reverse
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from dojo.authorization.models import Product_Member, Role
+from dojo.models import DojoMeta, Dojo_User, Product, Product_Type
+
+from .dojo_test_case import DojoTestCase
+from .test_permissions_audit import LegacyAuthMirrorMixin
+
+PASSWORD = "testTEST1234!@#$"  # noqa: S105
+
+
+class TestMetadataCrossTenantAuthorization(LegacyAuthMirrorMixin, DojoTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        owner_role = Role.objects.get(name="Owner")
+
+        cls.pt_src = Product_Type.objects.create(name="Meta Authz SRC PT")
+        cls.pt_outside = Product_Type.objects.create(name="Meta Authz OUTSIDE PT")
+        cls.product_src = Product.objects.create(
+            name="Meta Authz Src Product", description="src", prod_type=cls.pt_src,
+        )
+        cls.product_outside = Product.objects.create(
+            name="Meta Authz Outside Product", description="out", prod_type=cls.pt_outside,
+        )
+
+        cls.user = Dojo_User.objects.create_user(
+            username="meta_authz_user", password=PASSWORD, is_active=True,
+        )
+        # Edit on the source product only; no membership on product_outside.
+        Product_Member.objects.create(
+            product=cls.product_src, user=cls.user, role=owner_role,
+        )
+
+        cls.meta = DojoMeta.objects.create(
+            product=cls.product_src, name="k", value="v",
+        )
+        cls.token = Token.objects.create(user=cls.user)
+
+    def _client(self):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        return client
+
+    def _relink_payload(self):
+        return {"product": self.product_outside.id, "name": "k", "value": "v"}
+
+    def _assert_rejected(self, response):
+        self.assertIn(
+            response.status_code, [400, 403],
+            msg=f"Expected 400/403, got {response.status_code}: {response.content[:500]!r}",
+        )
+
+    def test_put_relink_to_unauthorized_product_blocked(self):
+        r = self._client().put(
+            reverse("metadata-detail", args=(self.meta.id,)),
+            self._relink_payload(),
+            format="json",
+        )
+        self._assert_rejected(r)
+        self.meta.refresh_from_db()
+        self.assertEqual(self.meta.product_id, self.product_src.id)
+
+    def test_patch_relink_to_unauthorized_product_blocked(self):
+        r = self._client().patch(
+            reverse("metadata-detail", args=(self.meta.id,)),
+            self._relink_payload(),
+            format="json",
+        )
+        self._assert_rejected(r)
+        self.meta.refresh_from_db()
+        self.assertEqual(self.meta.product_id, self.product_src.id)
+
+    def test_metadata_list_available_to_non_superuser(self):
+        r = self._client().get(reverse("metadata-list"))
+        self.assertEqual(r.status_code, 200, r.content[:500])

--- a/unittests/test_apiv2_metadata_cross_tenant_authz.py
+++ b/unittests/test_apiv2_metadata_cross_tenant_authz.py
@@ -11,12 +11,12 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
 from dojo.authorization.models import Product_Member, Role
-from dojo.models import DojoMeta, Dojo_User, Product, Product_Type
+from dojo.models import Dojo_User, DojoMeta, Product, Product_Type
 
 from .dojo_test_case import DojoTestCase
 from .test_permissions_audit import LegacyAuthMirrorMixin
 
-PASSWORD = "testTEST1234!@#$"  # noqa: S105
+PASSWORD = "testTEST1234!@#$"
 
 
 class TestMetadataCrossTenantAuthorization(LegacyAuthMirrorMixin, DojoTestCase):


### PR DESCRIPTION
Consistency and hardening improvement to the API object permission checks. This makes the metadata endpoint apply its object-level authorization on every mutating verb rather than a subset of them, and corrects an error in the authorized metadata queryset so ordinary users can list their own metadata. Adds regression tests. No functional change for correctly-permissioned users.