### PR TITLE
Seed the search language facet from the authorized queryset

### DIFF
--- a/dojo/search/views.py
+++ b/dojo/search/views.py
@@ -17,8 +17,8 @@ from dojo.finding.queries import get_authorized_findings, get_authorized_vulnera
 from dojo.finding.ui.filters import FindingFilter, FindingFilterWithoutObjectLookups
 from dojo.forms import FindingBulkUpdateForm, SimpleSearchForm
 from dojo.location.queries import get_authorized_locations, prefetch_for_locations
-from dojo.models import Engagement, Finding, Finding_Template, Languages, Product, Test
-from dojo.product.queries import get_authorized_app_analysis, get_authorized_products
+from dojo.models import Engagement, Finding, Finding_Template, Product, Test
+from dojo.product.queries import get_authorized_app_analysis, get_authorized_languages, get_authorized_products
 from dojo.test.queries import get_authorized_tests
 from dojo.utils import add_breadcrumb, get_page_items, get_system_setting, get_words_for_field
 
@@ -139,6 +139,7 @@ def simple_search(request):
                 authorized_endpoints = get_authorized_endpoints("view")
             authorized_finding_templates = Finding_Template.objects.all()
             authorized_app_analysis = get_authorized_app_analysis("view")
+            authorized_languages = get_authorized_languages("view")
             authorized_vulnerability_ids = get_authorized_vulnerability_ids("view")
 
             # TODO: better get findings in their own query and match on id. that would allow filtering on additional fields such prod_id, etc.
@@ -313,7 +314,7 @@ def simple_search(request):
             if search_languages:
                 logger.debug("searching languages")
 
-                languages = Languages.objects.filter(language__language__icontains=keywords_query)
+                languages = authorized_languages.filter(language__language__icontains=keywords_query)
                 languages = languages.prefetch_related("product", "product__tags")
                 languages = languages[:max_results]
             else:

--- a/unittests/test_simple_search_scoping.py
+++ b/unittests/test_simple_search_scoping.py
@@ -1,0 +1,45 @@
+from django.test import override_settings
+from django.urls import reverse
+
+from dojo.models import Dojo_User, Language_Type, Languages, Product, Product_Type, System_Settings
+from unittests.dojo_test_case import DojoTestCase
+
+
+# Every facet on the search page is seeded from a get_authorized_* queryset so that a
+# result row can never reference a product the caller is not authorized on. Assert that
+# for the language facet, which is the one that had no such seed. The helpers themselves
+# are covered by test_authorization_queryset_coverage.py; this covers the view calling them.
+#
+# V3_FEATURE_LOCATIONS is pinned off to match OSS CI defaults, as in
+# test_watson_search_disabled.py.
+@override_settings(SECURE_SSL_REDIRECT=False, V3_FEATURE_LOCATIONS=False, WATSON_SEARCH_ENABLED=True)
+class TestSimpleSearchProductScoping(DojoTestCase):
+
+    def setUp(self):
+        System_Settings.objects.get_or_create(id=1)
+        super().setUp()
+        product_type = Product_Type.objects.create(name="search-scoping-pt")
+        self.my_product = Product.objects.create(
+            name="search-scoping-mine", description="mine", prod_type=product_type)
+        self.other_product = Product.objects.create(
+            name="search-scoping-theirs", description="theirs", prod_type=product_type)
+        Languages.objects.create(
+            product=self.my_product,
+            language=Language_Type.objects.create(language="ScopingLangMine"))
+        Languages.objects.create(
+            product=self.other_product,
+            language=Language_Type.objects.create(language="ScopingLangTheirs"))
+
+        # OSS authorization keys off the legacy authorized_users M2M, and is_staff
+        # bypasses it, so the user has to be a plain authorized user to be meaningful.
+        self.user = Dojo_User.objects.create(username="search-scoping-member", is_active=True)
+        self.my_product.authorized_users.add(self.user)
+        self.client.force_login(self.user)
+
+    def test_language_facet_excludes_unauthorized_products(self):
+        response = self.client.get(reverse("simple_search"), {"query": "language:ScopingLang"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            {row.product_id for row in response.context["languages"]},
+            {self.my_product.id},
+        )


### PR DESCRIPTION
Consistency fix on the search page. Every product-scoped facet there is built from a
`get_authorized_*` helper, except one, which was built from the model manager. This switches it
to the helper that already exists for that model and adds a regression test asserting the facet
only returns rows for products the caller is authorized on.

No functional change for correctly-permissioned users.
