### PR TITLE
fix(search): render result panes, open the right tab, survive bad input

### DIFF
--- a/dojo/search/views.py
+++ b/dojo/search/views.py
@@ -97,6 +97,11 @@ def simple_search(request):
     findings_filter = None
     title_words = None
     component_words = None
+    # Only the GET branch below fills these in, but every request reaches the render
+    # call at the end -- including the HEAD and OPTIONS requests that monitoring and
+    # link-preview bots send, which CSRF does not turn away.
+    generic = None
+    activetab = "generic"
 
     # if request.method == 'GET' and "query" in request.GET:
     if request.method == "GET":
@@ -162,7 +167,10 @@ def simple_search(request):
                 logger.debug("searching finding id")
 
                 findings = authorized_findings
-                findings = findings.filter(id=operators["id"][0])
+                finding_id = operators["id"][0]
+                # ids come straight from the query string, so anything that is not a
+                # plain number would blow up the queryset instead of finding nothing.
+                findings = findings.filter(id=finding_id) if finding_id.isdigit() else findings.none()
 
             elif search_findings:
                 logger.debug("searching findings")
@@ -370,14 +378,22 @@ def simple_search(request):
 
         add_breadcrumb(title=_("Simple Search"), top_level=True, request=request)
 
-        activetab = "findings" if findings \
-            else "products" if products \
-                else "engagements" if engagements else \
-                    "tests" if tests else \
-                         "endpoint" if endpoints else \
-                            "tagged" if tagged_results else \
-                                "vulnerability_ids" if vulnerability_ids else \
-                                    "generic"
+        # The tab to open on load: the first facet that has results. Every name here has
+        # to be one the template knows how to map to a pane, otherwise it falls through to
+        # the "no pane opens" case and the results area looks empty until the visitor
+        # clicks a tab themselves.
+        activetab = next((name for name, results in (
+            ("findings", findings),
+            ("products", products),
+            ("engagements", engagements),
+            ("tests", tests),
+            ("endpoints", endpoints),
+            ("tagged", tagged_results),
+            ("vulnerability_ids", vulnerability_ids),
+            ("finding_templates", finding_templates),
+            ("languages", languages),
+            ("technologies", app_analysis),
+        ) if results), "generic")
 
     response = render(request, "dojo/simple_search.html", {
         "clean_query": original_clean_query,
@@ -423,7 +439,14 @@ def parse_search_query(clean_query):
     operators = {}  # operator:parameter formatted in searchquery, i.e. tag:php
     keywords = []  # just keywords to search on
 
-    query_parts = shlex.split(clean_query)
+    try:
+        query_parts = shlex.split(clean_query)
+    except ValueError:
+        # shlex raises on an unbalanced quote, which a visitor types the moment they
+        # start wrapping a phrase in quotes. Fall back to a plain whitespace split so
+        # they get results for what they typed so far instead of a 500.
+        logger.debug("could not shlex-split query, falling back to a whitespace split: %s", clean_query)
+        query_parts = clean_query.split()
 
     for query_part in query_parts:
         if ":" in query_part:

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -490,7 +490,7 @@
                                 </ul>
                                 <div class="tab-content">
                                     {% if top_ten_products %}
-                                        <div class="table-responsive tab-pane" id="tabs-1" x-show="activeTab === 'tabs-1'" x-cloak>
+                                        <div class="table-responsive tab-pane" id="tabs-1" :class="activeTab === 'tabs-1' && 'active'">
                                             <table
                                                     class="table table-bordered table-condensed table-striped table-400">
                                                 <tr>
@@ -515,7 +515,7 @@
                                             </table>
                                         </div>
                                     {% endif %}
-                                    <div class="tab-pane table-responsive" id="tabs-2" x-show="activeTab === 'tabs-2'" x-cloak>
+                                    <div class="tab-pane table-responsive" id="tabs-2" :class="activeTab === 'tabs-2' && 'active'">
                                         {% if findings.count > max_findings_details %}
                                         <div>
                                             <em>Note:</em> {{ max_findings_details }} Findings listed of {{ findings.count }} total.
@@ -557,7 +557,7 @@
                                             {% endfor %}
                                         </table>
                                     </div>
-                                    <div class="tab-pane" id="tabs-3" x-show="activeTab === 'tabs-3'" x-cloak>
+                                    <div class="tab-pane" id="tabs-3" :class="activeTab === 'tabs-3' && 'active'">
                                         <div class="table-responsive">
                                             <h4>{% trans "Opened During Period" %}</h4>
                                             <table
@@ -608,7 +608,7 @@
                                             </table>
                                         </div>
                                     </div>
-                                    <div class="tab-pane" id="tabs-4" x-show="activeTab === 'tabs-4'" x-cloak>
+                                    <div class="tab-pane" id="tabs-4" :class="activeTab === 'tabs-4' && 'active'">
                                         <div class="table-responsive">
                                             <h4>{% trans "Accepted in Period" %}</h4>
                                             <table
@@ -661,7 +661,7 @@
 
 
                                     </div>
-                                    <div class="tab-pane" id="tabs-5" x-show="activeTab === 'tabs-5'" x-cloak>
+                                    <div class="tab-pane" id="tabs-5" :class="activeTab === 'tabs-5' && 'active'">
                                         <div class="table-responsive">
                                             <h4>{% trans "Closed in Period" %}</h4>
                                             <table
@@ -713,7 +713,7 @@
                                             </table>
                                         </div>
                                     </div>
-                                    <div class="tab-pane" id="tabs-6" x-show="activeTab === 'tabs-6'" x-cloak>
+                                    <div class="tab-pane" id="tabs-6" :class="activeTab === 'tabs-6' && 'active'">
                                         <div class="metric-half table-responsive">
                                             <table class="table table-bordered table-condensed table-striped">
                                                 <tr>
@@ -768,7 +768,7 @@
                                             <p>{% trans "*Closed findings may have been opened outside of requested period." %}</p>
                                         </div>
                                     </div>
-                                    <div class="tab-pane" id="tabs-7" x-show="activeTab === 'tabs-7'" x-cloak>
+                                    <div class="tab-pane" id="tabs-7" :class="activeTab === 'tabs-7' && 'active'">
                                         <div class="metric-half table-responsive">
                                             <table class="table table-bordered table-condensed table-striped">
                                                 <tr>
@@ -818,7 +818,7 @@
                                             </table>
                                         </div>
                                     </div>
-                                    <div class="tab-pane table-responsive" id="tabs-8" x-show="activeTab === 'tabs-8'" x-cloak>
+                                    <div class="tab-pane table-responsive" id="tabs-8" :class="activeTab === 'tabs-8' && 'active'">
                                         <table
                                                 class="table table-bordered table-condensed table-striped table-400">
                                             <tr>

--- a/dojo/templates/dojo/simple_search.html
+++ b/dojo/templates/dojo/simple_search.html
@@ -35,7 +35,7 @@
         <p></p>
     </div>
 
-    <div role="tabpanel" x-data="{ activeTab: '{% if activetab == 'findings' %}tabs-1{% elif activetab == 'vulnerability_ids' %}tabs-2{% elif activetab == 'products' %}tabs-3{% elif activetab == 'engagements' %}tabs-4{% elif activetab == 'tests' %}tabs-5{% elif activetab == 'endpoints' %}tabs-6{% elif activetab == 'tagged' %}tabs-10{% elif activetab == 'generic' %}tabs-11{% else %}tabs-1{% endif %}' }">
+    <div role="tabpanel" x-data="{ activeTab: '{% if activetab == 'findings' %}tabs-1{% elif activetab == 'vulnerability_ids' %}tabs-2{% elif activetab == 'products' %}tabs-3{% elif activetab == 'engagements' %}tabs-4{% elif activetab == 'tests' %}tabs-5{% elif activetab == 'endpoints' %}tabs-6{% elif activetab == 'finding_templates' %}tabs-7{% elif activetab == 'languages' %}tabs-8{% elif activetab == 'technologies' %}tabs-9{% elif activetab == 'tagged' %}tabs-10{% elif activetab == 'generic' %}tabs-11{% else %}tabs-1{% endif %}' }">
 
         <!-- Nav tabs -->
         <ul class="nav nav-tabs" role="tablist">
@@ -101,13 +101,13 @@
         <!-- Tab panes -->
         <div class="tab-content">
             {% if findings %}
-                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-1" x-show="activeTab === 'tabs-1'" x-cloak>
+                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-1" :class="activeTab === 'tabs-1' && 'active'">
                     {% comment %} include inherits the current context so findings, filtered and other variables {% endcomment %}
                     {% include "dojo/findings_list_snippet.html" with form_id="custom_search_filter" %}
                 </div>
             {% endif %}
             {% if vulnerability_ids %}
-                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-2" x-show="activeTab === 'tabs-2'" x-cloak>
+                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-2" :class="activeTab === 'tabs-2' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -160,7 +160,7 @@
                 </div>
             {% endif %}
             {% if products %}
-                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-3" x-show="activeTab === 'tabs-3'" x-cloak>
+                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-3" :class="activeTab === 'tabs-3' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -186,7 +186,7 @@
                 </div>
             {% endif %}
             {% if engagements %}
-                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-4" x-show="activeTab === 'tabs-4'" x-cloak>
+                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-4" :class="activeTab === 'tabs-4' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -219,7 +219,7 @@
                 </div>
             {% endif %}
             {% if tests %}
-                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-5" x-show="activeTab === 'tabs-5'" x-cloak>
+                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-5" :class="activeTab === 'tabs-5' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -257,7 +257,7 @@
                 </div>
             {% endif %}
             {% if endpoints %}
-                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-6" x-show="activeTab === 'tabs-6'" x-cloak>
+                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-6" :class="activeTab === 'tabs-6' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -295,7 +295,7 @@
                 </div>
             {% endif %}
             {% if finding_templates %}
-                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-7" x-show="activeTab === 'tabs-7'" x-cloak>
+                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-7" :class="activeTab === 'tabs-7' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -320,7 +320,7 @@
             {% if languages %}
             <div role="tabpanel"
                  class="table-responsive tab-pane"
-                 id="tabs-8" x-show="activeTab === 'tabs-8'" x-cloak>
+                 id="tabs-8" :class="activeTab === 'tabs-8' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -345,7 +345,7 @@
             {% if app_analysis %}
             <div role="tabpanel"
                  class="table-responsive tab-pane"
-                 id="tabs-9" x-show="activeTab === 'tabs-9'" x-cloak>
+                 id="tabs-9" :class="activeTab === 'tabs-9' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -370,7 +370,7 @@
             {% if tagged_findings or tagged_finding_templates or tagged_products or tagged_tests or tagged_endpoints or tagged_engagements %}
                 <div role="tabpanel"
                      class="table-responsive tab-pane"
-                     id="tabs-10" x-show="activeTab === 'tabs-10'" x-cloak>
+                     id="tabs-10" :class="activeTab === 'tabs-10' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -440,7 +440,7 @@
             {% endif %}
             {% if generic %}
                 <div role="tabpanel" class="table-responsive tab-pane"
-                     id="tabs-11" x-show="activeTab === 'tabs-11'" x-cloak>
+                     id="tabs-11" :class="activeTab === 'tabs-11' && 'active'">
                     <table class="table table-striped">
                         <thead>
                         <tr>

--- a/dojo/templates_classic/dojo/simple_search.html
+++ b/dojo/templates_classic/dojo/simple_search.html
@@ -70,17 +70,17 @@
                 </li>
             {% endif %}
             {% if finding_templates %}
-                <li role="presentation">
+                <li role="presentation" {% if activetab == 'finding_templates' %}class="active"{% endif %}>
                     <a href="#tabs-7" role="tab" data-toggle="tab">{% trans "Finding Templates" %} ({{ finding_templates|length }})</a>
                 </li>
             {% endif %}
             {% if languages %}
-                <li role="presentation">
+                <li role="presentation" {% if activetab == 'languages' %}class="active"{% endif %}>
                     <a href="#tabs-8" role="tab" data-toggle="tab">{% trans "Languages" %} ({{ languages|length }})</a>
                 </li>
             {% endif %}
             {% if app_analysis %}
-                <li role="presentation">
+                <li role="presentation" {% if activetab == 'technologies' %}class="active"{% endif %}>
                     <a href="#tabs-9" role="tab" data-toggle="tab">{% trans "Application Technolgies" %} ({{ app_analysis|length }})</a>
                 </li>
             {% endif %}
@@ -295,7 +295,7 @@
                 </div>
             {% endif %}
             {% if finding_templates %}
-                <div role="tabpanel" class="table-responsive tab-pane" id="tabs-7">
+                <div role="tabpanel" class="table-responsive tab-pane {% if activetab == 'finding_templates' %}active{% endif %}" id="tabs-7">
                     <table class="table table-striped">
                         <thead>
                         <tr>
@@ -319,7 +319,7 @@
             {% endif %}
             {% if languages %}
             <div role="tabpanel"
-                 class="table-responsive tab-pane"
+                 class="table-responsive tab-pane {% if activetab == 'languages' %}active{% endif %}"
                  id="tabs-8">
                     <table class="table table-striped">
                         <thead>
@@ -344,7 +344,7 @@
             {% endif %}
             {% if app_analysis %}
             <div role="tabpanel"
-                 class="table-responsive tab-pane"
+                 class="table-responsive tab-pane {% if activetab == 'technologies' %}active{% endif %}"
                  id="tabs-9">
                     <table class="table table-striped">
                         <thead>

--- a/dojo/templatetags/filter_tags.py
+++ b/dojo/templatetags/filter_tags.py
@@ -100,7 +100,15 @@ def get_filter_groups(form):
         {% for group in filter_groups %}
             {{ group.name }} — {{ group.fields }}
         {% endfor %}
+
+    Pages that render a filter panel without having a filter form -- the search page
+    does that for an ``id:`` query -- resolve ``form`` to the empty string, so return
+    no groups rather than raising. The classic templates looped over
+    ``form.visible_fields`` directly, which failed silently the same way.
     """
+    if not hasattr(form, "visible_fields"):
+        return []
+
     visible_fields = list(form.visible_fields())
 
     if not _is_finding_filter(form):

--- a/unittests/test_search_parser.py
+++ b/unittests/test_search_parser.py
@@ -66,3 +66,12 @@ class TestSearch(DojoTestCase):
         self.assertEqual(operators["cve"][0], "CVE-2020-1234")
         self.assertEqual(len(keywords), 1)
         self.assertEqual(keywords[0], "jquery")
+
+    def test_parse_query_with_unbalanced_quote(self):
+        # A visitor typing a quoted phrase has an unbalanced quote for as long as it
+        # takes them to type the closing one, and shlex refuses to split that. Parsing
+        # falls back to a whitespace split rather than raising.
+        operators, keywords = parse_search_query('tags:anchore "space inside')
+        self.assertEqual(len(operators), 1)
+        self.assertEqual(operators["tags"][0], "anchore")
+        self.assertEqual(keywords, ['"space', "inside"])

--- a/unittests/test_simple_search_bad_input.py
+++ b/unittests/test_simple_search_bad_input.py
@@ -1,0 +1,40 @@
+from django.test import override_settings
+from django.urls import reverse
+
+from dojo.models import Dojo_User
+from unittests.dojo_test_case import DojoTestCase, versioned_fixtures
+
+# Each of these used to return a 500. The query string is visitor input and the request
+# method is whatever a client decides to send, so neither may reach an unguarded queryset
+# or a local the view only assigns on the GET path.
+#
+# V3_FEATURE_LOCATIONS is pinned off to match OSS CI defaults, as in
+# test_simple_search_scoping.py.
+
+
+@override_settings(SECURE_SSL_REDIRECT=False, V3_FEATURE_LOCATIONS=False, WATSON_SEARCH_ENABLED=True)
+@versioned_fixtures
+class TestSimpleSearchBadInput(DojoTestCase):
+    fixtures = ["dojo_testdata.json"]
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(Dojo_User.objects.get(username="admin"))
+        self.url = reverse("simple_search")
+
+    def test_non_numeric_finding_id_finds_nothing(self):
+        response = self.client.get(self.url, {"query": "id:abc"})
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["findings"])
+
+    def test_unbalanced_quote_still_searches(self):
+        response = self.client.get(self.url, {"query": '"unbalanced'})
+        self.assertEqual(response.status_code, 200)
+
+    def test_head_request_renders(self):
+        # Uptime monitors and link-preview bots send these, and CSRF does not turn a
+        # safe method away.
+        self.assertEqual(self.client.head(self.url, {"query": "anything"}).status_code, 200)
+
+    def test_options_request_renders(self):
+        self.assertEqual(self.client.options(self.url).status_code, 200)

--- a/unittests/test_simple_search_tab_panes.py
+++ b/unittests/test_simple_search_tab_panes.py
@@ -1,0 +1,60 @@
+import re
+
+from django.test import override_settings
+from django.urls import reverse
+
+from dojo.models import Dojo_User, Finding, UserContactInfo
+from unittests.dojo_test_case import DojoTestCase, versioned_fixtures
+
+# Opening tag of the findings result pane. [^>] also matches newlines, so a pane whose
+# attributes are spread over several lines is still caught, and it cannot run past the
+# end of the tag.
+FINDINGS_PANE_TAG = re.compile(r'<div[^>]*\bid="tabs-1"[^>]*>')
+CARRIES_ACTIVE = re.compile(r"\bactive\b")
+
+# The stylesheet hides every result pane that does not carry the `active` class:
+#     .tab-content > .tab-pane { display: none }
+#     .tab-content > .tab-pane.active { display: block }
+# so the pane of the tab the view opened on has to get that class from somewhere -- a
+# literal class in the classic templates, an Alpine `:class` binding in the Tailwind
+# ones. Alpine's x-show cannot do that job: it only clears the inline `display: none`
+# it set itself, which leaves the class rule in force and the pane invisible. That is
+# what made the whole results area render blank while the tab headers and their result
+# counts rendered fine.
+#
+# Both UI trees are covered, because UIPreferenceLoader picks the tree per user and the
+# panes are wired up differently in each. The status code assertion matters as much as
+# the pane assertion for the Tailwind tree: an `id:` query leaves the view without a
+# filter form, which used to make the filter panel raise while rendering.
+#
+# V3_FEATURE_LOCATIONS is pinned off to match OSS CI defaults, as in
+# test_simple_search_scoping.py.
+
+
+@override_settings(SECURE_SSL_REDIRECT=False, V3_FEATURE_LOCATIONS=False, WATSON_SEARCH_ENABLED=True)
+@versioned_fixtures
+class TestSimpleSearchTabPanes(DojoTestCase):
+    fixtures = ["dojo_testdata.json"]
+
+    def _findings_pane_for_ui(self, *, use_tailwind):
+        admin = Dojo_User.objects.get(username="admin")
+        contact, _ = UserContactInfo.objects.get_or_create(user=admin)
+        contact.ui_use_tailwind = use_tailwind
+        contact.save()
+        self.client.force_login(admin)
+
+        # An `id:` query needs no watson index, so the findings tab opens deterministically.
+        finding = Finding.objects.first()
+        response = self.client.get(reverse("simple_search"), {"query": f"id:{finding.id}"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["activetab"], "findings")
+
+        pane = FINDINGS_PANE_TAG.search(response.content.decode())
+        self.assertIsNotNone(pane, "findings result pane did not render")
+        return pane.group(0)
+
+    def test_active_pane_is_displayable_in_tailwind_ui(self):
+        self.assertRegex(self._findings_pane_for_ui(use_tailwind=True), CARRIES_ACTIVE)
+
+    def test_active_pane_is_displayable_in_classic_ui(self):
+        self.assertRegex(self._findings_pane_for_ui(use_tailwind=False), CARRIES_ACTIVE)


### PR DESCRIPTION
Shortcut: [sc-14109](https://app.shortcut.com/defectdojo/story/14109)

## Problem

Reported from the field, reproducible on the demo instance: `/simple_search?query=Apple` returns a **completely blank results area**. The server was finding results the whole time — the response carried 44 findings and 548KB of rendered rows — but every pane was invisible, so the page showed tab headers with counts above an empty box.

## Root cause

The stylesheet drives pane visibility off a class:

```css
.tab-content>.tab-pane{display:none}
.tab-content>.tab-pane.active{display:block}
```

The Tailwind rebuild (#14865) moved the tab strip from Bootstrap JS to Alpine, but the panes got `x-show` + `x-cloak` instead of that class. `x-show` only *clears the inline `display:none` it set itself* — it never sets `display:block` — so the class rule stayed in force and no pane could ever be shown. The `<li>` nav items did get `:class="... && 'active'"`, which is why the headers highlighted correctly while the body stayed empty.

Confirmed in the live DOM: Alpine state `{activeTab: "tabs-1"}`, inline style correctly removed, computed display still `none`, 548KB of rows inside. Adding `active` by hand made 2184px of results appear.

## Changes

**1. Result panes bind the class the CSS looks for** — 11 panes in `dojo/simple_search.html`, matching the pattern the nav items in the same file already use. `dojo/metrics.html` had the identical defect on all 8 of its panes (Top Ten, Detail Breakdown, Opened/Accepted/Closed, Trending, Age of Issues all rendered blank), fixed the same way. These are the only two templates in the Tailwind tree that use `.tab-pane`.

**2. The right tab opens** — `activetab` emitted `"endpoint"` while both template trees match on `'endpoints'`, and had no branch at all for finding templates, languages or technologies. Those facets fell through to `{% else %}tabs-1`, naming a pane that doesn't exist for them, so nothing opened. Rewrote the nested conditional as an ordered list (same precedence, three names appended) and added the `tabs-7/8/9` mappings. The classic tree got matching `active` markup on the same three nav items and panes so both UIs behave identically.

**3. Three ways to 500 the page**, all reachable by any logged-in user:

| Request | Was | Cause |
|---|---|---|
| `?query="foo` | 500 | `shlex.split` raises `ValueError: No closing quotation` |
| `?query=id:abc` | 500 | `filter(id="abc")` raises `ValueError` |
| `HEAD` / `OPTIONS` | 500 | `generic` and `activetab` only assigned on the GET path |

The third is the nastiest in practice: `HEAD` and `OPTIONS` are CSRF-exempt safe methods, so uptime monitors and link-preview bots hitting `/simple_search` get a 500 and an error notification. A stray quote now costs nothing — `?query="Critical` returns the same `Findings (4)` as `Critical`, since watson tokenizes it away — and balanced phrases still go through `shlex` unchanged.

**4. Filter panel no longer raises without a form** — an `id:` query leaves the view with `findings_filter = None`, so `{% include "dojo/filter_snippet.html" with form=filtered.form %}` resolves `form` to the empty string and the Tailwind tree's `{% get_filter_groups form %}` tag called `''.visible_fields()`. Guarded the tag, which restores the classic templates' silent-empty behaviour and protects every other page that includes that panel.

## Verification

Reproduced and fixed against a local instance (before/after on the same URL, same browser, only the code changed):

- `?query=Critical` → Findings tab opens with rows (was blank)
- `language:python`, `technology:apache`, `template:xss`, `endpoint:demo.local` → each auto-opens its own tab (was blank until clicked)
- `?query=id:1` → 200 (was 500)
- `/metrics/all` → 8 panes render again
- Clicking between tabs still swaps panes correctly

## Tests

New `unittests/test_simple_search_tab_panes.py` asserts the pane of whatever tab the view opened on carries `active`, across **both** UI trees — `UIPreferenceLoader` picks the tree per user, and a first draft passed even with the fix reverted because the fixture admin renders classic, so the test pins `ui_use_tailwind` explicitly. New `unittests/test_simple_search_bad_input.py` covers the non-numeric id, unbalanced quote, HEAD and OPTIONS. One case added to `test_search_parser.py` for the parser fallback.

Every new test was confirmed to fail on the unfixed code, with the expected exceptions:

```
Regex didn't match: '\bactive\b' not found in '<div ... x-show="activeTab === 'tabs-1'" x-cloak>'
ValueError: No closing quotation
ValueError: Field 'id' expected a number but got 'abc'.
UnboundLocalError: cannot access local variable 'activetab'
```

Related suites green with the fixes in place — 17 tests, OK (2 skipped) across `test_search_parser`, `test_simple_search_scoping`, `test_simple_search_tab_panes`, `test_simple_search_bad_input`, `test_watson_search_disabled`, `test_watson_async_search_index`, `test_metrics_queries`. Repo-pinned ruff clean.

## Notes for reviewers

- No configuration or watson reindex is needed to pick this up — it is purely a rendering fix.
- Pro overrides `/simple_search` with its native search, so it is unaffected on this route, but the same Alpine-vs-`.tab-pane` conversion is worth grepping for in the Pro template tree.
- Two related issues found while verifying and **deliberately left out** of this PR: bare keywords never match tags (tags aren't in the watson index, and the tagged facet's include/exclude conditions cancel out for keyword-only queries), and `language:`/`technology:`/`template:` ignore their operator value entirely. The second needs a product decision on what those operators should mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194T9DVqApVwSDQD4rjT9NX