### PR TITLE
fix(importers): keep the reimport target test when a report declares no tests

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -273,7 +273,16 @@ class BaseImporter(ImporterOptions):
         # Make sure we have at least one test returned
         if len(tests) == 0:
             logger.info(f"No tests found in import for {self.scan_type}")
-            self.test = None
+            # A report that describes no tests is a report with no findings, not a failure: every
+            # later step (dedupe algorithm, close-old-findings bookkeeping, timestamps, product
+            # grading) still needs a Test to work against, so self.test must never be left unset.
+            #
+            # On reimport the caller supplied the Test being reimported into; clearing it here made
+            # the whole rest of the reimport operate on None and surfaced as a 500 for what is a
+            # valid empty report. On import there is no Test yet and none can be named from the
+            # report, so fall back to the scan type exactly as the static-test-type path does.
+            if not self.test:
+                self.create_test(self.scan_type)
             return parsed_findings
         # for now we only consider the first test in the list and artificially aggregate all findings of all tests
         # this is the same as the old behavior as current import/reimporter implementation doesn't handle the case

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -301,9 +301,16 @@ class BaseImporter(ImporterOptions):
             # During reimport, validate that the test_type matches the incoming report.
             # Accept either the current (idempotent) name or the legacy name the pre-patch code
             # produced, so reimports into tests created before the doubling fix keep working.
+            #
+            # The bare scan type is accepted too. A report that declares no tests names no tool
+            # either, so the Test created for it falls back to the scan type; the same is true of
+            # a Test created outside the dynamic path. The check exists to stop a report from a
+            # different tool being reimported into a Test, and the bare scan type carries no tool
+            # identity to conflict with. The historical name is kept rather than rewritten, as it
+            # is for the legacy name above.
             expected_test_type_name = self.resolve_dynamic_test_type_name(test_raw.type)
             legacy_test_type_name = self.legacy_dynamic_test_type_name(test_raw.type)
-            if self.test.test_type.name not in {expected_test_type_name, legacy_test_type_name}:
+            if self.test.test_type.name not in {expected_test_type_name, legacy_test_type_name, self.scan_type}:
                 msg = (
                     f"Test type mismatch: Test {self.test.id} has test_type '{self.test.test_type.name}', "
                     f"but the report contains test_type '{expected_test_type_name}'. "

--- a/unittests/scans/sarif/no_runs.sarif
+++ b/unittests/scans/sarif/no_runs.sarif
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": []
+}

--- a/unittests/test_importers_importer.py
+++ b/unittests/test_importers_importer.py
@@ -588,6 +588,128 @@ class TestDojoDefaultImporter(DojoTestCase):
         self.assertEqual(legacy_doubled_name, test.test_type.name)
         self.assertGreater(len_new_findings, 0)
 
+    # Regression: a dynamic-test-type report carrying no tests dropped the reimport target test
+    def _setup_dynamic_no_runs_reimport(self, suffix: str):
+        """Import a SARIF report with one finding and return (test, user, environment) for a reimport."""
+        scan_type = "SARIF"
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type, _ = Product_Type.objects.get_or_create(name=f"test_no_runs_{suffix}")
+        product, _ = Product.objects.get_or_create(
+            name=f"TestNoRuns{suffix}",
+            description="test product",
+            prod_type=product_type,
+        )
+        engagement, _ = Engagement.objects.get_or_create(
+            name=f"Test No Runs {suffix} Engagement",
+            product=product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        environment, _ = Development_Environment.objects.get_or_create(name="Development")
+        import_options = {
+            "user": user,
+            "lead": user,
+            "scan_date": None,
+            "environment": environment,
+            "minimum_severity": "Info",
+            "active": True,
+            "verified": True,
+            "scan_type": scan_type,
+            "engagement": engagement,
+            "close_old_findings": False,
+        }
+        with (get_unit_tests_scans_path("sarif") / "appendix_k2.sarif").open(encoding="utf-8") as scan:
+            test, _, len_new_findings, _, _, _, _ = DefaultImporter(**import_options).process_scan(scan)
+        self.assertGreater(len_new_findings, 0)
+        return test, user, environment
+
+    def test_reimport_dynamic_test_type_report_without_tests_keeps_test(self):
+        """A report with zero tests must not drop the reimport target: the supplied test is returned unchanged."""
+        test, user, environment = self._setup_dynamic_no_runs_reimport("Keep")
+        original_test_type_name = test.test_type.name
+        reimport_options = {
+            "test": test,
+            "user": user,
+            "lead": user,
+            "scan_date": None,
+            "environment": environment,
+            "minimum_severity": "Info",
+            "active": True,
+            "verified": True,
+            "scan_type": "SARIF",
+            "close_old_findings": False,
+        }
+        reimporter = DefaultReImporter(**reimport_options)
+        with (get_unit_tests_scans_path("sarif") / "no_runs.sarif").open(encoding="utf-8") as scan:
+            # Must NOT raise "'NoneType' object has no attribute ..." for an empty report
+            test_after_reimport, _, len_new_findings, _, _, _, _ = reimporter.process_scan(scan)
+        self.assertIsNotNone(test_after_reimport)
+        self.assertEqual(test.id, test_after_reimport.id)
+        self.assertEqual(0, len_new_findings)
+        test.refresh_from_db()
+        self.assertEqual(original_test_type_name, test.test_type.name)
+
+    def test_import_dynamic_test_type_report_without_tests_creates_empty_test(self):
+        """A first import of a report with zero tests must yield an empty test rather than failing."""
+        scan_type = "SARIF"
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type, _ = Product_Type.objects.get_or_create(name="test_no_runs_import")
+        product, _ = Product.objects.get_or_create(
+            name="TestNoRunsImport",
+            description="test product",
+            prod_type=product_type,
+        )
+        engagement, _ = Engagement.objects.get_or_create(
+            name="Test No Runs Import Engagement",
+            product=product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        environment, _ = Development_Environment.objects.get_or_create(name="Development")
+        import_options = {
+            "user": user,
+            "lead": user,
+            "scan_date": None,
+            "environment": environment,
+            "minimum_severity": "Info",
+            "active": True,
+            "verified": True,
+            "scan_type": scan_type,
+            "engagement": engagement,
+            "close_old_findings": False,
+        }
+        importer = DefaultImporter(**import_options)
+        with (get_unit_tests_scans_path("sarif") / "no_runs.sarif").open(encoding="utf-8") as scan:
+            test, _, len_new_findings, _, _, _, _ = importer.process_scan(scan)
+        self.assertIsNotNone(test)
+        self.assertEqual(0, len_new_findings)
+        # No report content to name the test type after, so it falls back to the scan type
+        self.assertEqual(scan_type, test.test_type.name)
+
+    def test_reimport_dynamic_test_type_report_without_tests_closes_old_findings(self):
+        """Zero tests means zero findings reported, so close_old_findings must mitigate what the test still holds."""
+        test, user, environment = self._setup_dynamic_no_runs_reimport("Close")
+        reimport_options = {
+            "test": test,
+            "user": user,
+            "lead": user,
+            "scan_date": None,
+            "environment": environment,
+            "minimum_severity": "Info",
+            "active": True,
+            "verified": True,
+            "scan_type": "SARIF",
+            "close_old_findings": True,
+        }
+        reimporter = DefaultReImporter(**reimport_options)
+        with (get_unit_tests_scans_path("sarif") / "no_runs.sarif").open(encoding="utf-8") as scan:
+            _, _, _, len_closed_findings, _, _, _ = reimporter.process_scan(scan)
+        self.assertGreater(len_closed_findings, 0)
+        self.assertFalse(
+            Finding.objects.filter(test=test, is_mitigated=False).exists(),
+            msg="every finding in the test should be mitigated after reimporting a report with no results",
+        )
+
 
 class FlexibleImportTestAPI(DojoAPITestCase):
     def __init__(self, *args, **kwargs):

--- a/unittests/test_importers_importer.py
+++ b/unittests/test_importers_importer.py
@@ -686,6 +686,29 @@ class TestDojoDefaultImporter(DojoTestCase):
         # No report content to name the test type after, so it falls back to the scan type
         self.assertEqual(scan_type, test.test_type.name)
 
+        # A later report that does name a tool must still reimport into that test: the bare scan
+        # type is not a "Test type mismatch", or the first empty report would poison the test.
+        reimport_options = {
+            "test": test,
+            "user": user,
+            "lead": user,
+            "scan_date": None,
+            "environment": environment,
+            "minimum_severity": "Info",
+            "active": True,
+            "verified": True,
+            "scan_type": scan_type,
+            "close_old_findings": False,
+        }
+        reimporter = DefaultReImporter(**reimport_options)
+        with (get_unit_tests_scans_path("sarif") / "appendix_k2.sarif").open(encoding="utf-8") as scan:
+            test_after_reimport, _, len_new_findings, _, _, _, _ = reimporter.process_scan(scan)
+        self.assertEqual(test.id, test_after_reimport.id)
+        self.assertGreater(len_new_findings, 0)
+        test.refresh_from_db()
+        # The historical name is preserved, as it is for legacy doubled names
+        self.assertEqual(scan_type, test.test_type.name)
+
     def test_reimport_dynamic_test_type_report_without_tests_closes_old_findings(self):
         """Zero tests means zero findings reported, so close_old_findings must mitigate what the test still holds."""
         test, user, environment = self._setup_dynamic_no_runs_reimport("Close")


### PR DESCRIPTION
**Description**

A reimport of a **dynamic-test-type report that declares no tests** fails with an HTTP 500 and this error:

```
AttributeError: 'NoneType' object has no attribute 'deduplication_algorithm'
```

Dynamic test types are the meta formats whose `Test_Type` name comes from the report rather than from the scan type — SARIF, Generic Findings Import and the ~9 others whose parser exposes `get_tests()`. For SARIF, `get_tests()` iterates `runs`, so a report with `"runs": []` yields **zero tests**. That is a well-formed report: a merge step that had no scanner output to combine emits exactly this.

`BaseImporter.consolidate_dynamic_tests()` responded to zero tests by clearing `self.test`:

```python
if len(tests) == 0:
    logger.info(f"No tests found in import for {self.scan_type}")
    self.test = None
    return parsed_findings
```

On reimport that discards the Test the caller supplied, and every later step then runs against `None`. The first one to touch it is the dedupe-algorithm lookup at the top of `_process_findings_internal`, so the request dies before anything about the report is processed:

```
dojo/importers/default_reimporter.py:121   in process_scan          -> self.process_findings(...)
dojo/importers/default_reimporter.py:281   in process_findings      -> self._process_findings_internal(...)
dojo/importers/default_reimporter.py:308   in _process_findings_internal
                                           -> self.determine_deduplication_algorithm()
dojo/importers/base_importer.py:355        in determine_deduplication_algorithm
                                           -> return self.test.deduplication_algorithm
AttributeError: 'NoneType' object has no attribute 'deduplication_algorithm'
```

Reported from a production instance: 10 occurrences inside two minutes on `reimport-scan`, every one of them the same SARIF report with no runs, so a CI job that emits an empty merged report cannot reimport at all.

**The import path is the same endpoint, so it is in scope**

The same branch breaks import too, one step further along: no Test exists yet and none is created, so `_process_findings_internal` fails at `perform_product_grading(self.test.engagement.product)` with `'NoneType' object has no attribute 'engagement'`.

That is reachable from the very same API call. `ReImportScanSerializer.process_scan` routes to the **importer** when no Test matches and `auto_create_context` is set, which is exactly the reported payload. The instance that alerted already had its Test, so it took the reimport branch — but the first empty report on a new product, engagement or branch takes the import branch and fails just as hard. Fixing only the reimport half would leave `reimport-scan` still 500ing on an empty report for anyone who has not uploaded that scan before.

**Fix**

An empty report is a report with **zero findings**, not a failure, and every later step (dedupe algorithm, close-old-findings bookkeeping, timestamps, product grading) still needs a Test to work against. So `self.test` is never left unset:

- **Reimport** keeps the Test it was given. `close_old_findings` then does what the empty report actually means and mitigates the findings the report no longer contains.
- **Import** has no Test yet and cannot name one from an empty report, so it falls back to the scan type — exactly what `parse_findings_static_test_type` already does for non-dynamic parsers.

The `if not self.test` guard is what separates the two, so `create_test` (which only the importer defines) is never reached from the reimporter.

**Second commit: not trading one failure for another**

Creating that Test has a consequence worth calling out, because getting it wrong would have been a regression rather than a fix. With no tool named anywhere in an empty report, the new Test's type is the bare scan type (`SARIF`). A **later** report that *does* name a tool would then have been rejected against that Test as `Test type mismatch`, so a first empty report would have permanently poisoned the Test it created — breaking a call that works today.

So the bare scan type is now accepted alongside the resolved and legacy names. That check exists to stop a report from a *different tool* being reimported into a Test; the bare scan type names no tool, so there is nothing for it to conflict with. Tests created outside the dynamic path are named this way too and gain the same tolerance. The historical name is preserved rather than rewritten, matching how the legacy doubled name is already handled.

**Test results**

TDD, failing test first. New fixture `unittests/scans/sarif/no_runs.sarif` (a SARIF report with `"runs": []`) plus regression tests in `unittests/test_importers_importer.py`:

| Test | Before | After |
|---|---|---|
| reimport keeps its target test | fails — `'NoneType' object has no attribute 'deduplication_algorithm'` | passes |
| reimport with `close_old_findings` mitigates every finding left in the test | fails — same | passes |
| first import creates an empty test named after the scan type | fails — `'NoneType' object has no attribute 'engagement'` | passes |
| …and a later report naming a tool still reimports into that test | n/a (unreachable before) | passes |

The two reimport failures reproduce the reported traceback frame for frame, down to `_process_findings_internal` line 308.

No collateral damage:

- `unittests.test_importers_importer`, `test_import_reimport`, `test_importers_closeold`, `test_importers_deduplication`, `test_apiv2_scan_import_options`, `test_import_execution_mode` — **260 passed, 0 failures**, re-run after the second commit
- `ruff check --config ruff.toml` with the pinned 0.15.20 — clean on both changed files

> Environment note: this sandbox has no Docker, so the suites were run through `manage.py test` against a locally provisioned PostgreSQL 16 cluster on Python 3.13 rather than `run-unittest.sh`. CI is the authority.

**Impact on the Pro plugin**

Checked as part of the acceptance criteria; **no Pro change is required.**

- Pro does not override `consolidate_dynamic_tests`, so it inherits the fix. It is the Pro importer hierarchy that the reported traceback runs through: `ProReImporter.determine_deduplication_algorithm` overrides the OS one and reaches `test.test_type.name` first, so the same defect surfaces there as `'NoneType' object has no attribute 'test_type'` — same cause, same line 308, one attribute earlier in the expression.
- Pro's `if not self.test` short-circuits (`_prefetch_sla_for_import`, `process_test_metadata`, the enhanced-test progress writer) all keep working now that the Test is set — they simply stop short-circuiting, which is the intended behaviour. `unsaved_metadata` is initialised in `Test.__init__`, so `process_test_metadata` is safe on a freshly created Test.
- Pro stores the uploaded report against `self.test or self.engagement`. For an empty dynamic report that target moves from the engagement to the Test, which is the correct owner and matches every non-empty report.
- The bare-scan-type tolerance helps Pro specifically: its import preview engine creates Tests with `test_type` set to the scan type, and a dynamic-format reimport into one of those would have hit `Test type mismatch` before this change.
- `ProReImporter.__init__` already carries a guard for a reimporter constructed without a test (the Smart Importer path). That guard is unrelated to this branch and is untouched.

**Documentation**

No documentation change: this restores the documented behaviour of import/reimport (the 500 was never an expected outcome) and adds no setting, input, output or API surface. The reasoning is captured in comments at both changed branches.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch — based on and targeting `bugfix`.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant — tests were run on 3.13.
- [x] Add applicable tests to the unit tests.
- [ ] Model changes must include the necessary migrations — N/A, no model changes.
- [x] Label suggested: `bugfix`.

**Reported via**

- https://defectdojo-workspace.slack.com/archives/C0BK62Q76P8/p1785461402674499
- https://defectdojo-workspace.slack.com/archives/C0BK62Q76P8/p1785461521501049

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhG7DzWsVpuozjFjJMP9rw