### PR TITLE
docs: correct the Threat Intelligence floor to describe Priority, not just the Risk band

### DIFF
--- a/docs/content/asset_modelling/PRO_hierarchy/threat_intelligence.md
+++ b/docs/content/asset_modelling/PRO_hierarchy/threat_intelligence.md
@@ -64,15 +64,16 @@ exploited in the wild receives only a small absolute bump, and could still sit i
 under Low.
 
 So there is a second, categorical rule. When threat intelligence reports **active
-exploitation in the wild**, the finding's Risk band is raised to a configured minimum
-regardless of what Priority alone would have produced. It ships set to **Needs Action**;
-each product type can raise it to Urgent, lower it, or clear it to switch the floor off, in
-Prioritization Engine settings under *Actively-Exploited Risk Floor*.
+exploitation in the wild**, the finding's Priority is raised to at least the level of a
+configured Risk band, regardless of what the weighted calculation alone produced. It ships
+set to **Needs Action**; each product type can raise it to Urgent, lower it, or clear it to
+switch the floor off, in Prioritization Engine settings under *Actively-Exploited Risk
+Floor*.
 
-The floor only ever raises a band — it never moves a finding down, and a finding that
-already bands higher on its own is untouched. Priority itself is left exactly as calculated,
-so that number stays explainable; the Risk band and Risk score are floored together, so
-sorting and filtering by Risk stay consistent.
+The floor only ever raises — it never moves a finding down, and a finding that already
+scores higher on its own is untouched. Because it applies to Priority, the Risk band and
+Risk score follow from it automatically, so every list, filter, chart and SLA calculation
+sees the same consistent number.
 
 ## Findings without a CVE
 


### PR DESCRIPTION
## Description

Follow-up correction to #15450, which merged while the Pro-side implementation was still
being revised.

That page currently says the actively-exploited floor raises the finding's **Risk band**,
and that "Priority itself is left exactly as calculated". Both were true of the first
implementation, and are no longer: exploitability is scoring input, so the floor now raises
**Priority**, with the Risk band and Risk score following from it. That keeps every list,
filter, chart and SLA calculation consistent with one another.

Docs-only, one file, no code.
