### PR TITLE
refactor(reimport): extract get_original_findings as an override point; guard debug renders

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -2,11 +2,12 @@ import contextlib
 import logging
 from itertools import batched
 
-import dojo.finding.helper as finding_helper
 from django.conf import settings
 from django.core.exceptions import EmptyResultSet
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.db.models.query_utils import Q
+
+import dojo.finding.helper as finding_helper
 from dojo.celery_dispatch import dojo_dispatch_task
 from dojo.finding.deduplication import (
     find_candidates_for_deduplication_hash,

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -2,12 +2,11 @@ import contextlib
 import logging
 from itertools import batched
 
+import dojo.finding.helper as finding_helper
 from django.conf import settings
 from django.core.exceptions import EmptyResultSet
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.db.models.query_utils import Q
-
-import dojo.finding.helper as finding_helper
 from dojo.celery_dispatch import dojo_dispatch_task
 from dojo.finding.deduplication import (
     find_candidates_for_deduplication_hash,

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -278,25 +278,40 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         with tag_inheritance.suppress_tag_inheritance():
             return self._process_findings_internal(parsed_findings, **kwargs)
 
+    def get_original_findings(self):
+        """
+        Queryset of findings already in the test that "old finding" bookkeeping runs over.
+
+        Only findings with the same service value (or None) are candidates: even though the
+        service value is part of the hash_code calculation, closing must never touch findings
+        with a different service value.
+        https://github.com/DefectDojo/django-DefectDojo/issues/12754
+
+        This is intentionally a separate method (like get_reimport_match_candidates_for_batch)
+        so downstream editions can override it without copying the full process_findings()
+        implementation: _process_findings_internal materializes this queryset solely to compute
+        to_mitigate/untouched, so an importer that defers close-old bookkeeping to its own
+        sync-wide pass (e.g. Dojo Pro's batched chunk imports) can return Finding.objects.none()
+        to keep a batch's memory bounded by the batch instead of by the whole test.
+        """
+        if self.service is not None:
+            return self.test.finding_set.all().filter(service=self.service)
+        return self.test.finding_set.all().filter(Q(service__isnull=True) | Q(service__exact=""))
+
     def _process_findings_internal(
         self,
         parsed_findings: list[Finding],
         **kwargs: dict,
     ) -> tuple[list[Finding], list[Finding], list[Finding], list[Finding]]:
         self.deduplication_algorithm = self.determine_deduplication_algorithm()
-        # Only process findings with the same service value (or None)
-        # Even though the service values is used in the hash_code calculation,
-        # we need to make sure there are no side effects such as closing findings
-        # for findings with a different service value
-        # https://github.com/DefectDojo/django-DefectDojo/issues/12754
-        if self.service is not None:
-            original_findings = self.test.finding_set.all().filter(service=self.service)
-        else:
-            original_findings = self.test.finding_set.all().filter(Q(service__isnull=True) | Q(service__exact=""))
+        original_findings = self.get_original_findings()
 
         logger.debug(f"original_findings_qyer: {original_findings.query}")
         self.original_items = list(original_findings)
-        logger.debug(f"original_items: {[(item.id, item.hash_code) for item in self.original_items]}")
+        if logger.isEnabledFor(logging.DEBUG):
+            # Guarded: this renders (id, hash) for every finding already in the test, which on
+            # a large test is millions of tuples built even when DEBUG logging is off.
+            logger.debug(f"original_items: {[(item.id, item.hash_code) for item in self.original_items]}")
         self.new_items = []
         self.reactivated_items = []
         self.unchanged_items = []

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -1,7 +1,9 @@
+import contextlib
 import logging
 from itertools import batched
 
 from django.conf import settings
+from django.core.exceptions import EmptyResultSet
 from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.db.models.query_utils import Q
 
@@ -306,11 +308,15 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         self.deduplication_algorithm = self.determine_deduplication_algorithm()
         original_findings = self.get_original_findings()
 
-        logger.debug(f"original_findings_qyer: {original_findings.query}")
+        if logger.isEnabledFor(logging.DEBUG):
+            # Guarded twice over: rendering .query raises EmptyResultSet for a none() queryset
+            # (a legitimate get_original_findings() override), and the original_items render
+            # builds (id, hash) tuples for every finding already in the test — millions on a
+            # large test — even when DEBUG logging is off, because f-strings always evaluate.
+            with contextlib.suppress(EmptyResultSet):
+                logger.debug(f"original_findings_qyer: {original_findings.query}")
         self.original_items = list(original_findings)
         if logger.isEnabledFor(logging.DEBUG):
-            # Guarded: this renders (id, hash) for every finding already in the test, which on
-            # a large test is millions of tuples built even when DEBUG logging is off.
             logger.debug(f"original_items: {[(item.id, item.hash_code) for item in self.original_items]}")
         self.new_items = []
         self.reactivated_items = []


### PR DESCRIPTION
## What

Extracts the "findings already in the test" queryset that `_process_findings_internal` materializes for to_mitigate/untouched bookkeeping into a dedicated `get_original_findings()` method — the same downstream extension pattern as `get_reimport_match_candidates_for_batch` — and makes the adjacent debug logging safe:

- both debug renders are now guarded by `isEnabledFor(logging.DEBUG)`: the `original_items` render builds an (id, hash) tuple for every finding already in the test (millions of tuples on a very large test) even when debug logging is off, because f-strings always evaluate;
- rendering `.query` raises `EmptyResultSet` for a `none()` queryset — a legitimate override return value — so that render is additionally wrapped in `contextlib.suppress(EmptyResultSet)`.

## Why

A reimport run's memory floor is currently every finding already in the test, materialized purely for close-old bookkeeping. A downstream importer that batches one very large logical import into several bounded reimport runs (deferring close-old to its own final pass over the union of batches) needs to opt out of that materialization to keep a batch's memory proportional to the batch — returning `Finding.objects.none()` from the new override point does exactly that.

No behavior change for existing callers: the extracted method returns the identical queryset (same service scoping, #12754 preserved), and the debug output is unchanged when debug logging is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)