### PR TITLE
fix(importers): skip child rows buffered for a finding deleted mid-batch

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -838,9 +838,50 @@ class BaseImporter(ImporterOptions):
                 burpResponseBase64=base64.b64encode(unsaved_response.encode()),
             ))
 
+    def drop_rows_for_deleted_findings(self, rows: list) -> list:
+        """
+        Return only the buffered child rows whose finding still exists.
+
+        Child rows are buffered while a batch of up to a thousand findings is processed
+        and inserted in bulk at the batch boundary, so a finding stays referenced by the
+        buffer for as long as the rest of its batch takes. A finding row can go away
+        inside that window: the excess-duplicate cleanup task deletes findings, and so
+        does a user deleting findings or a delete cascading from a test or engagement.
+        The buffered row then points at a primary key that is no longer in dojo_finding.
+
+        Because Django declares its foreign keys DEFERRABLE INITIALLY DEFERRED, that
+        insert does not fail where it is issued. PostgreSQL raises it at COMMIT, past
+        every handler that knew what the import was doing, so the whole import dies with
+        an IntegrityError naming a database constraint and takes the rest of the batch --
+        findings that were perfectly fine -- with it.
+
+        A finding that is gone has nothing to own these rows, so dropping just those rows
+        is the correct outcome, and it costs one indexed primary-key lookup per flush.
+        Rows whose finding id is not resolvable yet are left alone: bulk_create fills the
+        id in from the related object, and reporting on them is its job, not this guard's.
+        """
+        finding_ids = {row.finding_id for row in rows if row.finding_id is not None}
+        if not finding_ids:
+            return rows
+        live_finding_ids = set(
+            Finding.objects.filter(pk__in=finding_ids).values_list("pk", flat=True),
+        )
+        deleted_finding_ids = finding_ids - live_finding_ids
+        if not deleted_finding_ids:
+            return rows
+        logger.warning(
+            "skipping %s row(s) buffered for %s finding(s) deleted during the import: %s",
+            sum(1 for row in rows if row.finding_id in deleted_finding_ids),
+            len(deleted_finding_ids),
+            sorted(deleted_finding_ids),
+        )
+        return [row for row in rows if row.finding_id not in deleted_finding_ids]
+
     def flush_burp_request_response(self) -> None:
         if self.pending_burp_rr:
-            BurpRawRequestResponse.objects.bulk_create(self.pending_burp_rr, batch_size=1000)
+            rows = self.drop_rows_for_deleted_findings(self.pending_burp_rr)
+            if rows:
+                BurpRawRequestResponse.objects.bulk_create(rows, batch_size=1000)
             self.pending_burp_rr.clear()
 
     def process_locations(
@@ -908,7 +949,9 @@ class BaseImporter(ImporterOptions):
             Vulnerability_Id.objects.filter(finding_id__in=self.pending_vuln_id_deletes).delete()
             self.pending_vuln_id_deletes.clear()
         if self.pending_vulnerability_ids:
-            Vulnerability_Id.objects.bulk_create(self.pending_vulnerability_ids, batch_size=1000)
+            rows = self.drop_rows_for_deleted_findings(self.pending_vulnerability_ids)
+            if rows:
+                Vulnerability_Id.objects.bulk_create(rows, batch_size=1000)
             self.pending_vulnerability_ids.clear()
 
     def process_files(

--- a/unittests/test_importers_deleted_finding_child_rows.py
+++ b/unittests/test_importers_deleted_finding_child_rows.py
@@ -1,0 +1,248 @@
+import base64
+import logging
+
+from django.db import connection
+from django.utils import timezone
+
+from dojo.importers.default_importer import DefaultImporter
+from dojo.importers.default_reimporter import DefaultReImporter
+from dojo.models import (
+    BurpRawRequestResponse,
+    Development_Environment,
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    User,
+    Vulnerability_Id,
+)
+
+from .dojo_test_case import DojoTestCase, get_unit_tests_scans_path
+
+logger = logging.getLogger(__name__)
+
+SCAN_TYPE = "Acunetix Scan"
+SCAN_FILE = "many_findings.xml"
+REQUEST = b"GET / HTTP/1.1"
+RESPONSE = b"HTTP/1.1 200 OK"
+
+
+class TestImportersDeletedFindingChildRows(DojoTestCase):
+
+    """
+    Regression: child rows buffered for a finding deleted mid-batch broke the whole import.
+
+    Vulnerability ids and Burp request/response pairs are not written as each finding is
+    processed. They are buffered and bulk-inserted at the batch boundary, so a finding is
+    live in the buffer for as long as it takes to process the rest of its batch (up to a
+    thousand findings). A finding row can go away inside that window -- the excess
+    duplicate cleanup task deletes findings, and so does a user deleting findings or a
+    delete cascading from a test or engagement -- and the buffered row then points at a
+    primary key that is no longer in dojo_finding.
+
+    Django declares its foreign keys DEFERRABLE INITIALLY DEFERRED, so that insert does
+    not fail where it is issued: PostgreSQL raises it at COMMIT, past every handler that
+    knew what the import was doing. The reported symptom is an import that dies with
+    'insert or update on table "dojo_vulnerability_id" violates foreign key constraint
+    ... Key (finding_id)=(...) is not present in table "dojo_finding"' and takes the rest
+    of the batch -- findings that were perfectly fine -- down with it.
+
+    connection.check_constraints() below is the check PostgreSQL runs at COMMIT in
+    production; the test transaction never commits, so the violation has to be asked for.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user, _ = User.objects.get_or_create(username="admin")
+        product_type, _ = Product_Type.objects.get_or_create(name="deleted_finding_child_rows")
+        self.environment, _ = Development_Environment.objects.get_or_create(name="Development")
+        self.product, _ = Product.objects.get_or_create(
+            name="TestImportersDeletedFindingChildRows",
+            description="Test",
+            prod_type=product_type,
+        )
+        self.engagement, _ = Engagement.objects.get_or_create(
+            name="Deleted Finding Child Rows",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        with (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan:
+            self.test, _, len_new_findings, _, _, _, _ = self._importer().process_scan(scan)
+        self.assertEqual(4, len_new_findings)
+        self.findings = list(Finding.objects.filter(test=self.test).order_by("id"))
+        self.assertGreaterEqual(len(self.findings), 2)
+
+    def _options(self, **overrides):
+        options = {
+            "user": self.user,
+            "lead": self.user,
+            "scan_date": None,
+            "environment": self.environment,
+            "active": True,
+            "verified": False,
+            "scan_type": SCAN_TYPE,
+        }
+        options.update(overrides)
+        return options
+
+    def _importer(self):
+        return DefaultImporter(close_old_findings=False, **self._options(engagement=self.engagement))
+
+    def _reimporter(self):
+        return DefaultReImporter(close_old_findings=False, **self._options(test=self.test))
+
+    def _buffer_vulnerability_ids(self, importer, finding, vulnerability_ids):
+        """Buffer vulnerability ids for `finding` the way the import path does."""
+        finding.unsaved_vulnerability_ids = list(vulnerability_ids)
+        importer.store_vulnerability_ids(finding)
+
+    def _buffer_request_response(self, importer, finding):
+        """Buffer a Burp request/response pair for `finding` the way a dynamic parser does."""
+        importer.pending_burp_rr.append(BurpRawRequestResponse(
+            finding=finding,
+            burpRequestBase64=base64.b64encode(REQUEST),
+            burpResponseBase64=base64.b64encode(RESPONSE),
+        ))
+
+    def _buffered_request_response_count(self, finding):
+        """
+        Count only the pairs this test buffered.
+
+        The scan the fixture imports brings its own request/response pairs, so the guard
+        has to be judged on the rows under test rather than on the finding's total.
+        """
+        return BurpRawRequestResponse.objects.filter(
+            finding_id=finding.pk,
+            burpRequestBase64=base64.b64encode(REQUEST),
+        ).count()
+
+    def test_flush_vulnerability_ids_skips_a_finding_deleted_after_buffering(self):
+        """The deleted finding's rows are dropped; the rest of the batch is still written."""
+        importer = self._importer()
+        deleted_finding, surviving_finding = self.findings[0], self.findings[1]
+        self._buffer_vulnerability_ids(importer, deleted_finding, ["CVE-2020-1234"])
+        self._buffer_vulnerability_ids(importer, surviving_finding, ["CVE-2020-5678"])
+        deleted_pk = deleted_finding.pk
+        Finding.objects.filter(pk=deleted_pk).delete()
+
+        importer.flush_vulnerability_ids()
+        connection.check_constraints()
+
+        self.assertFalse(
+            Vulnerability_Id.objects.filter(finding_id=deleted_pk).exists(),
+            msg=f"no vulnerability id may be written for deleted finding {deleted_pk}",
+        )
+        self.assertEqual(
+            ["CVE-2020-5678"],
+            [
+                row.vulnerability_id
+                for row in Vulnerability_Id.objects.filter(finding_id=surviving_finding.pk)
+            ],
+            msg="the surviving finding's vulnerability id must still be written",
+        )
+
+    def test_flush_vulnerability_ids_writes_everything_when_nothing_was_deleted(self):
+        """Control case: the guard must not drop rows on a run where every finding is still there."""
+        importer = self._importer()
+        for index, finding in enumerate(self.findings):
+            self._buffer_vulnerability_ids(importer, finding, [f"CVE-2020-100{index}"])
+
+        importer.flush_vulnerability_ids()
+        connection.check_constraints()
+
+        for index, finding in enumerate(self.findings):
+            self.assertEqual(
+                [f"CVE-2020-100{index}"],
+                [row.vulnerability_id for row in Vulnerability_Id.objects.filter(finding_id=finding.pk)],
+                msg=f"finding {finding.pk} lost its vulnerability id",
+            )
+
+    def test_flush_vulnerability_ids_clears_the_buffer_after_dropping_rows(self):
+        """A dropped row must not be retried by the next batch's flush."""
+        importer = self._importer()
+        deleted_finding = self.findings[0]
+        self._buffer_vulnerability_ids(importer, deleted_finding, ["CVE-2020-1234"])
+        deleted_pk = deleted_finding.pk
+        Finding.objects.filter(pk=deleted_pk).delete()
+
+        importer.flush_vulnerability_ids()
+        self.assertEqual([], importer.pending_vulnerability_ids)
+
+        # A second flush stands in for the next batch boundary of the same import.
+        importer.flush_vulnerability_ids()
+        connection.check_constraints()
+        self.assertFalse(Vulnerability_Id.objects.filter(finding_id=deleted_pk).exists())
+
+    def test_reimport_reconcile_and_flush_survives_a_finding_deleted_mid_batch(self):
+        """
+        The reported path: reimport reconciles an existing finding's vulnerability ids.
+
+        reconcile_vulnerability_ids() buffers a delete plus the replacement rows for a
+        finding that already exists, and the flush happens at the batch boundary. The
+        finding is deleted in between, which is where the dangling insert came from.
+        """
+        reimporter = self._reimporter()
+        deleted_finding, surviving_finding = self.findings[0], self.findings[1]
+        for finding, vulnerability_id in (
+            (deleted_finding, "CVE-2021-1111"),
+            (surviving_finding, "CVE-2021-2222"),
+        ):
+            finding.unsaved_vulnerability_ids = [vulnerability_id]
+            reimporter.reconcile_vulnerability_ids(finding)
+        deleted_pk = deleted_finding.pk
+        Finding.objects.filter(pk=deleted_pk).delete()
+
+        reimporter.flush_vulnerability_ids()
+        connection.check_constraints()
+
+        self.assertFalse(
+            Vulnerability_Id.objects.filter(finding_id=deleted_pk).exists(),
+            msg=f"no vulnerability id may be written for deleted finding {deleted_pk}",
+        )
+        self.assertEqual(
+            ["CVE-2021-2222"],
+            [
+                row.vulnerability_id
+                for row in Vulnerability_Id.objects.filter(finding_id=surviving_finding.pk)
+            ],
+            msg="the surviving finding's reconciled vulnerability id must still be written",
+        )
+
+    def test_flush_burp_request_response_skips_a_finding_deleted_after_buffering(self):
+        """Request/response pairs are buffered and flushed the same way, so they need the same guard."""
+        importer = self._importer()
+        deleted_finding, surviving_finding = self.findings[0], self.findings[1]
+        self._buffer_request_response(importer, deleted_finding)
+        self._buffer_request_response(importer, surviving_finding)
+        deleted_pk = deleted_finding.pk
+        Finding.objects.filter(pk=deleted_pk).delete()
+
+        importer.flush_burp_request_response()
+        connection.check_constraints()
+
+        self.assertFalse(
+            BurpRawRequestResponse.objects.filter(finding_id=deleted_pk).exists(),
+            msg=f"no request/response pair may be written for deleted finding {deleted_pk}",
+        )
+        self.assertEqual(
+            1,
+            self._buffered_request_response_count(surviving_finding),
+            msg="the surviving finding's request/response pair must still be written",
+        )
+
+    def test_flush_burp_request_response_writes_everything_when_nothing_was_deleted(self):
+        """Control case for the request/response buffer."""
+        importer = self._importer()
+        for finding in self.findings:
+            self._buffer_request_response(importer, finding)
+
+        importer.flush_burp_request_response()
+        connection.check_constraints()
+
+        for finding in self.findings:
+            self.assertEqual(
+                1,
+                self._buffered_request_response_count(finding),
+                msg=f"finding {finding.pk} lost its request/response pair",
+            )

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -343,9 +343,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=157,
+            expected_num_queries1=158,
             expected_num_async_tasks1=2,
-            expected_num_queries2=122,
+            expected_num_queries2=123,
             expected_num_async_tasks2=1,
             expected_num_queries3=29,
             expected_num_async_tasks3=1,
@@ -367,9 +367,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=173,
+            expected_num_queries1=174,
             expected_num_async_tasks1=2,
-            expected_num_queries2=130,
+            expected_num_queries2=131,
             expected_num_async_tasks2=1,
             expected_num_queries3=37,
             expected_num_async_tasks3=1,
@@ -392,9 +392,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=183,
+            expected_num_queries1=184,
             expected_num_async_tasks1=4,
-            expected_num_queries2=140,
+            expected_num_queries2=141,
             expected_num_async_tasks2=3,
             expected_num_queries3=44,
             expected_num_async_tasks3=3,
@@ -526,9 +526,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=93,
+            expected_num_queries1=94,
             expected_num_async_tasks1=2,
-            expected_num_queries2=73,
+            expected_num_queries2=74,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -547,9 +547,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=109,
+            expected_num_queries1=110,
             expected_num_async_tasks1=2,
-            expected_num_queries2=90,
+            expected_num_queries2=91,
             expected_num_async_tasks2=2,
         )
 
@@ -580,9 +580,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         # returns instantly without executing dedup on the request's DB connection.
         with patch("celery.result.AsyncResult.get", return_value=None):
             self._deduplication_performance(
-                expected_num_queries1=94,
+                expected_num_queries1=95,
                 expected_num_async_tasks1=2,
-                expected_num_queries2=74,
+                expected_num_queries2=75,
                 expected_num_async_tasks2=2,
                 dedup_mode="async_wait",
                 check_duplicates=False,
@@ -670,9 +670,9 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=164,
+            expected_num_queries1=165,
             expected_num_async_tasks1=2,
-            expected_num_queries2=131,
+            expected_num_queries2=132,
             expected_num_async_tasks2=1,
             expected_num_queries3=37,
             expected_num_async_tasks3=1,
@@ -694,9 +694,9 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=182,
+            expected_num_queries1=183,
             expected_num_async_tasks1=2,
-            expected_num_queries2=141,
+            expected_num_queries2=142,
             expected_num_async_tasks2=1,
             expected_num_queries3=47,
             expected_num_async_tasks3=1,
@@ -719,9 +719,9 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=195,
+            expected_num_queries1=196,
             expected_num_async_tasks1=4,
-            expected_num_queries2=154,
+            expected_num_queries2=155,
             expected_num_async_tasks2=3,
             expected_num_queries3=54,
             expected_num_async_tasks3=3,
@@ -826,9 +826,9 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=100,
+            expected_num_queries1=101,
             expected_num_async_tasks1=2,
-            expected_num_queries2=76,
+            expected_num_queries2=77,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -846,8 +846,8 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=118,
+            expected_num_queries1=119,
             expected_num_async_tasks1=2,
-            expected_num_queries2=201,
+            expected_num_queries2=202,
             expected_num_async_tasks2=2,
         )

--- a/unittests/test_tag_inheritance_perf.py
+++ b/unittests/test_tag_inheritance_perf.py
@@ -590,9 +590,15 @@ class TagInheritanceImportPerfBaselines(DojoAPITestCase):
     # the async watson indexer, executed inline under CELERY_TASK_ALWAYS_EAGER);
     # +5 reimport (no-change + with-new) queries from removal of
     # WATSON_ASYNC_INDEX_UPDATE_THRESHOLD making async dispatch unconditional.
-    EXPECTED_ZAP_IMPORT_V2 = 287
-    EXPECTED_ZAP_IMPORT_V3 = 311
+    # +1 on the paths that buffer child rows: the batch flush confirms the buffered
+    # findings still exist before inserting their vulnerability ids, instead of letting
+    # a finding deleted mid-batch turn the bulk insert into a dangling foreign key that
+    # PostgreSQL only rejects at COMMIT. One primary-key lookup per flush that has
+    # something to insert, which is why the no-change reimport (nothing buffered, so no
+    # lookup) is unchanged.
+    EXPECTED_ZAP_IMPORT_V2 = 288
+    EXPECTED_ZAP_IMPORT_V3 = 312
     EXPECTED_ZAP_REIMPORT_NO_CHANGE_V2 = 74
     EXPECTED_ZAP_REIMPORT_NO_CHANGE_V3 = 86
-    EXPECTED_ZAP_REIMPORT_WITH_NEW_V2 = 148
-    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 177
+    EXPECTED_ZAP_REIMPORT_WITH_NEW_V2 = 149
+    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 178


### PR DESCRIPTION
**Description**

An async reimport fails with a `500` / failed task and this `IntegrityError` whenever a finding it has already processed is deleted before the batch it belongs to is flushed:

```
django.db.utils.IntegrityError: insert or update on table "dojo_vulnerability_id"
violates foreign key constraint "dojo_vulnerability_r_finding_id_c9d59919_fk_dojo_find"
DETAIL:  Key (finding_id)=(...) is not present in table "dojo_finding".
```

Reported twice within four seconds from a production instance on `reimport-scan` (Generic Findings Import), against two different tests of the same product — the shape of a delete racing a batch of reimports rather than a one-off.

The sequence:

1. Vulnerability ids are **not** written as each finding is processed. `store_vulnerability_ids()` (import) and `reconcile_vulnerability_ids()` (reimport) append `Vulnerability_Id` objects to `self.pending_vulnerability_ids`, and `flush_vulnerability_ids()` bulk-inserts them at the batch boundary — up to a thousand findings later.
2. A finding referenced by that buffer can be deleted inside the window. `async_dupe_delete` deletes excess duplicates when `delete_duplicates` is enabled, and a user deleting findings or a delete cascading from a test or engagement does the same.
3. The bulk insert then carries a `finding_id` that is no longer in `dojo_finding`.

Because Django declares its foreign keys `DEFERRABLE INITIALLY DEFERRED`, that insert does not fail where it is issued — PostgreSQL raises it at `COMMIT`. That is why the reported traceback contains **no application frames at all**, only the commit path: the failure surfaces past every handler that still knew what the import was doing. The whole import dies, taking the rest of the batch — findings that were perfectly fine — with it.

`BurpRawRequestResponse` is buffered and flushed through exactly the same pattern (`process_request_response_pairs` → `flush_burp_request_response`) and has the same exposure, so it is fixed alongside rather than left as the next incident.

### The change

Both flushes now filter the buffer through a new `BaseImporter.drop_rows_for_deleted_findings()`, which keeps only the rows whose finding still exists and logs at warning level which finding ids were dropped and how many rows went with them.

Dropping is the correct outcome rather than a suppression: a finding that has been deleted has nothing to own these child rows. This is the same posture `close_old_findings()` already takes — `_sync_close_old_finding_status_fields()` returns only the candidates that still exist, precisely because a candidate can be deleted mid-reimport (#15408). This PR extends that guard to the other place in the same run that holds finding references across a batch.

Deliberately out of scope: why a finding may be deleted mid-run (that is the caller's workflow), and the `pending_vuln_id_deletes` half of the flush, which is a `DELETE ... WHERE finding_id IN (...)` and is unaffected by a missing row.

### Performance impact

One indexed primary-key `SELECT` per flush **that has something to insert**, independent of finding count. Measured across the pinned baselines, every delta is exactly **+1**, and the no-change reimport — where nothing is buffered, so no lookup happens — is **unchanged**. That split is itself the evidence the cost is O(1) per flush and not O(findings):

| | before | after |
|---|---|---|
| `EXPECTED_ZAP_IMPORT_V2` / `_V3` | 287 / 311 | 288 / 312 |
| `EXPECTED_ZAP_REIMPORT_WITH_NEW_V2` / `_V3` | 148 / 177 | 149 / 178 |
| `EXPECTED_ZAP_REIMPORT_NO_CHANGE_V2` / `_V3` | 74 / 86 | 74 / 86 (unchanged) |

In `test_importers_performance.py`, `expected_num_queries1` and `expected_num_queries2` move +1 in all 11 affected cases; `expected_num_queries3` (no-change reimport) and `expected_num_queries4` are untouched. Async task counts are unchanged.

### Impact on the Pro plugin

Checked as part of the acceptance criteria.

- No Pro code change is required for the fix itself. `ProImporter` / `ProReImporter` derive from `DefaultImporter` / `DefaultReImporter` and override neither `flush_vulnerability_ids`, `flush_burp_request_response`, `store_vulnerability_ids` nor `reconcile_vulnerability_ids`, so they inherit the guard — which is what matters here, because the reported traceback runs through the Pro async importer into this file. No Pro module bulk-creates `Vulnerability_Id` on the import path, so there is no second copy of this defect to fix there.
- The new method name does not collide with anything in the Pro importer hierarchy.
- **Pro does need a follow-up commit for its own pinned query counts.** Pro keeps a separate `test_importers_performance.py` with its own `expected_num_queries*` values, which will shift by the same +1 on the buffering paths (and stay unchanged on the no-change reimport) once this merges. Those numbers have to be **measured** in the Pro stack, not carried over from the table above, and this sandbox has no Docker so they could not be produced here. Flagging rather than guessing.
- One Pro observation worth noting separately, not a blocker for this PR: `pro/finding/helpers.py` creates a single `Vulnerability_Id` during EPSS enrichment for a finding held in memory, which is the same class of exposure in a different task. Different code path, different repo, not touched here.

**Test results**

New `unittests/test_importers_deleted_finding_child_rows.py`, 6 tests. The 4 guard tests were confirmed failing on `bugfix` before the change, each with the dangling-reference violation this PR is about:

```
FAILED (failures=1, errors=4)
django.db.utils.IntegrityError: update or delete on table "dojo_finding" violates foreign key
constraint "dojo_vulnerability_r_finding_id_c9d59919_fk_dojo_find" on table "dojo_vulnerability_id"
django.db.utils.IntegrityError: update or delete on table "dojo_finding" violates foreign key
constraint "dojo_burprawrequestr_finding_id_57e40ea9_fk_dojo_find" on table "dojo_burprawrequestresponse"
```

Each test calls `connection.check_constraints()` after the flush — the check PostgreSQL runs at `COMMIT` in production. The test transaction never commits, so without asking for it explicitly the production failure would not appear in a test at all.

Coverage: the import-path flush with a finding deleted after buffering; the reported reimport path through `reconcile_vulnerability_ids`; that a dropped row is not retried by the next batch's flush; the request/response buffer; and two control cases asserting a run where nothing was deleted still writes every row.

Run against PostgreSQL on Python 3.13 (the deferred-constraint behaviour is backend-specific):

- `unittests.test_importers_deleted_finding_child_rows` — **6 passed**
- `unittests.test_importers_performance`, `unittests.test_tag_inheritance_perf` — **35 passed** (26 count assertions failing on the un-updated baselines first, then green on the updated ones)
- `unittests.test_import_reimport`, `test_importers_importer`, `test_importers_closeold`, `test_importers_deduplication`, `test_reimport_prefetch`, `test_import_execution_mode`, `test_duplication_loops` — **283 passed, 1 skipped, 0 failures**
- `ruff check --config ruff.toml` with the pinned 0.15.20 — clean on all four touched files

> Environment note: this sandbox has no Docker, so suites were run through `manage.py test` against a locally provisioned PostgreSQL 16 cluster rather than `run-unittest.sh`, and `scripts/update_performance_test_counts.py` (which shells out to `run-unittest.sh`) could not be used. Every updated count is the value the assertion itself reported, re-verified on a second full run. CI is the authority.

**Documentation**

No documentation change: this restores the documented behaviour of import/reimport (the failure was never an expected outcome) and adds no setting, input, output, or API surface.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch — based on and targeting `bugfix`.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant — tests were run on 3.13.
- [x] Add applicable tests to the unit tests.
- [ ] Model changes must include the necessary migrations — N/A, no model changes.

Reported internally:
- https://defectdojo-workspace.slack.com/archives/C0BK62Q76P8/p1785386119745169
- https://defectdojo-workspace.slack.com/archives/C0BK62Q76P8/p1785386123906449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrYDZdT84SC27Mz53w1Yuj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrYDZdT84SC27Mz53w1Yuj)_