### PR TITLE
refactor(finding): extract save()'s field derivation so batched writers can reuse it

### DIFF
--- a/dojo/finding/models.py
+++ b/dojo/finding/models.py
@@ -571,7 +571,7 @@ class Finding(BaseModel):
         """
         return titlecase((title or "")[:cls._meta.get_field("title").max_length])
 
-    def derive_persisted_fields(self, *, dedupe_option: bool = True) -> None:
+    def derive_persisted_fields(self, *, dedupe_option: bool = True, is_new_finding: bool = False) -> None:
         """Normalize and derive the fields that must hold for any persisted finding.
 
         This is the transform ``save()`` applies to a finding's own columns before the row
@@ -640,22 +640,11 @@ class Finding(BaseModel):
 
         self.set_hash_code(dedupe_option)
 
-    def save(self, dedupe_option=True, rules_option=True, product_grading_option=True,  # noqa: FBT002
-             issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):  # noqa: FBT002 - this is bit hard to fix nice have this universally fixed
-        logger.debug("Start saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is %s)", "None" if self.pk is None else "not None")
-        from dojo.finding import helper as finding_helper  # noqa: PLC0415 -- lazy import, avoids circular dependency
-
-        is_new_finding = self.pk is None
-
-        # if not isinstance(self.date, (datetime, date)):
-        #     raise ValidationError(_("The 'date' field must be a valid date or datetime object."))
-
-        if not user:
-            from dojo.utils import get_current_user  # noqa: PLC0415 -- lazy import, avoids circular dependency
-            user = get_current_user()
-        self.derive_persisted_fields(dedupe_option=dedupe_option)
-
         if is_new_finding:
+            # A new finding's static/dynamic flags come from file_path plus the locations
+            # the parser attached, both of which are in memory -- no row required. The
+            # equivalent branch for an *existing* finding queries self.locations/endpoints
+            # and so stays in save().
             if settings.V3_FEATURE_LOCATIONS:
                 if (self.file_path is not None) and (len(self.unsaved_locations) == 0):
                     self.static_finding = True
@@ -669,6 +658,22 @@ class Finding(BaseModel):
             elif (self.file_path is not None):
                 self.static_finding = True
 
+    def save(self, dedupe_option=True, rules_option=True, product_grading_option=True,  # noqa: FBT002
+             issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):  # noqa: FBT002 - this is bit hard to fix nice have this universally fixed
+        logger.debug("Start saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is %s)", "None" if self.pk is None else "not None")
+        from dojo.finding import helper as finding_helper  # noqa: PLC0415 -- lazy import, avoids circular dependency
+
+        is_new_finding = self.pk is None
+
+        # if not isinstance(self.date, (datetime, date)):
+        #     raise ValidationError(_("The 'date' field must be a valid date or datetime object."))
+
+        if not user:
+            from dojo.utils import get_current_user  # noqa: PLC0415 -- lazy import, avoids circular dependency
+            user = get_current_user()
+        self.derive_persisted_fields(dedupe_option=dedupe_option, is_new_finding=is_new_finding)
+
+        if is_new_finding:
             # because we have reduced the number of (super()).save() calls, the helper is no longer called for new findings
             # so we call it manually
             finding_helper.update_finding_status(self, user, changed_fields={"id": (None, None)})

--- a/dojo/finding/models.py
+++ b/dojo/finding/models.py
@@ -555,21 +555,47 @@ class Finding(BaseModel):
     def __str__(self):
         return self.title
 
-    def save(self, dedupe_option=True, rules_option=True, product_grading_option=True,  # noqa: FBT002
-             issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):  # noqa: FBT002 - this is bit hard to fix nice have this universally fixed
-        logger.debug("Start saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is %s)", "None" if self.pk is None else "not None")
-        from dojo.finding import helper as finding_helper  # noqa: PLC0415 -- lazy import, avoids circular dependency
+    @classmethod
+    def persisted_title(cls, title: str | None) -> str:
+        """Return a title in the exact form a persisted finding carries.
 
-        is_new_finding = self.pk is None
+        The single source of truth for the title transform. Anything that needs to know
+        what a title *will* look like once stored -- notably a hash computed before the
+        row is written, which must match the hash computed after -- calls this instead of
+        repeating the transform.
 
-        # if not isinstance(self.date, (datetime, date)):
-        #     raise ValidationError(_("The 'date' field must be a valid date or datetime object."))
+        Note that ``titlecase()`` is not merely a case change: it also normalizes
+        whitespace, collapsing consecutive newlines and turning tabs into spaces. A
+        reimplementation that truncated but did not titlecase therefore diverged for any
+        multi-line title, which is a bug that has already been paid for once.
+        """
+        return titlecase((title or "")[:cls._meta.get_field("title").max_length])
 
-        if not user:
-            from dojo.utils import get_current_user  # noqa: PLC0415 -- lazy import, avoids circular dependency
-            user = get_current_user()
+    def derive_persisted_fields(self, *, dedupe_option: bool = True) -> None:
+        """Normalize and derive the fields that must hold for any persisted finding.
+
+        This is the transform ``save()`` applies to a finding's own columns before the row
+        is written: title casing/truncation, blank-component normalization, the date
+        default, numerical severity, CVSS vector parsing, and the same-tool hash. It reads
+        configuration but performs no writes, touches no relations, and dispatches nothing,
+        so it is safe to call on an unsaved instance and on many instances in a loop.
+
+        It exists as a separate method so that batched writers -- anything using
+        ``bulk_create``/``bulk_update``, which bypass ``save()`` and its signals entirely --
+        can produce rows identical to the ones ``save()`` produces, by calling this rather
+        than reimplementing it. A second copy of this logic is not a hypothetical risk: Pro's
+        reimport hashing previously re-derived only the title truncation, and the missing
+        ``titlecase()`` (which also collapses whitespace) made the pre-save lookup hash and
+        the stored hash diverge for any multi-line title, so those findings were closed and
+        recreated on every single reimport.
+
+        Anything requiring a primary key -- ``found_by``, location/endpoint queries, SLA
+        expiry, status bookkeeping, post-save dispatch -- deliberately stays in ``save()``,
+        because a batched writer needs a genuinely different (set-based) implementation of
+        those rather than a shared one.
+        """
         # Title Casing
-        self.title = titlecase(self.title[:511])
+        self.title = Finding.persisted_title(self.title)
         # Normalize blank component fields to NULL so that findings without a component
         # group together. An empty string is treated as a distinct value from NULL by the
         # database, which would otherwise produce a separate "None" component group (SC-13073).
@@ -613,6 +639,21 @@ class Finding(BaseModel):
                 self.cvssv4 = None
 
         self.set_hash_code(dedupe_option)
+
+    def save(self, dedupe_option=True, rules_option=True, product_grading_option=True,  # noqa: FBT002
+             issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):  # noqa: FBT002 - this is bit hard to fix nice have this universally fixed
+        logger.debug("Start saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is %s)", "None" if self.pk is None else "not None")
+        from dojo.finding import helper as finding_helper  # noqa: PLC0415 -- lazy import, avoids circular dependency
+
+        is_new_finding = self.pk is None
+
+        # if not isinstance(self.date, (datetime, date)):
+        #     raise ValidationError(_("The 'date' field must be a valid date or datetime object."))
+
+        if not user:
+            from dojo.utils import get_current_user  # noqa: PLC0415 -- lazy import, avoids circular dependency
+            user = get_current_user()
+        self.derive_persisted_fields(dedupe_option=dedupe_option)
 
         if is_new_finding:
             if settings.V3_FEATURE_LOCATIONS:

--- a/dojo/finding/models.py
+++ b/dojo/finding/models.py
@@ -557,7 +557,8 @@ class Finding(BaseModel):
 
     @classmethod
     def persisted_title(cls, title: str | None) -> str:
-        """Return a title in the exact form a persisted finding carries.
+        """
+        Return a title in the exact form a persisted finding carries.
 
         The single source of truth for the title transform. Anything that needs to know
         what a title *will* look like once stored -- notably a hash computed before the
@@ -572,7 +573,8 @@ class Finding(BaseModel):
         return titlecase((title or "")[:cls._meta.get_field("title").max_length])
 
     def derive_persisted_fields(self, *, dedupe_option: bool = True, is_new_finding: bool = False) -> None:
-        """Normalize and derive the fields that must hold for any persisted finding.
+        """
+        Normalize and derive the fields that must hold for any persisted finding.
 
         This is the transform ``save()`` applies to a finding's own columns before the row
         is written: title casing/truncation, blank-component normalization, the date


### PR DESCRIPTION
## Summary

Extracts the field derivation `Finding.save()` performs into a reusable method, so code that writes findings without going through `save()` can produce identical rows instead of reimplementing the transform.

No behavior change: `save()` calls the extracted method at exactly the point the inline block used to run, and the block moved verbatim.

## Why

`save()` currently does two separable things:

1. **Derive the finding's own columns** — title casing and truncation, blank-component normalization, the `date` default, `numerical_severity`, CVSS v3/v4 vector parsing and scoring, and the same-tool hash. This reads configuration but writes nothing, touches no relations, and dispatches nothing.
2. **Everything requiring a primary key** — `found_by`, location/endpoint queries, SLA expiry, status bookkeeping, and the post-save dispatch.

Only (1) is meaningful for a caller that writes rows in bulk. `bulk_create` and `bulk_update` bypass `save()` and its signals entirely, so any batched writer must either reimplement (1) or produce rows that differ from every other finding in the database — different casing, a missing `numerical_severity`, an unparsed CVSS vector, no hash.

**Reimplementing it is not a hypothetical risk; it has already cost us once.** A downstream hash computation re-derived only the title truncation and omitted `titlecase()`. Because `titlecase()` also normalizes whitespace — collapsing consecutive newlines, turning tabs into spaces — the pre-save lookup hash and the stored hash diverged for any multi-line title. Reports carrying an embedded `\n\n` in the title matched nothing on reimport, so those findings were closed and recreated on **every single run**, even though the titles were far under the length limit.

## Changes

**`Finding.persisted_title(title)`** (new classmethod) — the single source of truth for the title transform, reading `max_length` from the field rather than hardcoding it. Anything needing to know what a title *will* look like once stored calls this.

**`Finding.derive_persisted_fields(*, dedupe_option=True, is_new_finding=False)`** (new method) — the derivation block, moved verbatim. Safe to call on an unsaved instance and in a loop.

`is_new_finding` also carries across the static/dynamic flag derivation from `save()`'s new-finding branch. Those flags come from `file_path` plus the parser-attached `unsaved_locations`/`unsaved_endpoints`, all in memory, so they belong with the rest of the derivation rather than somewhere a batched writer would have to reimplement them. The equivalent branch for an *existing* finding queries `self.locations`/`self.endpoints` and stays in `save()`.

**`Finding.save()`** — now calls `derive_persisted_fields()` in place of the inline blocks, passing `is_new_finding` through. Behavior is unchanged.

Fields requiring a PK deliberately stay in `save()`. A batched writer needs a genuinely set-based implementation of those (bulk through-rows, one dispatch instead of N), not a shared one, so hoisting them would create a false promise of reuse.

## What this makes possible

With the derivation shared, a caller that writes findings in bulk can produce rows that differ from a `save()`-written row **only in the primary key**. Everything `save()` derives happens before its INSERT and none of it needs a row to exist — `update_finding_status()` only assigns fields, and `set_sla_expiration_date()` only computes a date — so a batched writer needs no second UPDATE pass over the rows it just inserted.

That is verified downstream by a test asserting column-for-column equality between the two paths and enumerating the ones that legitimately differ, so a future derivation added to `save()` but not to this method fails loudly rather than silently producing malformed rows in a bulk path.

## Risk

The extracted block is unchanged, and it runs at the same point in `save()` with the same inputs, so single-finding behavior is identical. The new method is additive and has no callers in this PR beyond `save()` itself.

The one deliberate difference is `persisted_title()` reading `Finding.title.max_length` where the inline code hardcoded `511`. Those are the same value today; reading the field means they cannot silently diverge if the column is ever widened.
