### PR TITLE
Apply login rate limiter to the API token auth endpoint

### DIFF
--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -36,6 +36,7 @@ from dojo.asset.urls import urlpatterns as asset_urls
 from dojo.banner.ui.urls import urlpatterns as banner_urls
 from dojo.benchmark.ui.urls import urlpatterns as benchmark_urls
 from dojo.components.urls import urlpatterns as component_urls
+from dojo.decorators import dojo_ratelimit
 from dojo.development_environment.api.urls import add_development_environment_urls
 from dojo.development_environment.ui.urls import urlpatterns as dev_env_urls
 from dojo.endpoint.api.urls import add_endpoint_urls, register_endpoint_meta_import
@@ -201,10 +202,12 @@ api_v2_urls = [
 
 if hasattr(settings, "API_TOKENS_ENABLED") and hasattr(settings, "API_TOKEN_AUTH_ENDPOINT_ENABLED"):
     if settings.API_TOKENS_ENABLED and settings.API_TOKEN_AUTH_ENDPOINT_ENABLED:
+        # Keyed on IP: API clients post JSON, which leaves request.POST empty.
+        token_auth_view = dojo_ratelimit(key="ip")(tokenviews.obtain_auth_token)
         api_v2_urls += [
             re_path(
                 f"^{get_system_setting('url_prefix')}api/v2/api-token-auth/",
-                tokenviews.obtain_auth_token,
+                token_auth_view,
                 name="api-token-auth",
             ),
         ]

--- a/unittests/test_apiv2_user.py
+++ b/unittests/test_apiv2_user.py
@@ -1,4 +1,6 @@
 from django.contrib.auth.models import Permission
+from django.core.cache import cache
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.authtoken.models import Token
@@ -57,6 +59,22 @@ class UserTest(APITestCase):
         }, format="json")
         self.assertEqual(r.status_code, 400, r.content[:1000])
         self.assertIn("Password must contain at least 1 digit, 0-9.", r.content.decode("utf-8"))
+
+    @override_settings(RATE_LIMITER_ENABLED=True, RATE_LIMITER_BLOCK=True, RATE_LIMITER_RATE="3/m")
+    def test_api_token_auth_is_rate_limited(self):
+        # Posted as JSON, like API clients do: that leaves request.POST empty.
+        cache.clear()
+        anon = APIClient()
+        url = reverse("api-token-auth")
+        creds = {"username": "ratelimit-probe", "password": "not-the-real-password"}
+
+        reached_auth_view = 0
+        for _ in range(8):
+            r = anon.post(url, creds, format="json")
+            if b"non_field_errors" in r.content:
+                reached_auth_view += 1
+
+        self.assertEqual(reached_auth_view, 3, "api-token-auth should honor the configured rate limit")
 
     def test_user_change_password(self):
         # some user


### PR DESCRIPTION
The web login view honors the `DD_RATE_LIMITER_*` settings, but `/api/v2/api-token-auth/` checks the same username and password with no limit. This wires the token auth view through the same `dojo_ratelimit` decorator so operators who turn rate limiting on get consistent coverage across both credential entry points.

Keyed on IP rather than on a posted field, because API clients post JSON and that leaves `request.POST` empty, so a `post:` key would collapse to a single shared bucket for every caller.

Note that adding `DEFAULT_THROTTLE_CLASSES` would not work here: DRF's `ObtainAuthToken` sets `throttle_classes` to an empty tuple, so the global default never reaches this view.

No functional change while the limiter is disabled, which is the default. Adds a regression test.