### PR TITLE
docs(navigation): document the reorganized Pro Settings menu and the All Settings page

### DIFF
--- a/docs/content/asset_modelling/PRO_surveys/PRO__surveys.md
+++ b/docs/content/asset_modelling/PRO_surveys/PRO__surveys.md
@@ -118,7 +118,7 @@ To respond to a Survey, non-Superusers must have the link shared with them direc
 
 #### Enabling Anonymous Responses 
 
-By default, Surveys are only accessible by DefectDojo Users. To allow external parties to respond to DefectDojo Surveys, ensure the **Enable Anonymous Survey Responses** option has been toggled in the **System Settings**, which is found within the **Pro Settings** submenu within the sidebar.
+By default, Surveys are only accessible by DefectDojo Users. To allow external parties to respond to DefectDojo Surveys, ensure the **Enable Anonymous Survey Responses** option has been toggled in the **System Settings**, which is found under **Settings > System** in the sidebar (within the **Pro Settings** submenu on instances still using the previous menu layout).
 
 ![image](images/pq_ss6.png)
 

--- a/docs/content/get_started/about/ui_pro_vs_os.md
+++ b/docs/content/get_started/about/ui_pro_vs_os.md
@@ -36,7 +36,7 @@ To access the Pro UI, open your User Options menu from the top-right hand corner
 
 5. The **Settings** section allows you to configure your DefectDojo instance, including your Integrations, License, Cloud Settings, Users, Feature Configuration and admin-level Enterprise Settings.
 
-6. The **Pro Settings** section contains the System Settings, Banner Settings, Notification Settings, Jira Instances, Deduplication Settings, and Authentication Settings, including SAML, OIDC, OAuth, Login, and MFA forms.
+6. The **Settings** section holds the administrative pages, grouped as System, Users & Permissions, Finding Workflow, Configuration, Notifications, Operations, and License & Support, with an **All Settings** page that lists and searches all of them. See [The Settings Menu](/navigation/pro__settings_menu/).
 
 7. The Pro UI also has a **new table format**, used in the [Product Hierarchy](/asset_modelling/os_hierarchy/product_hierarchy/) to help with navigation.  Each column can be clicked on to apply a relevant filter, and columns can be reordered to present data however you like.
 

--- a/docs/content/issue_tracking/jira/PRO__jira_guide.md
+++ b/docs/content/issue_tracking/jira/PRO__jira_guide.md
@@ -30,7 +30,7 @@ While the integration is disabled, there is no **Jira Instances** entry in the s
 
 ### Enable the integration
 
-1. Navigate to **\<Your Edition\> Settings \> System Settings** from the DefectDojo sidebar.  The menu is named after your license package, so it reads **Pro Settings** on a Pro instance and **Enterprise Settings** on an Enterprise instance.
+1. Navigate to **Settings \> System \> System Settings** from the DefectDojo sidebar. On instances still using the previous menu layout this sits under a group named after your license package — **Pro Settings** or **Enterprise Settings**. See [The Settings Menu](/navigation/pro__settings_menu/).
 ​
 2. In the **Jira Integration Settings** section, check **Enable Jira Integration**.
 ​

--- a/docs/content/navigation/PRO__settings_menu.md
+++ b/docs/content/navigation/PRO__settings_menu.md
@@ -1,0 +1,79 @@
+---
+title: "The Settings Menu"
+description: "How the Settings section of the DefectDojo Pro sidebar is organized, the All Settings directory page, and how to switch between the current and previous layouts"
+weight: 6
+audience: pro
+---
+
+The Settings section of the sidebar groups every administrative page in DefectDojo Pro. Which layout you see depends on when your instance was created:
+
+- **New installations** open on the reorganized layout described below.
+- **Existing installations** keep the previous layout until an administrator turns on **Menu 2.0** (see [Switching layouts](#switching-layouts)).
+
+Either way, **every settings page keeps the same URL**. Bookmarks, saved links and anything in your own runbooks continue to work regardless of which layout is active.
+
+## The reorganized layout
+
+Settings is divided into seven groups, named for what you are trying to do rather than for the part of the system involved.
+
+| Group | What it holds |
+| --- | --- |
+| **System** | System Settings, Appearance, Announcement Banner, Login Banner, E-mail, Feature Flags |
+| **Users & Permissions** | Users, Groups, Roles |
+| **Finding Workflow** | The three Deduplication pages, Finding Enrichment, Service Level Agreements, Prioritization Engines, Mitigation Policies |
+| **Configuration** | Environments, Regulations, Note Types, Test Types, CI/CD Infrastructure, Tool Types, Tool Configurations |
+| **Notifications** | Notification Events, Notification Webhooks |
+| **Operations** | Audit Logs, Usage Logs, Schedules, Celery Status, and — on DefectDojo Cloud — Message Portal, Firewall Rules, Maintenance Windows |
+| **License & Support** | License Manager, Version Manager, Contact Support |
+
+You only ever see the entries your account has permission to open, and a group disappears entirely when none of its pages are available to you.
+
+Two conventions are worth knowing:
+
+- **There are no separate "New" entries.** Each list page has a **New** button that opens the create form, so the menu carries one entry per catalog instead of two. If your account can create a record but not list them, the menu entry takes you straight to the create form.
+- **Nothing nests more than one level below a group.** Reaching a page is at most Settings → group → page.
+
+## All Settings
+
+The first entry in the section, **All Settings**, opens a directory of every settings page your account can reach, arranged in the same groups as the menu and searchable by name or by what the page does. Searching `deduplication` finds the three deduplication pages *and* System Settings, because System Settings holds deduplication options too.
+
+The last category, **Elsewhere in the app**, lists pages that configure DefectDojo but live in other sidebar sections — the authorization providers, Login and MFA settings, Jira instances, the Upstream and Downstream connectors, and the Universal Parser. Each tile is chipped with the section it belongs to.
+
+## What moved
+
+If you are used to the previous layout:
+
+| Previously | Now |
+| --- | --- |
+| Settings → *(top level)* → Feature Flags | Settings → System → Feature Flags |
+| Settings → Pro Settings → System Settings | Settings → System → System Settings |
+| Settings → Pro Settings → Appearance | Settings → System → Appearance |
+| Settings → Pro Settings → Banner Settings → Announcement Banner Settings | Settings → System → Announcement Banner |
+| Settings → Pro Settings → Banner Settings → Login Banner Settings | Settings → System → Login Banner |
+| Settings → Pro Settings → E-mail Settings | Settings → System → E-mail |
+| Settings → Users → All Users / New User | Settings → Users & Permissions → Users |
+| Settings → Users → All Groups / New Group | Settings → Users & Permissions → Groups |
+| Settings → Users → Roles | Settings → Users & Permissions → Roles |
+| Settings → Pro Settings → Deduplication Settings → *(three pages)* | Settings → Finding Workflow → Same Tool / Cross Tool / Reimport Deduplication |
+| Settings → Pro Settings → Finding Enrichment Settings | Settings → Finding Workflow → Finding Enrichment |
+| Settings → Configuration → Service Level Agreements | Settings → Finding Workflow → Service Level Agreements |
+| Settings → Configuration → Prioritization Engines | Settings → Finding Workflow → Prioritization Engines |
+| Settings → Configuration → Mitigation Policies | Settings → Finding Workflow → Mitigation Policies |
+| Settings → Configuration → *(reference-data catalogs)* | Settings → Configuration → *(unchanged)* |
+| Settings → Pro Settings → Notification Settings | Settings → Notifications |
+| Settings → Configuration → Audit Logs | Settings → Operations → Audit Logs |
+| Settings → Configuration → Usage log | Settings → Operations → Usage Logs |
+| Settings → Configuration → All Schedules | Settings → Operations → Schedules |
+| Settings → Pro Settings → Celery Status | Settings → Operations → Celery Status |
+| Settings → Cloud Manager → *(cloud pages)* | Settings → Operations |
+| Settings → License Manager / Version Manager / Contact Support | Settings → License & Support |
+
+The group that was named after your license package — **Pro Settings** on a Pro instance, **Enterprise Settings** on an Enterprise one — no longer exists. Its pages are distributed across System, Finding Workflow, Notifications and Operations.
+
+## Switching layouts
+
+**Menu 2.0** on the [Feature Flags](/admin/feature_flags/pro__feature_flags/) page controls which layout is active. Turning it on or off reshapes the sidebar immediately; no restart is needed and nothing else about your instance changes.
+
+New installations start with it on. Existing installations start with it off, so an upgrade never rearranges the menu under a team mid-flight — turn it on when your administrators are ready.
+
+While it is off, the **All Settings** page is unavailable and its URL returns Not Found.

--- a/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.md
@@ -12,7 +12,7 @@ Deduplication Tuning is a DefectDojo Pro feature that gives you fine-grained con
 ## Deduplication Settings
 
 In DefectDojo Pro, you can access Deduplication Tuning through:
-**Settings > Pro Settings > Deduplication Settings**
+**Settings > Finding Workflow** (**Settings > Pro Settings > Deduplication Settings** on instances still using the previous menu layout)
 
 ![image](images/deduplication_tuning.png)
 

--- a/docs/content/triage_findings/finding_deduplication/PRO__global_component_deduplication.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__global_component_deduplication.md
@@ -19,7 +19,7 @@ Once the feature is enabled, **Global Component** will become available as an op
 
 ## Configuring Global Component Deduplication
 
-Global Component can be applied to Same-Tool Deduplication, Cross-Tool Deduplication, or both, and is configured per security tool from **Settings > Pro Settings > Deduplication Settings**.
+Global Component can be applied to Same-Tool Deduplication, Cross-Tool Deduplication, or both, and is configured per security tool from **Settings > Finding Workflow** (**Settings > Pro Settings > Deduplication Settings** on instances still using the previous menu layout; see [The Settings Menu](/navigation/pro__settings_menu/)).
 
 ### Same-Tool
 

--- a/docs/content/triage_findings/finding_deduplication/PRO__global_locations_deduplication.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__global_locations_deduplication.md
@@ -23,7 +23,7 @@ Once the feature is enabled, **Global Locations** becomes available as an option
 
 ## Configuring Global Locations Deduplication
 
-Global Locations can be applied to Same-Tool Deduplication, Cross-Tool Deduplication, or both, and is configured per security tool from **Settings > Pro Settings > Deduplication Settings**.
+Global Locations can be applied to Same-Tool Deduplication, Cross-Tool Deduplication, or both, and is configured per security tool from **Settings > Finding Workflow** (**Settings > Pro Settings > Deduplication Settings** on instances still using the previous menu layout; see [The Settings Menu](/navigation/pro__settings_menu/)).
 
 When you select **Global Locations**, the Hash Code Fields selector is hidden (it does not apply) and a **Location Types** selector appears instead.
 

--- a/docs/content/triage_findings/finding_deduplication/PRO__location_drift_matching.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__location_drift_matching.md
@@ -19,7 +19,7 @@ Each of these previously produced a closed finding plus a "new" finding — losi
 ## Enabling Location Tracking
 
 Location tracking is configured per tool under:
-**Settings > Pro Settings > Deduplication Settings > Reimport Deduplication**
+**Settings > Finding Workflow > Reimport Deduplication** (**Settings > Pro Settings > Deduplication Settings > Reimport Deduplication** on instances still using the previous menu layout)
 
 1. Select the **Security Tool**.
 2. Set the **Deduplication Algorithm** to **Hash Code**. Location tracking applies to the Hash Code algorithm only — tools with a reliable **Unique ID From Tool** already track movement through their stable IDs and do not need it.

--- a/docs/content/triage_findings/finding_deduplication/PRO_enabling_product_deduplication.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO_enabling_product_deduplication.md
@@ -10,7 +10,7 @@ Deduplication can be applied at a Product\-wide level, or scoped more narrowly t
 
 ## Deduplication for Products
 
-1. Navigate to the System Settings page: **Settings \> Pro Settings \> ⚙️ System Settings** on the sidebar.
+1. Navigate to the System Settings page: **Settings \> System \> ⚙️ System Settings** on the sidebar (**Settings \> Pro Settings \> System Settings** on instances still using the previous menu layout).
 
 ![image](images/enabling_product-level_deduplication.png)
 

--- a/docs/content/triage_findings/findings_workflows/finding_status_definitions.md
+++ b/docs/content/triage_findings/findings_workflows/finding_status_definitions.md
@@ -34,7 +34,7 @@ Just because a tool records a problem does not necessarily mean the Finding requ
 
 If you’re able to confirm that the Finding does exist, you can mark it as **Verified**.
 
-Certain DefectDojo functions require Findings to be Active and Verified.  If you don’t need to manually verify each Finding, you can deactivate the Verified requirement for any or all of these functions from the **System Settings** page (**Classic UI: Configuration > System Settings**, **Pro UI: Settings > Pro Settings > System Settings**).
+Certain DefectDojo functions require Findings to be Active and Verified.  If you don’t need to manually verify each Finding, you can deactivate the Verified requirement for any or all of these functions from the **System Settings** page (**Classic UI: Configuration > System Settings**, **Pro UI: Settings > System > System Settings**).
 
 ![image](images/verified_status_toggle.png)
 


### PR DESCRIPTION
## Description

Documents the reorganized Settings menu in DefectDojo Pro, which groups the sidebar's Settings section into seven task-based groups (System, Users & Permissions, Finding Workflow, Configuration, Notifications, Operations, License & Support) and adds an All Settings directory page.

Both layouts are live at once, so the docs have to serve both audiences: new installations start on the reorganized layout, while existing installations keep the previous one until an administrator enables the **Menu 2.0** feature flag. No page changed its URL in the reorganization, so nothing here re-points a link.

### Adds

`navigation/PRO__settings_menu.md` — the groups and what each holds, the All Settings page and its search, a full old-to-new path mapping table, and how to switch between layouts.

### Updates

Nine pages that named a menu path now give the current path first with the previous one in parentheses:

- `triage_findings/finding_deduplication/` — `PRO__deduplication_tuning`, `PRO__global_component_deduplication`, `PRO__global_locations_deduplication`, `PRO__location_drift_matching`, `PRO_enabling_product_deduplication`
- `triage_findings/findings_workflows/finding_status_definitions`
- `issue_tracking/jira/PRO__jira_guide`
- `asset_modelling/PRO_surveys/PRO__surveys`
- `get_started/about/ui_pro_vs_os`

`navigation/PRO__menu_badges` needed no change — the deprecated Tool Types and Tool Configurations entries stay under Configuration in both layouts.

Pairs with the corresponding DefectDojo Pro change, on the same release line.
