### PR TITLE
fix(finding): clear M2M through rows inside each chunk's delete transaction

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -751,7 +751,9 @@ def bulk_clear_finding_m2m(finding_qs):
     Bulk-clear M2M through tables for a queryset of findings.
 
     Must be called BEFORE cascade_delete since M2M through tables
-    are not discovered by _meta.related_objects.
+    are not discovered by _meta.related_objects, and inside the same
+    transaction as the delete it clears for -- see
+    _bulk_delete_findings_internal for why the two cannot be separated.
 
     Special handling for FileUpload: deletes via ORM so the custom
     FileUpload.delete() fires and removes files from disk storage.
@@ -823,10 +825,20 @@ def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=Fa
     """
     Delete findings and all related objects efficiently. Including any related object in Dojo-Pro
 
-    Sends the pre_bulk_delete signal, clears M2M through tables (not
-    discovered by _meta.related_objects), then uses cascade_delete for
-    all FK relations via raw SQL.
+    Sends the pre_bulk_delete signal, then per chunk clears the chunk's M2M through
+    tables (not discovered by _meta.related_objects) and uses cascade_delete for all
+    FK relations via raw SQL.
     Chunked with per-chunk transaction.atomic() for crash safety.
+
+    The M2M clear belongs inside the chunk's transaction, next to the delete it
+    protects. Clearing once up front for the whole queryset left every chunk after
+    the first exposed: each chunk commits separately, so a through row written after
+    that one pass -- a note added, a finding re-tagged by a concurrent import --
+    survived into its chunk's COMMIT, where the through table's foreign key rejected
+    it. Django declares those keys DEFERRABLE INITIALLY DEFERRED, so the failure
+    landed at COMMIT rather than at the delete, and the caller saw an opaque
+    constraint error naming an internal table. Per chunk, the through rows and the
+    findings they point at go in one transaction and no such window exists.
 
     When order_desc is True, findings are processed highest id first (matches
     finding_delete: duplicate_cluster.order_by("-id").delete()) so self-FK
@@ -839,7 +851,6 @@ def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=Fa
     )
 
     pre_bulk_delete_findings.send(sender=Finding, finding_qs=finding_qs)
-    bulk_clear_finding_m2m(finding_qs)
     ordered_qs = finding_qs.order_by("-id") if order_desc else finding_qs.order_by("id")
     for chunk_num, chunk_ids in enumerate(
         batched(
@@ -851,6 +862,7 @@ def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=Fa
     ):
         chunk_qs = Finding.objects.filter(id__in=chunk_ids)
         with transaction.atomic():
+            bulk_clear_finding_m2m(chunk_qs)
             cascade_delete_related_objects(Finding, chunk_qs, skip_relations={Finding}, skip_m2m_for={Finding})
             execute_delete_sql(chunk_qs)
         logger.info(

--- a/unittests/test_bulk_delete_findings_m2m.py
+++ b/unittests/test_bulk_delete_findings_m2m.py
@@ -193,3 +193,33 @@ class TestBulkDeleteFindingsM2M(DojoTestCase):
             "The orphaned Notes row should be deleted along with the finding.",
         )
         connection.check_constraints()
+
+    def test_note_shared_across_chunks(self):
+        """
+        A note attached to findings that land in different chunks is still resolved.
+
+        The first chunk deletes the shared Notes row, which cascades the second
+        finding's through row away before its own chunk is reached. Both findings must
+        still delete cleanly rather than tripping the constraint from the other side.
+        """
+        first = self._create_finding("M2M F7")
+        second = self._create_finding("M2M F8")
+        note = Notes.objects.create(entry="note shared by both findings", author=self.testuser)
+        first.notes.add(note)
+        second.notes.add(note)
+
+        bulk_delete_findings(
+            Finding.objects.filter(id__in=[first.id, second.id]),
+            chunk_size=1,
+        )
+
+        self.assertFalse(
+            Finding.objects.filter(id__in=[first.id, second.id]).exists(),
+            "Both findings should have been deleted.",
+        )
+        self.assertFalse(
+            Finding.notes.through.objects.filter(finding_id__in=[first.id, second.id]).exists(),
+            "No note through row may outlive the findings it pointed at.",
+        )
+        self.assertFalse(Notes.objects.filter(id=note.id).exists(), "The shared note should be gone.")
+        connection.check_constraints()

--- a/unittests/test_bulk_delete_findings_m2m.py
+++ b/unittests/test_bulk_delete_findings_m2m.py
@@ -1,0 +1,195 @@
+"""
+Unit tests for M2M through-table clearing in the chunked bulk finding delete.
+
+The chunked finding delete clears M2M through rows once up front for the whole
+queryset, but deletes the findings themselves in per-chunk transactions. A
+through row that appears after that one-shot pass survives into its chunk's
+COMMIT and violates the through table's foreign key.
+"""
+
+import logging
+
+from django.db import connection
+from django.utils import timezone
+
+from dojo import utils_cascade_delete
+from dojo.finding.helper import bulk_delete_findings
+from dojo.models import (
+    Engagement,
+    Finding,
+    Notes,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+    User,
+    UserContactInfo,
+)
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+class TestBulkDeleteFindingsM2M(DojoTestCase):
+
+    """M2M through rows must not outlive the findings they point at."""
+
+    def setUp(self):
+        super().setUp()
+        self.testuser = User.objects.create(
+            username="bulk_delete_m2m_user",
+            is_staff=True,
+            is_superuser=True,
+        )
+        UserContactInfo.objects.create(user=self.testuser, block_execution=True)
+        self.system_settings(enable_deduplication=False)
+        self.system_settings(enable_product_grade=False)
+
+        self.product_type = Product_Type.objects.create(name="Bulk Delete M2M PT")
+        self.product = Product.objects.create(
+            name="Bulk Delete M2M Product",
+            description="Test",
+            prod_type=self.product_type,
+        )
+        self.test_type = Test_Type.objects.get_or_create(name="Manual Test")[0]
+        self.engagement = Engagement.objects.create(
+            name="Bulk Delete M2M Engagement",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        self.test = Test.objects.create(
+            engagement=self.engagement,
+            test_type=self.test_type,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+
+    def _create_finding(self, title):
+        return Finding.objects.create(
+            test=self.test,
+            title=title,
+            severity="High",
+            description="Test",
+            mitigation="Test",
+            impact="Test",
+            reporter=self.testuser,
+        )
+
+    def _add_note(self, finding, entry):
+        note = Notes.objects.create(entry=entry, author=self.testuser)
+        finding.notes.add(note)
+        return note
+
+    def _delete_with_write_before_last_chunk(self, findings, attach_to, attach):
+        """
+        Delete ``findings`` one chunk at a time, writing to ``attach_to`` partway through.
+
+        ``attach`` is invoked from inside the delete, after the first chunk has been
+        handled and before ``attach_to``'s own chunk is reached. That is the interleaving
+        a concurrent writer produces in production: a note or tag lands on a finding that
+        the running delete has already selected but not yet reached.
+        """
+        # The delete imports execute_delete_sql at call time, so the patch has to land
+        # on the defining module rather than on dojo.finding.helper.
+        real_execute_delete_sql = utils_cascade_delete.execute_delete_sql
+        state = {"calls": 0}
+
+        def execute_delete_sql_with_concurrent_write(queryset, *args, **kwargs):
+            result = real_execute_delete_sql(queryset, *args, **kwargs)
+            state["calls"] += 1
+            if state["calls"] == 1:
+                attach()
+            return result
+
+        utils_cascade_delete.execute_delete_sql = execute_delete_sql_with_concurrent_write
+        try:
+            bulk_delete_findings(
+                Finding.objects.filter(id__in=[finding.id for finding in findings]),
+                chunk_size=1,
+            )
+        finally:
+            utils_cascade_delete.execute_delete_sql = real_execute_delete_sql
+        return state["calls"]
+
+    def test_note_added_during_delete_does_not_dangle(self):
+        """
+        A note attached mid-delete must be cleared with its finding's chunk.
+
+        Django declares its foreign keys DEFERRABLE INITIALLY DEFERRED, so in production
+        the leftover through row is only rejected at the chunk's COMMIT -- far from the
+        code that created it, surfacing as an opaque constraint error on the delete task.
+        Inside a TestCase transaction the same condition is what check_constraints()
+        reports.
+        """
+        first = self._create_finding("M2M F1")
+        second = self._create_finding("M2M F2")
+        self._add_note(first, "note on the first finding")
+
+        self._delete_with_write_before_last_chunk(
+            [first, second],
+            second,
+            lambda: self._add_note(second, "note that lands mid-delete"),
+        )
+
+        self.assertFalse(
+            Finding.objects.filter(id__in=[first.id, second.id]).exists(),
+            "Both findings should have been deleted.",
+        )
+        self.assertFalse(
+            Finding.notes.through.objects.filter(finding_id__in=[first.id, second.id]).exists(),
+            "No note through row may outlive the finding it points at.",
+        )
+        # The check Postgres runs at COMMIT, where a leftover through row is the
+        # IntegrityError that fails the delete in production.
+        connection.check_constraints()
+
+    def test_tag_added_during_delete_does_not_dangle(self):
+        """Same window, reached through the tag through table rather than notes."""
+        first = self._create_finding("M2M F3")
+        second = self._create_finding("M2M F4")
+        first.tags = ["tag-on-first"]
+        first.save()
+
+        def add_tag_to_second():
+            second.tags = ["tag-that-lands-mid-delete"]
+            second.save()
+
+        self._delete_with_write_before_last_chunk([first, second], second, add_tag_to_second)
+
+        self.assertFalse(
+            Finding.objects.filter(id__in=[first.id, second.id]).exists(),
+            "Both findings should have been deleted.",
+        )
+        self.assertFalse(
+            Finding.tags.through.objects.filter(finding_id__in=[first.id, second.id]).exists(),
+            "No tag through row may outlive the finding it points at.",
+        )
+        connection.check_constraints()
+
+    def test_notes_cleared_without_concurrent_write(self):
+        """Control: the ordinary path still clears notes and their Notes rows."""
+        first = self._create_finding("M2M F5")
+        second = self._create_finding("M2M F6")
+        note = self._add_note(first, "note on the first finding")
+        self._add_note(second, "note on the second finding")
+
+        bulk_delete_findings(
+            Finding.objects.filter(id__in=[first.id, second.id]),
+            chunk_size=1,
+        )
+
+        self.assertFalse(
+            Finding.objects.filter(id__in=[first.id, second.id]).exists(),
+            "Both findings should have been deleted.",
+        )
+        self.assertFalse(
+            Finding.notes.through.objects.filter(finding_id__in=[first.id, second.id]).exists(),
+            "Note through rows should be gone.",
+        )
+        self.assertFalse(
+            Notes.objects.filter(id=note.id).exists(),
+            "The orphaned Notes row should be deleted along with the finding.",
+        )
+        connection.check_constraints()


### PR DESCRIPTION
**Description**

The chunked bulk finding delete clears M2M through tables **once up front for the whole queryset**, then deletes the findings themselves in **per-chunk transactions**:

```python
bulk_clear_finding_m2m(finding_qs)          # one pass, whole queryset
for chunk_ids in batched(...):
    with transaction.atomic():              # each chunk commits separately
        cascade_delete_related_objects(...)
        execute_delete_sql(chunk_qs)
```

Every chunk after the first is unprotected. A through row written after that single pass — a note added to a finding, a finding re-tagged by a concurrent import — survives into its chunk's `COMMIT`, where the through table's foreign key rejects it.

Django declares those foreign keys `DEFERRABLE INITIALLY DEFERRED`, so the violation lands at `COMMIT` rather than at the delete, and the caller gets an opaque constraint error naming an internal through table instead of anything about the delete:

```
IntegrityError: update or delete on table "dojo_finding" violates foreign key constraint
"dojo_finding_notes_finding_id_701fd3e2_fk_dojo_finding_id" on table "dojo_finding_notes"
DETAIL:  Key (id)=(...) is still referenced from table "dojo_finding_notes".
```

Seen in production against both the notes and the tags through table, on two different callers — the periodic excess-duplicate delete (`dojo/tasks.py:191`) and the async cascade delete of a test (`dojo/utils.py:1878`). The excess-duplicate caller is the loud one: it passes a fixed id list, so the deleted set and the cleared set are identical by construction, which leaves a concurrent write during the delete as the only way a through row can be there at `COMMIT`.

**Fix**

Move the clear inside the per-chunk transaction and scope it to that chunk:

```python
 chunk_qs = Finding.objects.filter(id__in=chunk_ids)
 with transaction.atomic():
+    bulk_clear_finding_m2m(chunk_qs)
     cascade_delete_related_objects(Finding, chunk_qs, skip_relations={Finding}, skip_m2m_for={Finding})
     execute_delete_sql(chunk_qs)
```

A chunk's through rows and the findings they point at are now removed together, so no window exists between them. This is the same shape already used for the `duplicate_finding` self-FK: the cleanup belongs next to the delete it protects, not in a pre-pass, because each chunk commits separately.

Two notes on scope:

- The `pre_bulk_delete_findings` signal still fires **once with the full queryset**, unchanged — it is a notification hook, not part of the delete.
- Per-chunk clearing also bounds the note and file id lists that `bulk_clear_finding_m2m` materializes with `list(...)` to one chunk rather than the whole delete set. `bulk_clear_finding_m2m` has exactly one caller, so the change is self-contained.

**Test results**

New `unittests/test_bulk_delete_findings_m2m.py`, 4 cases. The interleaving is produced deterministically by wrapping `execute_delete_sql` so a note/tag is written after the first chunk's rows are gone and before the second chunk is reached — the interleaving a concurrent writer produces in production.

Deferred FKs are validated via `connection.check_constraints()`, so the assertion is the same check `COMMIT` performs rather than only a statement about resulting state.

| Case | Before | After |
|---|---|---|
| note written mid-delete | fails — `dojo_finding_notes_finding_id_701fd3e2_fk_dojo_finding_id` | passes |
| tag written mid-delete | fails — `dojo_finding_tags_finding_id_d4968e76_fk_dojo_finding_id` | passes |
| control, no concurrent write | passes | passes |
| note shared by findings in different chunks | passes | passes |

Both race cases fail pre-fix on *both* counts (the leftover through row assertion and the constraint check). The two controls passing before and after confirm the diagnosis is specific rather than a broad breakage of the delete path — the last one in particular covers the consequence of chunking the clear, where the first chunk deletes a shared `Notes` row and cascades the second finding's through row away before its own chunk is reached.

No collateral damage, run against PostgreSQL (SQLite does not reproduce the deferred-constraint behaviour):

- `test_async_delete`, `test_cascade_delete`, `test_duplication_loops`, `test_prepare_duplicates_for_delete`, `test_finding_helper`, `test_tag_utils_bulk`, and the new file — 119 tests, 1 failure (see below)
- `test_finding_model`, `test_deduplication_logic`, `test_utils_deduplication_reopen`, `test_delete_with_endpoints_v3`, `test_tags`, `test_tag_inheritance`, `test_apiv2_test_create_notes_readonly`, `test_bulk_finding_authorization` — 228 passed, 34 skipped
- `test_importers_deduplication`, `test_importers_deleted_target`, `test_import_reimport` — 188 passed
- `ruff check --config ruff.toml` (0.15.20, the pinned version) clean on both changed files

The one failure above, `test_duplication_loops.test_delete_duplicate_excess_with_chained_reference`, is **pre-existing and not caused by this change** — it reproduces identically on the unmodified base branch when those modules run together (116 tests, same single failure), and passes in isolation both with and without this change. It looks like a test-ordering interaction in that test rather than anything in the delete path; flagged here rather than fixed, as it is a separate concern.

> Note on the environment: this sandbox has no Docker, so the suites were run through `manage.py test` against a locally provisioned PostgreSQL 16 cluster on Python 3.13 rather than `run-unittest.sh`. CI is the authority.

**Impact on the Pro plugin**

Checked as part of the acceptance criteria; **no Pro change is required.**

- `pro/finding/bulk_delete.py` delegates straight to `_bulk_delete_findings_internal`, so Pro inherits the fix. Its `per_product` metering counts are taken from the queryset before deleting, so where the M2M clear happens does not affect them.
- Pro's `pre_bulk_delete_findings` receiver (`pro/finding/signals.py`) still receives the full queryset once, before any chunk — unchanged.
- Pro adds a reverse M2M to `Finding` (`pro.compliance` POAM items, `related_name="poam_items"`). `bulk_clear_finding_m2m` auto-discovers reverse M2M through models, so that table was already covered and is now cleared per chunk — same coverage, narrower window. It is a beneficiary of this fix, not a risk from it.
- Pro does not override `bulk_clear_finding_m2m`.

**Documentation**

No documentation change — internal bug fix to delete behaviour, with no new or changed inputs, outputs, settings, or API surface. The reasoning is captured in the two updated docstrings.

**Checklist**

- [x] Submitted against `bugfix` (bug fix, not a feature).
- [x] Meaningful PR name for the release notes.
- [x] Ruff compliant.
- [x] Python 3.13 compliant.
- [x] No model changes, so no migrations.
- [x] Tests added to the unit tests.
- [x] Label suggested: `bugfix`.

**Reported via**

- https://defectdojo-workspace.slack.com/archives/C0BK62Q76P8/p1785431107228909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAEqxx1qf29qrQni1L4Eia