### PR TITLE
fix(findings): clear review state when a finding is closed or reopened

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -1288,6 +1288,12 @@ def close_finding(
     finding.out_of_scope = bool(out_of_scope)
     finding.duplicate = bool(duplicate)
     finding.under_review = False
+    # Closing ends any open peer review, so the requester/reviewer record has
+    # to go with it. Leaving them set strands the review: the finding no
+    # longer offers "Clear Review" (that action is gated on under_review), yet
+    # it still reports reviewers, so queue views built on the reviewers M2M
+    # keep surfacing work nobody can act on.
+    finding.review_requested_by = None
     finding.last_reviewed = mitigated_date
     finding.last_reviewed_by = user
 
@@ -1320,6 +1326,10 @@ def close_finding(
     close_external_issue(finding.id, "Closed by defectdojo", "github")
 
     _save_finding_with_jira_sync(finding, new_note=new_note)
+
+    # Cleared after the save: the M2M write hits the DB immediately, so doing
+    # it earlier would drop the reviewers even if the save above raised.
+    finding.reviewers.clear()
 
     # Notification
     create_notification(

--- a/dojo/finding/ui/views.py
+++ b/dojo/finding/ui/views.py
@@ -1365,6 +1365,11 @@ def reopen_finding(request, fid):
     finding.last_reviewed = finding.mitigated
     finding.last_reviewed_by = request.user
     finding.under_review = False
+    # Same reasoning as close_finding: an open review does not survive the
+    # status change, so its requester/reviewers go with it. Reopening matters
+    # more than closing here — the finding comes back active, so stale
+    # reviewers would show up in reviewer-scoped queues as live work.
+    finding.review_requested_by = None
     if settings.V3_FEATURE_LOCATIONS:
         for ref in finding.locations.all():
             ref.set_status(FindingLocationStatus.Active, request.user, timezone.now())
@@ -1379,6 +1384,8 @@ def reopen_finding(request, fid):
     # Clear the risk acceptance, if present
     ra_helper.risk_unaccept(request.user, finding)
     finding.save(dedupe_option=False, push_to_jira=False)
+    # After the save so a failed save doesn't leave the M2M already emptied.
+    finding.reviewers.clear()
     if jira_services.is_push_all_issues(finding) or jira_services.is_keep_in_sync(finding):
         jira_services.push(finding)
 

--- a/dojo/notifications/templates/notifications/webhooks/review_requested.tpl
+++ b/dojo/notifications/templates/notifications/webhooks/review_requested.tpl
@@ -1,0 +1,30 @@
+{% load display_tags %}
+{% load as_json %}
+{% include 'notifications/webhooks/subtemplates/base.tpl' %}
+{% include 'notifications/webhooks/subtemplates/test.tpl' with test=finding.test %}
+{% url 'view_finding' finding.id as finding_url_ui %}
+{% url 'finding-detail' finding.id as finding_url_api %}
+finding:
+    id: {{ finding.pk }}
+    title: {{ finding.title | as_json_no_html_esc }}
+    severity: {{ finding.severity | as_json_no_html_esc }}
+    url_ui: {{ finding_url_ui | full_url | as_json_no_html_esc }}
+    url_api: {{ finding_url_api | full_url | as_json_no_html_esc }}
+{% if requested_by %}
+requested_by:
+    id: {{ requested_by.pk }}
+    username: {{ requested_by.username | as_json_no_html_esc }}
+    first_name: {{ requested_by.first_name | as_json_no_html_esc }}
+    last_name: {{ requested_by.last_name | as_json_no_html_esc }}
+{% else %}
+requested_by: {{ requested_by | as_json_no_html_esc }}
+{% endif %}
+reviewers:
+{% for reviewer in reviewers %}
+    - id: {{ reviewer.pk }}
+      username: {{ reviewer.username | as_json_no_html_esc }}
+      first_name: {{ reviewer.first_name | as_json_no_html_esc }}
+      last_name: {{ reviewer.last_name | as_json_no_html_esc }}
+{% empty %}
+    []
+{% endfor %}

--- a/unittests/test_finding_model.py
+++ b/unittests/test_finding_model.py
@@ -76,7 +76,8 @@ class TestFindingModelMixin:
         self.assertFalse(is_naive(self.finding.mitigated))
 
     def test_close_finding_clears_open_review(self):
-        """Closing must end an in-flight peer review, not just unflag it.
+        """
+        Closing must end an in-flight peer review, not just unflag it.
 
         ``under_review`` was already cleared here, but the reviewers M2M and
         ``review_requested_by`` were left behind. That combination is

--- a/unittests/test_finding_model.py
+++ b/unittests/test_finding_model.py
@@ -6,6 +6,7 @@ from django.utils.timezone import is_naive, now
 from dojo.finding.helper import close_finding
 from dojo.location.status import FindingLocationStatus
 from dojo.models import (
+    Dojo_User,
     DojoMeta,
     Endpoint,
     Endpoint_Status,
@@ -73,6 +74,39 @@ class TestFindingModelMixin:
             duplicate=False,
         )
         self.assertFalse(is_naive(self.finding.mitigated))
+
+    def test_close_finding_clears_open_review(self):
+        """Closing must end an in-flight peer review, not just unflag it.
+
+        ``under_review`` was already cleared here, but the reviewers M2M and
+        ``review_requested_by`` were left behind. That combination is
+        unreachable in the UI — "Clear Review" is gated on ``under_review`` —
+        so the review could never be closed out, and anything listing findings
+        by reviewer kept showing the finding as outstanding work.
+        """
+        # Dojo_User, not User: Finding.reviewers targets dojo.Dojo_User, and
+        # ``.set()`` with a plain User raises "Field 'id' expected a number".
+        reviewer = Dojo_User.objects.create(username="close-finding-reviewer")
+        self.finding.under_review = True
+        self.finding.review_requested_by = self.user
+        self.finding.save()
+        self.finding.reviewers.set([reviewer])
+
+        close_finding(
+            finding=self.finding,
+            user=self.user,
+            is_mitigated=True,
+            mitigated=None,
+            mitigated_by=None,
+            false_p=False,
+            out_of_scope=False,
+            duplicate=False,
+        )
+
+        self.finding.refresh_from_db()
+        self.assertFalse(self.finding.under_review)
+        self.assertIsNone(self.finding.review_requested_by)
+        self.assertEqual(list(self.finding.reviewers.all()), [])
 
     def test_get_sast_source_file_path_with_link_no_file_path(self):
         finding = Finding()

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -36,6 +36,7 @@ from dojo.models import (
 )
 from dojo.notifications.helper import (
     AlertNotificationManger,
+    NotificationManagerHelpers,
     WebhookNotificationManger,
     async_create_notification,
     create_notification,
@@ -1380,7 +1381,9 @@ class TestProcessTagNotifications(DojoTestCase):
 
 @versioned_fixtures
 class TestReviewRequestedWebhookTemplate(DojoTestCase):
-    """The webhooks channel needs its own review_requested template.
+
+    """
+    The webhooks channel needs its own review_requested template.
 
     ``NotificationManagerHelpers._create_notification_message`` renders
     ``notifications/<channel>/<event>.tpl`` and, on TemplateDoesNotExist,
@@ -1393,8 +1396,6 @@ class TestReviewRequestedWebhookTemplate(DojoTestCase):
     fixtures = ["dojo_testdata.json"]
 
     def _render(self, channel):
-        from dojo.notifications.helper import NotificationManagerHelpers
-
         finding = Finding.objects.first()
         requested_by = Dojo_User.objects.get(username="admin")
         reviewer = Dojo_User.objects.create(username="wh-reviewer", first_name="Wanda", last_name="Reviewer")
@@ -1423,14 +1424,13 @@ class TestReviewRequestedWebhookTemplate(DojoTestCase):
         self.assertIn(reviewer.username, rendered)
 
     def test_webhook_payload_is_not_the_generic_fallback(self):
-        """Pin the fallback behaviour itself.
+        """
+        Pin the fallback behaviour itself.
 
         Rendering an event that genuinely has no webhook template gives the
         generic shape; review_requested must not match it. Comparing against
         a real fallback render keeps this honest if other.tpl changes.
         """
-        from dojo.notifications.helper import NotificationManagerHelpers
-
         rendered, _, _ = self._render("webhooks")
         fallback = NotificationManagerHelpers()._create_notification_message(
             event="event_with_no_template",

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -1376,3 +1376,67 @@ class TestProcessTagNotifications(DojoTestCase):
             Alerts.objects.filter(user_id=mentioned).exists(),
             "an email-like token in prose (no whitespace before '@') must not notify",
         )
+
+
+@versioned_fixtures
+class TestReviewRequestedWebhookTemplate(DojoTestCase):
+    """The webhooks channel needs its own review_requested template.
+
+    ``NotificationManagerHelpers._create_notification_message`` renders
+    ``notifications/<channel>/<event>.tpl`` and, on TemplateDoesNotExist,
+    quietly falls back to ``other.tpl``. That fallback is a generic
+    description blob: a webhook subscriber reacting to review requests
+    would receive no finding id, no reviewers, and no requester, with
+    nothing in the payload to indicate the specific template was missing.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    def _render(self, channel):
+        from dojo.notifications.helper import NotificationManagerHelpers
+
+        finding = Finding.objects.first()
+        requested_by = Dojo_User.objects.get(username="admin")
+        reviewer = Dojo_User.objects.create(username="wh-reviewer", first_name="Wanda", last_name="Reviewer")
+        return NotificationManagerHelpers()._create_notification_message(
+            event="review_requested",
+            user=requested_by,
+            notification_type=channel,
+            kwargs={
+                "finding": finding,
+                "requested_by": requested_by,
+                "reviewers": [reviewer],
+                "title": "Finding Review Requested",
+                "description": "admin has requested a review",
+                "url": reverse("view_finding", args=(finding.id,)),
+            },
+        ), finding, reviewer
+
+    def test_webhook_payload_carries_review_details(self):
+        rendered, finding, reviewer = self._render("webhooks")
+
+        # The event-specific fields are the whole point — other.tpl carries none of them.
+        self.assertIn("finding:", rendered)
+        self.assertIn(f"id: {finding.pk}", rendered)
+        self.assertIn("requested_by:", rendered)
+        self.assertIn("reviewers:", rendered)
+        self.assertIn(reviewer.username, rendered)
+
+    def test_webhook_payload_is_not_the_generic_fallback(self):
+        """Pin the fallback behaviour itself.
+
+        Rendering an event that genuinely has no webhook template gives the
+        generic shape; review_requested must not match it. Comparing against
+        a real fallback render keeps this honest if other.tpl changes.
+        """
+        from dojo.notifications.helper import NotificationManagerHelpers
+
+        rendered, _, _ = self._render("webhooks")
+        fallback = NotificationManagerHelpers()._create_notification_message(
+            event="event_with_no_template",
+            user=Dojo_User.objects.get(username="admin"),
+            notification_type="webhooks",
+            kwargs={"title": "Finding Review Requested", "description": "admin has requested a review"},
+        )
+        self.assertNotEqual(rendered.strip(), fallback.strip())
+        self.assertNotIn("finding:", fallback)


### PR DESCRIPTION
Closing or reopening a finding set `under_review = False` but left the `reviewers` M2M and `review_requested_by` populated.

That combination is unreachable in the UI: the **Clear Review** action only renders while `under_review` is set, so the review could never be closed out, and anything listing findings by reviewer kept reporting the finding as outstanding work. Reopening matters most — the finding comes back active, so the stale reviewers read as live work.

In both paths the M2M is cleared *after* the save, so a failed save does not leave the reviewers already dropped. Both callers of `close_finding` are single-finding user actions rather than the importer, so the extra delete costs nothing at import scale.

Also adds the missing `notifications/webhooks/review_requested.tpl`. Template lookup falls back to `other.tpl` when a channel template is absent, so webhook subscribers reacting to review requests were receiving a generic description blob — no finding, no requester, no reviewers, and nothing in the payload to indicate the specific template was missing.

### Tests

Added to `unittests/test_finding_model.py` and `unittests/test_notifications.py`:

- closing a finding with an open review clears `under_review`, `review_requested_by` and the reviewers M2M
- the rendered webhook payload carries the finding, requester and reviewers
- the payload is compared against a real `other.tpl` render, so the test still means something if the fallback template changes

Run against PostgreSQL on this branch: `unittests.test_finding_model` and `unittests.test_notifications` both pass (71 and 43 tests, skips are version-gated).

### Note on scope

`reopen_finding` and `close_finding` are covered here. The classic **bulk-edit** path (`dojo/finding/ui/views.py`) still sets `under_review` straight from a form field and can orphan the same way; that is left alone deliberately to keep this change small and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
