### PR TITLE
fix: add missing return after exception in GitHub issue handlers

### DIFF
--- a/dojo/github/services.py
+++ b/dojo/github/services.py
@@ -45,9 +45,9 @@ def reopen_external_issue_github(find, note, prod, eng):
         g_ctx = Github(auth=Auth.Token(github_product.git_conf.api_key))
         repo = g_ctx.get_repo(github_product.git_project)
         issue = repo.get_issue(int(g_issue.issue_id))
-    except:
-        e = sys.exc_info()[0]
-        logger.error("cannot update finding in github: " + e)
+    except Exception as e:
+        logger.error("cannot update finding in github: %s", str(e))
+        return
 
     logger.info("Will close github issue " + g_issue.issue_id)
     issue.edit(state="open")
@@ -80,9 +80,9 @@ def close_external_issue_github(find, note, prod, eng):
         g_ctx = Github(auth=Auth.Token(github_product.git_conf.api_key))
         repo = g_ctx.get_repo(github_product.git_project)
         issue = repo.get_issue(int(g_issue.issue_id))
-    except:
-        e = sys.exc_info()[0]
-        logger.error("cannot update finding in github: " + e)
+    except Exception as e:
+        logger.error("cannot update finding in github: %s", str(e))
+        return
 
     logger.info("Will close github issue " + g_issue.issue_id)
     issue.edit(state="closed")

--- a/dojo/github/services.py
+++ b/dojo/github/services.py
@@ -46,7 +46,7 @@ def reopen_external_issue_github(find, note, prod, eng):
         repo = g_ctx.get_repo(github_product.git_project)
         issue = repo.get_issue(int(g_issue.issue_id))
     except Exception as e:
-        logger.error("cannot update finding in github: %s", str(e))
+        logger.error("cannot update finding in github: %s", e)
         return
 
     logger.info("Will close github issue " + g_issue.issue_id)
@@ -81,7 +81,7 @@ def close_external_issue_github(find, note, prod, eng):
         repo = g_ctx.get_repo(github_product.git_project)
         issue = repo.get_issue(int(g_issue.issue_id))
     except Exception as e:
-        logger.error("cannot update finding in github: %s", str(e))
+        logger.error("cannot update finding in github: %s", e)
         return
 
     logger.info("Will close github issue " + g_issue.issue_id)


### PR DESCRIPTION
## Summary

Fix control flow bug in GitHub integration handlers in `dojo/github/services.py`.

## Problem

In `reopen_external_issue_github` and `close_external_issue_github`, when the GitHub API call fails inside the `try` block, the `except` clause logs the error but does not `return`. Execution continues to the next lines which reference `issue` (which may be undefined) and call `issue.edit()` / `issue.create_comment()`, causing an `UnboundLocalError`.

Additionally, bare `except:` clauses catch all exceptions including `SystemExit` and `KeyboardInterrupt`, which is a Python anti-pattern.

## Fix

1. Add `return` after logging the error in both functions to prevent fall-through
2. Replace bare `except:` with `except Exception as e:` for proper exception scoping
3. Use `%s` formatting instead of string concatenation for the error message (the original code tried to concatenate a string with `sys.exc_info()[0]` which is a type)

## Checklist

- [x] Single-focused change
- [x] No conflicting open PRs found
- [x] Local environment limitations, relying on CI/CD automated testing

I apologize for any inconvenience and appreciate the maintainers' time reviewing this contribution.
