### PR TITLE
Scope API scan configuration tool selection to authorized tool configurations

### DIFF
--- a/dojo/product/api/serializer.py
+++ b/dojo/product/api/serializer.py
@@ -1,7 +1,9 @@
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 
 from dojo.authorization.serializer_guards import AuthorizedUsersMemberGuardMixin
 from dojo.models import DojoMeta, Product, Product_API_Scan_Configuration
+from dojo.tool_config.queries import get_authorized_tool_configurations
 
 
 class ProductMetaSerializer(serializers.ModelSerializer):
@@ -14,6 +16,29 @@ class ProductAPIScanConfigurationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product_API_Scan_Configuration
         fields = "__all__"
+
+    def validate(self, data):
+        self._validate_tool_configuration_use(data)
+        return data
+
+    def _validate_tool_configuration_use(self, data):
+        """
+        Selecting a ``tool_configuration`` lets an import run authenticated
+        requests with the credential stored on it, so it is gated by the same
+        ``view_tool_configuration`` permission that guards the tool-configuration
+        views -- not just the product permission this endpoint already checks.
+
+        No-ops when the field is absent (replay-safe on PATCH), mirroring
+        dojo.authorization.api_permissions.check_update_permission.
+        """
+        if "tool_configuration" not in data:
+            return
+        tool_configuration = data.get("tool_configuration")
+        request = self.context.get("request")
+        request_user = getattr(request, "user", None)
+        if tool_configuration is not None and not get_authorized_tool_configurations(request_user).filter(pk=tool_configuration.pk).exists():
+            msg = "You do not have permission to use this tool configuration."
+            raise PermissionDenied(msg)
 
 
 class ProductSerializer(AuthorizedUsersMemberGuardMixin, serializers.ModelSerializer):

--- a/dojo/product/ui/forms.py
+++ b/dojo/product/ui/forms.py
@@ -13,6 +13,7 @@ from dojo.models import (
 )
 from dojo.product.queries import get_authorized_products
 from dojo.product_type.queries import get_authorized_product_types
+from dojo.tool_config.queries import get_authorized_tool_configurations
 from dojo.validators import tag_validator
 
 labels = get_labels()
@@ -132,14 +133,15 @@ class ProductTagCountsForm(ProductCountsFormBase):
 
 class Product_API_Scan_ConfigurationForm(forms.ModelForm):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     tool_configuration = forms.ModelChoiceField(
         label="Tool Configuration",
-        queryset=Tool_Configuration.objects.all().order_by("name"),
+        queryset=Tool_Configuration.objects.none(),
         required=True,
     )
+
+    def __init__(self, *args, user=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["tool_configuration"].queryset = get_authorized_tool_configurations(user)
 
     class Meta:
         model = Product_API_Scan_Configuration

--- a/dojo/product/ui/views.py
+++ b/dojo/product/ui/views.py
@@ -1706,7 +1706,7 @@ def delete_product_authorized_user(request, pid, user_id):
 def add_api_scan_configuration(request, pid):
     product = get_object_or_404(Product, id=pid)
     if request.method == "POST":
-        form = Product_API_Scan_ConfigurationForm(request.POST)
+        form = Product_API_Scan_ConfigurationForm(request.POST, user=request.user)
         if form.is_valid():
             product_api_scan_configuration = form.save(commit=False)
             product_api_scan_configuration.product = product
@@ -1733,7 +1733,7 @@ def add_api_scan_configuration(request, pid):
                                      str(e),
                                      extra_tags="alert-danger")
     else:
-        form = Product_API_Scan_ConfigurationForm()
+        form = Product_API_Scan_ConfigurationForm(user=request.user)
 
     product_tab = Product_Tab(product, title=_("Add API Scan Configuration"), tab="settings")
 
@@ -1767,7 +1767,7 @@ def edit_api_scan_configuration(request, pid, pascid):
         raise Http404
 
     if request.method == "POST":
-        form = Product_API_Scan_ConfigurationForm(request.POST, instance=product_api_scan_configuration)
+        form = Product_API_Scan_ConfigurationForm(request.POST, instance=product_api_scan_configuration, user=request.user)
         if form.is_valid():
             try:
                 form_copy = form.save(commit=False)
@@ -1792,7 +1792,7 @@ def edit_api_scan_configuration(request, pid, pascid):
                                      str(e),
                                      extra_tags="alert-danger")
     else:
-        form = Product_API_Scan_ConfigurationForm(instance=product_api_scan_configuration)
+        form = Product_API_Scan_ConfigurationForm(instance=product_api_scan_configuration, user=request.user)
 
     product_tab = Product_Tab(get_object_or_404(Product, id=pid), title=_("Edit API Scan Configuration"), tab="settings")
     return render(request,

--- a/dojo/tool_config/queries.py
+++ b/dojo/tool_config/queries.py
@@ -1,0 +1,12 @@
+from dojo.authorization.authorization import user_has_configuration_permission
+from dojo.tool_config.models import Tool_Configuration
+
+
+def get_authorized_tool_configurations(user):
+    """
+    Configs the user may select; empty queryset (not an error) if they lack view_tool_configuration.
+    Back a ModelChoiceField with it so the accepted POST value is gated too, not just the rendered choices.
+    """
+    if user_has_configuration_permission(user, "dojo.view_tool_configuration"):
+        return Tool_Configuration.objects.all().order_by("name")
+    return Tool_Configuration.objects.none()

--- a/unittests/test_api_scan_configuration_tool_authz.py
+++ b/unittests/test_api_scan_configuration_tool_authz.py
@@ -1,0 +1,74 @@
+"""
+Regression test: the "Add API Scan Configuration" form and its REST serializer
+must not offer or accept a Tool_Configuration the requesting user is not
+authorized to view.
+
+Selecting a tool configuration drives an authenticated request with the
+credential stored on it, so the choice is gated by the same
+``view_tool_configuration`` configuration permission that guards the
+tool-configuration views. A user without that permission gets an empty choice
+set, and a submitted pk is rejected, so narrowing the rendered <select> alone
+cannot be bypassed by POSTing the id directly, and the REST endpoint cannot be
+used to attach an unauthorized configuration either.
+"""
+from types import SimpleNamespace
+
+from rest_framework.exceptions import PermissionDenied
+
+from dojo.models import Dojo_User, Tool_Configuration, Tool_Type
+from dojo.product.api.serializer import ProductAPIScanConfigurationSerializer
+from dojo.product.ui.forms import Product_API_Scan_ConfigurationForm
+
+from .dojo_test_case import DojoTestCase
+
+
+class ApiScanConfigurationToolAuthzTest(DojoTestCase):
+    def setUp(self):
+        tool_type, _ = Tool_Type.objects.get_or_create(name="SonarQube")
+        self.tool_config = Tool_Configuration.objects.create(
+            name="prod-sonarqube", tool_type=tool_type, authentication_type="API",
+            url="http://example.invalid/api", api_key="ADMIN-TOKEN",
+        )
+        self.unprivileged = Dojo_User.objects.create(
+            username="scanconf_unprivileged", is_staff=False, is_superuser=False,
+        )
+        self.staff = Dojo_User.objects.create(
+            username="scanconf_staff", is_staff=True, is_superuser=False,
+        )
+        self.product_type = self.create_product_type("scanconf-org")
+
+    def _post(self, user):
+        return Product_API_Scan_ConfigurationForm(
+            {"tool_configuration": self.tool_config.pk, "service_key_1": "k1"},
+            user=user,
+        )
+
+    def test_unprivileged_user_is_offered_no_tool_configurations(self):
+        form = Product_API_Scan_ConfigurationForm(user=self.unprivileged)
+        self.assertNotIn(self.tool_config, form.fields["tool_configuration"].queryset)
+
+    def test_unprivileged_user_cannot_submit_a_tool_configuration(self):
+        form = self._post(self.unprivileged)
+        self.assertFalse(form.is_valid())
+        self.assertIn("tool_configuration", form.errors)
+
+    def test_privileged_user_can_select_the_tool_configuration(self):
+        form = self._post(self.staff)
+        self.assertIn(self.tool_config, form.fields["tool_configuration"].queryset)
+        self.assertNotIn("tool_configuration", form.errors)
+
+    def _serializer(self, user):
+        product = self.create_product("scanconf-product", prod_type=self.product_type)
+        return ProductAPIScanConfigurationSerializer(
+            data={"product": product.pk, "tool_configuration": self.tool_config.pk, "service_key_1": "k1"},
+            context={"request": SimpleNamespace(user=user)},
+        )
+
+    def test_rest_rejects_unauthorized_tool_configuration(self):
+        serializer = self._serializer(self.unprivileged)
+        with self.assertRaises(PermissionDenied):
+            serializer.is_valid(raise_exception=True)
+
+    def test_rest_allows_authorized_tool_configuration(self):
+        serializer = self._serializer(self.staff)
+        self.assertTrue(serializer.is_valid(), serializer.errors)


### PR DESCRIPTION
Hardening / consistency improvement to API scan configuration setup. The tool
configuration selected when adding or editing an API scan configuration is now
scoped to the configurations the requesting user is authorized to view, in both
the web form and the REST serializer, matching the authorization already
enforced on the tool-configuration views. Adds a regression test.

No functional change for correctly-permissioned users. Users who manage tool
configurations continue to select them as before; users without that permission
are no longer offered configurations they cannot otherwise access.
