### PR TITLE
fix(jira): stop assuming push_to_jira returns a tuple

### DIFF
--- a/dojo/finding/ui/views.py
+++ b/dojo/finding/ui/views.py
@@ -3283,7 +3283,7 @@ def push_to_jira(request, fid):
         # but cant't change too much now without having a test suite,
         # so leave as is for now with the addition warning message
         # to check alerts for background errors.
-        if jira_services.push(finding):
+        if jira_services.push_succeeded(jira_services.push(finding)):
             messages.add_message(
                 request,
                 messages.SUCCESS,

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -194,7 +194,7 @@ def push_to_jira(request, fgid):
 
         # it may look like success here, but the push_to_jira are swallowing exceptions
         # but cant't change too much now without having a test suite, so leave as is for now with the addition warning message to check alerts for background errors.
-        if jira_services.push(group, force_sync=True):
+        if jira_services.push_succeeded(jira_services.push(group, force_sync=True)):
             messages.add_message(
                 request,
                 messages.SUCCESS,

--- a/dojo/jira/helper.py
+++ b/dojo/jira/helper.py
@@ -756,7 +756,14 @@ def jira_environment(obj):
     return ""
 
 
-def push_to_jira(obj, *args, **kwargs) -> tuple[str, bool]:
+def push_to_jira(obj, *args, **kwargs):
+    """
+    Push an object to Jira, in the foreground or via a Celery worker.
+
+    Returns a (success, message) tuple when the push ran in the foreground, and
+    an AsyncResult when it was queued -- callers must not assume either shape.
+    Pass force_sync=True if you need the tuple, or use interpret_push_result.
+    """
     if obj is None:
         msg = "Cannot push None to JIRA"
         raise ValueError(msg)
@@ -1847,6 +1854,25 @@ def process_jira_project_form(request, instance=None, target=None, product=None,
     return not error, jform
 
 
+def interpret_push_result(result) -> tuple[bool, str | None]:
+    """
+    Normalise a push_to_jira return value into (success, message).
+
+    push_to_jira returns whatever dojo_dispatch_task returns, and that differs
+    per dispatch path: the task's own (success, message) tuple when it runs in
+    the foreground, but an AsyncResult when it is handed to a Celery worker.
+    A queued push has not reported a result yet, so treat it as success --
+    failures inside the worker surface as alerts, not as a return value.
+
+    Callers must not test the raw return value for truthiness: a populated
+    (False, message) tuple and an AsyncResult are both truthy, so a failed push
+    reads as a successful one.
+    """
+    if isinstance(result, tuple):
+        return result
+    return True, None
+
+
 # return True if no errors
 def process_jira_epic_form(request, engagement=None):
     if not get_system_setting("enable_jira"):
@@ -1869,7 +1895,9 @@ def process_jira_epic_form(request, engagement=None):
                 epic_priority = None
                 if jira_epic_form.cleaned_data.get("epic_priority"):
                     epic_priority = jira_epic_form.cleaned_data.get("epic_priority")
-                success, message = push_to_jira(engagement, epic_name=epic_name, epic_priority=epic_priority)
+                success, message = interpret_push_result(
+                    push_to_jira(engagement, epic_name=epic_name, epic_priority=epic_priority),
+                )
                 if success:
                     logger.debug("Push to JIRA for Epic queued successfully")
                     messages.add_message(

--- a/dojo/jira/services.py
+++ b/dojo/jira/services.py
@@ -24,9 +24,27 @@ def push(obj, *args, **kwargs):
     """
     Push a finding, finding group, or engagement to Jira.
 
+    Returns a (success, message) tuple when the push ran in the foreground and
+    an AsyncResult when it was queued. Do not test the return value for
+    truthiness -- both shapes are truthy even for a failed push. Pass it
+    through push_succeeded() instead.
+
     Wraps: jira_helper.push_to_jira
     """
     return _get_helper().push_to_jira(obj, *args, **kwargs)
+
+
+def push_succeeded(result) -> bool:
+    """
+    Report whether a push() return value represents a successful push.
+
+    A queued push counts as success: it has not reported a result yet, and
+    failures inside the worker surface as alerts.
+
+    Wraps: jira_helper.interpret_push_result
+    """
+    success, _message = _get_helper().interpret_push_result(result)
+    return success
 
 
 def add_comment(obj, note, *, force_push=False, **kwargs):

--- a/unittests/test_jira_config_engagement_epic.py
+++ b/unittests/test_jira_config_engagement_epic.py
@@ -1,9 +1,15 @@
 # from unittest import skip
 import logging
+from unittest.mock import patch
+from urllib.parse import urlencode
 
+from celery.result import AsyncResult
+from django.contrib.messages import get_messages
+from django.urls import reverse
 from vcr import VCR
 
-from unittests.dojo_test_case import DojoVCRTestCase, get_unit_tests_path, versioned_fixtures
+from dojo.models import Engagement
+from unittests.dojo_test_case import DojoTestCase, DojoVCRTestCase, get_unit_tests_path, versioned_fixtures
 from unittests.test_jira_config_engagement import JIRAConfigEngagementBase
 
 logger = logging.getLogger(__name__)
@@ -73,3 +79,144 @@ class JIRAConfigEngagementEpicTest(DojoVCRTestCase, JIRAConfigEngagementBase):
         self.assertIsNotNone(engagement)
         self.assertIsNotNone(engagement.jira_project)
         self.assertTrue(engagement.has_jira_issue)
+
+
+@versioned_fixtures
+class JIRAEpicMappingAsyncPushTest(DojoTestCase):
+
+    """
+    Regression: an engagement edit with epic mapping enabled returned a 500
+    ("TypeError: cannot unpack non-iterable AsyncResult object") whenever the
+    epic push was dispatched to a Celery worker instead of run inline.
+
+    JIRAConfigEngagementEpicTest above sets block_execution=True, which forces
+    the foreground path where push_to_jira returns a (success, message) tuple.
+    Leaving block_execution at its default sends the push to a worker, and the
+    return value is then an AsyncResult -- the shape real users hit.
+
+    push_to_jira is patched so no Jira calls are made and no cassette is needed.
+    The POST inherits the jira config from the product rather than setting an
+    engagement-level one, which is a no-op in process_jira_project_form (there
+    is no engagement-level JIRA_Project to remove) and so contacts no Jira
+    instance either -- while get_jira_project() still resolves the product's
+    config through inheritance, so the epic push is still attempted.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    # engagement 2 belongs to product 1, whose JIRA_Project has
+    # enable_engagement_epic_mapping set, inherited via get_jira_project()
+    engagement_id = 2
+
+    def setUp(self):
+        super().setUp()
+        self.system_settings(enable_jira=True)
+        self.user = self.get_test_admin()
+        self.client.force_login(self.user)
+        # deliberately NOT setting block_execution: the default sends the push
+        # to a worker, which is the path that used to raise
+        self.user.usercontactinfo.block_execution = False
+        self.user.usercontactinfo.save()
+
+    def _post_engagement_edit(self, engagement):
+        data = {
+            "name": engagement.name,
+            "description": engagement.description,
+            "lead": 1,
+            "product": engagement.product.id,
+            "target_start": "2070-11-27",
+            "target_end": "2070-12-04",
+            "status": "Not Started",
+            # keep inheriting the product's jira config so the project form is a
+            # no-op and only the epic push is exercised
+            "jira-project-form-inherit_from_product": "on",
+            "jira-project-form-epic_issue_type_name": "Epic",
+            "jira-project-form-enabled": "True",
+            "jira-epic-form-push_to_jira": "on",
+        }
+        return self.client.post(
+            reverse("edit_engagement", args=(engagement.id,)),
+            urlencode(data),
+            content_type="application/x-www-form-urlencoded",
+        )
+
+    def test_edit_engagement_with_queued_epic_push_redirects(self):
+        engagement = Engagement.objects.get(id=self.engagement_id)
+        queued = AsyncResult("11111111-2222-3333-4444-555555555555")
+
+        with patch("dojo.jira.helper.push_to_jira", return_value=queued) as push:
+            response = self._post_engagement_edit(engagement)
+
+        push.assert_called_once()
+        self.assertEqual(
+            302, response.status_code,
+            msg=f"expected a redirect after a queued epic push, got {response.status_code}",
+        )
+        self.assertEqual(
+            reverse("view_engagement", args=(engagement.id,)), response.url,
+            msg=f"expected redirect to the engagement, got {response.url}",
+        )
+
+    def test_edit_engagement_with_foreground_epic_push_failure_rerenders(self):
+        """Control: a foreground failure tuple must still be treated as an error."""
+        engagement = Engagement.objects.get(id=self.engagement_id)
+
+        with patch("dojo.jira.helper.push_to_jira", return_value=(False, "jira exploded")) as push:
+            response = self._post_engagement_edit(engagement)
+
+        push.assert_called_once()
+        self.assertEqual(
+            200, response.status_code,
+            msg=f"expected the form to re-render on push failure, got {response.status_code}",
+        )
+
+
+@versioned_fixtures
+class JIRAPushFailureReportingTest(DojoTestCase):
+
+    """
+    Regression: the finding "push to Jira" endpoint reported success even when
+    the push failed, because it tested push()'s raw return value for truthiness
+    and a (False, message) tuple is truthy. The alert-danger branch could never
+    be reached.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    finding_id = 2
+
+    def setUp(self):
+        super().setUp()
+        self.system_settings(enable_jira=True)
+        self.user = self.get_test_admin()
+        self.client.force_login(self.user)
+
+    def _push(self, push_return):
+        with patch("dojo.jira.helper.push_to_jira", return_value=push_return):
+            response = self.client.post(
+                reverse("finding_push_to_jira", args=(self.finding_id,)),
+            )
+        tags = [m.extra_tags for m in get_messages(response.wsgi_request)]
+        return response, tags
+
+    def test_failed_push_is_reported_as_an_error(self):
+        response, tags = self._push((False, "jira exploded"))
+
+        self.assertEqual(200, response.status_code)
+        self.assertIn(
+            "alert-danger", tags,
+            msg=f"a failed push must raise an alert-danger message, got tags={tags}",
+        )
+
+    def test_queued_push_is_reported_as_a_success(self):
+        """Control: a queued push has not failed, so it must not raise an error alert."""
+        queued = AsyncResult("11111111-2222-3333-4444-555555555555")
+
+        response, tags = self._push(queued)
+
+        self.assertEqual(200, response.status_code)
+        self.assertIn(
+            "alert-success", tags,
+            msg=f"a queued push must report success, got tags={tags}",
+        )
+        self.assertNotIn("alert-danger", tags)

--- a/unittests/test_jira_helper.py
+++ b/unittests/test_jira_helper.py
@@ -2,7 +2,10 @@ import logging
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
+from celery.result import AsyncResult
+
 import dojo.jira.helper as jira_helper
+from dojo.jira import services as jira_services
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +32,123 @@ class JIRAHelperTest(TestCase):
     def test_issue_from_jira_is_active_defaults_to_active_on_missing_attribute(self):
         """AttributeError anywhere in the fields.status.statusCategory.key chain defaults to active."""
         self.assertTrue(jira_helper.issue_from_jira_is_active(Mock(spec=[])))
+
+
+class JIRAEpicFormAsyncDispatchTest(TestCase):
+
+    """
+    Regression: saving an engagement with epic mapping enabled raised
+    "TypeError: cannot unpack non-iterable AsyncResult object" from
+    process_jira_epic_form.
+
+    push_to_jira returns whatever dojo_dispatch_task returns: the task's
+    (success, message) tuple when it runs in the foreground, but a Celery
+    AsyncResult when it is dispatched to a worker. process_jira_epic_form
+    unpacked the return value into two names unconditionally, so it only
+    worked on the foreground path -- which is why every existing test for
+    this view sets block_execution=True and never saw the failure.
+    """
+
+    def _form(self, *, push=True, epic_name=None, epic_priority=None):
+        form = Mock()
+        form.is_valid.return_value = True
+        form.cleaned_data = {
+            "push_to_jira": push,
+            "epic_name": epic_name,
+            "epic_priority": epic_priority,
+        }
+        return form
+
+    def _run(self, push_return):
+        """Drive process_jira_epic_form with push_to_jira returning push_return."""
+        form = self._form()
+        engagement = Mock(id=1, name="engagement")
+        with (
+            patch("dojo.jira.helper.get_system_setting", return_value=True),
+            patch("dojo.jira.helper.JIRAEngagementForm", return_value=form),
+            patch("dojo.jira.helper.get_jira_project", return_value=Mock()),
+            patch("dojo.jira.helper.messages") as messages,
+            patch("dojo.jira.helper.push_to_jira", return_value=push_return) as push,
+        ):
+            success, returned_form = jira_helper.process_jira_epic_form(
+                Mock(POST={}), engagement=engagement,
+            )
+        return success, returned_form, push, messages
+
+    def test_async_dispatch_returns_success_without_unpacking(self):
+        """The async path hands back an AsyncResult, which must not be unpacked."""
+        async_result = AsyncResult("11111111-2222-3333-4444-555555555555")
+
+        success, returned_form, push, messages = self._run(async_result)
+
+        self.assertTrue(
+            success,
+            msg=f"expected queued push to report success, got success={success}",
+        )
+        self.assertIsNotNone(returned_form)
+        push.assert_called_once()
+        _args, kwargs = messages.add_message.call_args
+        self.assertEqual("alert-success", kwargs["extra_tags"])
+
+    def test_sync_dispatch_success_tuple_is_still_honoured(self):
+        """Control: the foreground path returns (True, message) and still succeeds."""
+        success, returned_form, push, messages = self._run((True, "pushed"))
+
+        self.assertTrue(
+            success,
+            msg=f"expected foreground success tuple to report success, got success={success}",
+        )
+        self.assertIsNotNone(returned_form)
+        push.assert_called_once()
+        _args, kwargs = messages.add_message.call_args
+        self.assertEqual("alert-success", kwargs["extra_tags"])
+
+    def test_sync_dispatch_failure_tuple_still_surfaces_the_message(self):
+        """Control: a foreground failure must keep reporting the task's message."""
+        success, _returned_form, _push, messages = self._run((False, "jira exploded"))
+
+        self.assertFalse(
+            success,
+            msg=f"expected foreground failure tuple to report failure, got success={success}",
+        )
+        args, kwargs = messages.add_message.call_args
+        self.assertIn("jira exploded", args)
+        self.assertEqual("alert-danger", kwargs["extra_tags"])
+
+
+class JIRAPushResultInterpretationTest(TestCase):
+
+    """
+    Regression: callers tested a push_to_jira return value for truthiness to
+    decide whether the push worked. Both possible shapes -- a populated
+    (success, message) tuple and an AsyncResult -- are truthy, so a failed push
+    was reported to the user as a successful one and the failure branch was
+    unreachable.
+    """
+
+    def test_queued_push_is_success_with_no_message(self):
+        result = AsyncResult("11111111-2222-3333-4444-555555555555")
+        self.assertEqual((True, None), jira_helper.interpret_push_result(result))
+
+    def test_foreground_success_tuple_passes_through(self):
+        self.assertEqual((True, "ok"), jira_helper.interpret_push_result((True, "ok")))
+
+    def test_foreground_failure_tuple_reports_failure(self):
+        success, message = jira_helper.interpret_push_result((False, "jira exploded"))
+        self.assertFalse(
+            success,
+            msg=f"a (False, message) tuple must report failure, got success={success}",
+        )
+        self.assertEqual("jira exploded", message)
+
+    def test_push_succeeded_rejects_a_failure_tuple(self):
+        """The truthiness trap: bool((False, 'msg')) is True, push_succeeded must not be."""
+        self.assertTrue(bool((False, "jira exploded")))
+        self.assertFalse(jira_services.push_succeeded((False, "jira exploded")))
+
+    def test_push_succeeded_accepts_a_queued_push(self):
+        result = AsyncResult("11111111-2222-3333-4444-555555555555")
+        self.assertTrue(jira_services.push_succeeded(result))
 
 
 class JIRAComponentFieldTest(TestCase):


### PR DESCRIPTION
**Description**

Saving an engagement with Jira epic mapping enabled returns a 500:

```
File "dojo/engagement/ui/views.py", line 310, in edit_engagement
    success, jira_epic_form = jira_services.process_epic_form(request, engagement=engagement)
File "dojo/jira/services.py", line 165, in process_epic_form
    return _get_helper().process_jira_epic_form(request, engagement=engagement)
File "dojo/jira/helper.py", line 1872, in process_jira_epic_form
    success, message = push_to_jira(engagement, epic_name=epic_name, epic_priority=epic_priority)
TypeError: cannot unpack non-iterable AsyncResult object
```

Root cause: `push_to_jira` (`dojo/jira/helper.py:759`) returns whatever `dojo_dispatch_task` returns, and that shape depends on the dispatch path (`dojo/celery_dispatch.py:90-106`):

- foreground → the task's own `(success, message)` tuple
- queued → an `AsyncResult`

`process_jira_epic_form` unpacked the return value into two names unconditionally, so it only worked on the foreground path. **The queued path is the default**: `we_want_async` (`dojo/decorators.py:82`) returns `True` for any user who has not set `block_execution`, so this fails for most users rather than being an edge case. Two views reach it — the engagement edit view (`dojo/engagement/ui/views.py:310`) and new-engagement-for-asset (`dojo/product/ui/views.py:1149`).

The function's own success message already says *"Push to JIRA for Epic queued succesfully"*, so queued-is-success was the intent; only the unpacking was wrong. The stale `-> tuple[str, bool]` annotation on `push_to_jira` (reversed, and covering just one of the two shapes) is what made the wrong shape look correct at the call site.

**Two further callers had the same root cause, failing silently rather than loudly.** Both tested the raw return value for truthiness:

- `dojo/finding/ui/views.py:3286` — `if jira_services.push(finding):`
- `dojo/finding_group/views.py:197` — `if jira_services.push(group, force_sync=True):`

A populated `(False, message)` tuple and an `AsyncResult` are **both truthy**, so a failed push was reported to the user as a successful one and the `alert-danger` branch was unreachable. The `force_sync=True` variant is the clearer bug of the two: it always gets a tuple back, and a 2-tuple is truthy regardless of the boolean inside it.

The remaining callers were checked and are correct — `dojo/finding/api/serializer.py:474` unpacks but passes `force_sync=True`, so it is guaranteed the tuple shape.

**Fix.** Adds `interpret_push_result()` to normalise either shape into `(success, message)`, exposed through the service layer as `push_succeeded()` for the two callers that only need the boolean. A queued push counts as success: it has not reported a result yet, and failures inside the worker surface as alerts. Behaviour and messaging on the foreground path are unchanged; the only behavioural changes are that the queued path no longer raises, and that a foreground failure now reaches the failure branch it was always meant to reach.

**Test results**

Tests were committed ahead of the fix so the reproductions are on the record, and each was confirmed to fail against the unmodified code first.

`unittests/test_jira_config_engagement_epic.py`

- `JIRAEpicMappingAsyncPushTest` — the engagement edit view redirects instead of 500ing when the epic push is queued. Pre-fix this failed through exactly the frames in the report above (view → service → helper). Controls: a foreground failure tuple still re-renders the form.
- `JIRAPushFailureReportingTest` — the finding push endpoint raises an `alert-danger` message on a failed push. Pre-fix: `AssertionError: 'alert-danger' not found in ['alert-success']`. Control: a queued push reports success and raises no error alert.

Note on why this shipped: the pre-existing `JIRAConfigEngagementEpicTest` sets `block_execution = True` in `setUp`, which forces the foreground path — so the whole existing epic view suite only ever exercised the shape that worked. The new class deliberately leaves it off. Neither new class needs a VCR cassette: `push_to_jira` is patched, and the POST inherits the product's Jira config so `process_jira_project_form` short-circuits without contacting a Jira instance.

`unittests/test_jira_helper.py`

- `JIRAEpicFormAsyncDispatchTest` — the epic form over all three return shapes (queued, foreground success, foreground failure), asserting the failure message still reaches the user.
- `JIRAPushResultInterpretationTest` — `interpret_push_result` / `push_succeeded` over all three shapes, including an explicit assertion that `bool((False, message))` is `True` while `push_succeeded` is not, so the truthiness trap cannot silently return.

Suites run locally against Postgres:

- `test_jira_helper`, `test_jira_config_engagement_epic`, `test_jira_config_engagement` — 54 tests, OK
- `test_finding_helper`, `test_finding_model`, `test_finding_group_filter_context` — 89 tests, OK (29 skipped)
- `test_jira_import_and_pushing_api`, `test_jira_template`, `test_jira_webhook`, `test_jira_config_product`, `test_jira_finding_group_perf` — 96 tests, 1 failure: `test_add_jira_instance_unknown_host`, which asserts on a DNS resolver error string and fails identically on an unmodified checkout in this environment. Pre-existing and environmental, not related to this change.

Ruff clean against the pinned `ruff==0.15.20` with `ruff.toml`.

**Pro impact**

Checked as part of acceptance, since Pro overrides behaviour in this area:

- Pro does **not** override `process_jira_epic_form`, `push_to_jira`, or the Jira helper. `_get_helper()` in `dojo/jira/services.py` is a lazy-import shim to break an import cycle, not a registry override point, so there is no Pro-side variant of the crash to fix.
- Pro's three unpacking call sites (`pro/finding/api/serializers.py:279`, `pro/finding_groups/api/serializers.py:102` and `:129`) all pass `force_sync=True` and are already correct.
- Pro has **one matching silent occurrence not fixed here**: `pro/engagement/vue/views.py:222` assigns the result of `jira_services.push(...)` and then branches on `if not pushed_to_jira:`. Because the queued return value is truthy, the 503 "not pushed to Jira" branch is unreachable — the Vue engagement epic push reports success even when the push fails. That is the Vue counterpart of the same epic-push feature that crashes in the legacy UI here. It is pre-existing, is not affected either way by this PR, and needs its own change in the Pro repo; this PR is self-contained and does not require a paired Pro change to land.

**Documentation**

No documentation change. This is a bug fix with no change to configuration, inputs, outputs, or documented behaviour — the queued epic push is documented as queued and remains so.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch — based on and targeting `bugfix`.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR — `bugfix`.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder — n/a, no model changes.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation — n/a, bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Spk7bJoZdMsYjrLgHCjY7h

---
_Generated by [Claude Code](https://claude.ai/code/session_01Spk7bJoZdMsYjrLgHCjY7h)_