### PR TITLE
Scope importer file-attachment reuse to the owning finding

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 import time
+from uuid import uuid4
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -1080,8 +1081,16 @@ class BaseImporter(ImporterOptions):
             for unsaved_file in finding.unsaved_files:
                 data = base64.b64decode(unsaved_file.get("data"))
                 title = unsaved_file.get("title", "<No title>")
-                file_upload, _ = FileUpload.objects.get_or_create(title=title)
-                file_upload.file.save(title, ContentFile(data))
+                # FileUpload.title is unique per instance: only reuse a row this
+                # finding already owns, and give any new row a unique title.
+                file_upload = finding.files.filter(title=title).first()
+                if file_upload is None:
+                    unique_title = title
+                    if FileUpload.objects.filter(title=unique_title).exists():
+                        suffix = f" - {uuid4()!s:.8}"
+                        unique_title = f"{title[:100 - len(suffix)]}{suffix}"
+                    file_upload = FileUpload(title=unique_title)
+                file_upload.file.save(file_upload.title, ContentFile(data))
                 file_upload.save()
                 finding.files.add(file_upload)
 

--- a/unittests/test_importers_importer.py
+++ b/unittests/test_importers_importer.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 import uuid
 from unittest.mock import patch
@@ -1607,3 +1608,58 @@ class TestDojoImporterBatchPushToJira(DojoTestCase):
             flags[ungrouped_db.id],
             msg=f"ungrouped finding must be pushed individually, dispatched with push_to_jira={flags[ungrouped_db.id]}",
         )
+
+
+class ProcessFilesOwnershipTest(DojoTestCase):
+
+    """A file imported into one finding must not reuse or overwrite a FileUpload row owned by a finding in another product."""
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="admin")
+        Development_Environment.objects.get_or_create(name="Development")
+        self.importer = DefaultImporter.__new__(DefaultImporter)
+
+    def _finding_in_new_product(self, name):
+        product_type, _ = Product_Type.objects.get_or_create(name=f"{name}-pt")
+        product, _ = Product.objects.get_or_create(name=name, prod_type=product_type, description="t")
+        engagement = Engagement.objects.create(
+            name=f"{name}-eng", product=product,
+            target_start=timezone.now(), target_end=timezone.now())
+        test = Test.objects.create(
+            engagement=engagement, test_type=Test_Type.objects.get_or_create(name="Generic Findings Import")[0],
+            target_start=timezone.now(), target_end=timezone.now())
+        return Finding.objects.create(
+            test=test, title=f"{name}-finding", severity="Info",
+            description="t", reporter=self.user)
+
+    def _attach(self, finding, title, data):
+        finding.unsaved_files = [{"title": title, "data": base64.b64encode(data).decode()}]
+        self.importer.process_files(finding)
+
+    def test_same_title_across_products_does_not_cross_bind(self):
+        title = "evidence.png"
+        victim = self._finding_in_new_product("cross-bind-victim")
+        attacker = self._finding_in_new_product("cross-bind-attacker")
+
+        self._attach(victim, title, b"VICTIM-BYTES")
+        victim_file = victim.files.get()
+
+        # The attacker imports a file with the victim's exact title.
+        self._attach(attacker, title, b"ATTACKER-BYTES")
+        attacker_file = attacker.files.get()
+
+        self.assertNotEqual(victim_file.id, attacker_file.id)
+        victim_file.refresh_from_db()
+        self.assertEqual(victim_file.file.read(), b"VICTIM-BYTES")
+        self.assertNotIn(victim_file.id, attacker.files.values_list("id", flat=True))
+        self.assertNotIn(attacker_file.id, victim.files.values_list("id", flat=True))
+
+    def test_reimport_of_same_finding_reuses_its_own_row(self):
+        title = "evidence.png"
+        finding = self._finding_in_new_product("reuse-own")
+        self._attach(finding, title, b"FIRST")
+        first_id = finding.files.get().id
+        # Re-importing the same finding's own file keeps a single row.
+        self._attach(finding, title, b"SECOND")
+        self.assertEqual([first_id], list(finding.files.values_list("id", flat=True)))
+        self.assertEqual(finding.files.get().file.read(), b"SECOND")


### PR DESCRIPTION
Hardening / consistency improvement to scan-import file handling. The importer now reuses an uploaded-file row only when the finding being imported already references that title, and otherwise creates a new row (uniquifying the title on collision), instead of resolving the file title against the instance-wide namespace. Adds a regression test.

No functional change for a re-import of the same finding.