### PR TITLE
fix(govulncheck): sort symbol/location sets so hash_code is stable

### DIFF
--- a/dojo/tools/govulncheck/parser.py
+++ b/dojo/tools/govulncheck/parser.py
@@ -201,10 +201,14 @@ class GovulncheckParser:
                                     "imports"
                                 ][0]["symbols"],
                             )
-                        d["impact"] = "; ".join(impact) if impact else None
+                        # sorted(): both are sets, and iteration order of a set of
+                        # strings varies per process (PYTHONHASHSEED). description is
+                        # part of hash_code, so an unsorted join gives the same report a
+                        # different hash on every import.
+                        d["impact"] = "; ".join(sorted(impact)) if impact else None
                         d[
                             "description"
-                        ] = f"Vulnerable functions: {'; '.join(vuln_methods)}"
+                        ] = f"Vulnerable functions: {'; '.join(sorted(vuln_methods))}"
                         finding = Finding(**d)
                         if settings.V3_FEATURE_LOCATIONS and d["component_name"]:
                             finding.unsaved_locations.append(
@@ -237,8 +241,11 @@ class GovulncheckParser:
                             formatted_ranges.append(f"type {r['type']}: {'. '.join(event_pairs)}")
                         range_info = "\n ".join(formatted_ranges)
 
+                        # sorted(): a set of strings iterates in a different order in
+                        # every process (PYTHONHASHSEED), and this string goes into
+                        # description, which is hashed into hash_code.
                         vuln_functions = ", ".join(
-                            set(osv_data["affected"][0].get("ecosystem_specific", {}).get("imports", [{}])[0].get("symbols", [])),
+                            sorted(set(osv_data["affected"][0].get("ecosystem_specific", {}).get("imports", [{}])[0].get("symbols", []))),
                         )
 
                         description = (


### PR DESCRIPTION
## The bug

Re-importing an **unchanged** govulncheck report can close the existing findings and create duplicates, every time.

`dojo/tools/govulncheck/parser.py` joined unordered `set`s straight into the finding description:

```python
vuln_functions = ", ".join(set(...["symbols"]))                       # new streaming format
description    = f"Vulnerable functions: {'; '.join(vuln_methods)}"   # old dict format
```

Python randomises string hashing per process (`PYTHONHASHSEED`), so a set of symbol names iterates in a different order in every import worker.

That reaches `hash_code`: `Govulncheck Scanner` declares **no** entry in `HASHCODE_FIELDS_PER_SCANNER`, so `Finding.compute_hash_code()` falls through to `compute_hash_code_legacy()` (`dojo/finding/models.py:806`) = `title + cwe + line + file_path + description`. Description is hashed, so the same file hashed differently on every import.

## The fix

`sorted()` at the three join-over-set sites.

`impact` on the old-format path is joined from a set the same way. It is *not* in the legacy hash field list, but it **is** in `HASHCODE_ALLOWED_FIELDS` — so an install that configures it becomes exposed — and a field that reshuffles on every import is noise in the UI and in finding history regardless. Sorted too.

## Verification

Built the govulncheck sample corpus under `PYTHONHASHSEED=1`, `2` and `3`:

| | pre-fix | post-fix |
|---|---|---|
| `issue_14642.json` | `0e3c9ce0530c` / `10918ffa846c` / `16812379775d` | `01d4747c3c45` ×3 |
| `issue_15033.json` | `d64ba57e41e8` / `a50d8fd2ef29` / `440842c3c770` | `0b952c1fb4aa` ×3 |
| `many_vulns.json` | `a2bf130918d7` / `8bfe60930276` / `7a79b4144eda` | `8f2f1985fcd5` ×3 |
| `many_vulns_new_version_custom_severity.json` | `11e6a4ec2f96` / `51770f831c66` / `c1433c685f09` | `1e1029782e5d` ×3 |

4 of the 9 sample scans changed identity on every seed; post-fix all three seeds agree. Finding counts are unchanged (201 / 234 / 3 / 1 / 2 / 0 / 0) — the fix reorders text inside a description, it does not change what the parser produces. `unittests/tools/test_govulncheck_parser.py` passes unchanged; it only asserts `assertIsNotNone` on `description`/`impact`, so nothing depended on the order.

## Release notes

**This is an identity change for `Govulncheck Scanner` and should be called out as one.**

There is no stable prior identity to preserve: the old value was random per import, so no existing Govulncheck finding could be matched by its `hash_code` reliably anyway. Every hash this changes was already changing on its own. Targeting `dev` rather than `bugfix` for that reason — an identity change should not land in a patch release.

Note the dedupe algorithm for this scan type is `unique_id_from_tool`, which is stable, so OSS reimport *matching* was not the failure path. The exposure is everything else keyed on `hash_code`: false-positive history, risk-acceptance copy, similar-findings, and Pro's reimport hash.