### PR TITLE
fix(importers): stop the write-back re-creating a deleted import target

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -27,6 +27,7 @@ from dojo.models import (
     SEVERITIES,
     BurpRawRequestResponse,
     Endpoint,
+    Engagement,
     FileUpload,
     Finding,
     Test,
@@ -626,6 +627,44 @@ class BaseImporter(ImporterOptions):
 
         return message
 
+    def save_without_resurrecting(self, instance: Engagement | Test) -> None:
+        """
+        Persist an import target, refusing to re-create it if it was deleted mid-import.
+
+        Model.save() on an instance whose primary key is already set issues an UPDATE, and
+        Django falls back to an INSERT when that UPDATE matches no rows. The importer loads
+        its test and engagement at the start of a run that can take minutes, so a delete
+        landing mid-run turns a routine write-back into an INSERT that re-creates the
+        deleted row from the stale in-memory copy. That surfaced two ways:
+
+        - The parent went with it (an engagement delete cascades to its tests), so the
+          INSERT carried a dangling foreign key. Because Django declares its foreign keys
+          DEFERRABLE INITIALLY DEFERRED, the violation is only raised at COMMIT, well past
+          any handler that knew what the import was doing, and the caller got an opaque 500
+          naming a PostgreSQL constraint instead of the reason the import failed.
+        - The parent survived, so the INSERT succeeded and silently resurrected a row the
+          user had deleted, without the findings and history that were cascaded away with it.
+
+        Neither is a save the importer should be making: the target of the import is gone,
+        so the import cannot complete. Fail with a message that says exactly that.
+
+        The row is checked before the write rather than relying on save(force_update=True).
+        A forced update raises from inside the atomic block that Model.save_base opens
+        without a savepoint, which marks the whole surrounding transaction for rollback --
+        the caller's failure handling would then hit TransactionManagementError instead of
+        being able to record why the import failed. Costing one indexed primary-key lookup
+        keeps the transaction usable.
+        """
+        if instance.pk is not None and not type(instance)._base_manager.filter(pk=instance.pk).exists():
+            msg = (
+                f"The {instance._meta.verbose_name} this scan was being imported into "
+                f"(id {instance.pk}) was deleted while the scan was being processed, so "
+                f"the import could not be completed. Nothing was imported. Re-run the "
+                f"import against a {instance._meta.verbose_name} that still exists."
+            )
+            raise ValidationError(msg)
+        instance.save()
+
     def update_test_progress(
         self,
         percentage_value: int = 100,
@@ -636,7 +675,7 @@ class BaseImporter(ImporterOptions):
         Its purpose is to update the percent completion of the test to 100 percent
         """
         self.test.percent_complete = percentage_value
-        self.test.save()
+        self.save_without_resurrecting(self.test)
 
     def resolve_dynamic_test_type_name(self, raw_type: str | None) -> str:
         """

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -126,8 +126,8 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         # Update the test meta
         self.update_test_meta()
         # Save the test and engagement for changes to take affect
-        self.test.save()
-        self.test.engagement.save()
+        self.save_without_resurrecting(self.test)
+        self.save_without_resurrecting(self.test.engagement)
         # Create a test import history object to record the flags sent to the importer
         # This operation will return None if the user does not have the import history
         # feature enabled

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -131,8 +131,8 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         # Update the test tags
         self.update_test_tags()
         # Save the test and engagement for changes to take affect
-        self.test.save()
-        self.test.engagement.save()
+        self.save_without_resurrecting(self.test)
+        self.save_without_resurrecting(self.test.engagement)
         logger.debug("REIMPORT_SCAN: Updating test tags")
         # Create a test import history object to record the flags sent to the importer
         # This operation will return None if the user does not have the import history

--- a/unittests/test_importers_deleted_target.py
+++ b/unittests/test_importers_deleted_target.py
@@ -1,0 +1,200 @@
+import logging
+from unittest import mock
+
+from django.core.exceptions import ValidationError
+from django.utils import timezone
+
+from dojo.importers.default_importer import DefaultImporter
+from dojo.importers.default_reimporter import DefaultReImporter
+from dojo.models import (
+    Development_Environment,
+    Engagement,
+    Product,
+    Product_Type,
+    Test,
+    User,
+)
+
+from .dojo_test_case import DojoTestCase, get_unit_tests_scans_path
+
+logger = logging.getLogger(__name__)
+
+SCAN_TYPE = "Acunetix Scan"
+SCAN_FILE = "one_finding.xml"
+
+
+class TestImportersDeletedTarget(DojoTestCase):
+
+    """
+    Regression: an import target deleted while the scan was being processed was re-created
+    by the importer's closing write-back.
+
+    Model.save() on an instance whose primary key is already set issues an UPDATE and
+    falls back to an INSERT when that UPDATE matches no rows. The importer loads its Test
+    and Engagement at the start of a run that can take minutes, so a delete landing
+    mid-run turned the write-back into an INSERT of the deleted row from a stale in-memory
+    copy. Either the row was silently resurrected, or -- when the parent went with it --
+    the INSERT carried a dangling foreign key and the caller got an opaque 500 naming a
+    PostgreSQL constraint instead of the reason the import failed.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user, _ = User.objects.get_or_create(username="admin")
+        product_type, _ = Product_Type.objects.get_or_create(name="deleted_target")
+        self.environment, _ = Development_Environment.objects.get_or_create(name="Development")
+        self.product, _ = Product.objects.get_or_create(
+            name="TestImportersDeletedTarget",
+            description="Test",
+            prod_type=product_type,
+        )
+        self.engagement, _ = Engagement.objects.get_or_create(
+            name="Deleted Target Engagement",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        with (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan:
+            self.test, _, len_new_findings, _, _, _, _ = self._importer().process_scan(scan)
+        self.assertEqual(1, len_new_findings)
+
+    def _options(self, **overrides):
+        options = {
+            "user": self.user,
+            "lead": self.user,
+            "scan_date": None,
+            "environment": self.environment,
+            "active": True,
+            "verified": False,
+            "scan_type": SCAN_TYPE,
+        }
+        options.update(overrides)
+        return options
+
+    def _importer(self):
+        return DefaultImporter(close_old_findings=False, **self._options(engagement=self.engagement))
+
+    def _reimporter(self):
+        return DefaultReImporter(close_old_findings=False, **self._options(test=self.test))
+
+    def _process_with_delete_mid_run(self, importer, delete, hook):
+        """
+        Run a scan through `importer`, with `delete` firing just before the write-back.
+
+        `hook` is the last step the importer takes before it saves the test and its
+        engagement, so its call site is the window a concurrent delete lands in:
+        update_test_tags() on the reimport path, update_test_meta() on the import path.
+        """
+        with (
+            (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan,
+            mock.patch.object(importer, hook, side_effect=delete),
+        ):
+            return importer.process_scan(scan)
+
+    def test_reimport_does_not_resurrect_a_test_deleted_mid_run(self):
+        """A test deleted while its scan was processed must not be re-created by the write-back."""
+        test_pk = self.test.pk
+
+        with self.assertRaises(ValidationError) as caught:
+            self._process_with_delete_mid_run(
+                self._reimporter(),
+                lambda: Test.objects.filter(pk=test_pk).delete(),
+                "update_test_tags",
+            )
+
+        self.assertFalse(
+            Test.objects.filter(pk=test_pk).exists(),
+            msg=f"the deleted test (id {test_pk}) must not be re-inserted by the reimport write-back",
+        )
+        self.assertIn(
+            "deleted while the scan was being processed",
+            str(caught.exception),
+            msg=f"the error must say the import target was deleted, got: {caught.exception}",
+        )
+
+    def test_reimport_reports_the_deleted_target_not_a_constraint_violation(self):
+        """An engagement delete cascades to its tests; the caller gets the reason, not a constraint name."""
+        test_pk = self.test.pk
+        engagement_pk = self.engagement.pk
+
+        with self.assertRaises(ValidationError) as caught:
+            self._process_with_delete_mid_run(
+                self._reimporter(),
+                lambda: Engagement.objects.filter(pk=engagement_pk).delete(),
+                "update_test_meta",
+            )
+
+        message = str(caught.exception)
+        self.assertNotIn(
+            "foreign key constraint",
+            message,
+            msg=f"the caller must not be handed a database constraint violation, got: {message}",
+        )
+        self.assertIn("deleted while the scan was being processed", message, msg=message)
+        self.assertFalse(
+            Test.objects.filter(pk=test_pk).exists(),
+            msg=f"the cascaded test (id {test_pk}) must not be re-inserted with a dangling engagement",
+        )
+
+    def test_import_does_not_resurrect_a_test_deleted_mid_run(self):
+        """The import path shares the write-back, so it must refuse the same re-insert."""
+        importer = self._importer()
+        deleted_pks = []
+
+        def delete_the_new_test():
+            deleted_pks.append(importer.test.pk)
+            Test.objects.filter(pk=importer.test.pk).delete()
+
+        with self.assertRaises(ValidationError):
+            self._process_with_delete_mid_run(importer, delete_the_new_test, "update_test_meta")
+
+        self.assertEqual(1, len(deleted_pks), msg="the delete hook must have run")
+        self.assertFalse(
+            Test.objects.filter(pk=deleted_pks[0]).exists(),
+            msg=f"the deleted test (id {deleted_pks[0]}) must not be re-inserted by the import write-back",
+        )
+
+    def test_update_test_progress_does_not_resurrect_a_deleted_test(self):
+        """The closing progress write is the last save of a run and must not re-create the row either."""
+        test_pk = self.test.pk
+        importer = self._reimporter()
+        importer.test = self.test
+        Test.objects.filter(pk=test_pk).delete()
+
+        with self.assertRaises(ValidationError):
+            importer.update_test_progress()
+
+        self.assertFalse(
+            Test.objects.filter(pk=test_pk).exists(),
+            msg=f"the deleted test (id {test_pk}) must not be re-inserted by update_test_progress",
+        )
+
+    def test_deleted_engagement_is_not_resurrected(self):
+        """The engagement half of the write-back is guarded the same way as the test."""
+        engagement_pk = self.engagement.pk
+        importer = self._reimporter()
+        Engagement.objects.filter(pk=engagement_pk).delete()
+
+        with self.assertRaises(ValidationError) as caught:
+            importer.save_without_resurrecting(self.engagement)
+
+        self.assertFalse(
+            Engagement.objects.filter(pk=engagement_pk).exists(),
+            msg=f"the deleted engagement (id {engagement_pk}) must not be re-inserted",
+        )
+        self.assertIn("deleted while the scan was being processed", str(caught.exception))
+
+    def test_reimport_still_persists_the_write_back_when_nothing_was_deleted(self):
+        """Control case: the guard must not change a run whose target is still there."""
+        test_pk = self.test.pk
+
+        with (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan:
+            test, _, _, _, _, _, _ = self._reimporter().process_scan(scan)
+
+        self.assertEqual(test_pk, test.pk)
+        persisted = Test.objects.get(pk=test_pk)
+        self.assertEqual(
+            100, persisted.percent_complete,
+            msg=f"expected percent_complete=100, persisted={persisted.percent_complete}",
+        )
+        self.assertTrue(Engagement.objects.filter(pk=self.engagement.pk).exists())

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -343,13 +343,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=157,
+            expected_num_queries1=160,
             expected_num_async_tasks1=2,
-            expected_num_queries2=122,
+            expected_num_queries2=125,
             expected_num_async_tasks2=1,
-            expected_num_queries3=29,
+            expected_num_queries3=32,
             expected_num_async_tasks3=1,
-            expected_num_queries4=100,
+            expected_num_queries4=103,
             expected_num_async_tasks4=0,
         )
 
@@ -367,13 +367,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=173,
+            expected_num_queries1=176,
             expected_num_async_tasks1=2,
-            expected_num_queries2=130,
+            expected_num_queries2=133,
             expected_num_async_tasks2=1,
-            expected_num_queries3=37,
+            expected_num_queries3=40,
             expected_num_async_tasks3=1,
-            expected_num_queries4=100,
+            expected_num_queries4=103,
             expected_num_async_tasks4=0,
         )
 
@@ -392,13 +392,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=183,
+            expected_num_queries1=186,
             expected_num_async_tasks1=4,
-            expected_num_queries2=140,
+            expected_num_queries2=143,
             expected_num_async_tasks2=3,
-            expected_num_queries3=44,
+            expected_num_queries3=47,
             expected_num_async_tasks3=3,
-            expected_num_queries4=109,
+            expected_num_queries4=112,
             expected_num_async_tasks4=2,
         )
 
@@ -526,9 +526,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=93,
+            expected_num_queries1=96,
             expected_num_async_tasks1=2,
-            expected_num_queries2=73,
+            expected_num_queries2=76,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -547,9 +547,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=109,
+            expected_num_queries1=112,
             expected_num_async_tasks1=2,
-            expected_num_queries2=90,
+            expected_num_queries2=93,
             expected_num_async_tasks2=2,
         )
 
@@ -580,9 +580,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         # returns instantly without executing dedup on the request's DB connection.
         with patch("celery.result.AsyncResult.get", return_value=None):
             self._deduplication_performance(
-                expected_num_queries1=94,
+                expected_num_queries1=97,
                 expected_num_async_tasks1=2,
-                expected_num_queries2=74,
+                expected_num_queries2=77,
                 expected_num_async_tasks2=2,
                 dedup_mode="async_wait",
                 check_duplicates=False,
@@ -670,13 +670,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=164,
+            expected_num_queries1=167,
             expected_num_async_tasks1=2,
-            expected_num_queries2=131,
+            expected_num_queries2=134,
             expected_num_async_tasks2=1,
-            expected_num_queries3=37,
+            expected_num_queries3=40,
             expected_num_async_tasks3=1,
-            expected_num_queries4=101,
+            expected_num_queries4=104,
             expected_num_async_tasks4=0,
         )
 
@@ -694,13 +694,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=182,
+            expected_num_queries1=185,
             expected_num_async_tasks1=2,
-            expected_num_queries2=141,
+            expected_num_queries2=144,
             expected_num_async_tasks2=1,
-            expected_num_queries3=47,
+            expected_num_queries3=50,
             expected_num_async_tasks3=1,
-            expected_num_queries4=101,
+            expected_num_queries4=104,
             expected_num_async_tasks4=0,
         )
 
@@ -719,13 +719,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=195,
+            expected_num_queries1=198,
             expected_num_async_tasks1=4,
-            expected_num_queries2=154,
+            expected_num_queries2=157,
             expected_num_async_tasks2=3,
-            expected_num_queries3=54,
+            expected_num_queries3=57,
             expected_num_async_tasks3=3,
-            expected_num_queries4=113,
+            expected_num_queries4=116,
             expected_num_async_tasks4=2,
         )
 
@@ -826,9 +826,9 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=100,
+            expected_num_queries1=103,
             expected_num_async_tasks1=2,
-            expected_num_queries2=76,
+            expected_num_queries2=79,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -846,8 +846,8 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=118,
+            expected_num_queries1=121,
             expected_num_async_tasks1=2,
-            expected_num_queries2=201,
+            expected_num_queries2=204,
             expected_num_async_tasks2=2,
         )

--- a/unittests/test_tag_inheritance_perf.py
+++ b/unittests/test_tag_inheritance_perf.py
@@ -590,9 +590,15 @@ class TagInheritanceImportPerfBaselines(DojoAPITestCase):
     # the async watson indexer, executed inline under CELERY_TASK_ALWAYS_EAGER);
     # +5 reimport (no-change + with-new) queries from removal of
     # WATSON_ASYNC_INDEX_UPDATE_THRESHOLD making async dispatch unconditional.
-    EXPECTED_ZAP_IMPORT_V2 = 287
-    EXPECTED_ZAP_IMPORT_V3 = 311
-    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V2 = 74
-    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V3 = 86
-    EXPECTED_ZAP_REIMPORT_WITH_NEW_V2 = 148
-    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 177
+    # +3 on every path from save_without_resurrecting(): the importer confirms its
+    # test and engagement rows still exist before writing them back, instead of
+    # letting Model.save() fall back to an INSERT that re-creates a row deleted
+    # mid-import. One primary-key lookup per guarded save (test, engagement, and
+    # the closing update_test_progress), so the cost is constant rather than
+    # per-finding — which is why the delta is +3 on import and reimport alike.
+    EXPECTED_ZAP_IMPORT_V2 = 290
+    EXPECTED_ZAP_IMPORT_V3 = 314
+    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V2 = 77
+    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V3 = 89
+    EXPECTED_ZAP_REIMPORT_WITH_NEW_V2 = 151
+    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 180


### PR DESCRIPTION
**Description**

An object deleted while its scan was being processed was re-created by the importer's closing write-back.

`Model.save()` on an instance whose primary key is already set issues an `UPDATE`, and Django falls back to an `INSERT` when that `UPDATE` matches no rows. Both importers load their test and engagement at the start of a run that can take minutes, then save them again at the end (`default_importer.py` / `default_reimporter.py`, "Save the test and engagement for changes to take affect"). A delete landing in between turned that write-back into an `INSERT` of the deleted row from the stale in-memory copy. Two outcomes, both wrong:

- **The parent went with it.** An engagement delete cascades to its tests, so the `INSERT` carried a dangling `engagement_id`. Django declares its foreign keys `DEFERRABLE INITIALLY DEFERRED`, so the violation was only raised at `COMMIT` — past any handler that still knew what the import was doing. The API caller got an opaque 500 naming a PostgreSQL constraint (`dojo_test_engagement_id_..._fk_dojo_engagement_id`) instead of the reason the import failed.
- **The parent survived.** The `INSERT` succeeded and silently resurrected a row the user had deleted, without the findings and history that were cascaded away with it.

Observed on a production instance on the synchronous `reimport-scan` path, repeatedly, on an instance whose CI creates and tears down short-lived per-pull-request engagements. The tell was the failure order: the constraint violation named the *test* row as already having an id, which is only possible if the `UPDATE`-to-`INSERT` fallback had run.

### Fix

Both write-back sites and `update_test_progress()` now save through a new `BaseImporter.save_without_resurrecting()`, which confirms the row is still there and otherwise raises a `ValidationError` naming what was deleted. The import still fails — its target is gone, and it cannot complete — but it fails with the error that says so, and nothing is re-inserted.

The row is checked *before* the write rather than with `save(force_update=True)`. A forced update raises from inside the atomic block `Model.save_base` opens **without a savepoint**, which marks the whole surrounding transaction for rollback; the caller's failure handling would then hit `TransactionManagementError` instead of being able to record why the import failed. Confirmed experimentally while developing this — the follow-up query needed to classify the error was itself refused. Costing one indexed primary-key lookup keeps the transaction usable.

This is deliberately scoped to the resurrection. It does not change whether such an import succeeds, and it does not address why a target may be deleted mid-run — that is the caller's workflow.

### Performance impact

One primary-key `SELECT 1 ... LIMIT 1` per guarded save: **+3 queries per import/reimport, independent of finding count**. Expected counts in `test_importers_performance.py` are updated accordingly — all 34 deltas are exactly +3, which is itself the evidence that the cost is O(1) and not O(findings). Async task counts are unchanged.

### Impact on the Pro plugin

Checked as part of the acceptance criteria; no Pro change is required.

- Pro has **no** `test.save()` / `engagement.save()` of its own on the importer write-back path, so there is no second copy of this defect to fix there.
- `ProImporter` / `ProReImporter` derive from `DefaultImporter` / `DefaultReImporter` and do not override `update_test_progress`, so they inherit the guard. `ConnectorsImporter` and its subclasses inherit it too.
- Pro's importer wraps this `process_scan` in a try/except that records a failed status and re-raises as `type(exception)(exception)`. A Django `ValidationError` re-wraps cleanly, so the failure path is unaffected — and the message the caller now receives names the deleted object instead of an internal table.
- Follow-up worth considering on the Pro side (not needed for this fix): Pro surfaces this as a 500. A `ValidationError` from a vanished target is arguably a 4xx, which would be a change to Pro's import-error humanizer rather than to open source.

**Test results**

New `unittests/test_importers_deleted_target.py`, 6 tests. Every one was confirmed failing before the fix:

```
FAILED (failures=4, errors=1)   # the 6th is the control case, green throughout
AssertionError: ValidationError not raised
AttributeError: 'DefaultReImporter' object has no attribute 'save_without_resurrecting'
```

The pre-fix reimport did not merely fail — it **completed successfully and left the deleted row re-inserted**, which a direct probe confirmed:

```
deleted test row exists again after reimport: True
```

Coverage: the reimport write-back (test deleted, and engagement deleted so the test is cascaded away), the import write-back, `update_test_progress`, the engagement half of the guard, and a control case asserting a run whose target is still present is unchanged and still persists `percent_complete`.

After the fix, run against PostgreSQL (not SQLite — the deferred-constraint behaviour above is backend-specific):

- `unittests/test_importers_deleted_target.py` — 6 passed
- `test_importers_performance` — 11 passed (was 11 passed on the unmodified base, then 34 count assertions failing, now green on the updated counts)
- `test_importers_importer`, `test_importers_closeold`, `test_importers_deduplication`, `test_import_reimport`, `test_update_import_history`, `test_importers_performance`, `test_apiv2_scan_import_options`, `test_import_execution_mode`, `test_reimport_prefetch`, `test_endpoint_meta_import`, `test_generic_meta_import` — **325 passed, 24 skipped, 0 failures**
- `ruff check --config ruff.toml` (0.15.20, the pinned version) clean on `dojo/importers/` and both touched test files

> Note on the environment: this sandbox has no Docker, so the suites were run through `manage.py test` against a locally provisioned PostgreSQL 16 cluster on Python 3.13 rather than `run-unittest.sh`. For the same reason `scripts/update_performance_test_counts.py` (which shells out to `run-unittest.sh`) could not be used; the counts were taken from the actual values the assertions reported and each one re-verified. CI is the authority.

**Documentation**

No documentation change — this is a bug fix to internal importer behaviour, with no new or changed inputs, outputs, or settings.

**Checklist**

- [x] Submitted against `bugfix` (bug fix, not a feature).
- [x] Ruff compliant.
- [x] Python 3.13 compliant.
- [x] No model changes, so no migrations.
- [x] Tests added to the unit tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_019JguGJ8jEgLfr1RLecfnUU)_