### PR TITLE
maintenance: add a branch guard for the bugfix/dev/master release lines

### DIFF
--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Branch guard — makes the target release line explicit before any code lands.
+#
+# DefectDojo ships from three long-lived branches (see the "Branch Check" section
+# of AGENTS.md):
+#   bugfix  -> next PATCH release (fastest timeline)  <- bug fixes, regressions
+#   dev     -> next MINOR release                     <- features, refactors
+#   master  -> already released                       <- release / backport only
+#
+# A fix based on `dev` cannot ship until the next minor release, which is the most
+# common way an urgent fix quietly misses the patch line. This hook reports the
+# branch before work starts, and hard-blocks edits while on `master`.
+#
+# Three modes, all wired in .claude/settings.json:
+#   session   SessionStart: report the branch and its release line into context.
+#   edit      PreToolUse/Write|Edit: block edits while on `master`.
+#   commit    PreToolUse/Bash(git commit*): same block for hand-staged changes.
+#
+# The `master` block clears only once an ack file exists for this session. An agent
+# cannot create that file silently: `touch` is not allowlisted, so the ack command
+# surfaces as a permission prompt a human has to approve. Do NOT add `touch` to
+# permissions.allow — that would defeat the gate.
+#
+# Depends only on git and python3 (both already required to work on this repo).
+set -uo pipefail
+
+MODE="${1:-edit}"
+INPUT="$(cat 2>/dev/null || true)"
+PY="$(command -v python3 || command -v python || true)"
+
+# Read a top-level or nested string field out of the hook's stdin JSON.
+field() {
+    [ -z "$PY" ] && return 0
+    printf '%s' "$INPUT" | "$PY" -c '
+import json, sys
+try:
+    cur = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for key in sys.argv[1].split("."):
+    if not isinstance(cur, dict) or key not in cur:
+        sys.exit(0)
+    cur = cur[key]
+print(cur if isinstance(cur, str) else "")
+' "$1" 2>/dev/null
+}
+
+SESSION_ID="$(field 'session_id')"
+[ -z "$SESSION_ID" ] && SESSION_ID="nosession"
+
+REPO="${CLAUDE_PROJECT_DIR:-$PWD}"
+g() { git -C "$REPO" "$@" 2>/dev/null; }
+g rev-parse --git-dir >/dev/null || exit 0   # not a checkout, nothing to guard
+
+BRANCH="$(g symbolic-ref --quiet --short HEAD)"
+
+# Release line: patch | minor | released | detached | unknown. Topic branches are
+# classified by what they contain, not by their name — dev is checked first,
+# because dev contains bugfix once bugfix has been merged forward.
+line_of() {
+    case "$BRANCH" in
+        bugfix) echo patch;    return ;;
+        dev)    echo minor;    return ;;
+        master) echo released; return ;;
+    esac
+    if [ -z "$BRANCH" ]; then
+        local head master
+        head="$(g rev-parse HEAD)"
+        master="$(g rev-parse origin/master)"
+        if [ -n "$head" ] && [ "$head" = "$master" ]; then echo released; else echo detached; fi
+        return
+    fi
+    if g merge-base --is-ancestor origin/dev HEAD; then
+        echo minor
+    elif g merge-base --is-ancestor origin/bugfix HEAD; then
+        echo patch
+    else
+        echo unknown
+    fi
+}
+LINE="$(line_of)"
+
+# ---------------------------------------------------------------- session mode
+if [ "$MODE" = "session" ]; then
+    [ -z "$PY" ] && exit 0   # informational only; nothing to report without python3
+    case "$LINE" in
+        patch)    DESC="ships in the next PATCH release (the fast line): bug fixes and regressions belong here, features do not" ;;
+        minor)    DESC="ships in the next MINOR release: features and refactors belong here, and a BUG FIX based here will NOT ship until that minor release" ;;
+        released) DESC="is already-released code: nothing belongs here except a release or backport task, and edits are BLOCKED until a human confirms" ;;
+        detached) DESC="is a detached HEAD, so the release line is unclear" ;;
+        *)        DESC="contains neither origin/bugfix nor origin/dev, so its base is stale or unmerged: run 'git fetch' and check the base before editing" ;;
+    esac
+    "$PY" -c '
+import json, sys
+branch, desc = sys.argv[1], sys.argv[2]
+print(json.dumps({"hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": (
+        "Branch check: this checkout is on `" + branch + "`, which " + desc + ". "
+        "State the branch and its release line back to the user before editing files. "
+        "If the task is a bug fix sitting on the minor line, say so and offer to move it onto bugfix first."
+    ),
+}}))
+' "${BRANCH:-detached HEAD}" "$DESC"
+    exit 0
+fi
+
+# ------------------------------------------------------- edit / commit gating
+if [ "$BRANCH" = "master" ]; then
+    WHERE="the master branch"
+elif [ -z "$BRANCH" ] && [ "$LINE" = "released" ]; then
+    WHERE="a detached HEAD at origin/master"
+else
+    exit 0
+fi
+
+ACK_DIR="$(g rev-parse --absolute-git-dir)"
+ACK_FILE="${ACK_DIR:-/nonexistent}/claude-branch-ack-${SESSION_ID}"
+[ -f "$ACK_FILE" ] && exit 0
+
+if [ "$MODE" = "commit" ]; then ACTION="Committing"; else ACTION="Editing files"; fi
+
+REASON="BLOCKED: ${ACTION} is not allowed right now, because this checkout is on ${WHERE}, which holds already-released code. Bug fixes belong on \`bugfix\` (next patch release) and features on \`dev\` (next minor).
+
+Do NOT retry, and do NOT work around this. Instead:
+  1. Tell the user the checkout is on master and the change is blocked.
+  2. Ask them to confirm this work is genuinely intended for master (a release or a backport), and WAIT for their reply.
+  3. If they confirm, record it with:  touch '${ACK_FILE}'
+     (that command prompts them for approval, which IS the confirmation) then continue.
+  4. If they do not confirm, move the work first:  git switch -c <branch-name> origin/bugfix
+
+The ack lasts for this session only."
+
+if [ -n "$PY" ]; then
+    "$PY" -c '
+import json, sys
+reason, where = sys.argv[1], sys.argv[2]
+print(json.dumps({
+    "systemMessage": "Branch guard: blocked — this checkout is on " + where + ". Confirm before any change lands here.",
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": reason,
+    },
+}))
+' "$REASON" "$WHERE" && exit 0
+fi
+
+# No python3: exit 2 also blocks the tool and feeds stderr back to the agent.
+printf '%s\n' "$REASON" >&2
+exit 2

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -96,7 +96,7 @@ branch, desc = sys.argv[1], sys.argv[2]
 print(json.dumps({"hookSpecificOutput": {
     "hookEventName": "SessionStart",
     "additionalContext": (
-        "Branch check: this checkout is on `" + branch + "`, which " + desc + ". "
+        "Branch check: this checkout is on branch " + branch + ", which " + desc + ". "
         "State the branch and its release line back to the user before editing files. "
         "If the task is a bug fix sitting on the minor line, say so and offer to move it onto bugfix first."
     ),

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/branch-guard.sh\" session",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/branch-guard.sh\" edit",
+            "timeout": 15,
+            "statusMessage": "Checking release branch..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/branch-guard.sh\" commit",
+            "if": "Bash(git commit*)",
+            "timeout": 15,
+            "statusMessage": "Checking release branch..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,12 @@ docs/.hugo_build.lock
 
 # claude etc
 MEMORY.md
-.claude/
+# Personal agent config stays untracked; the shared branch guard is checked in.
+# (Negations require .claude/* rather than .claude/ — git cannot re-include a
+# path inside a directory that is itself excluded.)
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/settings.local.json
 CLAUDE.md
 CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,50 @@
 # DefectDojo Development Guide
 
+## Branch Check (do this before writing any code)
+
+Establish the current branch and its release line *before* editing files, and state
+both back to the user. This applies to every change, including one-line fixes.
+
+| Branch | Ships in | Base work here when |
+|--------|----------|---------------------|
+| `bugfix` | the next **patch** release (fastest timeline) | bug fixes, regressions, anything that should not wait |
+| `dev` | the next **minor** release | new features, refactors, schema/model changes |
+| `master` | already released | never, except an explicit release or backport task |
+
+```bash
+git branch --show-current
+# Which line was a topic branch cut from? Ancestry, not the branch name:
+for b in dev bugfix master; do
+  git merge-base --is-ancestor "origin/$b" HEAD 2>/dev/null && echo "contains origin/$b"
+done
+```
+
+Rules:
+
+- **A fix based on `dev` does not ship until the next minor release.** If the task is a
+  bug or regression and the branch is `dev` (or was cut from `dev`), say so before
+  starting and offer to move the work onto `bugfix`: `git switch -c <name> origin/bugfix`.
+  This is the most common way an urgent fix quietly misses the patch line.
+- **A feature based on `bugfix` inflates a patch release.** Same treatment in reverse:
+  point it out and offer `git switch -c <name> origin/dev`.
+- Judge a branch by what it was *cut from*, not by its name. A branch called
+  `fix/whatever` sitting on top of `dev` still ships with the minor release.
+- The PR base branch must match the line the work was cut from.
+
+### On `master`, stop and get explicit confirmation
+
+`.claude/hooks/branch-guard.sh` enforces this: it runs on `Write`/`Edit`/`NotebookEdit`
+and on `git commit`, and denies them while the checkout is on `master` (or a detached
+HEAD at `origin/master`). When it fires, do not retry and do not work around it. Tell the
+user the checkout is on `master`, ask them to confirm the change is genuinely intended
+for the released line (a release or backport task), and wait for the answer. On
+confirmation, run the `touch` command the hook prints; that command is deliberately not
+allowlisted, so approving its prompt *is* the confirmation. Without confirmation, move
+the work to `bugfix` first.
+
+The ack covers one session. A `SessionStart` hook reports the branch and its release line
+at startup so the branch is settled before the first edit.
+
 ## Project Overview
 
 DefectDojo is a Django application (`dojo` app) for vulnerability management. The codebase is undergoing a modular reorganization to move from monolithic files toward self-contained domain modules.


### PR DESCRIPTION
**Description**

A fix based on `dev` cannot ship until the next minor release, so an urgent fix that lands there quietly misses the patch line. Nothing surfaced the branch before work started, so the mistake was only visible once the diff already existed. This adds the missing check for agent-assisted work, and enforces the one part that can be enforced.

`AGENTS.md` gets a **Branch Check** section at the top:

| Branch | Ships in | Base work here when |
|--------|----------|---------------------|
| `bugfix` | next **patch** release (fastest) | bug fixes, regressions, anything that should not wait |
| `dev` | next **minor** release | features, refactors, schema changes |
| `master` | already released | never, except a release or backport task |

It also documents that a topic branch is judged by what it was **cut from** rather than by its name (`fix/whatever` on top of `dev` still ships with the minor release).

`.claude/hooks/branch-guard.sh` (new, wired in `.claude/settings.json`):

- `SessionStart` reports the branch and its release line into the agent's context.
- `PreToolUse` on `Write|Edit|NotebookEdit` and on `Bash(git commit*)` denies the operation while the checkout is on `master`, or on a detached HEAD at `origin/master`.
- The block clears only once a per-session ack file exists. The ack command is deliberately **not** allowlisted, so approving its permission prompt is a human's explicit confirmation rather than something an agent can grant itself.
- Depends only on `git` and `python3`, and fails closed: with no `python3` on `PATH` it still blocks via exit code 2.

Blocking is limited to a literal `master` checkout or a detached HEAD exactly at `origin/master`. Inferring "cut from master" through ancestry false-positives whenever `origin/*` refs are stale, and a wrongly blocked branch would be worse than the guidance it replaces.

**Note for reviewers — this un-ignores two files under `.claude/`**

`.gitignore` currently ignores `.claude/` wholesale. This PR narrows that so the two shared files are tracked while personal agent config stays untracked (`CLAUDE.md`, `MEMORY.md`, `.claude/settings.local.json`, and everything else under `.claude/`). The negation needs `.claude/*` rather than `.claude/`, because git cannot re-include a path inside a directory excluded by a trailing-slash pattern.

That reverses a deliberate decision, so it is worth an explicit call: if you would rather keep `.claude/` fully ignored, the alternative is to ship the script at a tracked path (e.g. `scripts/branch-guard.sh`) and document in `AGENTS.md` how contributors wire it into their own local settings. Enforcement then becomes opt-in per contributor. Happy to switch to that shape if you prefer it.

**Test results**

No product code changed, so the test suite is unaffected. The hook was pipe-tested against throwaway clones covering: on `master` (blocked), after ack (allowed), a different session id (still blocked), a detached HEAD at `origin/master` (blocked), a topic branch cut from `dev` (allowed, reported as the minor line), a topic branch cut from `bugfix` (allowed, reported as the patch line), and a `PATH` with neither `python3` nor `jq` (still blocks, exit 2). `.gitignore` behavior was verified with `git add --dry-run`: only `.claude/settings.json` and `.claude/hooks/branch-guard.sh` are addable, while `.claude/settings.local.json` and other paths under `.claude/` stay ignored.

**Documentation**

`AGENTS.md` is updated as part of this PR. No user-facing docs are affected, since this is contributor tooling.

**Checklist**

- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant — no Python changed (shell + markdown + JSON).
- [x] Add the proper label to categorize your PR — `maintenance`.
- [ ] Model changes must include the necessary migrations — N/A, no model changes.
- [ ] Add applicable tests to the unit tests — N/A, no Python; hook verified manually as described above.