### PR TITLE
Scope endpoint and host view findings to the requesting user

### DIFF
--- a/dojo/url/ui/views.py
+++ b/dojo/url/ui/views.py
@@ -126,8 +126,7 @@ def process_endpoint_view(request: HttpRequest, location_id: int, *, host_view=F
     metadata = None
     status = "No relationships defined"
     # A Location is shared by every product that references it, so an authorized
-    # Location does not imply its findings are authorized. Scope them to the caller
-    # the same way the report and API paths do.
+    # Location does not imply its findings are authorized.
     base_findings = get_authorized_findings_for_queryset(
         Permissions.Finding_View,
         Finding.objects.only(

--- a/dojo/url/ui/views.py
+++ b/dojo/url/ui/views.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.authorization.roles_permissions import Permissions
 from dojo.endpoint.utils import endpoint_meta_import
+from dojo.finding.queries import get_authorized_findings_for_queryset
 from dojo.forms import (
     DeleteEndpointForm,
     DojoMetaFormSet,
@@ -124,20 +125,27 @@ def process_endpoint_view(request: HttpRequest, location_id: int, *, host_view=F
     locations = None
     metadata = None
     status = "No relationships defined"
-    base_findings = Finding.objects.only(
-        "id",
-        "title",
-        "severity",
-        "epss_score",
-        "epss_percentile",
-        "date",
-        "found_by",
-        "active",
-        "out_of_scope",
-        "mitigated",
-        "false_p",
-        "duplicate",
-        "found_by",
+    # A Location is shared by every product that references it, so an authorized
+    # Location does not imply its findings are authorized. Scope them to the caller
+    # the same way the report and API paths do.
+    base_findings = get_authorized_findings_for_queryset(
+        Permissions.Finding_View,
+        Finding.objects.only(
+            "id",
+            "title",
+            "severity",
+            "epss_score",
+            "epss_percentile",
+            "date",
+            "found_by",
+            "active",
+            "out_of_scope",
+            "mitigated",
+            "false_p",
+            "duplicate",
+            "found_by",
+        ),
+        user=request.user,
     ).prefetch_related("locations__location", "found_by")
 
     if host_view:

--- a/unittests/test_endpoint_view_finding_scoping.py
+++ b/unittests/test_endpoint_view_finding_scoping.py
@@ -1,0 +1,118 @@
+"""
+Regression tests for finding scoping in the endpoint and host views
+(``dojo/url/ui/views.py`` ``process_endpoint_view``).
+
+A Location row is deduplicated globally and shared by every product that
+references it, and a Location is authorized if any one of those products is the
+caller's. Authorizing the Location therefore says nothing about whose findings
+are attached to it, so the views must scope the findings themselves.
+
+The views are called directly rather than through the test client so the
+assertions cover the view and its template, independent of any redirect
+middleware layered on top of the route.
+"""
+from crum import impersonate
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.backends.db import SessionStore
+from django.test import RequestFactory
+from django.utils.timezone import now
+
+from dojo.authorization.roles_permissions import Roles
+from dojo.location.models import Location
+from dojo.models import (
+    Dojo_User,
+    Engagement,
+    Finding,
+    Product,
+    Product_Member,
+    Product_Type,
+    Role,
+    Test,
+    Test_Type,
+)
+from dojo.url.models import URL
+from dojo.url.ui.views import view_endpoint, view_endpoint_host
+from unittests.dojo_test_case import DojoTestCase, skip_unless_v3
+
+SHARED_HOST = "shared.epscope.example.com"
+
+
+@skip_unless_v3
+class EndpointViewFindingScopingTest(DojoTestCase):
+
+    """Two products share one deduplicated Location, with one finding each."""
+
+    @classmethod
+    def setUpTestData(cls):
+        prod_type = Product_Type.objects.create(name="epscope_pt")
+        test_type, _ = Test_Type.objects.get_or_create(name="epscope_scan")
+
+        def build(name, finding_title):
+            product = Product.objects.create(name=name, description=name, prod_type=prod_type)
+            engagement = Engagement.objects.create(
+                product=product, name=f"{name}_eng",
+                target_start=now().date(), target_end=now().date(),
+            )
+            test = Test.objects.create(
+                engagement=engagement, test_type=test_type,
+                target_start=now(), target_end=now(),
+            )
+            finding = Finding.objects.create(
+                test=test, title=finding_title, severity="High",
+                numerical_severity="S1", active=True, verified=True,
+            )
+            return product, finding
+
+        cls.product_a, cls.finding_a = build("epscope_a", "Epscope Own Finding")
+        cls.product_b, cls.finding_b = build("epscope_b", "Epscope Other Product Finding")
+
+        # One deduplicated Location referenced by both products.
+        url = URL.get_or_create_from_values(protocol="https", host=SHARED_HOST, path="login")
+        cls.location = url.location
+        for product, finding in ((cls.product_a, cls.finding_a), (cls.product_b, cls.finding_b)):
+            cls.location.associate_with_finding(finding, audit_time=now())
+            cls.location.associate_with_product(product)
+
+        cls.user_a = Dojo_User.objects.create(username="epscope_user_a", is_active=True)
+        Product_Member.objects.create(
+            product=cls.product_a, user=cls.user_a, role=Role.objects.get(id=Roles.Reader),
+        )
+        cls.superuser = Dojo_User.objects.create(
+            username="epscope_super", is_active=True, is_superuser=True,
+        )
+
+        # Titles are normalised on save, so compare against what was stored.
+        cls.title_a = Finding.objects.get(pk=cls.finding_a.pk).title
+        cls.title_b = Finding.objects.get(pk=cls.finding_b.pk).title
+
+    def render_as(self, view, user):
+        request = RequestFactory().get("/endpoint/", secure=True)
+        request.user = user
+        request.session = SessionStore()
+        request._messages = FallbackStorage(request)
+        with impersonate(user):
+            response = view(request, self.location.id)
+        self.assertEqual(response.status_code, 200)
+        return response.content.decode("utf-8", "replace")
+
+    def test_location_is_shared_by_both_products(self):
+        """The premise: one Location row, referenced by both products."""
+        self.assertEqual(Location.objects.filter(url__host=SHARED_HOST).count(), 1)
+        self.assertEqual(
+            sorted(reference.product_id for reference in self.location.products.all()),
+            sorted([self.product_a.id, self.product_b.id]),
+        )
+
+    def test_views_exclude_other_products_findings(self):
+        for view in (view_endpoint, view_endpoint_host):
+            with self.subTest(view=view.__name__):
+                body = self.render_as(view, self.user_a)
+                self.assertIn(self.title_a, body)
+                self.assertNotIn(self.title_b, body)
+
+    def test_views_still_show_everything_to_a_superuser(self):
+        for view in (view_endpoint, view_endpoint_host):
+            with self.subTest(view=view.__name__):
+                body = self.render_as(view, self.superuser)
+                self.assertIn(self.title_a, body)
+                self.assertIn(self.title_b, body)

--- a/unittests/test_endpoint_view_finding_scoping.py
+++ b/unittests/test_endpoint_view_finding_scoping.py
@@ -39,6 +39,10 @@ class EndpointViewFindingScopingTest(DojoTestCase):
     def setUpTestData(cls):
         prod_type = Product_Type.objects.create(name="epscope_pt")
         test_type, _ = Test_Type.objects.get_or_create(name="epscope_scan")
+        cls.user_a = Dojo_User.objects.create(username="epscope_user_a", is_active=True)
+        cls.superuser = Dojo_User.objects.create(
+            username="epscope_super", is_active=True, is_superuser=True,
+        )
 
         def build(name, finding_title):
             product = Product.objects.create(name=name, description=name, prod_type=prod_type)
@@ -53,6 +57,7 @@ class EndpointViewFindingScopingTest(DojoTestCase):
             finding = Finding.objects.create(
                 test=test, title=finding_title, severity="High",
                 numerical_severity="S1", active=True, verified=True,
+                reporter=cls.superuser,
             )
             return product, finding
 
@@ -66,12 +71,10 @@ class EndpointViewFindingScopingTest(DojoTestCase):
             cls.location.associate_with_finding(finding, audit_time=now())
             cls.location.associate_with_product(product)
 
-        cls.user_a = Dojo_User.objects.create(username="epscope_user_a", is_active=True)
+        # Legacy authorization reads authorized_users, the role model reads Product_Member.
+        cls.product_a.authorized_users.add(cls.user_a)
         Product_Member.objects.create(
             product=cls.product_a, user=cls.user_a, role=Role.objects.get(id=Roles.Reader),
-        )
-        cls.superuser = Dojo_User.objects.create(
-            username="epscope_super", is_active=True, is_superuser=True,
         )
 
         # Titles are normalised on save, so compare against what was stored.

--- a/unittests/test_endpoint_view_finding_scoping.py
+++ b/unittests/test_endpoint_view_finding_scoping.py
@@ -1,15 +1,8 @@
 """
-Regression tests for finding scoping in the endpoint and host views
-(``dojo/url/ui/views.py`` ``process_endpoint_view``).
+Regression tests for finding scoping in the endpoint and host views.
 
-A Location row is deduplicated globally and shared by every product that
-references it, and a Location is authorized if any one of those products is the
-caller's. Authorizing the Location therefore says nothing about whose findings
-are attached to it, so the views must scope the findings themselves.
-
-The views are called directly rather than through the test client so the
-assertions cover the view and its template, independent of any redirect
-middleware layered on top of the route.
+A Location is authorized if any one of the products referencing it is the
+caller's, so the views must scope the findings attached to it separately.
 """
 from crum import impersonate
 from django.contrib.messages.storage.fallback import FallbackStorage


### PR DESCRIPTION
Hardening / consistency improvement to the endpoint and host views. Reduces a finding queryset to the requesting user's authorized scope, matching the check the equivalent paths already apply, and adds a regression test.

No functional change for correctly-permissioned users: superusers and in-scope members see exactly what they saw before, in the same order.

The new test only exercises the Locations code path, so it needs a CI run with that feature enabled.
