### PR TITLE
ci: retry Docker Hub image pulls before failing the job

### DIFF
--- a/.github/workflows/fetch-oas.yml
+++ b/.github/workflows/fetch-oas.yml
@@ -27,13 +27,38 @@ jobs:
           ref: ${{ env.release_version }}
 
       - name: Load docker images
+        timeout-minutes: 10
+        # image pulls from Docker Hub time out every so often, so retry before failing the job
         run: |-
-             docker pull defectdojo/defectdojo-django:${{ env.release_version }}-alpine
-             docker pull defectdojo/defectdojo-nginx:${{ env.release_version }}-alpine
+             RETRY=0
+             until docker pull defectdojo/defectdojo-django:${{ env.release_version }}-alpine \
+                   && docker pull defectdojo/defectdojo-nginx:${{ env.release_version }}-alpine
+               do
+               if [[ $RETRY -gt 2 ]]; then
+                 echo "ERROR: could not pull the release images after $RETRY retries"
+                 exit 1
+               fi
+               RETRY=$((RETRY+1))
+               echo "Attempt $RETRY to pull the release images"
+               sleep 15
+             done
              docker images
 
       - name: Start Dojo
-        run: docker compose up --no-deps -d valkey postgres uwsgi nginx
+        timeout-minutes: 10
+        # image pulls from Docker Hub time out every so often, so retry before failing the job
+        run: |-
+             RETRY=0
+             until docker compose up --no-deps -d valkey postgres uwsgi nginx
+               do
+               if [[ $RETRY -gt 2 ]]; then
+                 echo "ERROR: could not start Dojo after $RETRY retries"
+                 exit 1
+               fi
+               RETRY=$((RETRY+1))
+               echo "Attempt $RETRY to start Dojo"
+               sleep 15
+             done
         env:
           DJANGO_VERSION: ${{ env.release_version }}-alpine
           NGINX_VERSION: ${{ env.release_version }}-alpine

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -104,7 +104,20 @@ jobs:
         run: ln -s docker-compose.override.integration_tests.yml docker-compose.override.yml
 
       - name: Start Dojo
-        run: docker compose up --no-deps -d postgres nginx celerybeat celeryworker mailhog uwsgi valkey webhook.endpoint
+        timeout-minutes: 10
+        # image pulls from Docker Hub time out every so often, so retry before failing the job
+        run: |-
+             RETRY=0
+             until docker compose up --no-deps -d postgres nginx celerybeat celeryworker mailhog uwsgi valkey webhook.endpoint
+               do
+               if [[ $RETRY -gt 2 ]]; then
+                 echo "ERROR: could not start Dojo after $RETRY retries"
+                 exit 1
+               fi
+               RETRY=$((RETRY+1))
+               echo "Attempt $RETRY to start Dojo"
+               sleep 15
+             done
         env:
           DJANGO_VERSION: ${{ matrix.os }}
           NGINX_VERSION: alpine

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -36,7 +36,20 @@ jobs:
         run: docker/setEnv.sh unit_tests_cicd
 
       - name: Start Postgres and webhook.endpoint
-        run: docker compose up --no-deps -d postgres webhook.endpoint
+        timeout-minutes: 10
+        # image pulls from Docker Hub time out every so often, so retry before failing the job
+        run: |
+          RETRY=0
+          until docker compose up --no-deps -d postgres webhook.endpoint
+            do
+            if [[ $RETRY -gt 2 ]]; then
+              echo "ERROR: could not start Postgres and webhook.endpoint after $RETRY retries"
+              exit 1
+            fi
+            RETRY=$((RETRY+1))
+            echo "Attempt $RETRY to start Postgres and webhook.endpoint"
+            sleep 15
+          done
 
       - name: Start uwsgi (idle)
         timeout-minutes: 5

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -51,7 +51,20 @@ jobs:
 
       # phased startup so we can use the exit code from unit test container
       - name: Start Postgres and webhook.endpoint
-        run: docker compose up --no-deps -d postgres webhook.endpoint
+        timeout-minutes: 10
+        # image pulls from Docker Hub time out every so often, so retry before failing the job
+        run: |-
+             RETRY=0
+             until docker compose up --no-deps -d postgres webhook.endpoint
+               do
+               if [[ $RETRY -gt 2 ]]; then
+                 echo "ERROR: could not start Postgres and webhook.endpoint after $RETRY retries"
+                 exit 1
+               fi
+               RETRY=$((RETRY+1))
+               echo "Attempt $RETRY to start Postgres and webhook.endpoint"
+               sleep 15
+             done
 
       # no celery or initializer needed for unit tests
       - name: Unit tests


### PR DESCRIPTION
**Description**

CI fails every so often for a reason that has nothing to do with Dojo. The jobs that bring containers up pull `postgres`, `valkey`, `mailhog` and `webhook.endpoint` straight from Docker Hub, and the registry occasionally times out:

```
 valkey Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

[A recent example](https://github.com/DefectDojo/django-DefectDojo/actions/runs/30822933261/job/91718406167): the `Start Dojo` step died about 15 seconds in and took the whole matrix leg with it, before a single test ran. The only fix available today is a manual re-run.

This wraps the affected steps in a retry loop. Four attempts, 15 seconds apart, then it fails loud with a clear message. The pattern is copied from `k8s-tests.yml`, which already retries this way, so no new action or dependency comes in with it.

Steps covered:

| Workflow | Step |
|---|---|
| `integration-tests.yml` | Start Dojo |
| `rest-framework-tests.yml` | Start Postgres and webhook.endpoint |
| `performance-tests.yml` | Start Postgres and webhook.endpoint |
| `fetch-oas.yml` | Load docker images, Start Dojo |

Two things worth flagging for review:

The retried command is `docker compose up -d`, not a separate `docker compose pull`. Splitting the pull out would be tidier, but it would then try to fetch `defectdojo/defectdojo-django:debian` from the registry, and that tag only exists locally after the `docker load` from build artifacts. `up -d` is idempotent, so a second attempt reconciles whatever the first one partially created and re-pulls only what is missing.

I also added `timeout-minutes: 10` to the four retried steps that had no timeout. Slightly beyond the retry itself, but a retry loop with no ceiling is how a 15-second flake becomes a six-hour job. Happy to drop it if you'd rather keep the diff narrower.

`fetch-oas.yml` is included because it runs at release time, where the same flake blocks a release instead of a PR.

**Test results**

No test suite covers workflow YAML, so this was verified directly:

- All four files parse as YAML, and every retry block passes `bash -n`.
- Ran the `fetch-oas` two-command loop against a stub failing twice then succeeding. It recovers and exits 0.
- Ran the same loop against a stub that always fails. It prints the error and exits 1 after the third retry, so a real registry outage still fails the job rather than being papered over.
- Confirmed that under the runner's `bash -e`, a failing `until` condition does not trip errexit. The loop retries instead of aborting on the first attempt.

The real proof is CI on this PR going green, and the flake being rare means absence of failure is weak evidence either way. The loop only engages when a pull fails, so the happy path is unchanged.

**Documentation**

None needed. No user-facing behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
