### PR TITLE
fix(generic parser): ignore non-numeric values in numeric JSON fields

### DIFF
--- a/docs/content/supported_tools/parsers/file/generic.md
+++ b/docs/content/supported_tools/parsers/file/generic.md
@@ -98,6 +98,10 @@ The list of supported fields in JSON format:
 - fix_available: Bool
 - fix_version: String
 
+A numeric field may be given as a number or as a quoted number. A value that holds no
+number at all, such as a `"N/A"` placeholder for a line number the tool could not
+determine, is ignored and the field keeps its default.
+
 ### Example JSON
 
 ```JSON

--- a/dojo/tools/generic/json_parser.py
+++ b/dojo/tools/generic/json_parser.py
@@ -1,4 +1,5 @@
 import base64
+import math
 
 import dateutil
 from django.conf import settings
@@ -7,6 +8,33 @@ from django.core.files.base import ContentFile
 from dojo.models import Endpoint, FileUpload, Finding
 from dojo.tools.locations import LocationData
 from dojo.tools.parser_test import ParserTest
+
+# Accepted fields that map to a numeric column on Finding, and the type they hold.
+NUMERIC_FIELDS = {
+    "cvssv3_score": float,
+    "cvssv4_score": float,
+    "cwe": int,
+    "epss_percentile": float,
+    "epss_score": float,
+    "line": int,
+    "nb_occurences": int,
+    "sast_source_line": int,
+    "scanner_confidence": int,
+    "thread_id": int,
+}
+
+
+def to_number(value, converter):
+    """Convert value with converter, returning None when it does not hold a number."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+    try:
+        number = converter(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
 
 
 class GenericJSONParser:
@@ -116,6 +144,8 @@ class GenericJSONParser:
             if not_allowed:
                 msg = f"Not allowed fields are present: {not_allowed}"
                 raise ValueError(msg)
+
+            self._normalize_numeric_fields(item)
             finding = Finding(**item)
 
             # manage endpoints
@@ -180,3 +210,22 @@ class GenericJSONParser:
                     )
             test_internal.findings.append(finding)
         return test_internal
+
+    def _normalize_numeric_fields(self, item):
+        """
+        Coerce the numeric fields of a finding, dropping the ones that hold no number.
+
+        Django accepts any value on assignment and only rejects a non-numeric one when
+        the finding is written, so a report using a placeholder such as "N/A" for a line
+        number it could not determine aborts the whole import from deep inside the
+        database write. Dropping the key here lets the model default apply instead, and
+        a number that arrives quoted is kept by converting it.
+        """
+        for field, converter in NUMERIC_FIELDS.items():
+            if field not in item or item[field] is None:
+                continue
+            number = to_number(item[field], converter)
+            if number is None:
+                del item[field]
+            else:
+                item[field] = number

--- a/unittests/scans/generic/generic_non_numeric_fields.json
+++ b/unittests/scans/generic/generic_non_numeric_fields.json
@@ -1,0 +1,35 @@
+{
+    "findings": [
+        {
+            "title": "numeric fields reported as placeholders",
+            "severity": "Medium",
+            "description": "the tool could not determine the numeric values",
+            "cwe": "N/A",
+            "line": "N/A",
+            "nb_occurences": "N/A",
+            "sast_source_line": "N/A",
+            "scanner_confidence": "N/A",
+            "thread_id": "N/A",
+            "cvssv3_score": "N/A",
+            "cvssv4_score": "N/A",
+            "epss_percentile": "N/A",
+            "epss_score": "N/A"
+        },
+        {
+            "title": "numeric fields reported as strings",
+            "severity": "Medium",
+            "description": "the tool quoted its numeric values",
+            "cwe": "79",
+            "line": "42",
+            "epss_score": "0.5"
+        },
+        {
+            "title": "numeric fields reported as numbers",
+            "severity": "Medium",
+            "description": "the tool reported proper numeric values",
+            "cwe": 79,
+            "line": 42,
+            "epss_score": 0.5
+        }
+    ]
+}

--- a/unittests/test_importers_importer.py
+++ b/unittests/test_importers_importer.py
@@ -203,6 +203,44 @@ class TestDojoDefaultImporter(DojoTestCase):
             self.assertEqual(1, len_new_findings)
             self.assertEqual(0, len_closed_findings)
 
+    def test_import_generic_with_non_numeric_line_is_written(self):
+        """A report using a placeholder instead of a line number must not abort the import."""
+        generic_non_numeric_fields = get_unit_tests_scans_path("generic") / "generic_non_numeric_fields.json"
+        with generic_non_numeric_fields.open(encoding="utf-8") as scan:
+            user, _ = User.objects.get_or_create(username="admin")
+            product_type, _ = Product_Type.objects.get_or_create(name="test_generic_non_numeric")
+            product, _ = Product.objects.get_or_create(
+                name="TestGenericNonNumericImporter",
+                description="test product",
+                prod_type=product_type,
+            )
+            engagement, _ = Engagement.objects.get_or_create(
+                name="Test Generic Non Numeric Engagement",
+                product=product,
+                target_start=timezone.now(),
+                target_end=timezone.now(),
+            )
+            environment, _ = Development_Environment.objects.get_or_create(name="Development")
+            import_options = {
+                "user": user,
+                "lead": user,
+                "scan_date": None,
+                "environment": environment,
+                "minimum_severity": "Info",
+                "active": True,
+                "verified": True,
+                "scan_type": "Generic Findings Import",
+                "engagement": engagement,
+                "close_old_findings": False,
+            }
+            importer = DefaultImporter(**import_options)
+            test, _, len_new_findings, _, _, _, _ = importer.process_scan(scan)
+            self.assertEqual(3, len_new_findings)
+            findings = Finding.objects.filter(test=test).order_by("id")
+            self.assertIsNone(findings[0].line)
+            self.assertEqual(42, findings[1].line)
+            self.assertEqual(42, findings[2].line)
+
     def test_reimport_generic_with_matching_test_type(self):
         """Test Case 1: Reimport with matching test_type (should succeed)"""
         generic_test_type_1 = get_unit_tests_scans_path("generic") / "generic_test_type_1.json"

--- a/unittests/tools/test_generic_parser.py
+++ b/unittests/tools/test_generic_parser.py
@@ -661,6 +661,43 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
                     "Not allowed fields are present: ['invalid_field', 'last_status_update']"):
                 parser.get_findings(file, Test())
 
+    def test_parse_json_non_numeric_value_falls_back_to_default(self):
+        with (get_unit_tests_scans_path("generic") / "generic_non_numeric_fields.json").open(encoding="utf-8") as file:
+            parser = GenericParser()
+            findings = parser.get_findings(file, self.test)
+            self.validate_locations(findings)
+            finding = findings[0]
+            self.assertIsNone(finding.line)
+            self.assertIsNone(finding.nb_occurences)
+            self.assertIsNone(finding.sast_source_line)
+            self.assertIsNone(finding.scanner_confidence)
+            self.assertIsNone(finding.cvssv3_score)
+            self.assertIsNone(finding.cvssv4_score)
+            self.assertIsNone(finding.epss_percentile)
+            self.assertIsNone(finding.epss_score)
+            self.assertEqual(0, finding.cwe)
+            self.assertEqual(0, finding.thread_id)
+
+    def test_parse_json_numeric_value_given_as_string_is_converted(self):
+        with (get_unit_tests_scans_path("generic") / "generic_non_numeric_fields.json").open(encoding="utf-8") as file:
+            parser = GenericParser()
+            findings = parser.get_findings(file, self.test)
+            self.validate_locations(findings)
+            finding = findings[1]
+            self.assertEqual(42, finding.line)
+            self.assertEqual(79, finding.cwe)
+            self.assertEqual(0.5, finding.epss_score)
+
+    def test_parse_json_numeric_value_given_as_number_is_kept(self):
+        with (get_unit_tests_scans_path("generic") / "generic_non_numeric_fields.json").open(encoding="utf-8") as file:
+            parser = GenericParser()
+            findings = parser.get_findings(file, self.test)
+            self.validate_locations(findings)
+            finding = findings[2]
+            self.assertEqual(42, finding.line)
+            self.assertEqual(79, finding.cwe)
+            self.assertEqual(0.5, finding.epss_score)
+
     def test_parse_csv_with_epss(self):
         with (get_unit_tests_scans_path("generic") / "generic_csv_with_epss.csv").open(encoding="utf-8") as file:
             parser = GenericParser()


### PR DESCRIPTION
**Description**

A Generic Findings Import report that carries a placeholder such as `"N/A"` in a numeric field passes parsing untouched. `GenericJSONParser._get_test_json` builds the finding with `Finding(**item)`, and Django accepts any value on assignment — the value is only rejected when the finding is written.

The result is that the import does not fail at parse time with a useful message; it fails from deep inside the database write, aborting the whole scan task:

```
ValueError: invalid literal for int() with base 10: 'N/A'
...
  File ".../django/db/models/fields/__init__.py", line 2130, in get_prep_value
    raise e.__class__(
        "Field '%s' expected a number but got %r." % (self.name, value),
    ) from e
ValueError: Field 'line' expected a number but got 'N/A'.
```

This was observed repeatedly against the async import task, on both `import` and `reimport`, and every affected scan was lost. `line` is the field seen in the wild, but the same applies to every accepted field backed by a numeric column (`cwe`, `nb_occurences`, `sast_source_line`, `scanner_confidence`, `thread_id`, `cvssv3_score`, `cvssv4_score`, `epss_score`, `epss_percentile`).

The fix normalizes those fields in the parser, before the `Finding` is constructed:

- a number is kept as-is;
- a quoted number (`"42"`) is converted, so reports that stringify their numerics keep working;
- a value that holds no number at all is dropped, so the model default applies rather than the value reaching the database;
- an explicit `null` is left alone, preserving current behaviour;
- `bool` and non-finite floats are treated as "no number", so `true` or `NaN` cannot slip into a numeric column.

The CSV flavour of this parser never populates these fields from free-form input, so it is unaffected.

**Pro impact**

The failure was reported from the Pro async import task, but nothing in Pro overrides this parser or the parser registry — Pro consumes the same parser output through the shared importer. No Pro-side change is needed, and there is no data-shape regression to worry about: before this fix the import aborted, so a non-numeric value was never persisted.

**Test results**

TDD — tests written first and confirmed failing against the unpatched parser (`AssertionError: 'N/A' is not None`), then passing.

- `unittests/scans/generic/generic_non_numeric_fields.json` — new fixture with three findings covering the three input shapes (placeholder, quoted number, number).
- `unittests/tools/test_generic_parser.py` — three parser-level tests: placeholders fall back to the model default, quoted numbers are converted, real numbers are untouched.
- `unittests/test_importers_importer.py` — importer-level regression test that runs the fixture through `DefaultImporter.process_scan` and asserts the findings persist. Without the fix this test reproduces the reported failure exactly (`ValueError: Field 'cwe' expected a number but got 'N/A'`); with it, the findings are written with the numeric fields defaulted.

Run locally (Python 3.13, PostgreSQL):

```
python manage.py test unittests.tools.test_generic_parser \
  unittests.test_generic_meta_import unittests.test_importers_importer \
  unittests.test_import_reimport unittests.test_apiv2_scan_import_options
Ran 235 tests — OK
```

`ruff check --config ruff.toml` clean on all changed files.

**Documentation**

`docs/content/supported_tools/parsers/file/generic.md` — documents that a numeric field may be given as a number or a quoted number, and that a value holding no number is ignored.

**Reported in**

- https://defectdojo-workspace.slack.com/archives/C0BK62Q76P8/p1785447451468909

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn5pEjyW8HEnkmgMuUGuqW)_