### PR TITLE
add additional scanner protocols to whitelist

### DIFF
--- a/dojo/url/validators.py
+++ b/dojo/url/validators.py
@@ -102,7 +102,11 @@ DEFAULT_PORTS = {
     "mqtts": 8883,  # Secure MQTT
     "openvpn": 1194,  # included for completeness, though it doesn't fit the URL scheme exactly
     "irc": 194,
+    "snmp": 161,  # Simple Network Management Protocol (161/udp)
+    "ipp": 631,  # Internet Printing Protocol
     "tcp": None,
+    "udp": None,  # transport protocol; scanner supplies the actual port
+    "icmp": None,  # no port concept
     # Empty string is used when the protocol is not specified, port is then assumed to be None as well
     "": None,
 }

--- a/unittests/test_location_models.py
+++ b/unittests/test_location_models.py
@@ -85,6 +85,29 @@ class TestURLModel(DojoTestCase):
         url = URL.from_value("tcp://foo.bar/")
         self.assertIsNone(url.port)
 
+    # Regression: network/infra-scanner endpoints using udp/snmp/ipp/icmp
+    # protocols were rejected by URL validation ("<proto> is not a supported
+    # protocol"), so migrate_endpoints_to_locations silently dropped them —
+    # ~65% of endpoints on infra-scan-heavy instances.
+    def test_scanner_protocols_supported(self):
+        for protocol, expected_port in (
+            ("udp", None),
+            ("icmp", None),
+            ("snmp", 161),
+            ("ipp", 631),
+        ):
+            url = URL(protocol=protocol, host="foo.bar")
+            url.full_clean()  # must not raise
+            self.assertEqual(
+                url.port, expected_port,
+                msg=f"expected default port {expected_port} for {protocol!r}, got {url.port!r}",
+            )
+
+    def test_unsupported_protocol_still_rejected(self):
+        # Control: a genuinely unknown protocol must still fail validation.
+        url = URL(protocol="definitelynotaprotocol", host="foo.bar")
+        self.assertRaises(ValidationError, url.full_clean)
+
     def test_spacial_char(self):
         url = URL.from_value("http://foo.bar/beforeSpace%20afterSpace")
         self.assertEqual(url.path, "beforeSpace%20afterSpace")


### PR DESCRIPTION
## Background
The migrate_endpoints_to_locations management command (and live V3 scanner imports)
fail for endpoints whose protocol is udp, snmp, ipp, or icmp. The legacy
Endpoint model accepted any protocol, but the newer URL model enforces a whitelist
via validate_protocol, which rejects anything not in DEFAULT_PORTS. On an
infra-scan-heavy instance this silently dropped ~65% of endpoints, all with:

    django.core.exceptions.ValidationError: {'protocol': ['udp is not a supported protocol']}

BaseModel.save() calls full_clean(), which runs the validate_protocol field
validator on dojo/url/models.py → raises during the migration's per-endpoint save.

## Fix
In dojo/url/validators.py, add the four scanner protocols to the DEFAULT_PORTS
dict, next to the existing tcp entry, following the tcp: None precedent:

    "irc": 194,
    "snmp": 161,  # Simple Network Management Protocol (161/udp)
    "ipp": 631,  # Internet Printing Protocol
    "tcp": None,
    "udp": None,  # transport protocol; scanner supplies the actual port
    "icmp": None,  # no port concept
    # Empty string is used when the protocol is not specified, port is then assumed to be None as well
    "": None,
## Test (TDD — add the test and confirm it fails BEFORE the fix)
In unittests/test_location_models.py, add these two methods to the
TestURLModel class (right after test_ports):

    # Regression: network/infra-scanner endpoints using udp/snmp/ipp/icmp
    # protocols were rejected by URL validation ("<proto> is not a supported
    # protocol"), so migrate_endpoints_to_locations silently dropped them —
    # ~65% of endpoints on infra-scan-heavy instances.
    def test_scanner_protocols_supported(self):
        for protocol, expected_port in (
            ("udp", None),
            ("icmp", None),
            ("snmp", 161),
            ("ipp", 631),
        ):
            url = URL(protocol=protocol, host="foo.bar")
            url.full_clean()  # must not raise
            self.assertEqual(
                url.port, expected_port,
                msg=f"expected default port {expected_port} for {protocol!r}, got {url.port!r}",
            )

    def test_unsupported_protocol_still_rejected(self):
        # Control: a genuinely unknown protocol must still fail validation.
        url = URL(protocol="definitelynotaprotocol", host="foo.bar")
        self.assertRaises(ValidationError, url.full_clean)
ValidationError is already imported at the top of that file.

