### PR TITLE
docs: add Pro changelog entries for 3.1.301 and 3.1.302

### DIFF
--- a/docs/content/releases/pro/changelog.md
+++ b/docs/content/releases/pro/changelog.md
@@ -12,6 +12,29 @@ For Open Source release notes, please see the [Releases page on GitHub](https://
 
 ## July 2026: v3.1
 
+### July 29, 2026: v3.1.302
+
+* **(Connectors)** Added another large batch of Connectors to the Pro UI. New findings connectors: AppCheck, CyCognito, Picus, Red Hat Satellite, ImmuniWeb, Trustwave Fusion, Scantist, Black Duck Continuous Dynamic, Finite State, SOOS, Ostorlab, Automox, Qwiet AI, HiddenLayer, Nozomi Networks, NetRise, Uptycs, Klocwork, Parasoft DTP, CI Fuzz, Akto, BigID, Action1, ManageEngine Vulnerability Manager Plus, Zimperium, Dragos, CyberArk Certificate Manager, Calico Cloud, Rapid7 InsightCloudSec, Holm Security, Wazuh SCA, Fleet, and Elastic Security.
+* **(Connectors)** Checkmarx One branch tracking now accepts wildcard branch patterns, and JFrog Xray gained a `repository_filter` that scopes discovery before any per-repository work is done. The all-records view can now be filtered by record state.
+* **(Connectors)** Fixed a Microsoft Defender export page whose body arrives truncated being dropped instead of refetched, Microsoft Defender for Cloud now tolerates Azure Resource Graph shape drift on `additionalData.cve`, and a Checkmarx One wildcard that matches no branch in the scan window now skips the sync instead of closing every finding.
+* **(Performance)** Connector syncs now fetch only the records they need rather than the full record set.
+* **(Security)** Hardened SAML assertion handling, and the login rate limiter now also applies to the API token authentication endpoint.
+* **(Import)** Failure-path cleanup no longer masks the real import error, and import/reimport failures keep their intended status codes.
+* **(Search)** The search language facet is now seeded from the authorized queryset.
+* **(Bug Fixes)** The affected-engagements recompute no longer deadlocks concurrent risk acceptance updates, and stored JFrog api-summary deduplication settings are refreshed to match the current algorithm.
+
+### July 28, 2026: v3.1.301
+
+* **(Connectors)** Added nine parser-backed findings connectors: Google Artifact Analysis, Zora, PingCastle, Promptfoo, Alert Logic, Cyberwatch, WebInspect Enterprise, TruffleHog, and Chef Automate. Each mirrors its existing DefectDojo parser's mapping and scan type, so connector imports and file imports land in the same parser and the same deduplication configuration. Also wired up the credential forms for the Coverity, Cobalt.io, and Nuclei connectors, and gave five connectors their own logo.
+* **(Connectors)** Connector syncs can now stream findings in chunks, so very large syncs no longer exhaust memory. Checkmarx One per-branch tracking now defaults on for new installations only, leaving existing installations on their current behavior.
+* **(FIPS)** Added optional FIPS 140-3 image variants (CMVP #5247) for the connectors service, MCP server, integrators, and PSIRT advisory engine, deployable via `fips.enabled` in the Helm chart.
+* **(Integrations)** Added Opsgenie and ServiceNow SecOps / Vulnerability Response outbound integrators.
+* **(SSO)** Added structured attribute-mapping editors for SAML, LDAP, and OIDC in the Tuner, along with OIDC group mapping.
+* **(Pro UI)** Feature Flags and Appearance are now flagged as new in the menu, and dropdown menu triggers are hidden when they have no visible items.
+* **(Authorization)** Risk acceptances are now scoped by their accepted findings, the Jira finding-mapping project field and the bulk-update target finding group are restricted to authorized objects, the member-management check is applied on every serializer exposing the field, metadata API object authorization was hardened, and finding and engagement UI actions now require POST.
+* **(Bug Fixes)** Locations are now carried across a finding merge; the risk acceptance expiration job no longer aborts on an unattached risk acceptance; chained duplicates are re-pointed before excess duplicates are deleted; the deduplication hash-recompute task no longer prefetches deprecated endpoints; and the API returns a validation error instead of a 500 when `environment` is omitted.
+* **(Docs)** Documented the SSO attribute-mapping editors and OIDC group mapping, and enabling the Jira integration in System Settings. Clarified that the Jira webhook secret authenticates incoming requests.
+
 ### July 27, 2026: v3.1.300
 
 * **(RBAC)** Added user-defined Custom Roles. You can now create your own roles with a granular permission set per object type, instead of being limited to the built-in roles.


### PR DESCRIPTION
**Shortcut:** [sc-14057](https://app.shortcut.com/defectdojo/story/14057)

## Summary

Adds Pro changelog entries for **3.1.301** (July 28, 2026) and **3.1.302** (July 29, 2026), built from the release PR lists across the Pro repositories. Entries are grouped by type and follow the existing UX-focused style of the file.

## Notes

- Connectors are listed under the release in which they became available in the Pro UI, not necessarily the release that shipped them in the connectors service. The wave-6, wave-8, SOC/EDR, and AppCheck connector batches landed in the connectors service for 3.1.301 but were only registered in the Pro UI for 3.1.302, so they appear under 3.1.302. The nine parser-backed wave-5 connectors were registered in the UI for 3.1.301 and appear there.
- Connector names for the batch PRs were taken from the registration PR bodies, since the PR titles only referenced wave numbers. `venafi` is listed as CyberArk Certificate Manager, matching the display name used in the UI.
- Omitted as not user-facing: dependency bumps, a migration rename, CLAUDE.md and tooling changes, a Vue test-mock fix, a compose platform pin, and the OSS release-line branch guard.

Docs-only change; no code or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL5XG4LuJDrhEzK4NJKrX8
