### PR TITLE
docs(compliance): document the CMMC partial-credit column

### DIFF
--- a/docs/content/federal_compliance/cmmc_assessments.md
+++ b/docs/content/federal_compliance/cmmc_assessments.md
@@ -26,12 +26,21 @@ Record a result for each of the 110 requirements:
 
 ![The requirements workflow](images/06-cmmc-requirements.png)
 
+### Partial credit
+
+A few requirements have a documented partial condition that the methodology scores at a reduced
+deduction rather than the full weight. Where one exists, the **Partial Credit** column lets you
+record it, and the requirement deducts the reduced points instead. `3.13.11` is the example:
+encryption employed, but not FIPS-validated, deducts 3 instead of 5.
+
+Requirements with no documented partial condition always deduct their full weight.
+
 ## What the assessment computes
 
 ### SPRS score
 
-110 minus the weight of every requirement that is not met or merely planned. Weights are 1, 3, or
-5 points, so scores range from 110 down to -203.
+110 minus the deduction for every requirement that is not met or merely planned. Weights are 1, 3,
+or 5 points, so scores range from 110 down to -203.
 
 Requirement 3.12.4 (the System Security Plan requirement) scores as not applicable, per the
 methodology.


### PR DESCRIPTION
Documents the CMMC **Partial Credit** column, which the Federal Compliance section currently shows in a screenshot without explaining anywhere.

A few requirements have a documented partial condition that the DoD methodology scores at a reduced deduction rather than the full weight. `3.13.11` is the example: encryption employed but not FIPS-validated deducts 3 instead of 5. Requirements with no documented partial condition always deduct their full weight.

Also corrects the SPRS description just below it, which said the score subtracts "the weight of" every unmet requirement. With partial credit that is not true — it subtracts the *deduction*, which is the reduced value where one applies.

### Why this is a separate PR

It missed the merge window on #15453 by minutes. The content was written while reviewing the CMMC screenshots for that PR, and the branch was pushed after #15453 had already merged, so it has been sitting unattached since.

One file, +11/-2, no new links or shortcodes. Branch is up to date with `bugfix`.
