### PR TITLE
docs(pro): several optional features are now always on, and one is support-enabled

### DIFF
--- a/docs/content/admin/feature_flags/PRO__feature_flags.md
+++ b/docs/content/admin/feature_flags/PRO__feature_flags.md
@@ -22,6 +22,25 @@ The page lists every optional feature with:
 
 Use the search box to filter the list by feature name or description.
 
+### Features that are not listed
+
+The page lists the features you can choose to adopt. Two kinds of feature are absent from it.
+
+**Always on.** Once a feature reaches general availability it is on for every instance and stops being listed, because there is no longer a decision to make:
+
+* **Downstream Connections** — see [Pro Integrations](/issue_tracking/pro_integration/integrations/)
+* **Universal Parser** — see [Universal Parser](/import_data/pro/specialized_import/universal_parser/)
+* **Asset Hierarchy** — see [Asset Hierarchy](/asset_modelling/pro_hierarchy/asset_hierarchy/)
+* **Appearance** and **Feature Flags** — the two Settings pages of the same name
+
+Nothing changes for your instance if you had one of these turned on. If you had one turned off, it is now on: these features are part of DefectDojo Pro rather than opt-in. Contact [DefectDojo Support](mailto:support@defectdojo.com) if that is a problem for your instance.
+
+**Enabled by DefectDojo on request.** A few capabilities depend on infrastructure that is provisioned per instance, so they are switched on by DefectDojo rather than from this page:
+
+* **Scheduling Service** — see [Scheduling Rules](/automation/rules_engine/scheduling/)
+
+Contact [DefectDojo Support](mailto:support@defectdojo.com) to have one of these enabled. If it is already on for your instance, it stays on.
+
 ## Turning a feature on or off
 
 1. Find the feature in the list.
@@ -89,7 +108,6 @@ Most features are available on both installation types. The exceptions are:
 
 | Feature | Availability | How it is controlled |
 | --- | --- | --- |
-| Downstream Connections | [DefectDojo Pro (Cloud)](/get_started/pro/cloud/) only | Feature Flags page. Shown as **Unavailable on This Deployment** on-premise, which does not run the required infrastructure. See [Pro Integrations](/issue_tracking/pro_integration/integrations/). |
 | Request a New Connector | [DefectDojo Pro (Cloud)](/get_started/pro/cloud/) only | Feature Flags page. Shown as **Unavailable on This Deployment** on-premise. |
 | Locations | Both | Feature Flags page. Note that Locations cannot be turned back off once it is enabled. See [Locations Overview](/asset_modelling/locations/pro__locations_overview/). |
 | Organization / Asset Relabeling | Both | Deployment configuration: `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL`. |

--- a/docs/content/asset_modelling/PRO_hierarchy/asset_hierarchy.md
+++ b/docs/content/asset_modelling/PRO_hierarchy/asset_hierarchy.md
@@ -9,19 +9,15 @@ aliases:
 ---
 DefectDojo Pro is extending the Product/Product Type object classes to provide greater flexibility with the data model.
 
-Currently, this feature is in Beta.
-
 ## Enabling the Hierarchy Feature
 
-Hierarchy features ship with new versions of DefectDojo Pro by default, but existing customers who wish to migrate these features can do so using the following methods
-
-The two pieces are enabled separately, and by different means.
+The two pieces below are separate, and are controlled by different means.
 
 ### Asset Hierarchy
 
-**Asset Hierarchy** enables parent/child relationships between Assets. Once enabled, the hierarchy can be viewed and managed from the **Product** tab in the navigation.
+**Asset Hierarchy** enables parent/child relationships between Assets. The hierarchy is viewed and managed from the **Product** tab in the navigation.
 
-A superuser can turn it on from **Settings > Feature Flags**, on both Cloud and On-Premise instances. See [Feature Flags](/admin/feature_flags/pro__feature_flags/).
+Asset Hierarchy is generally available and on for every instance, Cloud and On-Premise. There is nothing to enable, and it is no longer listed on the Feature Flags page.
 
 ### Label Changes (optional)
 

--- a/docs/content/automation/rules_engine/scheduling.md
+++ b/docs/content/automation/rules_engine/scheduling.md
@@ -8,7 +8,7 @@ audience: pro
 
 Rules can be scheduled to run automatically rather than triggered manually each time.  A scheduled rule will execute against all Findings that match its filter conditions at the configured time.
 
-Scheduling is off by default. A superuser can turn on the **Scheduling Service** from **Settings > Feature Flags**, on both Cloud and On-Premise instances (see [Feature Flags](/admin/feature_flags/pro__feature_flags/)); the **Schedule Rule** option appears once it is enabled.
+Scheduling is off by default and is enabled per instance by DefectDojo rather than from the Feature Flags page. Contact [DefectDojo Support](mailto:support@defectdojo.com) to have the **Scheduling Service** turned on; the **Schedule Rule** option appears once it is. See [Feature Flags](/admin/feature_flags/pro__feature_flags/) for how features DefectDojo manages centrally are shown.
 
 The user setting up the schedule must have the **Change Scheduling Service Schedule** configuration permission.
 

--- a/docs/content/import_data/pro/specialized_import/universal_parser.md
+++ b/docs/content/import_data/pro/specialized_import/universal_parser.md
@@ -9,7 +9,7 @@ aliases:
 ---
 <span style="background-color:rgba(242, 86, 29, 0.3)">Note: The Universal Parser is only available in DefectDojo Pro.</span>
 
-The Universal Parser is currently in Beta.  See our [announcement presentation](https://community.defectdojo.com/universalparser) for more information.
+The Universal Parser is on for every DefectDojo Pro instance; there is nothing to enable. See our [announcement presentation](https://community.defectdojo.com/universalparser) for more information.
 
 ## About Universal Parser
 DefectDojo has a large, regularly updated library of parsers to help security teams ingest data.  However, sometimes users have a tool that's unsupported by the parsers, or they may want to import data into the DefectDojo model differently from the way the parser does.

--- a/docs/content/issue_tracking/pro_integration/integrations.md
+++ b/docs/content/issue_tracking/pro_integration/integrations.md
@@ -5,9 +5,7 @@ audience: pro
 aliases:
   - /en/share_your_findings/integrations
 ---
-**Availability:** Integrations is currently in **Beta** and is only available for **Cloud-hosted** DefectDojo Pro instances. On-premise deployments do not yet have the required infrastructure to support Integrations. If you are an on-premise customer interested in this feature, please contact [support@defectdojo.com](mailto:support@defectdojo.com) for updates on availability.
-
-**Enabling Integrations:** On a Cloud instance, a superuser can turn Integrations on from **Settings > Feature Flags**, where it is listed as **Downstream Connections**. See [Feature Flags](/admin/feature_flags/pro__feature_flags/). On an on-premise instance it is shown as **Unavailable on This Deployment**.
+**Availability:** Integrations are generally available and on for every DefectDojo Pro instance, both Cloud and On-Premise. There is nothing to enable, and they are no longer listed on the Feature Flags page.
 
 DefectDojo Pro's Integrations let you push your Findings and Finding Groups to ticket tracking systems to easily integrate security remediation with your teams existing development workflow.
 


### PR DESCRIPTION
Documentation for a change in which optional Pro features are opt-in.

Five capabilities are now generally available — on for every instance, Cloud and On-Premise, and no longer listed on the Feature Flags page because there is no longer a decision to make:

- Downstream Connections
- Universal Parser
- Asset Hierarchy
- the Appearance settings page
- the Feature Flags settings page

Pages that told readers to switch these on from **Settings > Feature Flags** now say there is nothing to enable, and the beta notices are removed.

Scheduling Service is a separate case. It stays off by default, but it is switched on by DefectDojo per instance rather than from the Feature Flags page, so the Scheduling Rules page now directs readers to support instead of to a toggle that is no longer there.

The Feature Flags page gains a **Features that are not listed** section. Absence from that list previously had no explanation at all, which left a reader who went looking for one of these features with nothing to go on. The section distinguishes the two reasons a feature can be missing — always on, versus enabled by DefectDojo on request — and states what happens to an instance that had one of them turned off.

### Two corrections

Both were pre-existing inaccuracies noticed while writing the above, and are fixed here rather than left in place:

- The Pro Integrations page stated that Integrations were available only on Cloud instances. They have never been restricted by deployment type, and they are on for On-Premise instances too.
- The Universal Parser page still described the feature as being in beta. It is not.

### Also

The Downstream Connections row is removed from the deployment-availability table, since the feature is neither deployment-gated nor listed any more.

### Notes for review

- No content changes outside `docs/content/`.
- New cross-links were checked against the files they resolve to, and follow the lowercase path convention already used elsewhere for the same pages — worth a look regardless, since broken documentation links are not caught automatically.
