### PR TITLE
fix(jfrog): stable reimport identity for JFrog Xray API Summary Artifact Scan

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1348,7 +1348,14 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     "SpotBugs Scan": DEDUPE_ALGO_HASH_CODE,
     "JFrog Xray Unified Scan": DEDUPE_ALGO_HASH_CODE,
     "JFrog Xray On Demand Binary Scan": DEDUPE_ALGO_HASH_CODE,
-    "JFrog Xray API Summary Artifact Scan": DEDUPE_ALGO_HASH_CODE,
+    # The parser emits a stable unique_id_from_tool (sha256 over the artifact digest, the impacted
+    # component name/version and the Xray issue id), so match on that first and keep hash_code only
+    # as the fallback. Matching purely on hash_code made a finding's identity depend on its
+    # description, which for this parser embeds JFrog's own CVE prose — vendor-maintained text that
+    # changes whenever Xray refreshes its vulnerability database. When it changed, reimport could no
+    # longer find the existing finding and closed + recreated it (observed in the field: thousands of
+    # findings mitigated and re-created in one reimport of otherwise unchanged data).
+    "JFrog Xray API Summary Artifact Scan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
     "Scout Suite Scan": DEDUPE_ALGO_HASH_CODE,
     "AWS Security Hub Scan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     "Meterian Scan": DEDUPE_ALGO_HASH_CODE,

--- a/dojo/tools/jfrog_xray_api_summary_artifact/parser.py
+++ b/dojo/tools/jfrog_xray_api_summary_artifact/parser.py
@@ -62,7 +62,6 @@ def get_item(
     artifact_version,
     artifact_sha256,
 ):
-    cve = None
     cwe = None
     cvssv3 = None
     impact_path = ImpactPath("", "", "")
@@ -93,6 +92,10 @@ def get_item(
     if len(impact_paths) > 0:
         impact_path = decode_impact_path(impact_paths[0])
 
+    # unique_id_from_tool is this parser's stable identity and drives reimport matching (see
+    # DEDUPLICATION_ALGORITHM_PER_PARSER): it must depend only on values that identify the finding
+    # (artifact digest, impacted component, Xray issue id) and never on vendor-maintained prose such
+    # as the CVE description, which Xray rewrites as it refreshes its vulnerability database.
     result = hashlib.sha256()
     if "issue_id" in vulnerability:
         unique_id = str(
@@ -102,9 +105,11 @@ def get_item(
             + vulnerability["issue_id"],
         )
         vuln_id_from_tool = vulnerability["issue_id"]
-    elif cve:
-        unique_id = str(artifact_sha256 + impact_path.name + impact_path.version + cve)
     else:
+        # No issue id: fall back to the summary, which is the only other per-issue identifier the
+        # payload carries. (A `cve` branch used to sit here but was unreachable — the local was
+        # never assigned — and left vuln_id_from_tool unbound, so it would have raised had the
+        # condition ever become true.)
         unique_id = str(
             artifact_sha256
             + impact_path.name
@@ -134,7 +139,8 @@ def get_item(
         severity=severity,
         description=description,
         test=test,
-        file_path=impact_paths[0],
+        # An issue with no impact_path at all would otherwise IndexError and fail the whole import.
+        file_path=impact_paths[0] if len(impact_paths) > 0 else "",
         component_name=artifact_name,
         component_version=artifact_version,
         static_finding=True,

--- a/unittests/tools/test_jfrog_xray_api_summary_artifact_parser.py
+++ b/unittests/tools/test_jfrog_xray_api_summary_artifact_parser.py
@@ -1,4 +1,6 @@
+import copy
 import hashlib
+import json
 
 from dojo.models import Test
 from dojo.tools.jfrog_xray_api_summary_artifact.parser import (
@@ -75,3 +77,49 @@ class TestJFrogXrayApiSummaryArtifactParser(DojoTestCase):
         self.assertIsNone(finding.cvssv3)
         self.assertEqual(2, len(finding.unsaved_vulnerability_ids))
         self.assertEqual("XRAY-523195", finding.unsaved_vulnerability_ids[1])
+
+    def test_unique_id_is_stable_when_vendor_prose_changes(self):
+        """
+        The finding's identity must not move when Xray rewrites its CVE prose.
+
+        This parser's findings are matched on reimport by unique_id_from_tool (see
+        DEDUPLICATION_ALGORITHM_PER_PARSER). Xray refreshes the description text of an issue as
+        its vulnerability database is updated; when identity depended on that text, a reimport of
+        otherwise unchanged data closed every affected finding and created a replacement.
+        """
+        with (get_unit_tests_scans_path("jfrog_xray_api_summary_artifact") / "one_vuln.json").open(
+            encoding="utf-8",
+        ) as testfile:
+            original = json.load(testfile)
+
+        parser = JFrogXrayApiSummaryArtifactParser()
+        before = parser.get_items(copy.deepcopy(original), Test())[0]
+
+        rewritten = copy.deepcopy(original)
+        issue = rewritten["artifacts"][0]["issues"][0]
+        issue["description"] = "A substantially rewritten vendor description with new prose. " * 8
+
+        after = parser.get_items(rewritten, Test())[0]
+
+        self.assertNotEqual(before.description, after.description, "test premise: prose did change")
+        self.assertEqual(before.unique_id_from_tool, after.unique_id_from_tool)
+        self.assertEqual(before.vuln_id_from_tool, after.vuln_id_from_tool)
+
+    def test_issue_without_impact_path_does_not_break_the_import(self):
+        """
+        An issue carrying no impact_path must still parse.
+
+        It used to IndexError on file_path, which failed the entire report instead of the one
+        affected issue.
+        """
+        with (get_unit_tests_scans_path("jfrog_xray_api_summary_artifact") / "one_vuln.json").open(
+            encoding="utf-8",
+        ) as testfile:
+            tree = json.load(testfile)
+
+        tree["artifacts"][0]["issues"][0].pop("impact_path", None)
+
+        findings = JFrogXrayApiSummaryArtifactParser().get_items(tree, Test())
+        self.assertEqual(1, len(findings))
+        self.assertEqual("", findings[0].file_path)
+        self.assertTrue(findings[0].unique_id_from_tool)


### PR DESCRIPTION
## Problem

Findings from `JFrog Xray API Summary Artifact Scan` were matched on reimport by `hash_code`, whose configured fields include **description**. This parser builds `description` from JFrog's own CVE prose — vendor-maintained text that Xray rewrites whenever it refreshes its vulnerability database. When that text changes, reimport can no longer find the existing finding: it closes it and creates a replacement, even though the upstream scan is untouched.

Reported from the field as thousands of findings mitigated and re-created in a single reimport, recurring across imports. A measured pair from the affected instance: identical `title`, `component_name`, `component_version`, `unique_id_from_tool` (`3286f2aa…`) and `vuln_id_from_tool` (`XRAY-1013852`), while the description grew **429 → 779 characters** as the vendor rewrote it — so the reimport hash moved and the old finding was closed alongside a fresh duplicate.

## Fix

The parser already emits a stable `unique_id_from_tool`: sha256 over the artifact digest, the impacted component name/version and the Xray issue id — none of which is prose. Switch the scan type to `unique_id_from_tool_or_hash_code` so reimport matches on that id first and keeps `hash_code` as the fallback.

**No migration or one-time churn:** existing findings already store this `unique_id_from_tool`, so they start matching on the very next reimport. (Contrast with changing the hash fields, which would invalidate every stored hash and force exactly the close/recreate cycle this fixes.) This mirrors how the sibling `JFrog Xray Unified Scan` avoids description-based identity.

### Parser hardening while here

- Removed an unreachable `elif cve:` branch: its local was never assigned, so the branch was dead — **and it left `vuln_id_from_tool` unbound**, so it would have raised had the condition ever become true.
- An issue with no `impact_path` no longer `IndexError`s on `file_path`, which failed the whole report rather than the one affected issue.

## Tests

- New: identity is stable across a rewritten vendor description (same `unique_id_from_tool` / `vuln_id_from_tool`, different description) — the regression this fixes.
- New: an issue with no `impact_path` parses instead of failing the import.
- All JFrog parser suites (api-summary-artifact, xray, unified): 16 tests pass. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)