### PR TITLE
docs(agents): milestone every new PR at creation, from milestones that already exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,50 @@ the work to `bugfix` first.
 The ack covers one session. A `SessionStart` hook reports the branch and its release line
 at startup so the branch is settled before the first edit.
 
+## Pull Requests
+
+### Every new PR gets a milestone, and that milestone already exists
+
+Set the milestone in the same step that opens the PR, not in a later cleanup pass. Which
+milestone follows from the PR's **base branch**, for the same reason the Branch Check
+above matters: a `dev` PR cannot ship in a patch release, so it must not carry a patch
+milestone.
+
+| Base branch | Milestone to attach | Example, for a PR opened 2026-08-03 |
+|-------------|---------------------|-------------------------------------|
+| `bugfix` | next weekly patch, `X.Y.<hundreds>` | `3.2.100` |
+| `dev` | next monthly minor, `X.Y.0` | `3.3.0` |
+| `master` | the version actually being released or backported into — ask, do not guess | `3.2.0` |
+
+"Next" means the earliest **open** milestone of that kind whose due date is still in the
+future. A milestone due today or overdue is usually a release already cut, so a PR opened
+now will not make it. Read the answer out of the repo instead of from memory:
+
+```bash
+# base bugfix -> next weekly patch milestone
+gh api repos/DefectDojo/django-DefectDojo/milestones --paginate --jq \
+  '[.[] | select(.state=="open" and (.title|test("\\.[1-9]00$")) and .due_on > (now|todate))] | sort_by(.due_on)[0].title'
+# base dev -> next monthly minor milestone
+gh api repos/DefectDojo/django-DefectDojo/milestones --paginate --jq \
+  '[.[] | select(.state=="open" and (.title|test("\\.0$")) and .due_on > (now|todate))] | sort_by(.due_on)[0].title'
+```
+
+Attach it on creation, or immediately after if the body is written in a second step:
+
+```bash
+gh pr create ... --milestone "3.2.100"
+gh pr edit <n> --milestone "3.2.100"
+```
+
+**Never create a milestone.** The milestone list is the published release schedule, so a
+milestone invented at PR time is a release that does not exist. If the query returns
+`null`, the schedule has not been extended that far: say so and leave the PR
+unmilestoned.
+
+**Retargeting the base changes the milestone.** Moving a PR between `bugfix` and `dev`
+moves which release it ships in, so re-run the query for the new base and `gh pr edit
+--milestone` to match.
+
 ## Project Overview
 
 DefectDojo is a Django application (`dojo` app) for vulnerability management. The codebase is undergoing a modular reorganization to move from monolithic files toward self-contained domain modules.


### PR DESCRIPTION
[sc-14144]

**Description**

Documentation only: adds a Pull Requests section to `AGENTS.md`, next to the existing
Branch Check.

Every new PR carries a milestone from the moment it is opened, derived from the PR's base
branch rather than picked by feel:

| Base branch | Milestone |
|-------------|-----------|
| `bugfix` | next weekly patch, `X.Y.<hundreds>` |
| `dev` | next monthly minor, `X.Y.0` |
| `master` | the version actually being released or backported into (ask) |

"Next" is the earliest open milestone of that kind whose due date is still in the future,
so a release already cut (due today or overdue) is skipped. The section includes the
`gh api .../milestones --jq ...` one-liner per line, so the target is read out of the repo
rather than remembered, plus the `gh pr create --milestone` / `gh pr edit --milestone`
commands.

Two rules go with it:

- **Milestones are never created at PR time.** The milestone list is the published release
  schedule, so an invented milestone is a release that does not exist. If no future
  milestone of the right kind exists, say so and leave the PR unmilestoned.
- **Retargeting the base re-derives the milestone**, since moving a PR between `bugfix` and
  `dev` moves which release it ships in.

**Test results**

No code changes, so there is nothing to add to the test suite. The `jq` selection commands
in the new section were run against this repo's live milestone list before committing (base
`bugfix` → `3.2.100`, base `dev` → `3.3.0`), and this PR is milestoned by its own rule.

**Documentation**

`AGENTS.md` is the documentation changed here; no user-facing docs under `docs/` are
affected.
