### PR TITLE
fix(api): return 409 instead of 500 on a unique-constraint violation

### DIFF
--- a/dojo/api_v2/exception_handler.py
+++ b/dojo/api_v2/exception_handler.py
@@ -2,6 +2,7 @@ import logging
 
 from django.core.exceptions import ValidationError
 from django.db.models.deletion import RestrictedError
+from django.db.utils import IntegrityError
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from rest_framework.status import (
@@ -15,6 +16,46 @@ from dojo.models import System_Settings
 from dojo.product_announcements import ErrorPageProductAnnouncement
 
 logger = logging.getLogger(__name__)
+
+# SQLSTATE class 23505 = unique_violation. Checked on the driver exception Django
+# wraps, so detection does not depend on the wording of the message.
+UNIQUE_VIOLATION_SQLSTATE = "23505"
+
+# Fallback for drivers that expose no SQLSTATE, and for IntegrityErrors raised
+# without a wrapped cause.
+UNIQUE_VIOLATION_MESSAGE_MARKERS = (
+    "unique constraint",  # PostgreSQL
+    "duplicate entry",  # MySQL / MariaDB
+    "unique_violation",
+)
+
+# Deliberately generic: the driver message carries the constraint name, the table
+# name and the offending value, none of which belong in an API response body.
+UNIQUE_VIOLATION_RESPONSE_MESSAGE = (
+    "The request conflicts with an existing record because a unique field value "
+    "already exists. Retrieve or update the existing record instead of creating "
+    "a new one."
+)
+
+
+def _is_unique_violation(exc) -> bool:
+    """
+    Return True when ``exc`` is a database unique-constraint violation.
+
+    A unique violation means the caller asked for a record that is already
+    there — a conflict it can resolve — whereas every other IntegrityError
+    (foreign key, not-null, check constraint) points at a defect on our side
+    and must keep surfacing as a 500.
+    """
+    # Django wraps the driver exception; psycopg exposes SQLSTATE as `sqlstate`
+    # and psycopg2 as `pgcode`.
+    cause = exc.__cause__
+    for attribute in ("sqlstate", "pgcode"):
+        if getattr(cause, attribute, None) == UNIQUE_VIOLATION_SQLSTATE:
+            return True
+
+    text = str(exc).lower()
+    return any(marker in text for marker in UNIQUE_VIOLATION_MESSAGE_MARKERS)
 
 
 def custom_exception_handler(exc, context):
@@ -38,6 +79,26 @@ def custom_exception_handler(exc, context):
         response.data = {}
         response.data["message"] = str(exc)
         ErrorPageProductAnnouncement(response=response)
+    elif isinstance(exc, IntegrityError) and _is_unique_violation(exc):
+        # The row the caller wanted to create already exists. Serializers built
+        # from a unique model field do check first, but that SELECT and the
+        # INSERT are not atomic, so concurrent writers both pass validation and
+        # the loser lands here. That is a conflict the caller can act on, not a
+        # server fault, so answer 409 rather than letting it fall through to the
+        # generic 500 branch below.
+        # Logged at info, not error: this is an expected outcome of concurrent
+        # writers, and logging it as an error keeps it in error reporting where
+        # it reads as an outage.
+        logger.info(
+            "unique constraint violation on %s: %s",
+            (context or {}).get("request", "unknown request"),
+            exc,
+        )
+        response = Response()
+        response.status_code = HTTP_409_CONFLICT
+        # Matching the RestrictedError 409 above, no product announcement is
+        # attached to a conflict response.
+        response.data = {"message": UNIQUE_VIOLATION_RESPONSE_MESSAGE}
     elif response is None:
         if System_Settings.objects.get().api_expose_error_details:
             exception_message = str(exc.args[0])

--- a/unittests/test_apiv2_unique_violation_conflict.py
+++ b/unittests/test_apiv2_unique_violation_conflict.py
@@ -1,0 +1,210 @@
+"""
+Regression tests: a database unique-constraint violation that reaches the API
+layer must produce a client-actionable ``409 Conflict``, not a bare ``500``.
+
+Two guards check uniqueness before the INSERT, and both are check-then-insert
+rather than atomic:
+
+* DRF builds a ``UniqueValidator`` for any serializer field backed by a model
+  field with ``unique=True``, which SELECTs during validation.
+* ``BaseModelWithoutTimeMeta.save()`` calls ``full_clean()`` — and so
+  ``validate_unique()`` — but only when ``V3_FEATURE_LOCATIONS`` is enabled,
+  since ``skip_validation`` defaults to ``not settings.V3_FEATURE_LOCATIONS``.
+
+Concurrent writers can pass both: at the moment each ran its SELECT the winning
+row was not committed yet. The loser's INSERT then hits the constraint and the
+database raises ``IntegrityError``. Nothing in the DRF stack handled that, so it
+fell through to the generic branch of ``custom_exception_handler`` and the caller
+received ``500 Internal server error`` — no indication that the record it wanted
+already exists, and an entry in error reporting that reads like an outage.
+
+Reported from a production asset-create endpoint driven by a CI service account
+running parallel jobs, which makes the losing writer routine rather than rare.
+
+Only *unique* violations translate to 409. Other ``IntegrityError`` subtypes
+(foreign key, not-null, check constraints) indicate a server-side defect and
+must keep returning 500 so they stay visible.
+"""
+
+from unittest.mock import patch
+
+from django.db import transaction
+from django.db.utils import IntegrityError
+from django.urls import reverse
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient, APITestCase
+
+from dojo.api_v2.exception_handler import custom_exception_handler
+from dojo.models import Product
+from unittests.dojo_test_case import versioned_fixtures
+
+# SQLSTATE 23505 = unique_violation.
+UNIQUE_VIOLATION_SQLSTATE = "23505"
+
+# Message shapes as the drivers word them, for the no-SQLSTATE fallback path.
+POSTGRES_UNIQUE_MESSAGE = (
+    'duplicate key value violates unique constraint "dojo_product_name_key"\n'
+    "DETAIL:  Key (name)=(some asset) already exists."
+)
+MYSQL_UNIQUE_MESSAGE = "(1062, \"Duplicate entry 'some asset' for key 'name'\")"
+FOREIGN_KEY_MESSAGE = (
+    'update or delete on table "dojo_tagulous_test_tags" violates foreign key '
+    'constraint "dojo_test_tags_tagulous_test_tags_i_6336441a_fk_dojo_tagu" '
+    'on table "dojo_test_tags"\n'
+    'DETAIL:  Key (id)=(1) is still referenced from table "dojo_test_tags".'
+)
+NOT_NULL_MESSAGE = 'null value in column "name" of relation "dojo_product" violates not-null constraint'
+
+
+@versioned_fixtures
+class UniqueViolationExceptionHandlerTest(APITestCase):
+
+    """Coverage of the handler's IntegrityError branch."""
+
+    fixtures = ["dojo_testdata.json"]
+
+    def test_postgres_unique_violation_returns_409(self):
+        response = custom_exception_handler(IntegrityError(POSTGRES_UNIQUE_MESSAGE), {})
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, 409)
+
+    def test_mysql_duplicate_entry_returns_409(self):
+        response = custom_exception_handler(IntegrityError(MYSQL_UNIQUE_MESSAGE), {})
+
+        self.assertEqual(response.status_code, 409)
+
+    def test_sqlstate_is_honoured_when_message_is_unrecognised(self):
+        """
+        Detection must not depend on driver wording.
+
+        A driver that words the message differently but reports SQLSTATE 23505
+        still has to be recognised, so the check reads the wrapped cause first.
+        """
+
+        class DriverError(Exception):
+            sqlstate = UNIQUE_VIOLATION_SQLSTATE
+
+        exc = IntegrityError("a future driver wording this differently")
+        exc.__cause__ = DriverError()
+
+        response = custom_exception_handler(exc, {})
+
+        self.assertEqual(response.status_code, 409)
+
+    def test_conflict_message_does_not_leak_database_internals(self):
+        response = custom_exception_handler(IntegrityError(POSTGRES_UNIQUE_MESSAGE), {})
+
+        message = response.data["message"]
+        # Constraint name, table name and the offending value are database
+        # internals / payload echoes. None of them belong in a response body.
+        self.assertNotIn("dojo_product_name_key", message)
+        self.assertNotIn("DETAIL", message)
+        self.assertNotIn("some asset", message)
+        self.assertIn("already exists", message.lower())
+
+    def test_foreign_key_violation_still_returns_500(self):
+        response = custom_exception_handler(IntegrityError(FOREIGN_KEY_MESSAGE), {})
+
+        self.assertIsNotNone(response)
+        self.assertEqual(response.status_code, 500)
+
+    def test_not_null_violation_still_returns_500(self):
+        response = custom_exception_handler(IntegrityError(NOT_NULL_MESSAGE), {})
+
+        self.assertEqual(response.status_code, 500)
+
+    def test_real_driver_unique_violation_returns_409(self):
+        """
+        Feed the handler the exception the database actually raises.
+
+        The message-shape cases above are hand-built. This one provokes a
+        genuine duplicate INSERT — ``skip_validation=True`` bypasses
+        ``full_clean()`` exactly as the losing writer effectively does, since its
+        uniqueness SELECT ran before the winning row was committed — and asserts
+        both that the driver reports SQLSTATE 23505 and that the handler
+        translates it.
+        """
+        existing = Product.objects.first()
+        duplicate = Product(
+            name=existing.name,
+            description="created by a parallel CI job",
+            prod_type=existing.prod_type,
+        )
+
+        # Inner atomic block so the failed statement does not poison the
+        # surrounding test transaction.
+        with transaction.atomic(), self.assertRaises(IntegrityError) as caught:
+            duplicate.save(skip_validation=True)
+
+        exc = caught.exception
+        self.assertEqual(getattr(exc.__cause__, "sqlstate", None), UNIQUE_VIOLATION_SQLSTATE)
+
+        response = custom_exception_handler(exc, {})
+
+        self.assertEqual(response.status_code, 409)
+
+
+@versioned_fixtures
+class UniqueViolationApiTest(APITestCase):
+
+    """Coverage through a real create endpoint and the configured handler."""
+
+    fixtures = ["dojo_testdata.json"]
+
+    def setUp(self):
+        token = Token.objects.get(user__username="admin")
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+        self.existing = Product.objects.first()
+
+    def _post_duplicate(self):
+        return self.client.post(
+            reverse("asset-list"),
+            {
+                "name": self.existing.name,
+                "description": "created by a parallel CI job",
+                "organization": self.existing.prod_type_id,
+            },
+            format="json",
+        )
+
+    def test_duplicate_name_is_still_rejected_with_400(self):
+        """The uncontended path is unchanged: DRF rejects before the INSERT."""
+        response = self._post_duplicate()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["name"][0].code, "unique")
+
+    def test_lost_create_race_returns_409_not_500(self):
+        """
+        Both pre-INSERT uniqueness SELECTs are neutralised together.
+
+        That is precisely what the losing writer experiences: neither its
+        serializer-level check nor its model-level check could see the winning
+        row, because that row was not committed until after both had run. With
+        both bypassed the request reaches the INSERT and the database constraint
+        is the only thing left to reject it.
+        """
+        with (
+            patch("rest_framework.validators.UniqueValidator.__call__", return_value=None),
+            patch.object(Product, "validate_unique", return_value=None),
+        ):
+            response = self._post_duplicate()
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("already exists", response.data["message"].lower())
+
+    def test_unique_name_still_creates_successfully(self):
+        """Guard against the handler swallowing legitimate creates."""
+        response = self.client.post(
+            reverse("asset-list"),
+            {
+                "name": "an asset name not present in the fixtures",
+                "description": "created by a parallel CI job",
+                "organization": self.existing.prod_type_id,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, 201)


### PR DESCRIPTION
**Description**

A database `IntegrityError` raised at INSERT time had no branch in `custom_exception_handler`, so it fell through to the generic branch and the caller received `500 Internal server error` with no indication that the record it asked for already exists.

Uniqueness is checked twice before the INSERT, and neither check is atomic with it:

- DRF builds a `UniqueValidator` for any serializer field backed by a model field with `unique=True`, which SELECTs during validation.
- `BaseModelWithoutTimeMeta.save()` calls `full_clean()`, and therefore `validate_unique()` — but only when `V3_FEATURE_LOCATIONS` is enabled, since `skip_validation` defaults to `not V3_FEATURE_LOCATIONS`. With the flag off, the serializer validator is the only guard.

Concurrent writers pass both: at the moment each ran its SELECT, the winning row was not committed yet. The loser's INSERT then hits the constraint. This was reported from a production create endpoint driven by a CI service account running parallel jobs, which makes the losing writer routine rather than rare. A 500 gives such a client nothing to branch on, and it files the request in error reporting as though it were an outage.

**The change**

Translate a unique violation into `409 Conflict`, matching how the adjacent `RestrictedError` branch already reports a conflict, and log it at `info` rather than `error`.

- Detection reads SQLSTATE `23505` off the wrapped driver exception (`sqlstate` on psycopg, `pgcode` on psycopg2), so it does not depend on message wording. It falls back to message markers when no SQLSTATE is exposed.
- Every other `IntegrityError` — foreign key, not-null, check constraint — indicates a defect on our side and keeps returning 500, so those stay visible.
- The response body is deliberately generic. The driver message carries the constraint name, the table name and the offending value; none of those belong in an API response.
- No product announcement is attached, matching the existing `RestrictedError` 409.

This is the last line of defence, not a replacement for the pre-INSERT checks — the uncontended duplicate still returns 400 from `UniqueValidator`, unchanged.

**Test results**

New file `unittests/test_apiv2_unique_violation_conflict.py`, 10 tests, covering:

- 409 for a Postgres duplicate-key message and for a MySQL/MariaDB `Duplicate entry` message
- 409 driven by SQLSTATE alone, when the message wording is unrecognised
- 409 for a **genuine driver-raised** violation: a real duplicate INSERT is provoked and the test asserts both that the driver reports SQLSTATE `23505` and that the handler translates it, so the fix is verified against what the database actually raises rather than only against hand-built messages
- 500 preserved for foreign-key and not-null violations
- the response body leaks neither the constraint name, nor `DETAIL`, nor the offending value
- through the real endpoint and configured handler: the uncontended duplicate still returns 400 with error code `unique`; the simulated lost race returns 409; a unique create still returns 201

Verified locally against PostgreSQL on this branch:

- the 10 new tests fail before the change (6 failures) and pass after it
- `unittests.test_rest_framework`, `unittests.test_apiv2_methods_and_endpoints` and `unittests.test_apiv2_metadata` alongside the new file: **904 tests, OK** (377 skipped, version-gated)
- Ruff clean against `ruff.toml`

**Documentation**

No documentation change. There is no reference page enumerating API error codes, and this is a bug fix in a patch line rather than a documented contract change — the previous behaviour (500) was not documented as an expected response.

**Downstream / Pro consideration**

Pro wraps this handler (`pro_exception_handler` calls `custom_exception_handler`), so the change reaches Pro's API with no Pro-side edit. Two consequences reviewers should be aware of, both intended:

- Pro's `_attach_error_reference` only fires for `status_code >= 500`. Reclassifying these to 409 therefore stops them generating a backend diagnostics report — which is the point: a caller-resolvable conflict should not page anyone.
- Pro's `EnhancedAssetSerializer.create()` is `@transaction.atomic`, so the failed INSERT is rolled back by the atomic block before the handler runs; the handler performs no query on the 409 path in any case.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch — based on and targeting `bugfix`.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant — tests were run on 3.13.
- [x] Add applicable tests to the unit tests.
- [ ] Model changes must include the necessary migrations — N/A, no model changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RGNDB958xocB9FahuBZqG

---
_Generated by [Claude Code](https://claude.ai/code/session_013RGNDB958xocB9FahuBZqG)_