### PR TITLE
fix: support new Popeye report sections format

### DIFF
--- a/dojo/tools/popeye/parser.py
+++ b/dojo/tools/popeye/parser.py
@@ -22,7 +22,7 @@ class PopeyeParser:
         data = json.load(file)
 
         dupes = {}
-        for sanitizer in data["popeye"]["sanitizers"]:
+        for sanitizer in self._get_sanitizer_entries(data):
             issues = sanitizer.get("issues")
             if issues:
                 for issue_group, issue_list in issues.items():
@@ -73,6 +73,18 @@ class PopeyeParser:
                             if dupe_key not in dupes:
                                 dupes[dupe_key] = finding
         return list(dupes.values())
+
+    def _get_sanitizer_entries(self, data):
+        popeye_report = data["popeye"]
+        if "sanitizers" in popeye_report:
+            return popeye_report["sanitizers"]
+        return [
+            {
+                "sanitizer": section["linter"],
+                "issues": section.get("issues"),
+            }
+            for section in popeye_report.get("sections", [])
+        ]
 
     def get_popeye_level_string(self, level):
         if level == 1:

--- a/unittests/scans/popeye/popeye_new_format.json
+++ b/unittests/scans/popeye/popeye_new_format.json
@@ -1,0 +1,30 @@
+{
+  "popeye": {
+    "report_time": "2026-07-30T00:00:00Z",
+    "score": 75,
+    "grade": "C",
+    "sections": [
+      {
+        "linter": "pods",
+        "gvr": "v1/pods",
+        "tally": {
+          "ok": 0,
+          "info": 0,
+          "warning": 1,
+          "error": 0,
+          "score": 0
+        },
+        "issues": {
+          "test-namespace/6cff44dc94-d92km": [
+            {
+              "group": "test-group",
+              "gvr": "v1/pods",
+              "level": 2,
+              "message": "[POP-106] No resources requests/limits defined"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/unittests/tools/test_popeye_parser.py
+++ b/unittests/tools/test_popeye_parser.py
@@ -36,3 +36,18 @@ class TestPopeyeParser(DojoTestCase):
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(229, len(findings))
+
+    def test_popeye_parser_with_new_sections_format_has_findings(self):
+        testfile = (get_unit_tests_scans_path("popeye") / "popeye_new_format.json").open(encoding="utf-8")
+        parser = PopeyeParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+
+        self.assertEqual(1, len(findings))
+        self.assertEqual("Low", findings[0].severity)
+        self.assertEqual(
+            "pods test-namespace/6cff44dc94-d92km [POP-106] No resources requests/limits defined",
+            findings[0].title,
+        )
+        self.assertIn("**Sanitizer** : pods", findings[0].description)
+        self.assertEqual("POP-106", findings[0].vuln_id_from_tool)


### PR DESCRIPTION
**Description**

Closes #15431.

Recent Popeye JSON reports use `popeye.sections` entries instead of the older `popeye.sanitizers` list. The parser currently indexes `data["popeye"]["sanitizers"]`, so importing those reports raises before findings can be created.

This keeps the existing `sanitizers` path and adds a compatibility adapter for the newer `sections` shape, mapping each section's `linter` to the parser's sanitizer label and reading the same `issues` payload.

**Test results**

- Added `unittests/scans/popeye/popeye_new_format.json` covering a recent sections-format report.
- Added a parser regression test that asserts the new sample produces the expected finding and `POP-106` vuln id.
- `python3 /tmp/verify_popeye_parser.py` → `custom parser smoke passed: old=1 new=1`
- `ruff check --config ruff.toml dojo/tools/popeye/parser.py unittests/tools/test_popeye_parser.py` → `All checks passed!`

Note: `python manage.py test unittests.tools.test_popeye_parser --keepdb` is currently blocked in this checkout before the Popeye tests run by a pre-existing syntax error in `dojo/jira/views.py` while importing `unittests.dojo_test_case`.

**Documentation**

No documentation changes needed; this is a parser compatibility bug fix with a fixture and regression test.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `bugfix`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Add applicable tests to the unit tests.
