### PR TITLE
docs(notes): document markdown, editing and history in notes

### DIFF
--- a/docs/content/triage_findings/findings_workflows/intro_to_findings.md
+++ b/docs/content/triage_findings/findings_workflows/intro_to_findings.md
@@ -68,6 +68,22 @@ The Finding Page contains various components. Each will be populated by the Impo
 
 The **Notes** page on a Finding is where your team records context that isn't part of the imported scan data — mitigation progress, triage decisions, or any other commentary. Notes are DefectDojo-only metadata and are never created at import time.
 
+Notes appear as a feed, newest first, and you can flip the order to oldest first. Each note shows its author, when it was written, its note type, and a **Private** badge when the note is private. A private note is only ever shown to the person who wrote it.
+
+### Writing notes in markdown
+
+Note entries support markdown, so you can use headings, **bold** and *italic* text, bullet and numbered lists, block quotes, tables, links, and fenced code blocks. The note editor is the same one used for a Finding's description, with a toolbar for the common formatting options. To read a note exactly as it was typed rather than as formatted text, use the toggle in the top right of the note body.
+
+### Editing, deleting and history
+
+Every note carries an actions menu with **Edit**, **View History** and **Delete**, and each entry appears only when you are allowed to use it:
+
+* You can always edit, delete and read the history of a note you wrote yourself.
+* To manage someone else's note you need the matching role permission on the object the note belongs to: Note Edit, Note Delete, or Note View History.
+* Adding a note requires Note Add, which every role above Reader holds, and Readers hold as well.
+
+An edited note is labelled **(edited)** and records who changed it and when. **View History** lists every revision of the note, newest first, so nothing is lost when a note is rewritten. Only the entry itself can be changed: a note's type and its private flag are fixed once the note is created.
+
 ### Mentioning a user with @
 
 When you add a note, you can **@mention** another DefectDojo user to notify them. Type `@` immediately followed by their username (for example `@alice`) anywhere in the note. When you save the note, each mentioned user receives a **user-mentioned** notification that links back to the note.
@@ -79,7 +95,7 @@ A few details worth knowing:
 * A trailing period is ignored, so a mention that ends a sentence (`thanks @alice.`) still resolves.
 * You can mention more than one user in a single note.
 
-You can @mention users in notes on **Findings** and **Tests** from the UI, and in notes added to **Engagements** and **Risk Acceptances** through the API.
+You can @mention users from the UI in notes on **Findings**, **Tests**, **Engagements** and **Risk Acceptances**. Typing `@` opens a list of matching users; picking one from that list is the reliable way to mention someone, because it inserts the username exactly as the notification lookup expects it.
 
 The mention is delivered through the `user_mentioned` notification event. See [Notifications](/admin/notifications/about_notifications/) for how notifications are delivered and configured — in particular, `user_mentioned` is one of the events a system-level setting can still deliver even when a user has otherwise quieted their notifications (see [Specific overrides](/admin/notifications/about_notifications/#specific-overrides)).
 


### PR DESCRIPTION
## Description

Documents the reworked Notes experience in the Pro UI, and corrects one statement about @mentions that is no longer accurate.

Notes previously rendered as plain text and could only be created from the UI. They now render markdown, and can be edited and deleted, with every revision kept and viewable. The "Notes and @mentions" section of *Introduction to Findings* did not describe any of that.

### What was added

- **The note feed.** Newest first with an option to flip the order, showing each note's author, timestamp and type, plus a **Private** badge. A private note is only ever shown to the person who wrote it.
- **Writing notes in markdown.** Which constructs are supported, that the editor is the same one used for a Finding's description, and the toggle for reading a note exactly as it was typed.
- **Editing, deleting and history.** The per-note actions and the permission rules behind them: you can always manage a note you wrote yourself, and managing someone else's needs Note Edit, Note Delete or Note View History on the object the note belongs to. Adding a note needs Note Add, which every role holds. An edited note is labelled and records who changed it and when, and the history lists every revision. A note's type and private flag are fixed once it is created.

### What was corrected

The page said UI @mentions were limited to Findings and Tests, with Engagements and Risk Acceptances reachable only through the API. That is no longer true: all four support mentions from the UI. The replacement text also points readers at the suggestion list, since picking a name from it inserts the username in the exact form the notification lookup matches.

## Testing

Documentation only. No code, templates or settings are touched, so there is nothing to run. The prose was checked against the shipped behaviour it describes.

## Notes for reviewers

The change is confined to one file, `docs/content/triage_findings/findings_workflows/intro_to_findings.md`: 17 lines added and 1 replaced, all inside the existing "Notes and @mentions" section. No new page, no navigation change, no images.
