### PR TITLE
fix(awssecurityhub): sort resource IDs so hash_code is stable

### DIFF
--- a/docs/content/releases/os_upgrading/3.2.md
+++ b/docs/content/releases/os_upgrading/3.2.md
@@ -2,7 +2,7 @@
 title: 'Upgrading to DefectDojo Version 3.2.x'
 toc_hide: true
 weight: -20260701
-description: Vulnerability ids gain an autodetected type and a uniqueness constraint; findings can now carry multiple CWEs via a new Finding_CWE relationship. Migrations add the type column, de-duplicate vulnerability-id rows, add the uniqueness constraint, create the CWE table, and backfill it. Existing hash codes are unaffected. This release also deprecates the API-based (pull) parsers, the Tool Type / Tool Configuration feature, and the django-dbbackup integration, all scheduled for removal in 3.5.0.
+description: Vulnerability ids gain an autodetected type and a uniqueness constraint; findings can now carry multiple CWEs via a new Finding_CWE relationship. Migrations add the type column, de-duplicate vulnerability-id rows, add the uniqueness constraint, create the CWE table, and backfill it. The vulnerability id and CWE changes leave existing hash codes untouched; the AWS Security Hub parser now sorts resource IDs, which is an identity change for findings that report more than one resource. This release also deprecates the API-based (pull) parsers, the Tool Type / Tool Configuration feature, and the django-dbbackup integration, all scheduled for removal in 3.5.0.
 ---
 
 ## Vulnerability id type
@@ -55,6 +55,30 @@ The `manage.py migrate_cwe` management command is **optional** and is *not* requ
 (it would repeat the work `0285` already did). It exists only as an idempotent re-scan you can run
 later — for example after a parser upgrade changes how a scan's CWEs are derived — to reconcile
 `Finding_CWE` rows from the current `Finding.cwe` values.
+
+## AWS Security Hub parser: deterministic resource IDs
+
+The AWS Security Hub parser lists the resources a finding applies to in the finding description, under a **Resource IDs:** heading. It built that list by joining an unordered Python `set`. Python randomizes string hashing per process, so the resource ARNs came out in a different order in every import — and for a finding that reports more than one resource, that made the description itself different each time.
+
+The description matters here because "AWS Security Hub Scan" declares no entry in `HASHCODE_FIELDS_PER_SCANNER`, so its findings fall back to the legacy hash, which is computed over title, CWE, line, file path and **description**. Re-importing the same unchanged report therefore stored a different `hash_code` every time.
+
+The parser now sorts the resource ARNs before joining them, so the description — and the `hash_code` derived from it — are stable across re-imports. The Test description (**AWS Accounts** and **Finding Origins**) was built the same way and is now sorted too; it is not hashed, but it reshuffled in the UI on every import.
+
+### What you need to do
+
+Nothing is required, but note that this is an identity change for **AWS Security Hub Scan**.
+
+It affects only findings that carry two or more resources. A finding with zero or one resource has just one possible ordering, so its `hash_code` is unchanged by this release.
+
+For the multi-resource findings there is no stable prior identity to preserve: the old value was effectively random per import, so no existing `hash_code` can be matched reliably. Every hash this changes was already changing on its own.
+
+Deduplication for this scan type keys on `unique_id_from_tool` (the Security Hub finding ARN) rather than on `hash_code`, so import and re-import matching itself was never affected. The exposure is the features that read `hash_code`: false positive history, risk acceptance copies, and similar findings.
+
+## Yarn Audit parser: deterministic tree versions and dependents
+
+The Yarn Audit parser (Yarn 2 output) joined unordered `set`s into the finding description and into `component_version`, so the listed dependents and tree versions reshuffled between imports. Both are now sorted.
+
+This is not an identity change: "Yarn Audit Scan" declares its own hash fields (title, severity, file path, vulnerability IDs, CWE), and neither the description nor `component_version` is among them, so no `hash_code` changes. The only difference is that the values stop flapping in the UI.
 
 ## Deprecation: API-based (pull) parsers
 

--- a/dojo/tools/awssecurityhub/compliance.py
+++ b/dojo/tools/awssecurityhub/compliance.py
@@ -34,7 +34,10 @@ class Compliance:
         mitigation += "\n" + finding.get("Remediation", {}).get("Recommendation", {}).get("Url", "")
         description = "This is a Security Hub Finding \n" + finding.get("Description", "") + "\n"
         description += f"**AWS Finding ARN:** {finding_id}\n"
-        description += f"**Resource IDs:** {', '.join(set(resource_arns))}\n"
+        # sorted(): a set of strings iterates in a different order in every process
+        # (PYTHONHASHSEED). description is hashed into hash_code, so an unsorted join
+        # gives the same report a different hash on every import.
+        description += f"**Resource IDs:** {', '.join(sorted(set(resource_arns)))}\n"
         description += f"**AwsAccountId:** {finding.get('AwsAccountId', '')}\n"
         if finding.get("Region"):
             description += f"**Region:** {finding.get('Region', '')}\n"

--- a/dojo/tools/awssecurityhub/parser.py
+++ b/dojo/tools/awssecurityhub/parser.py
@@ -33,8 +33,11 @@ class AwsSecurityHubParser:
         test = ParserTest(
             name=self.ID, parser_type=self.ID, version="",
         )
-        test.description = "**AWS Accounts:** " + ", ".join(set(aws_acc)) + "\n"
-        test.description += "**Finding Origins:** " + ", ".join(set(prod)) + "\n"
+        # sorted(): set iteration order varies per process (PYTHONHASHSEED). This is the
+        # Test description rather than a Finding field, so it is not hashed, but leaving
+        # it unsorted reshuffles the text on every import.
+        test.description = "**AWS Accounts:** " + ", ".join(sorted(set(aws_acc))) + "\n"
+        test.description += "**Finding Origins:** " + ", ".join(sorted(set(prod))) + "\n"
         test.findings = self.get_items(data, report_date)
         return [test]
 

--- a/dojo/tools/yarn_audit/parser.py
+++ b/dojo/tools/yarn_audit/parser.py
@@ -59,8 +59,11 @@ class YarnAuditParser:
             childissue = child.get("Issue")
             childseverity = child.get("Severity")
             child_vuln_version = child.get("Vulnerable Versions")
-            child_tree_versions = ", ".join(set(child.get("Tree Versions")))
-            child_dependents = ", ".join(set(child.get("Dependents")))
+            # sorted(): set iteration order varies per process (PYTHONHASHSEED).
+            # "Yarn Audit Scan" declares hash fields that cover neither description nor
+            # component_version, so neither is hashed -- but both flap between imports.
+            child_tree_versions = ", ".join(sorted(set(child.get("Tree Versions"))))
+            child_dependents = ", ".join(sorted(set(child.get("Dependents"))))
             description += childissue + "\n"
             description += "**Vulnerable Versions:** " + child_vuln_version + "\n"
             description += "**Dependents:** " + child_dependents + "\n"
@@ -81,7 +84,7 @@ class YarnAuditParser:
             if value is not None:
                 dojo_finding.component_name = value
                 if settings.V3_FEATURE_LOCATIONS:
-                    for version in set(child.get("Tree Versions")):
+                    for version in sorted(set(child.get("Tree Versions"))):
                         dojo_finding.unsaved_locations.append(
                             LocationData.dependency(purl_type="npm", name=value, version=str(version)),
                         )

--- a/unittests/scans/awssecurityhub/config_multiple_resources.json
+++ b/unittests/scans/awssecurityhub/config_multiple_resources.json
@@ -1,0 +1,132 @@
+{
+    "findings": [
+        {
+            "SchemaVersion": "2018-10-08",
+            "Id": "arn:aws:securityhub:us-east-1:012345678912:subscription/aws-foundational-security-best-practices/v/1.0.0/EC2.2/finding/a1b2c3d4-1111-2222-3333-444455556666",
+            "ProductArn": "arn:aws:securityhub:us-east-1::product/aws/securityhub",
+            "GeneratorId": "aws-foundational-security-best-practices/v/1.0.0/EC2.2",
+            "ProductName": "Security Hub",
+            "AwsAccountId": "012345678912",
+            "Types": [
+                "Software and Configuration Checks/Industry and Regulatory Standards/AWS-Foundational-Security-Best-Practices"
+            ],
+            "FirstObservedAt": "2024-03-02T10:15:00.000Z",
+            "LastObservedAt": "2024-03-09T10:15:00.000Z",
+            "CreatedAt": "2024-03-02T10:15:00.000Z",
+            "UpdatedAt": "2024-03-09T10:15:00.000Z",
+            "Severity": {
+                "Product": 70,
+                "Label": "HIGH",
+                "Normalized": 70,
+                "Original": "HIGH"
+            },
+            "Title": "EC2.2 The VPC default security group should not allow inbound and outbound traffic",
+            "Description": "This control checks whether the default security group of a VPC allows inbound or outbound traffic.",
+            "Remediation": {
+                "Recommendation": {
+                    "Text": "For directions on how to fix this issue, please consult the AWS Security Hub Foundational Security Best Practices documentation.",
+                    "Url": "https://docs.aws.amazon.com/console/securityhub/EC2.2/remediation"
+                }
+            },
+            "ProductFields": {
+                "StandardsArn": "arn:aws:securityhub:::standards/aws-foundational-security-best-practices/v/1.0.0",
+                "ControlId": "EC2.2",
+                "RecommendationUrl": "https://docs.aws.amazon.com/console/securityhub/EC2.2/remediation",
+                "StandardsControlArn": "arn:aws:securityhub:us-east-1:012345678912:control/aws-foundational-security-best-practices/v/1.0.0/EC2.2",
+                "aws/securityhub/SeverityLabel": "HIGH",
+                "aws/securityhub/ProductName": "Security Hub",
+                "aws/securityhub/CompanyName": "AWS",
+                "aws/securityhub/FindingId": "arn:aws:securityhub:us-east-1::product/aws/securityhub/arn:aws:securityhub:us-east-1:012345678912:subscription/aws-foundational-security-best-practices/v/1.0.0/EC2.2/finding/a1b2c3d4-1111-2222-3333-444455556666"
+            },
+            "Resources": [
+                {
+                    "Type": "AwsEc2SecurityGroup",
+                    "Id": "arn:aws:ec2:us-east-1:012345678912:security-group/sg-0fff2222bbbb1111a",
+                    "Partition": "aws",
+                    "Region": "us-east-1"
+                },
+                {
+                    "Type": "AwsEc2SecurityGroup",
+                    "Id": "arn:aws:ec2:us-east-1:012345678912:security-group/sg-0aaa1111cccc2222b",
+                    "Partition": "aws",
+                    "Region": "us-east-1"
+                },
+                {
+                    "Type": "AwsEc2Vpc",
+                    "Id": "arn:aws:ec2:us-east-1:012345678912:vpc/vpc-0bbb3333dddd4444c",
+                    "Partition": "aws",
+                    "Region": "us-east-1"
+                }
+            ],
+            "Compliance": {
+                "Status": "FAILED"
+            },
+            "WorkflowState": "NEW",
+            "Workflow": {
+                "Status": "NEW"
+            },
+            "RecordState": "ACTIVE"
+        },
+        {
+            "SchemaVersion": "2018-10-08",
+            "Id": "arn:aws:securityhub:us-east-1:001122334455:subscription/aws-foundational-security-best-practices/v/1.0.0/S3.8/finding/b2c3d4e5-5555-6666-7777-888899990000",
+            "ProductArn": "arn:aws:securityhub:us-east-1::product/aws/securityhub",
+            "GeneratorId": "aws-foundational-security-best-practices/v/1.0.0/S3.8",
+            "ProductName": "Config",
+            "AwsAccountId": "001122334455",
+            "Types": [
+                "Software and Configuration Checks/Industry and Regulatory Standards/AWS-Foundational-Security-Best-Practices"
+            ],
+            "FirstObservedAt": "2024-03-02T10:15:00.000Z",
+            "LastObservedAt": "2024-03-09T10:15:00.000Z",
+            "CreatedAt": "2024-03-02T10:15:00.000Z",
+            "UpdatedAt": "2024-03-09T10:15:00.000Z",
+            "Severity": {
+                "Product": 40,
+                "Label": "MEDIUM",
+                "Normalized": 40,
+                "Original": "MEDIUM"
+            },
+            "Title": "S3.8 S3 Block Public Access setting should be enabled at the bucket level",
+            "Description": "This control checks whether S3 buckets have bucket-level public access blocks applied.",
+            "Remediation": {
+                "Recommendation": {
+                    "Text": "For directions on how to fix this issue, please consult the AWS Security Hub Foundational Security Best Practices documentation.",
+                    "Url": "https://docs.aws.amazon.com/console/securityhub/S3.8/remediation"
+                }
+            },
+            "ProductFields": {
+                "StandardsArn": "arn:aws:securityhub:::standards/aws-foundational-security-best-practices/v/1.0.0",
+                "ControlId": "S3.8",
+                "RecommendationUrl": "https://docs.aws.amazon.com/console/securityhub/S3.8/remediation",
+                "StandardsControlArn": "arn:aws:securityhub:us-east-1:001122334455:control/aws-foundational-security-best-practices/v/1.0.0/S3.8",
+                "aws/securityhub/SeverityLabel": "MEDIUM",
+                "aws/securityhub/ProductName": "Security Hub",
+                "aws/securityhub/CompanyName": "AWS",
+                "aws/securityhub/FindingId": "arn:aws:securityhub:us-east-1::product/aws/securityhub/arn:aws:securityhub:us-east-1:001122334455:subscription/aws-foundational-security-best-practices/v/1.0.0/S3.8/finding/b2c3d4e5-5555-6666-7777-888899990000"
+            },
+            "Resources": [
+                {
+                    "Type": "AwsS3Bucket",
+                    "Id": "arn:aws:s3:::zeta-reports-bucket",
+                    "Partition": "aws",
+                    "Region": "us-east-1"
+                },
+                {
+                    "Type": "AwsS3Bucket",
+                    "Id": "arn:aws:s3:::alpha-artifacts-bucket",
+                    "Partition": "aws",
+                    "Region": "us-east-1"
+                }
+            ],
+            "Compliance": {
+                "Status": "FAILED"
+            },
+            "WorkflowState": "NEW",
+            "Workflow": {
+                "Status": "NEW"
+            },
+            "RecordState": "ACTIVE"
+        }
+    ]
+}

--- a/unittests/tools/test_awssecurityhub_parser.py
+++ b/unittests/tools/test_awssecurityhub_parser.py
@@ -50,6 +50,62 @@ class TestAwsSecurityHubParser(DojoTestCase):
             self.assertEqual(1, len(findings))
             self.validate_locations(findings)
 
+    def test_multiple_resource_ids_are_sorted(self):
+        # A finding carrying several Resources is the only case that can expose an
+        # unordered join: a set of 0 or 1 elements has just one possible ordering.
+        # description feeds compute_hash_code_legacy(), so the order has to be stable.
+        with sample_path("config_multiple_resources.json").open(encoding="utf-8") as test_file:
+            parser = AwsSecurityHubParser()
+            findings = parser.get_findings(test_file, Test())
+            self.assertEqual(2, len(findings))
+            self.validate_locations(findings)
+
+            self.assertEqual(
+                "**Resource IDs:** "
+                "arn:aws:ec2:us-east-1:012345678912:security-group/sg-0aaa1111cccc2222b, "
+                "arn:aws:ec2:us-east-1:012345678912:security-group/sg-0fff2222bbbb1111a, "
+                "arn:aws:ec2:us-east-1:012345678912:vpc/vpc-0bbb3333dddd4444c",
+                self._resource_id_line(findings[0]),
+            )
+            self.assertEqual(
+                "**Resource IDs:** "
+                "arn:aws:s3:::alpha-artifacts-bucket, arn:aws:s3:::zeta-reports-bucket",
+                self._resource_id_line(findings[1]),
+            )
+
+    def test_multiple_resource_ids_do_not_follow_document_order(self):
+        # Guards the assertions above against a fix that merely drops set() and takes
+        # the report's own order: in this sample the two differ.
+        with sample_path("config_multiple_resources.json").open(encoding="utf-8") as test_file:
+            parser = AwsSecurityHubParser()
+            findings = parser.get_findings(test_file, Test())
+            for finding in findings:
+                arns = self._resource_id_line(finding).removeprefix("**Resource IDs:** ").split(", ")
+                self.assertEqual(sorted(arns), arns)
+            self.assertTrue(
+                self._resource_id_line(findings[1]).index("alpha-artifacts")
+                < self._resource_id_line(findings[1]).index("zeta-reports"),
+            )
+
+    def test_get_tests_description_is_sorted(self):
+        # Same unordered join in the Test description. Not hashed, but it reshuffled
+        # in the UI on every import.
+        with sample_path("config_multiple_resources.json").open(encoding="utf-8") as test_file:
+            tests = AwsSecurityHubParser().get_tests("AWS Security Hub Scan", test_file)
+            self.assertEqual(1, len(tests))
+            self.assertEqual(
+                "**AWS Accounts:** 001122334455, 012345678912\n"
+                "**Finding Origins:** Config, Security Hub\n",
+                tests[0].description,
+            )
+
+    @staticmethod
+    def _resource_id_line(finding):
+        return next(
+            line for line in finding.description.splitlines()
+            if line.startswith("**Resource IDs:**")
+        )
+
     def test_unique_id(self):
         with sample_path("config_one_finding.json").open(encoding="utf-8") as test_file:
             parser = AwsSecurityHubParser()


### PR DESCRIPTION
**Description**

The AWS Security Hub parser joined an unordered `set` straight into the finding description:

```python
description += f"**Resource IDs:** {', '.join(set(resource_arns))}\n"
```

Python randomises string hashing per process, so a set of ARNs iterates in a different order in every import worker.

`"AWS Security Hub Scan"` declares no entry in `HASHCODE_FIELDS_PER_SCANNER` — it appears only in `HASHCODE_ALLOWS_NULL_CWE` and `DEDUPLICATION_ALGORITHM_PER_PARSER` — so `Finding.compute_hash_code()` falls through to `compute_hash_code_legacy()`, which hashes title + cwe + line + file_path + **description**. The same unchanged report therefore stored a different `hash_code` on every import.

Only findings with **two or more** `Resources` are affected: a set of 0 or 1 elements has a single possible ordering.

That is also why the sample corpus never caught this. All 11 pre-existing `unittests/scans/awssecurityhub/` files carry at most one resource Id per finding, so no reordering is expressible. Real Security Hub findings routinely carry several `Resources`. This PR adds `config_multiple_resources.json` (findings with 3 and 2 resource Ids, listed in an order deliberately *not* equal to sorted order) so the case is actually exercised.

Two related sites are sorted in the same pass:

* `awssecurityhub/parser.py` builds the **Test** description (`AWS Accounts` / `Finding Origins`) from sets the same way. That is Test metadata, not a Finding field, so it never reached `hash_code` — but it reshuffled in the UI on every import.
* `yarn_audit/parser.py` (yarn2 path) joins sets into `description` and `component_version`, and iterates one to build `unsaved_locations`. `"Yarn Audit Scan"` declares hash fields (`title`, `severity`, `file_path`, `vulnerability_ids`, `cwe`) that cover none of those, so no `hash_code` moves — display noise only, sorted for the same reason.

**Test results**

New tests in `unittests/tools/test_awssecurityhub_parser.py`:

* `test_multiple_resource_ids_are_sorted` — pins the exact `**Resource IDs:**` line for both findings.
* `test_multiple_resource_ids_do_not_follow_document_order` — guards those assertions against a "fix" that merely drops `set()` and takes the report's own order; in this sample the two differ.
* `test_get_tests_description_is_sorted` — covers the Test description.

`manage.py test unittests.tools.test_awssecurityhub_parser unittests.tools.test_yarn_audit_parser` — **24 passed**.

Determinism verified by digesting the legacy hash fields over the whole sample corpus under varying `PYTHONHASHSEED`:

* pre-fix, the new multi-resource sample yields **three different digests** across seeds 1–5;
* post-fix, seeds 1–8 agree, and so do seeds 1/2/3 run against the real parser under Django (13 files, byte-identical).

**Every pre-existing sample's digest is byte-identical before and after.** Sorting a ≤1-element set is a no-op, so no existing single-resource finding changes identity.

**Documentation**

`docs/content/releases/os_upgrading/3.2.md` gains a section calling this out as an identity change for AWS Security Hub Scan, plus a short note that the Yarn Audit change is display-only.

There is no stable prior identity to preserve for multi-resource findings: the old value was random per import, so no existing `hash_code` can be matched reliably. Every hash this changes was already changing on its own.

Deduplication for this scan type keys on `unique_id_from_tool` (the Security Hub finding ARN), so import/reimport matching itself was never affected. The exposure is the features that read `hash_code`: false positive history, risk acceptance copies, and similar findings.

**Checklist**

- [x] Submitted against `dev`, so this ships in 3.2.0. It is a bug fix, but it changes `hash_code` for multi-resource AWS Security Hub findings, so it goes out with a minor release rather than a weekly 3.1.x patch. Release notes are in `os_upgrading/3.2.md` accordingly.
- [x] Ruff compliant (`ruff==0.15.20`, the pinned version — clean).
- [x] No model changes, so no migrations.
- [x] Tests added.
