### PR TITLE
ci: make ruff a hard gate for the unit-tests workflow chain

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -2,6 +2,8 @@ name: Ruff Linter
 
 on:
   workflow_dispatch:
+  # called by unit-tests.yml as a gate: nothing else runs until ruff passes
+  workflow_call:
   push:
   pull_request:
 jobs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,13 @@ on:
       - hotfix/**
 
 jobs:
+  # hard gate: linting must pass before we spend any time building images or running tests
+  ruff:
+    uses: ./.github/workflows/ruff.yml
+    secrets: inherit
+
   build-docker-containers:
+    needs: ruff
     strategy:
         matrix:
           platform: ['linux/amd64', 'linux/arm64']


### PR DESCRIPTION
**Shortcut:** [sc-14037](https://app.shortcut.com/defectdojo/story/14037)

## Summary

Ruff currently runs in parallel with everything else, so a PR with a lint error still burns a full docker image build (2 platforms × 3 images) plus the performance, rest-framework, integration and k8s matrices before anyone looks at the linter.

This makes ruff a hard gate for that chain:

- `ruff.yml` gains a `workflow_call` trigger so it can be reused.
- `unit-tests.yml` calls it as a `ruff` job, and `build-docker-containers` gets `needs: ruff`.

Every downstream job (`test-performance`, `test-rest-framework`, `test-user-interface`, `test-k8s`) already depends on `build-docker-containers`, so gating that single job blocks the whole chain. A ruff failure now means zero image builds and zero test jobs, all reported as skipped.

## Notes

- Ruff keeps its existing `push` / `pull_request` / `workflow_dispatch` triggers, so direct pushes and non-gated branches are still linted. The cost is one duplicate run per PR (~30s), which was the deliberate trade-off over losing push coverage.
- `shellcheck.yml`, `test-helm-chart.yml` and `validate_docs_build.yml` are intentionally left ungated: they're cheap, fail fast, and run independently.

## Test plan

- [ ] CI on this PR shows `Unit tests / ruff` completing before `build-docker-containers` starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVw5x5Vq5XAeZ2E2zxDibN
