### PR TITLE
Harden authorization on finding-template apply/read views

### DIFF
--- a/dojo/finding/ui/views.py
+++ b/dojo/finding/ui/views.py
@@ -1849,6 +1849,7 @@ def find_template_to_apply(request, fid):
 def choose_finding_template_options(request, tid, fid):
     finding = get_object_or_404(Finding, id=fid)
     user_has_permission_or_403(request.user, finding, "edit")
+    user_has_global_permission_or_403(request.user, "edit")
     template = get_object_or_404(Finding_Template, id=tid)
     data = finding.__dict__.copy()
     # Remove tags and other non-serializable fields
@@ -1937,6 +1938,7 @@ def choose_finding_template_options(request, tid, fid):
 def apply_template_to_finding(request, fid, tid):
     finding = get_object_or_404(Finding, id=fid)
     user_has_permission_or_403(request.user, finding, "edit")
+    user_has_global_permission_or_403(request.user, "edit")
     template = get_object_or_404(Finding_Template, id=tid)
 
     if request.method == "POST":

--- a/dojo/test/ui/views.py
+++ b/dojo/test/ui/views.py
@@ -23,7 +23,7 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie
 
 import dojo.finding.helper as finding_helper
-from dojo.authorization.authorization import user_has_permission_or_403
+from dojo.authorization.authorization import user_has_global_permission_or_403, user_has_permission_or_403
 from dojo.engagement.queries import get_authorized_engagements
 from dojo.finding.queries import prefetch_for_findings
 from dojo.finding.ui.filters import FindingFilter, FindingFilterWithoutObjectLookups, TemplateFindingFilter
@@ -636,6 +636,8 @@ def add_finding_from_template(request, tid, fid):
     jform = None
     test = get_object_or_404(Test, id=tid)
     user_has_permission_or_403(request.user, test, "add")
+    # fid is a Finding_Template id, not a finding; templates are a shared cross-product store
+    user_has_global_permission_or_403(request.user, "edit")
     template = get_object_or_404(Finding_Template, id=fid)
     findings = Finding_Template.objects.all()
     push_all_jira_issues = jira_services.is_push_all_issues(template)

--- a/unittests/test_apply_finding_template.py
+++ b/unittests/test_apply_finding_template.py
@@ -225,10 +225,12 @@ class TestApplyFindingTemplate(DojoTestCase):
                                     "impact": "template impact"},
                                    )
 
-    def test_authorized_user_can_apply_template(self):
+    def test_product_member_without_global_edit_cannot_apply_template(self):
         """
-        Legacy: any user in product.authorized_users can apply a template
-        (Reader/Writer/Maintainer/Owner all collapse to one bit of access).
+        A user authorized on the target finding's product but without global
+        template access must not apply a template: applying reads the template's
+        content, and templates are a global, cross-product store. This matches
+        the gate already on find_template_to_apply and the /template list view.
         """
         product = self.finding.test.engagement.product
         member = FindingTemplateTestUtil.create_user_with_role(product, "Writer", is_staff=False)
@@ -242,10 +244,8 @@ class TestApplyFindingTemplate(DojoTestCase):
                   "mitigation": "template mitigation",
                   "impact": "template impact"},
         )
-        with impersonate(member):
-            result = views.apply_template_to_finding(request, fid=self.finding.id, tid=self.template.id)
-            self.assertEqual(302, result.status_code)
-            self.assertEqual(f"/finding/{self.finding.id}", result.url)
+        with impersonate(member), self.assertRaises(PermissionDenied):
+            views.apply_template_to_finding(request, fid=self.finding.id, tid=self.template.id)
 
     def test_non_member_cannot_apply_template(self):
         """
@@ -618,3 +618,75 @@ class TestAddFindingFromTemplate(DojoTestCase):
         self.assertIsNotNone(self.template.last_used)
         if original_last_used:
             self.assertGreaterEqual(self.template.last_used, original_last_used)
+
+
+@versioned_fixtures
+class TestFindingTemplateCrossTenantReadAuthz(DojoTestCase):
+
+    """
+    Regression for the report: a user who can edit a finding in one product must
+    not read arbitrary Finding_Template content through the views that take a
+    template id directly. find_template_to_apply and the /template list already
+    require global template access; choose_finding_template_options,
+    apply_template_to_finding and add_finding_from_template must match it, so the
+    permission checked is on the same object whose data is returned.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    SECRET = "TENANT_B_SECRET_TEMPLATE_BODY"
+
+    def setUp(self):
+        super().setUp()
+        System_Settings().save()
+        pt_a, _ = Product_Type.objects.get_or_create(name="TPLR-A PT")
+        tt, _ = Test_Type.objects.get_or_create(name="TPLR Scan")
+
+        prod_a = Product.objects.create(name="TPLR Product A", description="A", prod_type=pt_a)
+        eng_a = Engagement.objects.create(name="TPLR Eng A", product=prod_a, target_start=timezone.now(), target_end=timezone.now())
+        self.test_a = Test.objects.create(engagement=eng_a, test_type=tt, target_start=timezone.now(), target_end=timezone.now())
+        self.own_finding = Finding.objects.create(
+            test=self.test_a, title="TPLR own finding A", description="benign",
+            severity="Low", numerical_severity="S3", active=True,
+        )
+
+        self.template = Finding_Template.objects.create(
+            title="TPLR confidential template", cwe=89, severity="Critical",
+            description=self.SECRET, mitigation=self.SECRET, impact=self.SECRET,
+        )
+
+        # Attacker: non-staff, non-superuser, Writer on product A only, no global role.
+        self.attacker = FindingTemplateTestUtil.create_user_with_role(prod_a, "Writer", is_staff=False)
+        prod_a.authorized_users.add(Dojo_User.objects.get(pk=self.attacker.pk))
+
+    def test_choose_finding_template_options_denied(self):
+        request = FindingTemplateTestUtil.create_get_request(
+            self.attacker, f"finding/{self.template.id}/{self.own_finding.id}/choose_finding_template_options")
+        with impersonate(self.attacker), self.assertRaises(PermissionDenied):
+            views.choose_finding_template_options(request, tid=self.template.id, fid=self.own_finding.id)
+
+    def test_apply_template_to_finding_denied(self):
+        request = FindingTemplateTestUtil.create_post_request(
+            self.attacker, f"finding/{self.own_finding.id}/{self.template.id}/apply_template_to_finding",
+            data={"title": "x", "cwe": "89", "severity": "Low",
+                  "description": "x", "mitigation": "x", "impact": "x"})
+        with impersonate(self.attacker), self.assertRaises(PermissionDenied):
+            views.apply_template_to_finding(request, fid=self.own_finding.id, tid=self.template.id)
+        # The template content must not have been copied onto the attacker's finding.
+        self.own_finding.refresh_from_db()
+        self.assertNotIn(self.SECRET, self.own_finding.description)
+
+    def test_add_finding_from_template_denied(self):
+        request = FindingTemplateTestUtil.create_get_request(
+            self.attacker, f"/test/{self.test_a.id}/add_findings/{self.template.id}")
+        with impersonate(self.attacker), self.assertRaises(PermissionDenied):
+            test_views.add_finding_from_template(request, tid=self.test_a.id, fid=self.template.id)
+
+    def test_staff_with_global_edit_still_reads_template(self):
+        # The legitimate path keeps working for a user who holds global template access.
+        staff = FindingTemplateTestUtil.create_user(is_staff=True)
+        request = FindingTemplateTestUtil.create_get_request(
+            staff, f"finding/{self.template.id}/{self.own_finding.id}/choose_finding_template_options")
+        with impersonate(staff):
+            result = views.choose_finding_template_options(request, tid=self.template.id, fid=self.own_finding.id)
+        self.assertEqual(200, result.status_code)


### PR DESCRIPTION
Hardening / consistency improvement to finding-template authorization.

Three views accept a finding-template id directly and previously authorized only the related finding or test, not access to the template itself. This adds the same global template-access check that the apply-template flow and the template list view already enforce, so the permission checked matches the object whose data is returned. Includes regression tests. No functional change for correctly-permissioned users.
