### PR TITLE
Harden user account management authorization

### DIFF
--- a/dojo/user/api/views.py
+++ b/dojo/user/api/views.py
@@ -6,6 +6,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema_view
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
 from rest_framework.response import Response
@@ -20,6 +21,7 @@ from dojo.user.api.serializer import (
     UserSerializer,
 )
 from dojo.user.authentication import reset_token_for_user
+from dojo.user.utils import user_may_delete_account
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +48,9 @@ class UsersViewSet(
                 "Users may not delete themselves",
                 status=status.HTTP_400_BAD_REQUEST,
             )
+        if not user_may_delete_account(request.user, instance):
+            msg = "Only superusers are allowed to delete superusers or staff users."
+            raise PermissionDenied(msg)
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/dojo/user/ui/views.py
+++ b/dojo/user/ui/views.py
@@ -47,6 +47,7 @@ from dojo.user.ui.forms import (
     EditDojoUserForm,
     UserContactInfoForm,
 )
+from dojo.user.utils import user_may_delete_account
 from dojo.utils import add_breadcrumb, get_page_items, get_setting, get_system_setting
 
 logger = logging.getLogger(__name__)
@@ -442,10 +443,10 @@ def delete_user(request, uid):
         if "id" in request.POST and str(user.id) == request.POST["id"]:
             form = DeleteUserForm(request.POST, instance=user)
             if form.is_valid():
-                if not request.user.is_superuser and user.is_superuser:
+                if not user_may_delete_account(request.user, user):
                     messages.add_message(request,
                                         messages.ERROR,
-                                        _("Only superusers are allowed to delete superusers. User was not removed."),
+                                        _("Only superusers are allowed to delete superusers or staff users. User was not removed."),
                                         extra_tags="alert-danger")
                 else:
                     try:

--- a/dojo/user/utils.py
+++ b/dojo/user/utils.py
@@ -115,3 +115,16 @@ def get_configuration_permissions_codenames():
         codenames.extend(permission_field.codenames())
 
     return codenames
+
+
+def user_may_delete_account(acting_user, target_user):
+    """
+    Whether acting_user is allowed to delete target_user.
+
+    is_superuser and is_staff are both reserved to superusers on the write path
+    (UserSerializer.validate), and in Open Source is_staff is an unconditional
+    authorization bypass, so deletion honours the same floor.
+    """
+    if acting_user.is_superuser:
+        return True
+    return not (target_user.is_superuser or target_user.is_staff)

--- a/unittests/test_apiv2_user_delete_authz.py
+++ b/unittests/test_apiv2_user_delete_authz.py
@@ -1,0 +1,88 @@
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient, APITestCase
+
+from dojo.models import User
+from unittests.dojo_test_case import versioned_fixtures
+
+
+@versioned_fixtures
+class UserDeleteAuthzTest(APITestCase):
+
+    """
+    A non-superuser holding the user-management configuration permissions must
+    not be able to delete a superuser or a staff account. The write-path guards
+    in UserSerializer.validate() do not run on DELETE, so the viewset carries
+    the same privilege floor.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    def setUp(self):
+        self.delegate = User.objects.create_user(
+            username="delete_authz_delegate",
+            password="not-a-real-secret",  # noqa: S106 - test fixture user
+        )
+        self.delegate.user_permissions.add(
+            Permission.objects.get(codename="view_user", content_type__app_label="auth"),
+            Permission.objects.get(codename="change_user", content_type__app_label="auth"),
+            Permission.objects.get(codename="delete_user", content_type__app_label="auth"),
+        )
+        self.superuser_target = User.objects.create_user(
+            username="delete_authz_superuser",
+            password="not-a-real-secret",  # noqa: S106 - test fixture user
+            is_superuser=True,
+        )
+        self.staff_target = User.objects.create_user(
+            username="delete_authz_staff",
+            password="not-a-real-secret",  # noqa: S106 - test fixture user
+            is_staff=True,
+        )
+        self.regular_target = User.objects.create_user(
+            username="delete_authz_regular",
+            password="not-a-real-secret",  # noqa: S106 - test fixture user
+        )
+        token = Token.objects.create(user=self.delegate)
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+
+    def _user_url(self, user_id):
+        return f"{reverse('user-list')}{user_id}/"
+
+    def _superuser_client(self):
+        admin = User.objects.get(username="admin")
+        admin_token, _ = Token.objects.get_or_create(user=admin)
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION="Token " + admin_token.key)
+        return client
+
+    def test_delegate_cannot_delete_superuser(self):
+        r = self.client.delete(self._user_url(self.superuser_target.id))
+        self.assertEqual(r.status_code, 403, r.content[:1000])
+        self.assertTrue(User.objects.filter(pk=self.superuser_target.pk).exists())
+
+    def test_delegate_cannot_delete_staff_user(self):
+        r = self.client.delete(self._user_url(self.staff_target.id))
+        self.assertEqual(r.status_code, 403, r.content[:1000])
+        self.assertTrue(User.objects.filter(pk=self.staff_target.pk).exists())
+
+    def test_delegate_can_delete_regular_user(self):
+        r = self.client.delete(self._user_url(self.regular_target.id))
+        self.assertEqual(r.status_code, 204, r.content[:1000])
+        self.assertFalse(User.objects.filter(pk=self.regular_target.pk).exists())
+
+    def test_delegate_cannot_delete_themselves(self):
+        r = self.client.delete(self._user_url(self.delegate.id))
+        self.assertEqual(r.status_code, 400, r.content[:1000])
+        self.assertTrue(User.objects.filter(pk=self.delegate.pk).exists())
+
+    def test_superuser_can_delete_superuser(self):
+        r = self._superuser_client().delete(self._user_url(self.superuser_target.id))
+        self.assertEqual(r.status_code, 204, r.content[:1000])
+        self.assertFalse(User.objects.filter(pk=self.superuser_target.pk).exists())
+
+    def test_superuser_can_delete_staff_user(self):
+        r = self._superuser_client().delete(self._user_url(self.staff_target.id))
+        self.assertEqual(r.status_code, 204, r.content[:1000])
+        self.assertFalse(User.objects.filter(pk=self.staff_target.pk).exists())


### PR DESCRIPTION
Hardening / consistency improvement to user account management authorization. Adds an additional authorization check on an account management operation and a regression test. No functional change for correctly-permissioned users.