### PR TITLE
docs(rules-engine): document Rules Engine 2.0

### DIFF
--- a/docs/content/automation/rules_engine/about.md
+++ b/docs/content/automation/rules_engine/about.md
@@ -12,6 +12,8 @@ DefectDojo's Rules Engine allows you to build custom workflows and bulk actions 
 
 Rules Engine can only be accessed through the [Pro UI](/get_started/about/ui_pro_vs_os/).
 
+**Looking for the graph editor?** [Rules Engine 2.0](/automation/rules_engine_2/about/) builds automation as visual node graphs, and adds branching, outbound actions such as tickets and messages, per-run traces and a delivery ledger. Both engines run side by side, and existing rules can be [converted across](/automation/rules_engine_2/converting_from_rules_engine/).
+
 ## Enabling Rules Engine
 
 Rules Engine is in Beta and is off by default. A superuser can turn it on from **Settings > Feature Flags**, on both Cloud and On-Premise instances. See [Feature Flags](/admin/feature_flags/pro__feature_flags/).

--- a/docs/content/automation/rules_engine_2/_index.md
+++ b/docs/content/automation/rules_engine_2/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Rules Engine 2.0"
+description: "Build automation as visual node graphs, with per-run traces and a delivery ledger"
+summary: ""
+date: 2026-08-02T09:00:00+00:00
+lastmod: 2026-08-02T09:00:00+00:00
+draft: false
+weight: 99
+chapter: true
+seo:
+  title: "" # custom title (optional)
+  description: "" # custom description (recommended)
+  canonical: "" # custom canonical URL (optional)
+  robots: "" # custom robot tags (optional)
+exclude_search: true
+audience: pro
+---

--- a/docs/content/automation/rules_engine_2/about.md
+++ b/docs/content/automation/rules_engine_2/about.md
@@ -1,0 +1,117 @@
+---
+title: "About Rules Engine 2.0"
+description: "What Rules Engine 2.0 is, how to turn it on, and the concepts it is built from"
+weight: 1
+audience: pro
+aliases:
+  - /automation/rules_engine_v2/about/
+---
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Rules Engine 2.0 is a DefectDojo Pro-only feature.</span>
+
+Rules Engine 2.0 is a visual automation builder. Instead of a filter plus a flat list of actions, a rule is a **graph**: a trigger node that decides when the rule wakes up, and any number of logic, Finding and egress nodes wired together to say what happens next.
+
+Rules Engine 2.0 can only be accessed through the [Pro UI](/get_started/about/ui_pro_vs_os/).
+
+## What it adds over Rules Engine
+
+The original [Rules Engine](/automation/rules_engine/about/) applies an ordered list of actions to every Finding that matches one filter. Rules Engine 2.0 keeps that capability and adds four things:
+
+* **Branching.** An **If / Filter** node routes items down a true branch and a false branch, so one rule can treat Critical Findings differently from the rest without being split into two rules.
+* **Egress.** A rule can leave DefectDojo: open a JIRA issue or a downstream ticket, post to Slack or Microsoft Teams, send an email, call a webhook, raise an in-app alert, or generate a report.
+* **Traceability.** Every execution is recorded node by node as a [Run](../runs/), and every outbound send is recorded as a [Delivery](../deliveries/) that says exactly what was sent, where it went, and how it ended.
+* **A simulate mode.** A rule can record precisely what it would send without sending anything, which is how you test one safely before it touches the outside world.
+
+Both engines run side by side. Turning on Rules Engine 2.0 does not disable or convert your existing rules, and there is a [converter](../converting_from_rules_engine/) for when you want to move them across.
+
+## Enabling Rules Engine 2.0
+
+Rules Engine 2.0 is in Beta and is off by default. A superuser turns it on from **Settings > Feature Flags**, on both Cloud and On-Premise instances. See [Feature Flags](/admin/feature_flags/pro__feature_flags/).
+
+Once the flag is on, a **Rules Engine 2.0** section appears in the sidebar with three pages:
+
+| Page | What it is for |
+|------|----------------|
+| **All Rules** | The rule list. Create, edit, enable, run and delete rules from here. |
+| **Runs** | Every execution, with its per-node trace. |
+| **Deliveries** | The ledger of everything rules have sent outward. |
+
+### Permissions
+
+Access is governed by two global role permissions, shared with the original Rules Engine:
+
+* **Rule View** is required to see the sidebar section and everything under it.
+* **Rule Edit** is required to create, change, run, delete, convert, take ownership of, and replay.
+
+Rule Edit is close to an administrative permission. A rule author can reach any Finding their rule's owner can see, and can direct output at external systems, so grant it deliberately.
+
+## The concepts
+
+### Rules and graphs
+
+A rule is a name, a description, an owner, a mode, an enabled switch, and a graph. The graph is a set of **nodes** and the **edges** between them. It must contain exactly one trigger node and must not contain a cycle. Everything else is up to you, including leaving a node unconnected, which simply means it runs with nothing to work on.
+
+New rules are always created **disabled**, so enabling one is a deliberate act.
+
+### Items
+
+What travels along the edges of a graph is an **item**: a JSON snapshot of one Finding plus its surrounding context.
+
+```json
+{
+  "finding":      { "id": 1234, "title": "...", "severity": "High", "...": "..." },
+  "test":         { "id": 12, "title": "...", "scan_type": "..." },
+  "engagement":   { "id": 5,  "name": "..." },
+  "product":      { "id": 3,  "name": "..." },
+  "product_type": { "id": 1,  "name": "..." },
+  "ctx":          { "trigger": "finding.created", "depth": 0, "source": "app" }
+}
+```
+
+Conditions and message templates are written against the paths in that structure, for example `finding.severity` or `product.name`. The full field list is in [Building Rules](../building_rules/).
+
+### Owner
+
+Every rule runs **as its owner**. It sees exactly the Findings that user can see, through the same authorization used everywhere else in the product. Two consequences are worth knowing:
+
+* Narrowing a rule owner's access narrows the rule.
+* A rule whose owner's account is deleted has no owner, so it matches nothing at all and does nothing. Assign a new owner, or use **Take Ownership** from the rule list, to bring it back.
+
+### Mode: Simulate or Live
+
+Mode is set per rule, not per node.
+
+* **Simulate** (the default) runs the whole graph for real, including every Finding edit, but egress nodes record what they *would* have sent and stop there. Nothing leaves DefectDojo.
+* **Live** performs the sends.
+
+Simulated sends still appear in the Deliveries ledger, marked `simulated`, with their full payload. That is the intended way to review a rule before you let it out.
+
+Mode deliberately applies to the whole rule. A graph where some sends are real and others are not is harder to reason about than two rules.
+
+### Runs
+
+One execution of a rule is a [Run](../runs/). A run records the event that triggered it, its status, its per-node trace, and any error. A rule can only have one run in progress at a time, so a busy rule queues rather than racing with itself.
+
+### Deliveries
+
+Every outbound side effect is one row in the [Deliveries](../deliveries/) ledger, written **before** any network call happens. The row holds the payload, the resolved destination, the status, the retry count, and whatever the destination said back. Skips are recorded too, so "the rule did nothing" and "the rule did nothing because the Finding was already ticketed" are distinguishable.
+
+### Provenance
+
+Every change a rule makes to a Finding is attributed back to the rule, the run and the node that made it. That timeline is visible on the Finding itself, so you can answer "why did this Finding change?" without reading rule definitions.
+
+### Scale
+
+A rule processes everything its scope matches. There is no cap on how many Findings a run handles: it works through them in chunks so that memory stays bounded instead of coverage. Only Preview caps, and it tells you when it does.
+
+### Retention
+
+Runs and deliveries are both kept for 180 days by default, then pruned. The product shows you the window and the date a given record will be deleted rather than leaving it implicit, and both windows are configurable. See [Configuration](../configuration/#retention).
+
+## Where to go next
+
+* [Building Rules](../building_rules/) covers the editor, triggers, scope, conditions and templates.
+* [Node Reference](../node_reference/) documents all 25 nodes.
+* [Runs](../runs/) covers execution, traces, cascading and limits.
+* [Deliveries](../deliveries/) covers channels, statuses, retries and replay.
+* [Converting from Rules Engine](../converting_from_rules_engine/) covers moving existing rules across.
+* [Configuration](../configuration/) covers the deployment level settings.

--- a/docs/content/automation/rules_engine_2/building_rules.md
+++ b/docs/content/automation/rules_engine_2/building_rules.md
@@ -1,0 +1,196 @@
+---
+title: "Building Rules"
+description: "The graph editor, triggers, scope, conditions and message templates"
+weight: 2
+audience: pro
+aliases:
+  - /automation/rules_engine_v2/building_rules/
+---
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Rules Engine 2.0 is a DefectDojo Pro-only feature.</span>
+
+A rule is built on a canvas. You drag nodes out of a palette, wire them together, and configure each one in a side panel. This page covers the parts of that process that are the same whichever nodes you use. The nodes themselves are in the [Node Reference](../node_reference/).
+
+## The editor
+
+Open **Rules Engine 2.0 > All Rules** and choose **New Rule**, or open an existing rule to edit it.
+
+The palette is grouped into four categories, which is also the order items flow through a typical graph:
+
+| Category | What the nodes do |
+|----------|-------------------|
+| **Triggers** | Decide when the rule wakes up and which Findings enter it. Exactly one per graph. |
+| **Logic** | Route, limit and de-duplicate the items flowing through. |
+| **Findings** | Change the Findings. |
+| **Egress** | Send something outward: a ticket, a message, a report. |
+
+The palette is generated from the engine itself, so what you see in the editor is always exactly what the engine can execute.
+
+### Graph rules
+
+A graph is checked when you save it, and again before every run. It must satisfy all of the following:
+
+* It has at least one node.
+* It has **exactly one** trigger node.
+* Every node has a unique, non-empty id of 100 characters or fewer.
+* Every node is of a type the engine knows.
+* Every edge connects two nodes that exist.
+* It contains no cycle.
+
+A node with nothing wired into it is legal. It runs with an empty input list, which usually means it does nothing.
+
+A node with several incoming edges receives all of their outputs concatenated.
+
+### Previewing before you save
+
+**Preview** dry-runs the graph you currently have on the canvas and shows you the per-node trace it would produce: how many items entered each node, how many left by each output, and what each node would have changed.
+
+Preview runs the real engine, not a simulation of it, and then rolls the whole thing back. Nothing is written, no run is recorded, and egress is forced to simulate whatever the rule's mode says. It is the fastest way to check that your conditions match what you expected.
+
+Preview is the one execution that caps how many Findings it looks at, so that it stays fast. When it truncates, it says so in the trace. A real run has no such cap.
+
+## Triggers and scope
+
+Every graph starts with one of three triggers.
+
+* **On Finding Event** wakes the rule when Findings are created, updated, closed or reopened. Choose which of those in the node's **Event** setting, or `any` for all four.
+* **On a Schedule** sweeps Findings on a recurring schedule.
+* **Manual Run** sweeps Findings when you press **Run** on the rule.
+
+### Scope
+
+All three triggers take a **Scope**, and scope is how you narrow what the rule considers. It is the same filter vocabulary the original Rules Engine uses, roughly sixty filters spanning Findings and the objects around them, so a filter you already know how to write there means the same thing here.
+
+Two things about scope are worth understanding:
+
+* **Scope is applied on top of authorization, never instead of it.** The rule runs as its owner, so scope narrows an already-authorized set of Findings. Leaving scope empty does not mean "every Finding in the instance", it means "every Finding the rule owner can see".
+* **An invalid scope fails the run rather than widening it.** If a filter key does not exist, or a value is one the filter would silently discard, the run errors out. A rule that does nothing is recoverable. A rule that quietly edits every Finding in the instance is not.
+
+For an event trigger, scope acts as a second gate: the Findings named in the event are matched against it, and only those that pass enter the graph.
+
+### Scheduling
+
+A rule whose trigger is **On a Schedule** is scheduled from the rule itself. Setting the schedule needs Rule Edit, the same permission as editing the rule, because a schedule-triggered rule does nothing at all until it has one.
+
+Schedules are limited to quarter-hour marks. The minute field of a cron expression must be `0`, `15`, `30` or `45`.
+
+Valid examples:
+
+```
+0 * * * *     every hour, on the hour
+15 9 * * *    every day at 09:15
+0 15 * * 1    every Monday at 15:00
+30 2 * * *    every day at 02:30
+```
+
+## Referring to Finding data
+
+Two places in a rule read values out of the item flowing through it: **conditions** and **templates**. Both use the same dot paths.
+
+```
+finding.severity
+finding.title
+finding.vulnerability_ids.0
+product.name
+product_type.name
+test.scan_type
+ctx.rule_name
+```
+
+A path that does not resolve produces no value rather than an error.
+
+### Available fields
+
+Each item carries a fixed set of Finding fields. This list is a contract, so it changes only deliberately.
+
+| Group | Fields |
+|-------|--------|
+| Identity | `id`, `title`, `hash_code`, `unique_id_from_tool` |
+| Severity and scoring | `severity`, `numerical_severity`, `cvssv3`, `cvssv3_score`, `epss_score`, `epss_percentile`, `priority`, `risk`, `risk_score` |
+| Text | `description`, `mitigation`, `impact` |
+| Status | `active`, `verified`, `false_p`, `duplicate`, `is_mitigated`, `out_of_scope`, `risk_accepted`, `under_review` |
+| Dates | `date`, `mitigated`, `last_status_update`, `sla_expiration_date` |
+| Location | `file_path`, `line`, `component_name`, `component_version`, `service` |
+| Classification | `cwe`, `vulnerability_ids`, `tags` |
+
+Alongside `finding`, each item carries `test` (`id`, `title`, `scan_type`), `engagement` (`id`, `name`), `product` (`id`, `name`), `product_type` (`id`, `name`), and `ctx`.
+
+Dates are ISO-8601 strings. That is deliberate: it means `gt` and `lt` order them correctly as text, so `2026-07-28` is correctly greater than `2026-01-01`.
+
+`priority`, `risk` and `risk_score` come from Pro's prioritization. A Finding that has not been scored yet carries no value for them.
+
+### Conditions
+
+An **If / Filter** node holds a list of condition rows. Each row is a path, an operator, and a value. **Match** decides whether every row has to hold (`all`) or just one of them (`any`).
+
+| Operator | Meaning |
+|----------|---------|
+| `eq` | equals |
+| `neq` | does not equal |
+| `contains` | contains |
+| `not_contains` | does not contain |
+| `in` | is one of |
+| `not_in` | is not one of |
+| `gt` | is greater than |
+| `gte` | is greater than or equal to |
+| `lt` | is less than |
+| `lte` | is less than or equal to |
+| `startswith` | starts with |
+| `endswith` | ends with |
+| `exists` | is set |
+| `not_exists` | is not set |
+
+Comparisons are **loose**. A number is tried first, and if that fails the values are compared as trimmed, case-insensitive text. So a condition written as `finding.severity eq high` matches a Finding whose severity is `High`, which is almost always what the author meant.
+
+#### Transforms
+
+A condition row can post-process the value it read before comparing it.
+
+| Transform | Effect |
+|-----------|--------|
+| `int` | whole number |
+| `float` | decimal number |
+| `str` | text |
+| `first` | first entry of a list |
+| `list` | as a list |
+| `join` | joined with commas |
+| `upper` | UPPERCASE |
+| `lower` | lowercase |
+| `strip` | trimmed |
+| `cwe_int` | CWE number |
+| `severity` | normalized severity, so `critical`, `error` and `warning` style values from different scanners map onto DefectDojo's five levels |
+| `numerical_severity` | sortable severity code, for ordering comparisons |
+
+### Templates
+
+Any setting labelled as a message, note, title or value accepts `{{ path }}` placeholders, resolved per item:
+
+```
+{{finding.severity}}: {{finding.title}} ({{product.name}})
+```
+
+A path with no value renders as an empty string. A list renders comma-joined.
+
+Templates also see a `ctx` block carrying details about the run itself. The keys available depend on the node, but the common ones are:
+
+| Placeholder | Meaning |
+|-------------|---------|
+| `{{ctx.rule_name}}` | The name of the rule |
+| `{{ctx.count}}` | How many Findings the message covers |
+| `{{ctx.trigger}}` | The event that started the run |
+| `{{ctx.findings_html}}` | The rendered Finding list, in the email node |
+| `{{ctx.report_url}}` | The download link, in the report node |
+| `{{ctx.template_name}}` | The report template name, in the report node |
+
+Templates are plain substitution. There is no expression evaluation, no code execution, and no attribute access on objects anywhere in a rule config.
+
+## Testing a rule safely
+
+The recommended order for a rule that sends anything:
+
+1. Build the graph and use **Preview** until the item counts look right.
+2. Save it. New rules are created disabled.
+3. Leave the mode on **Simulate** and enable the rule.
+4. Let it run, then read **Deliveries** and check the recorded payloads are what you intended.
+5. Switch the mode to **Live**.
+
+Simulate is not a partial run. Every Finding edit in the graph happens for real in simulate mode. Only the outbound sends are held back.

--- a/docs/content/automation/rules_engine_2/configuration.md
+++ b/docs/content/automation/rules_engine_2/configuration.md
@@ -1,0 +1,140 @@
+---
+title: "Configuration"
+description: "Deployment level settings for Rules Engine 2.0"
+weight: 7
+audience: pro
+aliases:
+  - /automation/rules_engine_v2/configuration/
+---
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Rules Engine 2.0 is a DefectDojo Pro-only feature.</span>
+
+Rules Engine 2.0 works out of the box. The settings on this page are for deployments that need to tune throughput, retention, or outbound network policy. All of them are applied the same way as any other DefectDojo setting (see [Configuration](/get_started/open_source/configuration/)).
+
+Rules Engine 2.0 is configured separately from the original Rules Engine. The two engines share no tuning, so a `DD_RULES_ENGINE_*` setting does not affect Rules Engine 2.0 and a `DD_RULES_V2_*` setting does not affect the original engine.
+
+```python
+DD_RULES_V2_EVENT_BATCH=(int, 500),
+DD_RULES_V2_CHUNK_SIZE=(int, 1000),
+DD_RULES_V2_STALLED_AFTER_MINUTES=(int, 30),
+DD_RULES_V2_RUN_TIME_LIMIT_MINUTES=(int, 360),
+DD_RULES_V2_ALLOW_PRIVATE_EGRESS=(bool, False),
+DD_RULES_V2_DELIVERY_RETENTION_DAYS=(int, 180),
+DD_RULES_V2_RUN_RETENTION_DAYS=(int, 180),
+DD_RULES_V2_ENVELOPE_TEXT_MAX_CHARS=(int, 8000),
+DD_RULES_V2_MAX_PER_ITEM_SENDS=(int, 1000),
+```
+
+## Throughput
+
+### Findings per event (`DD_RULES_V2_EVENT_BATCH`)
+
+**Default: 500.**
+
+How many Finding ids a single event carries. Events cross an asynchronous boundary, so they are kept small enough to stay a cheap message. A larger write fans out into several events, each of which becomes its own run.
+
+Raising this produces fewer, larger runs. Lowering it produces more, smaller ones.
+
+### Findings per chunk (`DD_RULES_V2_CHUNK_SIZE`)
+
+**Default: 1000.**
+
+How many Findings a run holds in memory at once. A run is processed in chunks, so this is a memory knob and **not** a ceiling on what a rule handles: a rule always processes everything its scope matches.
+
+An envelope is roughly 2.7KB per Finding, so the default holds a few megabytes at a time. Raising it trades memory for fewer round trips. Lowering it does the reverse.
+
+### Envelope text cap (`DD_RULES_V2_ENVELOPE_TEXT_MAX_CHARS`)
+
+**Default: 8000. Set to 0 to disable.**
+
+How many characters of `description`, `mitigation` and `impact` an item carries.
+
+Those three fields are most of an envelope's size. The cap exists for the unusual case of a Finding with a very large description, where a full chunk of them would be far bigger than the chunk size suggests. It is generous enough that an ordinary instance never notices it.
+
+Note that this affects what conditions and templates can see. A condition matching against the tail of a very long description will not see text beyond the cap.
+
+## Run lifetime
+
+### Stall window (`DD_RULES_V2_STALLED_AFTER_MINUTES`)
+
+**Default: 30.**
+
+How long a run may go without a heartbeat before it is treated as abandoned, marked as errored, and its per-rule lock released.
+
+A run stamps a heartbeat after each chunk, so this is measured from the last heartbeat rather than from the start. A long sweep that is still making progress is never mistaken for a crashed worker, which is what lets the window stay short.
+
+### Run time limit (`DD_RULES_V2_RUN_TIME_LIMIT_MINUTES`)
+
+**Default: 360, which is six hours.**
+
+The longest a single run may take before the worker kills it.
+
+This is a guard against a rule that will never finish while holding a worker slot and its rule's execution lock. It is deliberately generous, because a chunked sweep over a very large scope is a workload this engine is built for.
+
+## Retention
+
+Two jobs bound the three tables this feature grows. Both default to **180 days**, and both take `0` to disable pruning entirely.
+
+Retention is surfaced in the product rather than left implicit: the API serves both the window and the date a given record will be deleted, and the pages that show a run or a delivery say it in a sentence. The date is computed on read, so changing the window takes effect immediately rather than applying only to new records.
+
+### `DD_RULES_V2_DELIVERY_RETENTION_DAYS`
+
+**Default: 180.**
+
+How many days a finished delivery is kept.
+
+This is the fastest-growing table in the feature. A per-Finding egress node writes up to a chunk's worth of rows per run, including in Simulate mode. Raise it if you need a longer outbound audit trail, and lower it if volume is a problem.
+
+### `DD_RULES_V2_RUN_RETENTION_DAYS`
+
+**Default: 180.**
+
+How many days a finished run is kept, along with its per-node rows and its Finding provenance.
+
+The run side grows faster than deliveries do, because provenance is one row per Finding per mutation node per run. An hourly rule over a large scope generates a lot of it.
+
+A run that still holds deliveries is kept until those are pruned, so setting a shorter run window than delivery window does not orphan anything.
+
+## Outbound destination validation
+
+Two node settings take a destination as free text rather than from a configured object: the **URL** on Call a Webhook, and the **To** on Send an Email. Both are validated when the rule is saved.
+
+For webhook URLs:
+
+* Only `http` and `https` are accepted. Other schemes are rejected outright.
+* The URL must have a host.
+* By default, a host that resolves to a loopback, link-local, private, reserved or multicast address is rejected.
+
+For email addresses, an empty address is rejected, and so is one containing a newline, which is header injection.
+
+The reason for the network check is that the worker sending the request usually sits inside your cluster and can reach far more of the internal network than the person authoring the rule can. Without the check, a free-text URL is a request forgery primitive: point it at a metadata service or an internal admin port and the response comes back through the delivery ledger.
+
+This is defence in depth rather than the only control. Rule Edit is close to administrative anyway. It is worth having so that the blast radius of one over-granted role is not "read any internal HTTP endpoint", and so a typo fails at save time with a clear message instead of at send time with a connection error.
+
+### Allowing private addresses (`DD_RULES_V2_ALLOW_PRIVATE_EGRESS`)
+
+**Default: off.**
+
+Turns off the network address check, so webhooks may post to loopback, link-local and private addresses. Scheme and shape validation still applies.
+
+Turn this on if you genuinely webhook to something on a private address, which a self-hosted chat or webhook receiver normally is.
+
+## Per-Finding send ceiling
+
+### `DD_RULES_V2_MAX_PER_ITEM_SENDS`
+
+**Default: 1000. Set to 0 to remove the ceiling.**
+
+The most per-Finding sends a single egress node will record in one run.
+
+A node with **One Message per Finding** turned on produces one delivery row and one queued task per Finding. Because a run has no item cap, a rule with a very broad scope and per-Finding sending on would otherwise mean an unbounded number of both.
+
+Past this ceiling the node records a **visible skip** saying how many Findings it did not send about. It does not fail the run, and it does not silently stop.
+
+## Related settings
+
+Some Rules Engine 2.0 nodes use system-wide integration configuration rather than their own:
+
+* **Send a Slack Message** uses the system Slack token, and falls back to the system Slack channel when the node names none.
+* **Send a Microsoft Teams Message** uses the Microsoft Teams webhook from system settings.
+* **Create a JIRA Issue** uses the product's JIRA configuration for the summary, description and priority.
+* **Raise an In-App Alert** respects each recipient's own **Rules Engine Match** notification setting.

--- a/docs/content/automation/rules_engine_2/converting_from_rules_engine.md
+++ b/docs/content/automation/rules_engine_2/converting_from_rules_engine.md
@@ -1,0 +1,88 @@
+---
+title: "Converting from Rules Engine"
+description: "Move existing Rules Engine rules across to Rules Engine 2.0 graphs"
+weight: 6
+audience: pro
+aliases:
+  - /automation/rules_engine_v2/converting_from_rules_engine/
+---
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Rules Engine 2.0 is a DefectDojo Pro-only feature.</span>
+
+Both engines run side by side. Turning on Rules Engine 2.0 changes nothing about your existing [Rules Engine](/automation/rules_engine/about/) rules, and there is no deadline by which you must move them.
+
+When you do want to move them, there is a converter. It translates a Rules Engine rule (a filter plus an ordered list of actions) into an equivalent Rules Engine 2.0 graph.
+
+## What the converter guarantees
+
+**A rule either converts cleanly or it does not convert at all.** Every conversion reports two kinds of result:
+
+* **Problems** mean the rule was not written. Nothing partial is saved.
+* **Warnings** mean the rule converted, but something about it moved and you should look at it.
+
+Nothing is silently approximated. The whole value of the converter is that you can trust a rule that converted without remark, and hand-check one that did not.
+
+**Converted rules are always created disabled.** Both engines are running, and two rules doing the same thing to the same Findings is the one outcome a converter must never produce on its own. Review each converted rule and enable it deliberately.
+
+**A rule converts once.** Each converted rule remembers the rule it came from, so running the converter twice skips what it already did rather than creating duplicates. Use the overwrite option to deliberately replace a previously converted graph.
+
+## Running the converter
+
+### From the UI
+
+The rule list offers a conversion action, which reports per rule what converted, what was skipped, and what failed.
+
+### From the command line
+
+```bash
+python manage.py convert_rules_to_v2
+```
+
+| Option | Effect |
+|--------|--------|
+| `--dry-run` | Print the graph each rule would produce and write nothing. |
+| `--rule-ids 1,2,3` | Convert only these rules. Converts every rule when omitted. |
+| `--overwrite` | Replace the graph of an already-converted rule and bump its version, instead of skipping it. |
+| `--activate-schedules` | Also copy each schedule onto its converted rule. Off by default. |
+| `--drop-invalid-filters` | Drop scope filters the filter set no longer recognises and warn, instead of failing the rule. |
+| `--json` | Print the report as JSON instead of text. |
+
+The command exits non-zero only when a rule fails to convert. Skips are reported but are not failures.
+
+Start with `--dry-run` on the full set to see what you are in for, then convert for real.
+
+## What the conversion produces
+
+| Rules Engine concept | Becomes |
+|----------------------|---------|
+| The rule's filter | The **Scope** on the trigger node. |
+| A rule with a schedule | An **On a Schedule** trigger. |
+| A rule with no schedule | A **Manual Run** trigger. |
+| Each action, in order | One node, chained in the same order. |
+| An action guarded by a condition | An **If / Filter** node in front of that node. |
+
+The filter vocabulary is shared between both engines, so a scope converts without translation. That is deliberate: it is the same filter set, with one implementation.
+
+Converted graphs are validated the same way a hand-built graph is, including per-node configuration and the allowed values of every dropdown. A rule holding a severity or risk value that the product has since moved on from is caught at conversion rather than at run time.
+
+## What does not carry over
+
+Four things to plan for. The converter reports these as notes on every run.
+
+* **Run history stays where it is.** Existing run history, and its affected and skipped records, remain in the Rules Engine UI. They are not copied.
+* **Schedules are not activated by default.** A schedule-triggered rule converts, but its schedule is not copied unless you pass `--activate-schedules`. This keeps sole ownership of live schedules with the original engine while both are running, so a converted rule cannot start firing behind your back. When you do copy a schedule, the copy is given a distinct name so it does not collide with the original.
+* **The concurrency model is different.** Rules Engine has one instance-wide run lock. Rules Engine 2.0 serialises per rule, so distinct rules run concurrently. A set of rules that used to take turns will now overlap.
+* **One action has no equivalent.** A "set false positive to false" action cannot be expressed as a Rules Engine 2.0 node and must be converted by hand.
+
+A rule whose owner is unset converts, with a warning. Remember that a rule with no owner sees no Findings, so assign one before enabling it.
+
+## A suggested order
+
+1. Turn on Rules Engine 2.0 and leave your existing rules running.
+2. Run the converter with `--dry-run` and read the report.
+3. Convert. Everything lands disabled.
+4. Open each converted rule, check the graph, and leave the mode on **Simulate**.
+5. Enable the converted rule, and let it run alongside the original for a while. Simulate means it changes Findings but sends nothing, so compare its runs against what the original did.
+6. When you are satisfied, disable the original rule and switch the converted one to **Live**.
+7. Copy the schedule across last, once nothing is running the old rule any more.
+
+Step 5 is the one worth not skipping. Both engines editing the same Findings is fine to observe, but you want to be the one who decides when the sends start.

--- a/docs/content/automation/rules_engine_2/deliveries.md
+++ b/docs/content/automation/rules_engine_2/deliveries.md
@@ -1,0 +1,118 @@
+---
+title: "Deliveries"
+description: "The ledger of everything rules send outward, and how retries and replay work"
+weight: 5
+audience: pro
+aliases:
+  - /automation/rules_engine_v2/deliveries/
+---
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Rules Engine 2.0 is a DefectDojo Pro-only feature.</span>
+
+Every outbound side effect a rule produces is one row in the delivery ledger. **Rules Engine 2.0 > Deliveries** lists them.
+
+The row is written **before** any network call happens, and it holds exactly what would be, or was, sent. That is what makes egress auditable rather than a log line you hope somebody kept, and it is why **Simulate** is not a separate code path: a simulated send is the same row with the dispatch step skipped.
+
+## What a delivery records
+
+| Field | Meaning |
+|-------|---------|
+| **Run** and **Node** | Which run and which egress node produced it. |
+| **Finding** | The Finding it is about, for a per-Finding send. Batch sends record the group instead. |
+| **Channel** | What kind of send it is. |
+| **Target** | The resolved destination: a JIRA project key, a channel, a URL, an address. |
+| **Title** | A one-line description of the send. |
+| **Payload** | Exactly what would be, or was, sent. |
+| **Mode** | `simulate` or `live`. |
+| **Status** | Where the delivery got to. |
+| **Attempts** | How many sends have been tried, against the maximum allowed. |
+| **Last error** | Why the last attempt failed, or why the delivery was skipped. |
+| **Response** | What the destination said back. |
+| **External reference** and **URL** | The ticket key, message id or file path the destination returned, and a link to it when there is one. |
+
+## Channels
+
+| Channel | Produced by |
+|---------|-------------|
+| **JIRA** | Create a JIRA Issue |
+| **Downstream connector** | Create a Downstream Ticket |
+| **Slack** | Send a Slack Message, and report announcements sent to Slack |
+| **Microsoft Teams** | Send a Microsoft Teams Message |
+| **Email** | Send an Email, and report announcements sent by email |
+| **Webhook** | Call a Webhook |
+| **Report** | Generate a Report |
+| **In-app alert** | Raise an In-App Alert |
+
+## Statuses
+
+| Status | Meaning |
+|--------|---------|
+| `simulated` | The rule was in Simulate mode. Nothing was sent, and nothing ever will be. |
+| `skipped` | Something already covered this send, or gating declined it. The reason is in the last error field. |
+| `pending` | Recorded in Live mode, waiting for its delivery task. |
+| `dispatched` | Handed to the integration service, waiting for confirmation. |
+| `sent` | Confirmed delivered. |
+| `failed` | Permanently rejected, for example a 4xx or a vendor error. Can be replayed. |
+| `dead` | Retries exhausted, or no confirmation ever arrived. Can be replayed. |
+
+`skipped` is worth dwelling on. Skips are recorded rather than silent, because "the rule did nothing" and "the rule did nothing because this Finding already had a ticket" are different answers, and only one of them is a problem.
+
+There are three common reasons for a skip, and the last error field always says which:
+
+* **Idempotency.** Something already covered this send.
+* **The channel is switched off.** A rule with a Slack node on an instance where Slack is disabled records a skip explaining that, rather than failing. A rule saved while a channel was on should not start erroring when somebody turns it off. See [node availability](../node_reference/#when-a-channel-is-unavailable).
+* **The per-Finding send ceiling was reached.** A node sending one message per Finding stops after 1,000 in a single run by default, and records how many it did not send about.
+
+### Payload fidelity
+
+The ledger is honest about how close the recorded payload is to the real wire body, because that varies by channel.
+
+| Fidelity | Meaning |
+|----------|---------|
+| `exact` | Byte-equivalent to what was sent. |
+| `rendered` | Rendered by the real helpers, but send-time gating may still trim it. |
+| `dojo request` | The exact request handed to the integration service. The vendor-specific payload is composed downstream. |
+| `summary` | A description of the send rather than a reproduction of it. A generated report is the example: the file is built from live data at send time, so a stored copy of it would be wrong the moment anything changed. |
+
+## The double-send guard
+
+Only one **active** delivery can exist per idempotency key, enforced in the database rather than by convention. Active means `pending`, `dispatched` or `sent`.
+
+A second send that would collide with an active one becomes a `skipped` row with its reason recorded. It is never a silent no-op, and it is never a duplicate ticket.
+
+Because `simulated`, `skipped`, `failed` and `dead` rows do not hold a claim, a failed delivery can be replayed in place without a second row fighting it for the same key.
+
+## Retries
+
+A live delivery is retried automatically. Each row carries its own attempt count and its own ceiling, six attempts by default, so a failing destination cannot take its siblings down with it. Retries back off between attempts.
+
+When the last retry is spent, the row is marked `dead` rather than left sitting at `pending`. Exhaustion is visible, not silent.
+
+If a worker is killed mid-send, the message is redelivered. The row is locked and its status re-checked before anything is sent again, so a redelivery cannot become a double-send.
+
+Deliveries handed to the integration service move to `dispatched` and wait for a confirmation callback. If no callback arrives within six hours, the row is marked `dead` so it can be replayed. That window is deliberately generous: a downstream queue backing up for an hour is normal, and burying a row too eagerly would turn a replay into a duplicate ticket.
+
+## Replaying a delivery
+
+A `failed` or `dead` delivery can be resent from the Deliveries page. The ledger records when it was replayed and by whom.
+
+Replay needs **Rule Edit**.
+
+Replay re-sends the recorded payload. For a report, that regenerates the report from current data, because the payload is a description of what to generate rather than the file itself.
+
+## Simulate
+
+In Simulate mode, every egress node writes its delivery row with status `simulated`, full payload, and resolved target, then stops. No dispatch is registered, so nothing can send later however the run unwinds. Preview behaves the same way, and does not even insert the rows.
+
+This is the intended way to review a rule before letting it out: enable it in Simulate, let it run against real Findings, then read the payloads it recorded.
+
+Remember that Simulate holds back **only** the outbound sends. Findings nodes still change Findings.
+
+## Retention
+
+Deliveries are kept for **180 days** by default, after which a retention job prunes them.
+
+This is the fastest-growing table in the feature, because a node sending one message per Finding writes a row per Finding, in Simulate mode as well as Live. The default is a real window rather than "keep everything", so the growth does not quietly become your problem.
+
+You are told about it rather than left to discover it. A delivery's detail shows the retention window and the date that row will be deleted, and the date is recalculated on read, so changing the window takes effect immediately.
+
+Set the window longer if you need a longer outbound audit trail, or to `0` to keep everything. See [Configuration](../configuration/#retention).

--- a/docs/content/automation/rules_engine_2/node_reference.md
+++ b/docs/content/automation/rules_engine_2/node_reference.md
@@ -1,0 +1,341 @@
+---
+title: "Node Reference"
+description: "Every node Rules Engine 2.0 ships with, and what each one does"
+weight: 3
+audience: pro
+aliases:
+  - /automation/rules_engine_v2/node_reference/
+---
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Rules Engine 2.0 is a DefectDojo Pro-only feature.</span>
+
+Rules Engine 2.0 ships 25 nodes in four categories. This page documents all of them.
+
+Unless stated otherwise, a node takes one input, produces one output called `out`, and passes every item it received on to that output. That matters when you chain nodes: a Findings node changes the Finding and then hands the item onward, so several of them in a row all apply.
+
+## Triggers
+
+Every graph has exactly one trigger, and only a trigger can start a run. All three produce Finding items and all three take a **Scope** that narrows which Findings they produce. See [Building Rules](../building_rules/) for how scope works.
+
+### On Finding Event
+
+`trigger.finding`
+
+Runs when Findings are created, updated, closed or reopened.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Event** | `created` | Which Finding change wakes this rule: `created`, `updated`, `closed`, `reopened`, or `any` for all four. |
+| **Scope** | empty | Which Findings this rule considers. Empty means every Finding the rule owner can see. |
+
+Findings named by the event are matched against scope before they enter the graph, so the event decides *when* and scope decides *which*.
+
+### On a Schedule
+
+`trigger.schedule`
+
+Sweeps every Finding in scope on a schedule. The schedule is configured on the rule and is limited to quarter-hour marks.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Scope** | empty | Which Findings this rule considers. |
+
+### Manual Run
+
+`trigger.manual`
+
+Sweeps every Finding in scope when you press **Run** on the rule.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Scope** | empty | Which Findings this rule considers. |
+
+## Logic
+
+### If / Filter
+
+`filter.if`
+
+Routes each item down the **true** or the **false** branch, by conditions. This is the only node with two outputs, and it is how a graph branches.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Conditions** | empty | Each row is a path, an operator and a value. See [Conditions](../building_rules/#conditions). |
+| **Match** | `all` | Whether every condition has to hold (`all`), or just one of them (`any`). |
+
+An empty condition list passes everything down the true branch. Both branches are optional: leaving the false branch unwired simply drops the items that failed.
+
+### Limit
+
+`flow.limit`
+
+Passes the first N items and drops the rest. Useful as a safety valve while you are testing a rule, and for capping how many tickets or messages a single run can produce.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Keep First** | `100` | How many items to pass on. |
+
+### De-duplicate Within Run
+
+`flow.dedupe_batch`
+
+Keeps the first item per key and drops later ones carrying the same key. Scoped to the run, so it de-duplicates within one execution and not across executions.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Key Path** | `finding.hash_code` | The item path whose value identifies a duplicate. |
+
+A common use is `finding.component_name`, to notify once per affected component instead of once per Finding.
+
+## Findings
+
+These nodes change Findings. Every change is attributed back to the rule, run and node that made it, and shows up on the Finding's provenance timeline.
+
+### Set Severity
+
+`finding.set_severity`
+
+Sets the severity, and recomputes the SLA date and priority with it.
+
+| Setting | Options |
+|---------|---------|
+| **Severity** | `Critical`, `High`, `Medium`, `Low`, `Info` |
+
+### Set a Field
+
+`finding.set_field`
+
+Sets, appends to, or prepends to a text field.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Field** | none | One of `component_name`, `component_version`, `cvssv3`, `cwe`, `description`, `file_path`, `impact`, `mitigation`, `service`, `title`. |
+| **Mode** | `set` | `set`, `append` or `prepend`. A CVSSv3 vector can only be replaced. |
+| **Value** | none | The text to write. Supports `{{finding.title}}` style placeholders. |
+
+### Set Status
+
+`finding.set_status`
+
+Moves the Finding to a status.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Status** | none | `active`, `inactive`, `verified`, `unverified`, `false_positive`, `mitigated`, `reopen`. |
+| **Note** | empty | An optional note recorded alongside the status change. |
+
+### Add Tags
+
+`finding.add_tags`
+
+Adds tags to the Finding. Existing tags are kept.
+
+| Setting | Notes |
+|---------|-------|
+| **Tags** | Comma separated. Supports `{{product.name}}` style placeholders, so you can tag with data from the Finding. |
+
+### Add a Note
+
+`finding.add_note`
+
+Adds a note to the Finding.
+
+| Setting | Notes |
+|---------|-------|
+| **Note** | The note text. Supports placeholders. |
+
+### Set Owners
+
+`finding.set_owners`
+
+Makes a group responsible for the Finding.
+
+| Setting | Notes |
+|---------|-------|
+| **Group** | The group that owns these Findings. |
+
+### Set Reviewers
+
+`finding.set_reviewers`
+
+Puts the Finding under review by the selected users.
+
+| Setting | Notes |
+|---------|-------|
+| **Reviewers** | One or more users who should review these Findings. |
+
+### Accept Risk
+
+`finding.risk_accept`
+
+Simple risk accepts the Finding, or adds it to a risk acceptance record.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **How** | `simple` | `simple` sets simple risk acceptance on the Finding. `acceptance` adds it to a risk acceptance record. |
+| **Accepted** | on | Shown for `simple`. Turn off to un-accept the risk. |
+| **Risk Acceptance** | none | Shown for `acceptance`. Which risk acceptance to add these Findings to. |
+
+### Set Mitigation Policy
+
+`finding.set_mitigation_policy`
+
+Sets the mitigation policy the Finding is remediated under.
+
+| Setting | Notes |
+|---------|-------|
+| **Mitigation Policy** | The policy to apply. |
+
+### Change Priority
+
+`finding.set_priority`
+
+Sets the priority, or adjusts it arithmetically. This overrides the calculated priority.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Operation** | `set` | `set`, `add`, `subtract`, `multiply`, `divide`. |
+| **Value** | none | The priority to set, or the amount to adjust by. |
+
+### Set Risk
+
+`finding.set_risk`
+
+Sets the risk, overriding the computed one.
+
+| Setting | Options |
+|---------|---------|
+| **Risk** | `Low`, `Medium`, `Needs Action`, `Urgent` |
+
+## Egress
+
+Egress nodes are the nodes that leave DefectDojo. Every one of them records a [Delivery](../deliveries/) before anything is sent, and every one of them honours the rule's **Simulate** or **Live** mode.
+
+Several of them offer the same **One Message per Finding** choice. Off, the node sends one message describing the whole batch, with a severity breakdown and a capped list of Findings. On, it sends one message per Finding.
+
+A node sending one message per Finding stops after 1,000 sends in a single run by default, and records a visible skip saying how many Findings it did not send about. See [Configuration](../configuration/#per-finding-send-ceiling).
+
+### When a channel is unavailable
+
+An egress node depends on something outside the rule: a Slack token, a Microsoft Teams webhook, a JIRA configuration, a licensed connector. When that is missing or switched off, the node cannot work, and Rules Engine 2.0 says so at three different moments rather than failing quietly:
+
+* **In the palette**, an unavailable node is marked as such, with the reason, before you drag it onto the canvas.
+* **On save**, a graph containing an unavailable node is refused. That is the moment somebody is present to pick a different one.
+* **At run time**, the delivery is **skipped** with the reason attached, not failed. A rule saved while Slack was on should not start erroring the day somebody turns Slack off. The honest record is a skipped delivery saying Slack is off.
+
+### Create a JIRA Issue
+
+`ticket.jira`
+
+Creates or updates the JIRA issue for the Finding.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Skip Findings That Already Have an Issue** | on | Leaves Findings that already have a JIRA issue alone. |
+| **Update an Existing Issue** | off | Shown when the skip above is off. Pushes Findings that already have an issue, so JIRA is updated. |
+
+The summary, description and priority come from the product's JIRA configuration, not from this node. A ticket a rule creates is therefore identical to one created by push all issues.
+
+### Create a Downstream Ticket
+
+`ticket.downstream`
+
+Creates or updates a ticket through a [Downstream Connector](/issue_tracking/pro_integration/integrations/).
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Issue Trackers** | `auto` | `auto` uses the issue trackers assigned to the engagement or product. `mapping` targets one specific mapping. |
+| **Issue Tracker Mapping** | none | Shown for `mapping`. Which mapping to push to. |
+| **Operation** | `create` | `create` a ticket, or `update` the one that exists. An update with no existing ticket creates it. |
+| **Skip Findings That Already Have a Ticket** | on | Leaves Findings that already have a ticket in the target mapping alone. |
+
+The rule replaces the assignment's automatic push settings: severity and active-only filters are not applied a second time here. A Finding whose ticket already exists is skipped however that ticket was created.
+
+### Send a Slack Message
+
+`notify.slack`
+
+Posts to a Slack channel using the system Slack token from **System Settings**.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Channel** | empty | For example `#appsec`. Empty uses the channel from system settings. |
+| **One Message per Finding** | off | Off sends one message about the batch. |
+| **Message** | `{{finding.severity}}: {{finding.title}} ({{product.name}})` | Rendered per Finding. |
+| **Findings Listed in the Digest** | `10` | Shown for batch messages. How many Findings the message lists before it says how many more there were. |
+
+### Send a Microsoft Teams Message
+
+`notify.msteams`
+
+Posts a card to the Microsoft Teams webhook configured in **System Settings**.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **One Message per Finding** | off | Off sends one card about the batch. |
+| **Message** | `{{finding.severity}}: {{finding.title}} ({{product.name}})` | Rendered per Finding. |
+| **Findings Listed in the Digest** | `10` | Shown for batch messages. |
+
+### Send an Email
+
+`notify.email`
+
+Emails a fixed list of addresses.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **To** | none | One or more addresses, comma separated. Required. |
+| **Subject** | `[DefectDojo] {{ctx.count}} finding(s) from rule {{ctx.rule_name}}` | Rendered once per message. |
+| **Body** | an HTML body containing `{{ctx.findings_html}}` | HTML. `{{ctx.findings_html}}` renders the Finding list. |
+| **One Message per Finding** | off | Off sends one email about the batch. |
+| **Findings Listed in the Body** | `25` | How many Findings `{{ctx.findings_html}}` lists before it says how many more there were. |
+
+### Call a Webhook
+
+`notify.webhook`
+
+POSTs JSON to a webhook endpoint.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Webhook Endpoint** | none | A configured [notification webhook](/automation/api/notification_webhooks/). Its custom header is sent with the request. |
+| **URL** | empty | Shown when no endpoint is selected. Where to POST. |
+| | | One of the two above is required. |
+| **Signing Secret** | empty | Signs the body as `X-DefectDojo-Signature: sha256=HMAC`. |
+| **One Message per Finding** | off | Off posts the whole batch in one request. |
+
+Two things to know. A signing secret typed here is stored with the rule, so for anything sensitive prefer a configured endpoint and its own header. And a webhook called by a rule never changes that endpoint's own health status, so a rule cannot disable your notification webhooks by failing.
+
+Free-text URLs are validated when you save. See [Configuration](../configuration/#outbound-destination-validation) for what is rejected and how to allow private addresses.
+
+### Raise an In-App Alert
+
+`notify.alert`
+
+Creates an in-app alert about the batch.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Title** | `Rules Engine 2.0: {{ctx.rule_name}}` | Rendered once for the whole batch. |
+| **Description** | `{{ctx.count}} finding(s) matched the rule {{ctx.rule_name}}.` | Rendered once for the whole batch. |
+| **Recipients** | empty | Usernames, comma separated. Empty alerts the administrators. |
+
+Recipients still control this through their own **Rules Engine Match** notification setting, so an alert cannot bypass a user's notification preferences.
+
+### Generate a Report
+
+`report.generate`
+
+Generates a report from a template, scoped to the Findings that reached this node, and can announce the download link.
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| **Report Template** | none | Which template to generate from. Required. |
+| **Format** | `pdf` | `pdf` or `html`. |
+| **Findings Included** | `batch_findings` | `batch_findings` limits the report to the Findings that reached this node. `template_default` lets the template use its own filters. |
+| **Announce the Report** | `none` | `none`, `email` or `slack`. Sends the download link once the report is generated. |
+| **Announce To** | empty | Shown when announcing. A Slack channel, or comma separated email addresses. Slack falls back to system settings. |
+| **Announcement** | `Report ready: {{ctx.report_url}}` | Shown when announcing. `{{ctx.report_url}}` is the download link. |
+
+`batch_findings` is what a rule can do that a scheduled report cannot: report on exactly the Findings that just matched.
+
+The announcement is recorded as its own delivery, separate from the report generation, so you can see the report succeed and the announcement fail independently.

--- a/docs/content/automation/rules_engine_2/runs.md
+++ b/docs/content/automation/rules_engine_2/runs.md
@@ -1,0 +1,131 @@
+---
+title: "Runs"
+description: "How a rule executes, what a run records, and how cascading is bounded"
+weight: 4
+audience: pro
+aliases:
+  - /automation/rules_engine_v2/runs/
+---
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Rules Engine 2.0 is a DefectDojo Pro-only feature.</span>
+
+A **run** is one execution of one rule. Every run is recorded, whether it succeeded or failed, and every node inside it leaves a trace. **Rules Engine 2.0 > Runs** lists them.
+
+## What a run records
+
+| Field | Meaning |
+|-------|---------|
+| **Rule** | The rule that executed. |
+| **Trigger** | The event that started it, for example `finding.created`, `schedule` or `manual`. |
+| **Triggered by** | The person who set it off, when a person did: whoever pressed Run, or whoever saved the Finding that triggered it. Empty for a schedule, and for a change nobody was present for such as an import or an API call with no user. This is distinct from the rule's owner, which is who the run executed **as**. |
+| **Status** | `Running`, `Success` or `Error`. |
+| **Started** and **Finished** | When it ran. Finished is empty only while it is still running. |
+| **Error** | The error that ended it, if it failed. |
+| **Stats** | Per-node totals, cascaded events, and deferred work. |
+| **Depth** | How many cascade hops away from the originating event this run is. |
+| **Source run** | The run whose emitted event triggered this one, for a cascaded run. |
+
+### The node trace
+
+Inside a run, every node records its own row:
+
+| Field | Meaning |
+|-------|---------|
+| **Order** | Where the node sat in the execution order. |
+| **Node** | Its id, its type, and its label if you gave it one. |
+| **Status** | Whether the node completed or raised. |
+| **Items in** | How many items entered. |
+| **Items out** | How many left, broken down per output handle, so an If / Filter node shows its true and false counts separately. |
+| **Summary** | Whatever counters the node reported, for example how many Findings it changed. |
+| **Error** | The error it raised, if it failed. |
+
+The trace is what you read when a rule did not do what you expected. An If / Filter node reporting 400 items in and 0 down the true branch tells you the conditions are wrong, without you having to guess.
+
+## Execution model
+
+Nodes execute in topological order: a node runs once everything feeding into it has run. A node with several incoming edges receives all of their outputs concatenated. A node with nothing feeding into it still runs, with an empty input list.
+
+### A failed run changes nothing
+
+A run is atomic. If any node raises, every Finding change the run made is rolled back.
+
+The trace is not rolled back with it. The node rows and the `Error` status are written afterwards, so a failed run tells you exactly which node broke while leaving no half-applied edits behind. This is the single most important guarantee to keep in mind when reading the Runs page: an errored run is a run that did nothing.
+
+Egress follows the same rule. Deliveries are recorded inside the run's transaction and only dispatched after it commits, so a run that rolls back sends nothing.
+
+### One run per rule at a time
+
+A rule can only have one run in progress. A second trigger for the same rule while it is still running does not race with it. It waits and retries.
+
+Different rules run fully concurrently, so a slow rule never holds up its siblings.
+
+If a run is somehow abandoned, for example because the worker executing it was killed, its lock is released after a stall window (30 minutes by default) so the rule is not wedged forever. A run approaching that window stops itself first, unwinding cleanly, so a merely slow run can never end up executing alongside its own replacement.
+
+## Cascading
+
+A rule that changes a Finding produces exactly the kind of event another rule can trigger on. Rules Engine 2.0 allows that, so `A -> B -> C` chains work, and bounds it in two independent ways:
+
+* **Depth.** An event may travel at most **3** cascade hops from the change that originated it.
+* **Chain membership.** Every event carries the list of rules already traversed in its chain, and a rule never runs twice in the same chain. So a rule cannot re-trigger itself, and two rules cannot ping-pong.
+
+A run's **Depth** and **Source run** fields let you follow a chain back to the change that started it. **Triggered by** is carried down the whole chain, so a cascade one person set off stays attributable to them at every hop.
+
+Changes made *by* a running rule are attributed to that rule's own cascade rather than looking like fresh user activity, so a rule delegating work internally does not inflate the chain.
+
+## Scale and limits
+
+**A run is not capped.** A rule processes everything its scope matches, however large that is. A rule that silently stopped at the first N Findings would be a rule you could not trust.
+
+Instead, a run is processed in **chunks**, 1,000 Findings at a time by default. Only the chunk is held in memory, so a sweep over a very large scope is bounded in memory rather than in coverage. The one exception is **Preview**, which does cap, and says so in its trace when it truncates.
+
+Two other numbers shape how work is divided:
+
+* **Findings per event**, 500 by default. A bulk change is split across several events, each becoming its own run. The practical effect for a large import is a manageable number of runs rather than one run per Finding.
+* **Per-Finding send ceiling**, 1,000 by default. An egress node set to send one message per Finding stops at this many in a single run and records a visible skip saying how many it did not send about. This bounds delivery rows and queued tasks, which a chunked run no longer bounds on its own.
+
+All three are deployment settings, documented in [Configuration](../configuration/).
+
+### How long a run may take
+
+A run stamps a **heartbeat** after each chunk. Stall detection reads that heartbeat rather than the start time, so a long sweep that is still making progress is never mistaken for a crashed worker.
+
+Two windows apply, both configurable:
+
+* A run that goes 30 minutes without a heartbeat is treated as abandoned, errored, and its lock released.
+* A run is killed outright after six hours, as a guard against one that will never finish.
+
+## Retention
+
+Runs are kept for **180 days** by default, along with their per-node rows and their Finding provenance. Deliveries are kept for 180 days separately.
+
+The product tells you this rather than leaving it implicit: a run's detail shows the retention window and the date that run will be deleted. A run still holding deliveries is kept until those are pruned.
+
+Both windows are configurable, and either can be set to keep records indefinitely. See [Configuration](../configuration/#retention).
+
+## Running a rule by hand
+
+A rule whose trigger is **Manual Run** is executed with the **Run** action on the rule list. Rules with other triggers run when their trigger fires.
+
+**Preview**, in the editor, is the other way to execute a graph. It runs the real engine and then rolls everything back, records no run, and forces egress to simulate. Use preview while building, and runs to see what actually happened.
+
+## Provenance on a Finding
+
+Runs answer "what did this rule do?". Provenance answers the opposite question: "why did this Finding change?".
+
+Every change a rule makes is recorded against the Finding with the rule, the run and the node responsible, and appears as a timeline on the Finding itself. The recorded actions are:
+
+| Action | Meaning |
+|--------|---------|
+| `created`, `updated`, `closed`, `reopened` | The Finding's lifecycle changed. |
+| `duplicate`, `status_change` | Its duplicate or status flags changed. |
+| `notified` | A notification went out about it. |
+| `delivered` | An outbound delivery covered it. |
+
+Field edits record what changed, including the before and after value of each field. Very long values are truncated in the record, so the timeline stays a record of the change rather than a second copy of the Finding.
+
+Notifications and deliveries are recorded here too. That is deliberate: a rule that sent a message but changed no field would otherwise leave no trace on the Finding at all.
+
+Provenance survives the rule. Deleting a rule or a run keeps the timeline entries and simply unlinks them, so history does not disappear when someone tidies up.
+
+## Deleting rules with history
+
+A rule that has produced deliveries cannot be deleted out from under them. Delete the deliveries first, or keep the rule and disable it. This is intentional: deliveries hold the record of what was actually sent to external systems, and a cascade delete would take in-flight sends with it.


### PR DESCRIPTION
**Description**

Documents Rules Engine 2.0, the node-graph automation builder in DefectDojo Pro, which had no user documentation at all until now.

The feature ships behind a beta feature flag and is substantial enough that a single page would not have covered it, so this adds a chapter under `automation/` alongside the existing Rules Engine docs:

| Page | Covers |
|------|--------|
| `about` | What it is, how to enable it, the permissions it needs, and the concepts: graphs, items, rule ownership, simulate and live modes, runs, deliveries, provenance, scale and retention |
| `building_rules` | The editor, graph validation rules, preview, the three trigger types and scope, scheduling, the item field reference, all 14 condition operators, all 12 transforms, and message templates |
| `node_reference` | All 25 nodes across Triggers, Logic, Findings and Egress, with every configuration option, default and allowed value |
| `runs` | The execution model, per-node traces, the all-or-nothing transaction contract, per-rule locking, cascading, chunking, heartbeats and retention |
| `deliveries` | The outbound ledger: 8 channels, 7 statuses, payload fidelity, the double-send guard, retries, replay and retention |
| `converting_from_rules_engine` | Moving existing Rules Engine rules across, what carries over, what does not, and a suggested order |
| `configuration` | The nine deployment settings, plus outbound destination validation |

The existing Rules Engine page gains one paragraph pointing at the new chapter, since a reader landing there should know the graph editor exists.

Every page carries an alias from an earlier `rules_engine_v2` path, so the in-product help links resolve to the new location rather than 404ing.

**Test results**

Not applicable: documentation only, no code changed.

Built locally with Hugo 0.151.0. Clean build, no warnings, all 8 new pages render, and the aliases resolve to the new paths. Internal links were checked against the files they target, and the five cross-page anchors were verified against the headings they point at in the generated HTML.

Worth noting for anyone building the docs locally: the pinned theme now needs a Hugo new enough to provide the `try` function (0.141 or later). An older Hugo fails to build the site at all, on a theme template rather than on any content.

**Documentation**

This PR is the documentation.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the docs.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.
