### PR TITLE
update fortify parsers to parse cwe

### DIFF
--- a/dojo/tools/fortify/fortify_data.py
+++ b/dojo/tools/fortify/fortify_data.py
@@ -59,3 +59,4 @@ class RuleData:
         self.confidentiality_impact: str = ""
         self.integrity_impact: str = ""
         self.remediation_effort: str = ""
+        self.cwe: int | None = None

--- a/dojo/tools/fortify/fpr_parser.py
+++ b/dojo/tools/fortify/fpr_parser.py
@@ -134,6 +134,8 @@ class FortifyFPRParser:
             finding.mitigation = self.format_mitigation(vuln_data, snippet, description, rule)
             finding.severity = self.compute_severity(vuln_data, rule)
             finding.impact = self.format_impact(related_data, vuln_data)
+            if rule and rule.cwe:
+                finding.cwe = rule.cwe
 
             finding.file_path = vuln_data.source_location_path
             finding.line = int(self.compute_line(vuln_data, snippet))
@@ -229,8 +231,22 @@ class FortifyFPRParser:
             rule_data.confidentiality_impact = rule.findtext("Group[@name='ConfidentialityImpact']", None, self.namespaces)
             rule_data.integrity_impact = rule.findtext("Group[@name='IntegrityImpact']", None, self.namespaces)
             rule_data.remediation_effort = rule.findtext("Group[@name='Recommendations']", None, self.namespaces)
+            rule_data.cwe = self.parse_cwe(rule.findtext("Group[@name='altcategoryCWE']", None, self.namespaces))
             logger.debug(f"Rule Impact: {rule_data.impact}")
         return rule_data
+
+    def parse_cwe(self, cwe_value: str | None) -> int | None:
+        """
+        Extract the first CWE id from a Fortify `altcategoryCWE` group value.
+
+        Values look like "CWE ID 352", may list several ("CWE ID 259,CWE ID 798"),
+        may be prefixed with an index ("[17] CWE ID 200"), or be absent/"None".
+        Finding.cwe holds a single integer, so we keep the first id.
+        """
+        if not cwe_value:
+            return None
+        match = re.search(r"CWE ID (\d+)", cwe_value)
+        return int(match.group(1)) if match else None
 
     def format_title(self, vulnerability, snippet) -> str:
         # defaults for when there is no snippet (shouldn't happen, future improvement: parser might also parse ReplacementDefinitions and/or Context elements)

--- a/unittests/tools/test_fortify_parser.py
+++ b/unittests/tools/test_fortify_parser.py
@@ -188,7 +188,8 @@ class TestFortifyParser(DojoTestCase):
                 self.assertEqual("src/main/java/hello/HelloWorld.java", finding.file_path)
                 self.assertEqual(5, finding.line)
                 # No rule/metainfo for this finding, so no CWE can be resolved
-                self.assertIsNone(finding.cwe)
+                # and the finding keeps the model default of 0
+                self.assertEqual(0, finding.cwe)
             with self.subTest(i=1):
                 finding = findings[1]
                 self.assertEqual("Password Management - HelloWorld.java: 13 (9C5BD1B5-C296-48d4-B5F5-5D2958661BC4)", finding.title)

--- a/unittests/tools/test_fortify_parser.py
+++ b/unittests/tools/test_fortify_parser.py
@@ -98,6 +98,7 @@ class TestFortifyParser(DojoTestCase):
                 self.assertEqual("1B87289954501EF8FD3861819DD98C27", finding.unique_id_from_tool)
                 self.assertEqual("public/category.html", finding.file_path)
                 self.assertEqual(219, finding.line)
+                self.assertEqual(352, finding.cwe)
             with self.subTest(i=1):
                 finding = findings[50]
                 self.assertEqual("Insecure Transport - footer.html: 104 (C72A3E77-8324-4FF9-B958-74FCDDF39D17)", finding.title)
@@ -105,6 +106,7 @@ class TestFortifyParser(DojoTestCase):
                 self.assertEqual("D739B2E51B127BDFA4FE07B5A7662A45", finding.unique_id_from_tool)
                 self.assertEqual("public/footer.html", finding.file_path)
                 self.assertEqual(104, finding.line)
+                self.assertEqual(297, finding.cwe)
 
     def test_fortify_hello_world_fpr_findings(self):
         with (get_unit_tests_scans_path("fortify") / "hello_world.fpr").open(encoding="utf-8") as testfile:
@@ -122,6 +124,7 @@ class TestFortifyParser(DojoTestCase):
                 self.assertEqual("A5338E223E737FF81F8A806C50A05969", finding.unique_id_from_tool)
                 self.assertEqual("src/main/java/hello/HelloWorld.java", finding.file_path)
                 self.assertEqual(5, finding.line)
+                self.assertEqual(615, finding.cwe)
             with self.subTest(i=1):
                 finding = findings[1]
                 self.assertEqual("Password Management - HelloWorld.java: 13 (9C5BD1B5-C296-48d4-B5F5-5D2958661BC4)", finding.title)
@@ -129,6 +132,8 @@ class TestFortifyParser(DojoTestCase):
                 self.assertEqual("D3166922519EDD92D132761602EB71B4", finding.unique_id_from_tool)
                 self.assertEqual("src/main/java/hello/HelloWorld.java", finding.file_path)
                 self.assertEqual(13, finding.line)
+                # altcategoryCWE lists two ids ("CWE ID 259,CWE ID 798"); we keep the first
+                self.assertEqual(259, finding.cwe)
 
     def test_fortify_webinspect_4_2_many_findings(self):
         with (get_unit_tests_scans_path("fortify") / "webinspect_4_2_many_findings.xml").open(encoding="utf-8") as testfile:
@@ -182,6 +187,8 @@ class TestFortifyParser(DojoTestCase):
                 self.assertEqual("A5338E223E737FF81F8A806C50A05969", finding.unique_id_from_tool)
                 self.assertEqual("src/main/java/hello/HelloWorld.java", finding.file_path)
                 self.assertEqual(5, finding.line)
+                # No rule/metainfo for this finding, so no CWE can be resolved
+                self.assertIsNone(finding.cwe)
             with self.subTest(i=1):
                 finding = findings[1]
                 self.assertEqual("Password Management - HelloWorld.java: 13 (9C5BD1B5-C296-48d4-B5F5-5D2958661BC4)", finding.title)
@@ -189,6 +196,7 @@ class TestFortifyParser(DojoTestCase):
                 self.assertEqual("D3166922519EDD92D132761602EB71B4", finding.unique_id_from_tool)
                 self.assertEqual("src/main/java/hello/HelloWorld.java", finding.file_path)
                 self.assertEqual(13, finding.line)
+                self.assertEqual(259, finding.cwe)
 
 
 class TestFortifyV2Parser(DojoTestCase):


### PR DESCRIPTION
Both instances of the fortify parser weren't correctly mapping CWE even though it was present in the file, this PR fixes that issue.