### PR TITLE
Risk acceptance: keep the requested expiration date, add expire/reinstate API actions, and fix broken links and the SonarQube status sync

### DIFF
--- a/docs/content/triage_findings/findings_workflows/OS__risk_acceptance.md
+++ b/docs/content/triage_findings/findings_workflows/OS__risk_acceptance.md
@@ -124,7 +124,14 @@ Moving the date to a date in the past does not immediately expire the Risk Accep
 
 ### What the API exposes
 
-API consumers can observe expiration state on the Risk Acceptance object via the `expiration_date`, `expiration_date_handled`, and `expiration_date_warned` fields.  A Risk Acceptance is "expired" precisely when `expiration_date_handled` is non-null.  When a reinstate happens, both `expiration_date_handled` and `expiration_date_warned` are cleared back to `null`, and `expiration_date` is updated to the reinstate target.
+API consumers can observe expiration state on the Risk Acceptance object via the `expiration_date`, `expiration_date_handled`, and `expiration_date_warned` fields.  A Risk Acceptance is "expired" precisely when `expiration_date_handled` is non-null.  When a reinstate happens, both `expiration_date_handled` and `expiration_date_warned` are cleared back to `null`, and `expiration_date` holds the date you sent — or today + N days when no date was requested.
+
+Expiring and reinstating are also available directly, so you do not have to drive them by editing `expiration_date`:
+
+- `POST /api/v2/risk_acceptance/{id}/expire/` expires it now.  Returns `400` if it has already expired.
+- `POST /api/v2/risk_acceptance/{id}/reinstate/` reinstates an expired one, re-accepting the Findings it covers.  Returns `400` if it has not expired.  Send `expiration_date` to choose how long for; omit it to use today + N days.
+
+Both accept an optional `reason`, which is recorded as a note on the Risk Acceptance along with who performed the action.  Both require the same permission as editing the Risk Acceptance.
 
 ## Risk Acceptance Best Practices 
 

--- a/docs/content/triage_findings/findings_workflows/OS__risk_acceptance.md
+++ b/docs/content/triage_findings/findings_workflows/OS__risk_acceptance.md
@@ -120,7 +120,7 @@ The date you enter is the date that is saved.  The system setting **Risk Accepta
 
 Moving the expiration date to an earlier-but-still-future date has no special behavior — the Risk Acceptance stays active and the new date is saved.
 
-Moving the date to a date in the past does not immediately expire the Risk Acceptance from the edit form; the next periodic expiration job will pick it up and apply the standard expiration behavior.  On an **already-expired** Risk Acceptance a past date is not a reinstatement at all — the next expiration run would simply lapse it again — so the reinstate falls back to today + N days.
+Moving the date to a date in the past does not immediately expire the Risk Acceptance from the edit form; the next periodic expiration job will pick it up and apply the standard expiration behavior.  That holds for an **already-expired** Risk Acceptance too: a past date is still the date you chose, so it is saved as-is and the next expiration run lapses the Risk Acceptance again.
 
 ### What the API exposes
 

--- a/docs/content/triage_findings/findings_workflows/OS__risk_acceptance.md
+++ b/docs/content/triage_findings/findings_workflows/OS__risk_acceptance.md
@@ -114,13 +114,13 @@ If the Risk Acceptance has **already expired** — meaning the periodic expirati
 - Every Finding linked to the Risk Acceptance that is currently Active is re-accepted (set back to Risk Accepted / Inactive).
 - A comment is posted to any linked Jira issues recording the reinstate.
 
-> **Important — your chosen date may be overridden.** When a previously-expired Risk Acceptance is reinstated, the expiration date that actually gets saved is **today + N days**, where `N` is the system setting **Risk Acceptance Form Default Days** (default: 90).  This means the date you typed into the edit form will be replaced during the reinstate.  If you need a specific future expiration date on a reinstated Risk Acceptance, edit the Risk Acceptance a second time after the reinstate completes.
+The date you enter is the date that is saved.  The system setting **Risk Acceptance Form Default Days** (default: 180) is only used when you did not ask for a particular date — for example when you use the **Reinstate** action, which reinstates the Risk Acceptance without editing its expiration date, and therefore sets it to today + N days.
 
 ### Moving the date backwards or to a date still in the past
 
 Moving the expiration date to an earlier-but-still-future date has no special behavior — the Risk Acceptance stays active and the new date is saved.
 
-Moving the date to a date in the past does not immediately expire the Risk Acceptance from the edit form; the next periodic expiration job will pick it up and apply the standard expiration behavior.
+Moving the date to a date in the past does not immediately expire the Risk Acceptance from the edit form; the next periodic expiration job will pick it up and apply the standard expiration behavior.  On an **already-expired** Risk Acceptance a past date is not a reinstatement at all — the next expiration run would simply lapse it again — so the reinstate falls back to today + N days.
 
 ### What the API exposes
 

--- a/docs/content/triage_findings/findings_workflows/PRO__risk_acceptance.md
+++ b/docs/content/triage_findings/findings_workflows/PRO__risk_acceptance.md
@@ -161,6 +161,13 @@ API consumers can observe expiration state on the Risk Acceptance object via the
 
 When a reinstate happens, both `expiration_date_handled` and `expiration_date_warned` are cleared back to `null`, and `expiration_date` holds the date you sent — or today + N days when the reinstate was triggered without a new date.  Tooling that watches Risk Acceptances for state changes can use the `expiration_date_handled` field as the canonical "is this Risk Acceptance currently expired?" flag.
 
+Expiring and reinstating are also available directly, so you do not have to drive them by editing `expiration_date`:
+
+- `POST /api/v2/risk_acceptance/{id}/expire/` expires it now.  Returns `400` if it has already expired.
+- `POST /api/v2/risk_acceptance/{id}/reinstate/` reinstates an expired one, re-accepting the Findings it covers.  Returns `400` if it has not expired.  Send `expiration_date` to choose how long for; omit it to use today + N days.
+
+Both accept an optional `reason`, which is recorded as a note on the Risk Acceptance along with who performed the action.  Both require the same permission as editing the Risk Acceptance.
+
 ## Risk Acceptance Best Practices 
 
 While it is possible to affect Findings within Full Risk Acceptance objects using Simple Risk Acceptance workflows (and vice versa), it is generally preferable to default to either process exclusively rather than having both enabled at once. 

--- a/docs/content/triage_findings/findings_workflows/PRO__risk_acceptance.md
+++ b/docs/content/triage_findings/findings_workflows/PRO__risk_acceptance.md
@@ -122,6 +122,17 @@ Risk Acceptance visibility is **gated by a distinct minimum permission from Find
 
 For the complete role-permission chart that lists Risk Acceptance permissions alongside other Asset-level actions, see [Action permission charts](/admin/user_management/user_permission_chart/#role-permission-chart).
 
+## Expiring and Reinstating a Risk Acceptance
+
+A Risk Acceptance that has expired is labelled **Expired** next to its expiration date in the Risk Acceptances table, so you can tell at a glance which ones are no longer suppressing their Findings.
+
+The gear menu on a Risk Acceptance — in the table or on its detail page — offers whichever of these applies:
+
+- **Expire Risk Acceptance**, on one that is still live.  It expires immediately rather than waiting for its expiration date, and its Findings are reactivated according to its **Reactivate Expired Findings** and **Restart SLA Expired** settings.
+- **Reinstate Risk Acceptance**, on one that has expired.  Its Findings are accepted again, and it expires after the number of days in the **Risk Acceptance Form Default Days** setting.
+
+Both require the same permission as editing the Risk Acceptance, and both ask for confirmation first.  To reinstate for a specific length of time instead of the default window, edit the expiration date rather than using the Reinstate action — see below.
+
 ## When a Risk Acceptance Expiration Date is Changed
 
 A Risk Acceptance's expiration date can be edited at any time after creation.  How DefectDojo responds depends on whether the Risk Acceptance is currently active or has already expired.

--- a/docs/content/triage_findings/findings_workflows/PRO__risk_acceptance.md
+++ b/docs/content/triage_findings/findings_workflows/PRO__risk_acceptance.md
@@ -143,7 +143,7 @@ If the Risk Acceptance has **already expired** — meaning the periodic job has 
 - Endpoint statuses on those Findings are updated to reflect the re-acceptance.
 - A comment is posted to any linked Jira issues recording the reinstate.
 
-> **Important — your chosen date may be overridden.** When a previously-expired Risk Acceptance is reinstated, the expiration date that actually gets saved is **today + N days**, where `N` is the system setting **Risk Acceptance Form Default Days** (default: 90).  This means the date you typed into the edit form will be replaced during the reinstate.  If you need a specific future expiration date on a reinstated Risk Acceptance, edit the Risk Acceptance a second time after the reinstate completes — at that point the Risk Acceptance is active again and the second edit will be saved as-is.
+The date you enter is the date that is saved.  The system setting **Risk Acceptance Form Default Days** (default: 180) is only used when you did not ask for a particular date — for example when you use the **Reinstate** action, which reinstates the Risk Acceptance without editing its expiration date, and therefore sets it to today + N days.
 
 ### Moving the date backwards or to a date still in the past
 
@@ -159,7 +159,7 @@ API consumers can observe expiration state on the Risk Acceptance object via the
 - `expiration_date_handled` is `null` while the Risk Acceptance is active, and is set to a timestamp when the periodic job has processed the expiration.  A Risk Acceptance is "expired" precisely when `expiration_date_handled` is non-null.
 - `expiration_date_warned` is set when the system has sent the expiration-warning notification.
 
-When a reinstate happens, both `expiration_date_handled` and `expiration_date_warned` are cleared back to `null`, and `expiration_date` is updated to the reinstate target (today + N days).  Tooling that watches Risk Acceptances for state changes can use the `expiration_date_handled` field as the canonical "is this Risk Acceptance currently expired?" flag.
+When a reinstate happens, both `expiration_date_handled` and `expiration_date_warned` are cleared back to `null`, and `expiration_date` holds the date you sent — or today + N days when the reinstate was triggered without a new date.  Tooling that watches Risk Acceptances for state changes can use the `expiration_date_handled` field as the canonical "is this Risk Acceptance currently expired?" flag.
 
 ## Risk Acceptance Best Practices 
 

--- a/dojo/engagement/ui/views.py
+++ b/dojo/engagement/ui/views.py
@@ -20,7 +20,15 @@ from django.db import DEFAULT_DB_ALIAS
 from django.db.models import OuterRef, Q, Value
 from django.db.models.functions import Coalesce
 from django.db.models.query import Prefetch, QuerySet
-from django.http import HttpRequest, HttpResponse, HttpResponseRedirect, JsonResponse, QueryDict, StreamingHttpResponse
+from django.http import (
+    Http404,
+    HttpRequest,
+    HttpResponse,
+    HttpResponseRedirect,
+    JsonResponse,
+    QueryDict,
+    StreamingHttpResponse,
+)
 from django.shortcuts import get_object_or_404, render
 from django.urls import Resolver404, reverse
 from django.utils import timezone
@@ -1483,7 +1491,14 @@ def download_risk_acceptance(request, eid, raid):
     # Ensure the risk acceptance is under the supplied engagement
     if not Engagement.objects.filter(risk_acceptance=risk_acceptance, id=eid).exists():
         raise PermissionDenied
-    file_handle = (Path(settings.MEDIA_ROOT) / risk_acceptance.path.name).open(mode="rb")
+    # No proof uploaded, or the file is gone from storage. Opening it blindly raises
+    # ValueError/FileNotFoundError, which surfaces as a 500 rather than a missing file.
+    if not risk_acceptance.path:
+        raise Http404
+    proof_path = Path(settings.MEDIA_ROOT) / risk_acceptance.path.name
+    if not proof_path.is_file():
+        raise Http404
+    file_handle = proof_path.open(mode="rb")
     response = StreamingHttpResponse(FileIterWrapper(file_handle))
     if hasattr(response, "_resource_closers"):
         response._resource_closers.append(file_handle.close)

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -1115,7 +1115,10 @@ class BaseImporter(ImporterOptions):
         )
         # Remove risk acceptance if present (vulnerability is now fixed)
         # risk_unaccept will check if finding.risk_accepted is True before proceeding
-        ra_helper.risk_unaccept(self.user, finding, perform_save=False, post_comments=False)
+        ra_helper.risk_unaccept(
+            self.user, finding, perform_save=False, post_comments=False,
+            source="reimport", reason="the scan no longer reports this finding",
+        )
         self.location_handler.record_mitigations_for_finding(finding, self.user)
         # to avoid pushing a finding group multiple times, we push those outside of the loop
         if finding_groups_enabled and finding.finding_group:

--- a/dojo/jira/helper.py
+++ b/dojo/jira/helper.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 import requests
-from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib import messages
 from django.core.cache import cache
@@ -2158,8 +2157,7 @@ def process_resolution_from_jira(
                     logger.debug(f"Creating risk acceptance for finding linked to {jira_issue.jira_key}.")
                     # loads the expiration from the system setting "Risk acceptance form default days" as otherwise
                     # the acceptance will never expire
-                    risk_acceptance_form_default_days = get_system_setting("risk_acceptance_form_default_days", 90)
-                    expiration_date_from_system_settings = timezone.now() + relativedelta(days=risk_acceptance_form_default_days)
+                    expiration_date_from_system_settings = ra_helper.default_expiration_date()
                     ra = Risk_Acceptance.objects.create(
                         accepted_by=assignee_name,
                         owner=finding.reporter,

--- a/dojo/notifications/templates/notifications/msteams/risk_acceptance_expiration.tpl
+++ b/dojo/notifications/templates/notifications/msteams/risk_acceptance_expiration.tpl
@@ -1,4 +1,4 @@
-{% load i18n %}{% load display_tags %}{% url 'view_risk_acceptance' risk_acceptance.id as url %}
+{% load i18n %}{% load display_tags %}
 {
     "type": "message",
     "attachments": [

--- a/dojo/notifications/templates/notifications/slack/risk_acceptance_expiration.tpl
+++ b/dojo/notifications/templates/notifications/slack/risk_acceptance_expiration.tpl
@@ -8,7 +8,7 @@
     {% trans "Risk Acceptance Will Expire Soon" %}
 {% endif %}
 
-{% blocktranslate trimmed with risk_url=risk_acceptance_url|full_url %}
+{% blocktranslate trimmed with risk_url=url|full_url %}
 Risk Acceptance can be viewed here: {{ risk_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer_notifications and system_settings.disclaimer_notifications.strip %}

--- a/dojo/risk_acceptance/api/serializer.py
+++ b/dojo/risk_acceptance/api/serializer.py
@@ -18,6 +18,22 @@ class RiskAcceptanceProofSerializer(serializers.ModelSerializer):
         fields = ["path"]
 
 
+class RiskAcceptanceExpireSerializer(serializers.Serializer):
+    reason = serializers.CharField(required=False, allow_blank=True, max_length=2000)
+
+
+class RiskAcceptanceReinstateSerializer(serializers.Serializer):
+    expiration_date = serializers.DateTimeField(
+        required=False,
+        allow_null=True,
+        help_text=(
+            "New expiration date. Omit it to reinstate for the number of days configured in "
+            "the Risk Acceptance Form Default Days system setting."
+        ),
+    )
+    reason = serializers.CharField(required=False, allow_blank=True, max_length=2000)
+
+
 class RiskAcceptanceToNotesSerializer(serializers.Serializer):
     risk_acceptance_id = serializers.PrimaryKeyRelatedField(
         queryset=Risk_Acceptance.objects.all(), many=False, allow_null=True,

--- a/dojo/risk_acceptance/api/views.py
+++ b/dojo/risk_acceptance/api/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.http import FileResponse
 from django.urls import reverse
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -16,9 +16,12 @@ from dojo.api_v2.views import PrefetchDojoModelViewSet
 from dojo.authorization import api_permissions as permissions
 from dojo.models import NoteHistory, Notes, Risk_Acceptance
 from dojo.notes.helper import notes_prefetch
+from dojo.risk_acceptance import helper as ra_helper
 from dojo.risk_acceptance.api.filters import ApiRiskAcceptanceFilter
 from dojo.risk_acceptance.api.serializer import (
+    RiskAcceptanceExpireSerializer,
     RiskAcceptanceProofSerializer,
+    RiskAcceptanceReinstateSerializer,
     RiskAcceptanceSerializer,
     RiskAcceptanceToNotesSerializer,
 )
@@ -111,6 +114,82 @@ class RiskAcceptanceViewSet(
             {"risk_acceptance_id": risk_acceptance, "notes": notes},
         )
         return Response(serialized_notes.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        methods=["POST"],
+        request=RiskAcceptanceExpireSerializer,
+        responses={
+            status.HTTP_200_OK: RiskAcceptanceSerializer,
+            status.HTTP_400_BAD_REQUEST: OpenApiResponse(
+                description="Returned if the risk acceptance has already expired",
+            ),
+        },
+    )
+    @action(detail=True, methods=["post"])
+    def expire(self, request, pk=None):
+        """Expire a risk acceptance now, instead of waiting for its expiration date."""
+        risk_acceptance = self.get_object()
+        if risk_acceptance.expiration_date_handled:
+            return Response(
+                {"error": "This risk acceptance has already expired."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        request_serializer = RiskAcceptanceExpireSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+
+        ra_helper.expire_now(
+            risk_acceptance,
+            user=request.user,
+            reason=request_serializer.validated_data.get("reason"),
+        )
+
+        risk_acceptance.refresh_from_db()
+        return Response(self.get_serializer(risk_acceptance).data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        methods=["POST"],
+        request=RiskAcceptanceReinstateSerializer,
+        responses={
+            status.HTTP_200_OK: RiskAcceptanceSerializer,
+            status.HTTP_400_BAD_REQUEST: OpenApiResponse(
+                description="Returned if the risk acceptance has not expired",
+            ),
+        },
+    )
+    @action(detail=True, methods=["post"])
+    def reinstate(self, request, pk=None):
+        """
+        Reinstate an expired risk acceptance, re-accepting the findings it covers.
+
+        Send `expiration_date` to say how long for. Without one the risk acceptance is
+        reinstated for the number of days in the Risk Acceptance Form Default Days setting.
+        """
+        risk_acceptance = self.get_object()
+        if not risk_acceptance.expiration_date_handled:
+            return Response(
+                {"error": "This risk acceptance has not expired, so it cannot be reinstated."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        request_serializer = RiskAcceptanceReinstateSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+
+        # reinstate() keeps a requested date that differs from the one already stored, which is
+        # how the edit form and the serializer hand it a new date too.
+        old_expiration_date = risk_acceptance.expiration_date
+        if requested_expiration_date := request_serializer.validated_data.get("expiration_date"):
+            risk_acceptance.expiration_date = requested_expiration_date
+
+        ra_helper.reinstate(
+            risk_acceptance,
+            old_expiration_date,
+            user=request.user,
+            reason=request_serializer.validated_data.get("reason"),
+        )
+
+        risk_acceptance.refresh_from_db()
+        return Response(self.get_serializer(risk_acceptance).data, status=status.HTTP_200_OK)
 
     @extend_schema(
         methods=["GET"],

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -68,7 +68,25 @@ def engagement_to_notify_about(risk_acceptance: Risk_Acceptance) -> Engagement |
     return None
 
 
-def expire_now(risk_acceptance):
+def note_on_risk_acceptance(risk_acceptance: Risk_Acceptance, user: Dojo_User | None, action: str, *, reason=None) -> None:
+    """
+    Record an action taken against the risk acceptance itself.
+
+    Skipped when there is no user: the scheduled expiry job acts on its own behalf and is
+    already covered by the expiration notification, so a note authored by nobody adds nothing.
+    """
+    if user is None:
+        return
+    risk_acceptance.notes.add(Notes.objects.create(
+        entry=(
+            f"{Dojo_User.generate_full_name(user)} ({user.id}) {action} this risk acceptance"
+            f"{describe_cause(reason=reason)}"
+        ),
+        author=user,
+    ))
+
+
+def expire_now(risk_acceptance, user=None, reason=None):
     logger.info("Expiring risk acceptance %i:%s with %i findings", risk_acceptance.id, risk_acceptance, len(risk_acceptance.accepted_findings.all()))
 
     reactivated_findings = []
@@ -101,6 +119,8 @@ def expire_now(risk_acceptance):
     risk_acceptance.expiration_date_handled = timezone.now()
     risk_acceptance.save()
 
+    note_on_risk_acceptance(risk_acceptance, user, "expired", reason=reason)
+
     # the expiry above is the job here, the notification below is best effort
     engagement = engagement_to_notify_about(risk_acceptance)
     if engagement is None:
@@ -116,7 +136,7 @@ def expire_now(risk_acceptance):
                          url=reverse("view_risk_acceptance", args=(engagement.id, risk_acceptance.id)))
 
 
-def reinstate(risk_acceptance, old_expiration_date):
+def reinstate(risk_acceptance, old_expiration_date, user=None, reason=None):
     if risk_acceptance.expiration_date_handled:
         logger.info("Reinstating risk acceptance %i:%s with %i findings", risk_acceptance.id, risk_acceptance, len(risk_acceptance.accepted_findings.all()))
 
@@ -146,6 +166,8 @@ def reinstate(risk_acceptance, old_expiration_date):
 
         # best effort JIRA integration, no status changes, just a comment
         post_jira_comments(risk_acceptance, risk_acceptance.accepted_findings.all(), reinstation_message_creator)
+
+        note_on_risk_acceptance(risk_acceptance, user, "reinstated", reason=reason)
 
     risk_acceptance.expiration_date_handled = None
     risk_acceptance.expiration_date_warned = None
@@ -411,7 +433,14 @@ def simple_risk_accept(user: Dojo_User, finding: Finding, *, perform_save=True) 
         ))
 
 
-def risk_unaccept(user: Dojo_User, finding: Finding, *, perform_save=True, post_comments=True) -> None:
+def risk_unaccept(user: Dojo_User, finding: Finding, *, perform_save=True, post_comments=True, reason=None, source=None) -> None:
+    """
+    Drop a finding's risk acceptance.
+
+    `source` names the mechanism that did it (for example the reimporter closing a fixed
+    finding) and `reason` carries free text. Both end up in the note left on the finding,
+    which is the only record that survives - the membership row itself is removed.
+    """
     logger.debug("unaccepting finding %i:%s if it is currently risk accepted", finding.id, finding)
     if finding.risk_accepted:
         logger.debug("unaccepting finding %i:%s", finding.id, finding)
@@ -438,9 +467,24 @@ def risk_unaccept(user: Dojo_User, finding: Finding, *, perform_save=True, post_
         # Add a note to reflect that the finding was removed from the risk acceptance
         if user is not None:
             finding.notes.add(Notes.objects.create(
-                entry=(f"{Dojo_User.generate_full_name(user)} ({user.id}) removed a risk exception from this finding"),
+                entry=(
+                    f"{Dojo_User.generate_full_name(user)} ({user.id}) removed a risk exception from this finding"
+                    f"{describe_cause(reason=reason, source=source)}"
+                ),
                 author=user,
             ))
+
+
+def describe_cause(*, reason=None, source=None) -> str:
+    """Render the optional source/reason of an action as a suffix for a note entry."""
+    parts = []
+    if source:
+        parts.append(f"via {source}")
+    if reason:
+        parts.append(f"reason: {reason}")
+    if not parts:
+        return ""
+    return " (" + ", ".join(parts) + ")"
 
 
 def remove_from_any_risk_acceptance(finding):

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -15,6 +15,25 @@ from dojo.utils import get_full_url, get_system_setting
 
 logger = logging.getLogger(__name__)
 
+# Mirrors the System_Settings.risk_acceptance_form_default_days column default. The column is
+# nullable, and get_system_setting() only substitutes its own default when the attribute is
+# missing entirely - a null column still returns None - so every caller needs this fallback to
+# avoid doing arithmetic with None.
+DEFAULT_RISK_ACCEPTANCE_EXPIRATION_DAYS = 180
+
+
+def expiration_days() -> int:
+    """Return the configured expiry window in days, falling back when the setting is unset."""
+    configured = get_system_setting("risk_acceptance_form_default_days")
+    if configured is None:
+        return DEFAULT_RISK_ACCEPTANCE_EXPIRATION_DAYS
+    return configured
+
+
+def default_expiration_date():
+    """Return the expiration date a risk acceptance gets when nobody asked for a specific one."""
+    return timezone.now() + relativedelta(days=expiration_days())
+
 
 def engagement_to_notify_about(risk_acceptance: Risk_Acceptance) -> Engagement | None:
     """
@@ -104,10 +123,9 @@ def reinstate(risk_acceptance, old_expiration_date):
         # The "Reinstate" button has no date to offer and passes the expiration date
         # unchanged, so fall back to the configured default for it. The edit form and
         # the API only reach this point because the caller supplied a new date, which
-        # is already on the instance — recomputing the default would throw it away.
+        # is already on the instance - recomputing the default would throw it away.
         if risk_acceptance.expiration_date == old_expiration_date:
-            expiration_delta_days = get_system_setting("risk_acceptance_form_default_days", 90)
-            risk_acceptance.expiration_date = timezone.now() + relativedelta(days=expiration_delta_days)
+            risk_acceptance.expiration_date = default_expiration_date()
 
         reinstated_findings = []
         for finding in risk_acceptance.accepted_findings.all():

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -1,5 +1,4 @@
 import logging
-from contextlib import suppress
 
 import pghistory
 from dateutil.relativedelta import relativedelta
@@ -35,6 +34,26 @@ def default_expiration_date():
     return timezone.now() + relativedelta(days=expiration_days())
 
 
+def engagement_for(risk_acceptance: Risk_Acceptance) -> Engagement | None:
+    """
+    Return an engagement this risk acceptance can be reached through, or None.
+
+    Prefers the `Engagement.risk_acceptance` link and falls back to the engagement of an
+    accepted finding, which is the same derivation `RiskAcceptanceSerializer` uses to attach
+    an engagement on create and to repair an orphan on update.
+    """
+    engagement = risk_acceptance.engagement
+    if engagement is not None:
+        return engagement
+
+    # iterate rather than .first(), to reuse the accepted_findings prefetch
+    accepted_finding = next(iter(risk_acceptance.accepted_findings.all()), None)
+    if accepted_finding is not None:
+        return accepted_finding.test.engagement
+
+    return None
+
+
 def engagement_to_notify_about(risk_acceptance: Risk_Acceptance) -> Engagement | None:
     """
     Return an engagement to address a risk acceptance's expiration notification to.
@@ -52,20 +71,13 @@ def engagement_to_notify_about(risk_acceptance: Risk_Acceptance) -> Engagement |
     nothing to notify about; the notification names a product and links to a per-engagement
     URL, and neither can be produced from an empty risk acceptance.
     """
-    engagement = risk_acceptance.engagement
-    if engagement is not None:
-        return engagement
-
-    # iterate rather than .first(), to reuse the accepted_findings prefetch
-    accepted_finding = next(iter(risk_acceptance.accepted_findings.all()), None)
-    if accepted_finding is not None:
-        return accepted_finding.test.engagement
-
-    logger.warning(
-        "risk acceptance %i:%s has no engagement and no findings, skipping its expiration notification",
-        risk_acceptance.id, risk_acceptance,
-    )
-    return None
+    engagement = engagement_for(risk_acceptance)
+    if engagement is None:
+        logger.warning(
+            "risk acceptance %i:%s has no engagement and no findings, skipping its expiration notification",
+            risk_acceptance.id, risk_acceptance,
+        )
+    return engagement
 
 
 def note_on_risk_acceptance(risk_acceptance: Risk_Acceptance, user: Dojo_User | None, action: str, *, reason=None) -> None:
@@ -301,13 +313,18 @@ def expiration_handler(*args, **kwargs):
 
 
 def get_view_risk_acceptance(risk_acceptance: Risk_Acceptance) -> str:
-    """Return the full qualified URL of the view risk acceptance page."""
-    # Suppressing this error because it does not happen under most circumstances that a risk acceptance does not have engagement
-    with suppress(AttributeError):
-        get_full_url(
-            reverse("view_risk_acceptance", args=(risk_acceptance.engagement.id, risk_acceptance.id)),
-        )
-    return ""
+    """
+    Return the full qualified URL of the view risk acceptance page, or "" if there is none.
+
+    The page is per-engagement, and a risk acceptance does not always have one - see
+    `engagement_to_notify_about` for why that is a supported state rather than corrupt data.
+    """
+    engagement = engagement_for(risk_acceptance)
+    if engagement is None:
+        return ""
+    return get_full_url(
+        reverse("view_risk_acceptance", args=(engagement.id, risk_acceptance.id)),
+    )
 
 
 def expiration_message_creator(risk_acceptance, heads_up_days=0):

--- a/dojo/risk_acceptance/models.py
+++ b/dojo/risk_acceptance/models.py
@@ -76,10 +76,14 @@ class Risk_Acceptance(models.Model):
         return str(self.name) + (" (expired " if self.is_expired else " (expires ") + (timezone.localtime(self.expiration_date).strftime("%b %d, %Y") if self.expiration_date else "Never") + ")"
 
     def get_breadcrumbs(self):
-        bc = self.engagement_set.first().get_breadcrumbs()
+        engagement = self.engagement
+        if engagement is None:
+            # a risk acceptance is not always reachable through an engagement, and both the
+            # parent crumbs and the URL below need one
+            return [{"title": str(self), "url": None}]
+        bc = engagement.get_breadcrumbs()
         bc += [{"title": str(self),
-                "url": reverse("view_risk_acceptance", args=(
-                    self.engagement_set.first().product.id, self.id))}]
+                "url": reverse("view_risk_acceptance", args=(engagement.id, self.id))}]
         return bc
 
     @property

--- a/dojo/risk_acceptance/ui/forms.py
+++ b/dojo/risk_acceptance/ui/forms.py
@@ -60,7 +60,9 @@ class RiskAcceptanceForm(EditRiskAcceptanceForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        expiration_delta_days = get_system_setting("risk_acceptance_form_default_days")
+        import dojo.risk_acceptance.helper as ra_helper  # noqa: PLC0415 -- lazy import, avoids circular dependency
+
+        expiration_delta_days = ra_helper.expiration_days()
         logger.debug("expiration_delta_days: %i", expiration_delta_days)
         if expiration_delta_days > 0:
             expiration_date = timezone.now().date() + relativedelta(days=expiration_delta_days)

--- a/dojo/risk_acceptance/ui/forms.py
+++ b/dojo/risk_acceptance/ui/forms.py
@@ -75,8 +75,12 @@ class RiskAcceptanceForm(EditRiskAcceptanceForm):
 
 
 class ReplaceRiskAcceptanceProofForm(forms.ModelForm):
-    path = forms.FileField(label="Proof", required=True, widget=forms.widgets.FileInput(attrs={"accept": ".jpg,.png,.pdf"}))
+    # same accept list and same clean_path validation as adding the proof in the first place:
+    # replacing it used to accept any extension, since it validated nothing
+    path = forms.FileField(label="Proof", required=True, widget=forms.widgets.FileInput(attrs={"accept": ", ".join(settings.FILE_IMPORT_TYPES)}))
 
     class Meta:
         model = Risk_Acceptance
         fields = ["path"]
+
+    clean_path = EditRiskAcceptanceForm.clean_path

--- a/dojo/templates_classic/notifications/msteams/risk_acceptance_expiration.tpl
+++ b/dojo/templates_classic/notifications/msteams/risk_acceptance_expiration.tpl
@@ -1,4 +1,4 @@
-{% load i18n %}{% load display_tags %}{% url 'view_risk_acceptance' risk_acceptance.id as url %}
+{% load i18n %}{% load display_tags %}
 {
     "type": "message",
     "attachments": [

--- a/dojo/templates_classic/notifications/slack/risk_acceptance_expiration.tpl
+++ b/dojo/templates_classic/notifications/slack/risk_acceptance_expiration.tpl
@@ -8,7 +8,7 @@
     {% trans "Risk Acceptance Will Expire Soon" %}
 {% endif %}
 
-{% blocktranslate trimmed with risk_url=risk_acceptance_url|full_url %}
+{% blocktranslate trimmed with risk_url=url|full_url %}
 Risk Acceptance can be viewed here: {{ risk_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer_notifications and system_settings.disclaimer_notifications.strip %}

--- a/dojo/tools/api_sonarqube/updater_from_source.py
+++ b/dojo/tools/api_sonarqube/updater_from_source.py
@@ -74,7 +74,7 @@ class SonarQubeApiUpdaterFromSource:
             finding.false_p = False
             finding.mitigated = None
             finding.is_mitigated = False
-            ra_helper.remove_finding.from_any_risk_acceptance(finding)
+            ra_helper.remove_from_any_risk_acceptance(finding)
 
         elif sonarqube_status == "CONFIRMED":
             finding.active = True
@@ -82,7 +82,7 @@ class SonarQubeApiUpdaterFromSource:
             finding.false_p = False
             finding.mitigated = None
             finding.is_mitigated = False
-            ra_helper.remove_finding.from_any_risk_acceptance(finding)
+            ra_helper.remove_from_any_risk_acceptance(finding)
 
         elif sonarqube_status == "FIXED":
             finding.active = False
@@ -90,7 +90,7 @@ class SonarQubeApiUpdaterFromSource:
             finding.false_p = False
             finding.mitigated = timezone.now()
             finding.is_mitigated = True
-            ra_helper.remove_finding.from_any_risk_acceptance(finding)
+            ra_helper.remove_from_any_risk_acceptance(finding)
 
         elif sonarqube_status == "WONTFIX":
             finding.active = False
@@ -98,9 +98,16 @@ class SonarQubeApiUpdaterFromSource:
             finding.false_p = False
             finding.mitigated = None
             finding.is_mitigated = False
-            Risk_Acceptance.objects.create(
+            finding.risk_accepted = True
+            risk_acceptance = Risk_Acceptance.objects.create(
+                name=f"SonarQube: {finding.title}"[:300],
                 owner=finding.reporter,
-            ).accepted_findings.set([finding])
+                decision=Risk_Acceptance.TREATMENT_ACCEPT,
+                decision_details="Automatically created from the SonarQube issue status WONTFIX.",
+                expiration_date=ra_helper.default_expiration_date(),
+            )
+            finding.test.engagement.risk_acceptance.add(risk_acceptance)
+            risk_acceptance.accepted_findings.set([finding])
 
         elif sonarqube_status == "FALSE-POSITIVE":
             finding.active = False
@@ -108,6 +115,6 @@ class SonarQubeApiUpdaterFromSource:
             finding.false_p = True
             finding.mitigated = None
             finding.is_mitigated = False
-            ra_helper.remove_finding.from_any_risk_acceptance(finding)
+            ra_helper.remove_from_any_risk_acceptance(finding)
 
         finding.save(issue_updater_option=False, dedupe_option=False)

--- a/unittests/test_api_sonarqube_updater_from_source.py
+++ b/unittests/test_api_sonarqube_updater_from_source.py
@@ -1,0 +1,67 @@
+from dojo.models import Finding, Risk_Acceptance
+from dojo.tools.api_sonarqube.updater_from_source import SonarQubeApiUpdaterFromSource
+
+from .dojo_test_case import DojoTestCase, versioned_fixtures
+
+
+@versioned_fixtures
+class TestSonarQubeApiUpdaterFromSource(DojoTestCase):
+
+    """
+    Covers the finding-status side of syncing a SonarQube issue status back onto a finding.
+
+    Every branch except WONTFIX called a helper that does not exist
+    (`ra_helper.remove_finding.from_any_risk_acceptance`), so any sync of an open, confirmed,
+    fixed or false-positive issue raised AttributeError.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    def accepted_finding(self):
+        """Return a finding that is risk accepted through a real risk acceptance."""
+        finding = Finding.objects.get(id=2)
+        risk_acceptance = Risk_Acceptance.objects.create(
+            name="Accepted for the updater test",
+            owner=self.get_test_admin(),
+            decision=Risk_Acceptance.TREATMENT_ACCEPT,
+        )
+        risk_acceptance.accepted_findings.set([finding])
+        finding.test.engagement.risk_acceptance.add(risk_acceptance)
+        finding.active = False
+        finding.risk_accepted = True
+        finding.save()
+        return finding
+
+    def test_open_status_drops_the_risk_acceptance(self):
+        finding = self.accepted_finding()
+
+        SonarQubeApiUpdaterFromSource.update_finding_status(finding, "OPEN")
+
+        finding.refresh_from_db()
+        self.assertTrue(finding.active)
+        self.assertEqual(0, finding.risk_acceptance_set.count())
+
+    def test_false_positive_status_drops_the_risk_acceptance(self):
+        finding = self.accepted_finding()
+
+        SonarQubeApiUpdaterFromSource.update_finding_status(finding, "FALSE-POSITIVE")
+
+        finding.refresh_from_db()
+        self.assertTrue(finding.false_p)
+        self.assertEqual(0, finding.risk_acceptance_set.count())
+
+    def test_wontfix_status_accepts_the_finding(self):
+        finding = Finding.objects.get(id=3)
+
+        SonarQubeApiUpdaterFromSource.update_finding_status(finding, "WONTFIX")
+
+        finding.refresh_from_db()
+        # the finding actually reads as accepted, which it did not before
+        self.assertTrue(finding.risk_accepted)
+        self.assertFalse(finding.active)
+
+        risk_acceptance = finding.risk_acceptance_set.get()
+        # named and reachable, rather than an unnamed row nobody can find
+        self.assertTrue(risk_acceptance.name)
+        self.assertIn(risk_acceptance, finding.test.engagement.risk_acceptance.all())
+        self.assertIsNotNone(risk_acceptance.expiration_date)

--- a/unittests/test_risk_acceptance.py
+++ b/unittests/test_risk_acceptance.py
@@ -264,20 +264,27 @@ class RiskAcceptanceTestUI(DojoTestCase):
         expected = timezone.now() + relativedelta(days=ra_helper.expiration_days())
         self.assertEqual(ra.expiration_date.date(), expected.date())
 
-    def test_reinstate_risk_acceptance_defaults_when_requested_date_is_not_in_the_future(self):
-        """A past date would lapse again on the next expiry run, so it is not a reinstatement."""
+    def test_reinstate_risk_acceptance_honors_a_past_date_the_caller_chose(self):
+        """
+        Any date the caller supplied is kept, including one in the past.
+
+        The fallback exists for the Reinstate action, which supplies no date at all. A past
+        date is still a deliberate choice, so it is stored as-is and the next expiration run
+        simply lapses the risk acceptance again - the alternative would be silently
+        overriding the user's input, which is the behaviour this whole path removed.
+        """
         self.test_expire_risk_acceptance_findings_active()
         ra = Risk_Acceptance.objects.last()
 
         old_expiration_date = ra.expiration_date
-        ra.expiration_date = timezone.now() - relativedelta(days=3)
+        requested_expiration_date = timezone.now() - relativedelta(days=3)
+        ra.expiration_date = requested_expiration_date
         ra.save()
 
         ra_helper.reinstate(ra, old_expiration_date)
 
         ra.refresh_from_db()
-        expected = timezone.now() + relativedelta(days=ra_helper.expiration_days())
-        self.assertEqual(ra.expiration_date.date(), expected.date())
+        self.assertEqual(ra.expiration_date.date(), requested_expiration_date.date())
 
     def test_audit_note_links_to_the_risk_acceptance(self):
         """The note written when a finding is accepted carries a usable link, not empty parens."""

--- a/unittests/test_risk_acceptance.py
+++ b/unittests/test_risk_acceptance.py
@@ -279,6 +279,56 @@ class RiskAcceptanceTestUI(DojoTestCase):
         expected = timezone.now() + relativedelta(days=ra_helper.expiration_days())
         self.assertEqual(ra.expiration_date.date(), expected.date())
 
+    def test_audit_note_links_to_the_risk_acceptance(self):
+        """The note written when a finding is accepted carries a usable link, not empty parens."""
+        self.test_add_risk_acceptance_multiple_findings_accepted()
+        ra = Risk_Acceptance.objects.last()
+        finding = ra.accepted_findings.first()
+
+        entries = [note.entry for note in finding.notes.all()]
+        self.assertTrue(entries, "accepting a finding should leave a note")
+        self.assertTrue(
+            any(f"/engagement/1/risk_acceptance/{ra.id}" in entry for entry in entries),
+            f"no note links to the risk acceptance: {entries}",
+        )
+        self.assertFalse(any("()" in entry for entry in entries), f"empty link in note: {entries}")
+
+    def test_get_view_risk_acceptance_without_an_engagement_link(self):
+        """A risk acceptance reachable only through its findings still resolves a URL."""
+        self.test_add_risk_acceptance_multiple_findings_accepted()
+        ra = Risk_Acceptance.objects.last()
+        for engagement in ra.engagement_set.all():
+            engagement.risk_acceptance.remove(ra)
+
+        self.assertIn(f"/engagement/1/risk_acceptance/{ra.id}", ra_helper.get_view_risk_acceptance(ra))
+
+    def test_get_view_risk_acceptance_with_nothing_to_link_to(self):
+        ra = Risk_Acceptance.objects.create(name="empty", owner=self.get_test_admin())
+
+        self.assertEqual("", ra_helper.get_view_risk_acceptance(ra))
+
+    def test_breadcrumbs_use_the_engagement(self):
+        self.test_add_risk_acceptance_multiple_findings_accepted()
+        ra = Risk_Acceptance.objects.last()
+
+        crumbs = ra.get_breadcrumbs()
+
+        self.assertEqual(f"/engagement/1/risk_acceptance/{ra.id}", crumbs[-1]["url"])
+
+    def test_breadcrumbs_without_an_engagement(self):
+        ra = Risk_Acceptance.objects.create(name="empty", owner=self.get_test_admin())
+
+        self.assertEqual([{"title": str(ra), "url": None}], ra.get_breadcrumbs())
+
+    def test_download_proof_without_a_proof_is_not_found(self):
+        self.test_add_risk_acceptance_multiple_findings_accepted()
+        ra = Risk_Acceptance.objects.last()
+        self.assertFalse(ra.path, "this risk acceptance is expected to have no proof")
+
+        response = self.client.get(reverse("download_risk_acceptance", args=(1, ra.id)))
+
+        self.assertEqual(404, response.status_code)
+
     def test_expiration_days_falls_back_when_setting_is_cleared(self):
         """The setting is nullable and get_system_setting() passes None straight through."""
         system_settings = System_Settings.objects.get(no_cache=True)

--- a/unittests/test_risk_acceptance.py
+++ b/unittests/test_risk_acceptance.py
@@ -230,6 +230,65 @@ class RiskAcceptanceTestUI(DojoTestCase):
         # findings remain in (expired) risk acceptance
         self.assertTrue(all(finding in ra.accepted_findings.all() for finding in findings))
 
+    def test_reinstate_risk_acceptance_keeps_requested_expiration_date(self):
+        """Extending an expired risk acceptance to a specific future date keeps that date."""
+        self.test_expire_risk_acceptance_findings_active()
+        ra = Risk_Acceptance.objects.last()
+        findings = ra.accepted_findings.all()
+
+        # The edit form and the API serializer both save the new date before calling reinstate,
+        # so reinstate sees the requested date on the instance and the previous one as argument.
+        old_expiration_date = ra.expiration_date
+        requested_expiration_date = timezone.now() + relativedelta(days=30)
+        ra.expiration_date = requested_expiration_date
+        ra.save()
+
+        ra_helper.reinstate(ra, old_expiration_date)
+
+        ra.refresh_from_db()
+        self.assertEqual(ra.expiration_date.date(), requested_expiration_date.date())
+        # and it is genuinely reinstated, not merely re-dated
+        self.assertIsNone(ra.expiration_date_handled)
+        self.assertIsNone(ra.expiration_date_warned)
+        self.assertTrue(self.assert_all_inactive_risk_accepted(findings))
+
+    def test_reinstate_risk_acceptance_defaults_when_no_date_requested(self):
+        """The Reinstate action edits no date, so the configured window applies."""
+        self.test_expire_risk_acceptance_findings_active()
+        ra = Risk_Acceptance.objects.last()
+
+        # what reinstate_risk_acceptance() passes: the date the risk acceptance already carries
+        ra_helper.reinstate(ra, ra.expiration_date)
+
+        ra.refresh_from_db()
+        expected = timezone.now() + relativedelta(days=ra_helper.expiration_days())
+        self.assertEqual(ra.expiration_date.date(), expected.date())
+
+    def test_reinstate_risk_acceptance_defaults_when_requested_date_is_not_in_the_future(self):
+        """A past date would lapse again on the next expiry run, so it is not a reinstatement."""
+        self.test_expire_risk_acceptance_findings_active()
+        ra = Risk_Acceptance.objects.last()
+
+        old_expiration_date = ra.expiration_date
+        ra.expiration_date = timezone.now() - relativedelta(days=3)
+        ra.save()
+
+        ra_helper.reinstate(ra, old_expiration_date)
+
+        ra.refresh_from_db()
+        expected = timezone.now() + relativedelta(days=ra_helper.expiration_days())
+        self.assertEqual(ra.expiration_date.date(), expected.date())
+
+    def test_expiration_days_falls_back_when_setting_is_cleared(self):
+        """The setting is nullable and get_system_setting() passes None straight through."""
+        system_settings = System_Settings.objects.get(no_cache=True)
+        system_settings.risk_acceptance_form_default_days = None
+        system_settings.save()
+
+        self.assertEqual(ra_helper.expiration_days(), ra_helper.DEFAULT_RISK_ACCEPTANCE_EXPIRATION_DAYS)
+        # and the derived date is a real datetime rather than an arithmetic error
+        self.assertGreater(ra_helper.default_expiration_date(), timezone.now())
+
     def create_multiple_ras(self):
         ra_data = copy.copy(self.data_risk_accceptance)
         ra_data["accepted_findings"] = [2]

--- a/unittests/test_risk_acceptance_api.py
+++ b/unittests/test_risk_acceptance_api.py
@@ -19,6 +19,7 @@ from dojo.models import (
     Test_Type,
     User,
 )
+from dojo.risk_acceptance import helper as ra_helper
 
 
 class TestRiskAcceptanceApi(APITestCase):
@@ -466,6 +467,94 @@ class TestRiskAcceptanceApi(APITestCase):
         ra.refresh_from_db()
         self.assertIsNone(ra.expiration_date_handled)
         self.assertIsNone(ra.expiration_date_warned)
+
+    def make_risk_acceptance(self, *, expired=False):
+        """Build a risk acceptance covering finding_a1, optionally in the post-expiry state."""
+        stamp = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=5)
+        risk_acceptance = Risk_Acceptance.objects.create(
+            name="RA under test",
+            recommendation="A",
+            decision="A",
+            accepted_by="Test User",
+            owner=self.user,
+            expiration_date=stamp if expired else datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=30),
+            expiration_date_handled=stamp if expired else None,
+        )
+        risk_acceptance.accepted_findings.add(self.finding_a1)
+        self.engagement_a.risk_acceptance.add(risk_acceptance)
+
+        self.finding_a1.active = expired
+        self.finding_a1.risk_accepted = not expired
+        self.finding_a1.save()
+        return risk_acceptance
+
+    def test_expire_action_expires_the_risk_acceptance(self):
+        risk_acceptance = self.make_risk_acceptance()
+
+        response = self.client.post(f"{self.url}{risk_acceptance.id}/expire/", {"reason": "no longer justified"}, format="json")
+        self.assertEqual(200, response.status_code, response.content)
+
+        risk_acceptance.refresh_from_db()
+        self.assertIsNotNone(risk_acceptance.expiration_date_handled)
+        # the finding it covered is open again
+        self.finding_a1.refresh_from_db()
+        self.assertTrue(self.finding_a1.active)
+        self.assertFalse(self.finding_a1.risk_accepted)
+        # and the reason is on the record
+        self.assertIn("no longer justified", " ".join(note.entry for note in risk_acceptance.notes.all()))
+
+    def test_expire_action_rejects_an_already_expired_risk_acceptance(self):
+        risk_acceptance = self.make_risk_acceptance(expired=True)
+
+        response = self.client.post(f"{self.url}{risk_acceptance.id}/expire/", {}, format="json")
+        self.assertEqual(400, response.status_code, response.content)
+
+    def test_reinstate_action_uses_the_requested_expiration_date(self):
+        risk_acceptance = self.make_risk_acceptance(expired=True)
+        requested_date = datetime.datetime.now(datetime.UTC) + datetime.timedelta(days=45)
+
+        response = self.client.post(
+            f"{self.url}{risk_acceptance.id}/reinstate/",
+            {"expiration_date": requested_date.strftime("%Y-%m-%dT%H:%M:%SZ"), "reason": "extended pending a fix"},
+            format="json",
+        )
+        self.assertEqual(200, response.status_code, response.content)
+
+        risk_acceptance.refresh_from_db()
+        self.assertEqual(risk_acceptance.expiration_date.date(), requested_date.date())
+        self.assertIsNone(risk_acceptance.expiration_date_handled)
+        self.finding_a1.refresh_from_db()
+        self.assertTrue(self.finding_a1.risk_accepted)
+        self.assertFalse(self.finding_a1.active)
+        self.assertIn("extended pending a fix", " ".join(note.entry for note in risk_acceptance.notes.all()))
+
+    def test_reinstate_action_without_a_date_uses_the_configured_window(self):
+        risk_acceptance = self.make_risk_acceptance(expired=True)
+
+        response = self.client.post(f"{self.url}{risk_acceptance.id}/reinstate/", {}, format="json")
+        self.assertEqual(200, response.status_code, response.content)
+
+        risk_acceptance.refresh_from_db()
+        expected = ra_helper.default_expiration_date()
+        self.assertEqual(risk_acceptance.expiration_date.date(), expected.date())
+
+    def test_reinstate_action_rejects_a_live_risk_acceptance(self):
+        risk_acceptance = self.make_risk_acceptance()
+
+        response = self.client.post(f"{self.url}{risk_acceptance.id}/reinstate/", {}, format="json")
+        self.assertEqual(400, response.status_code, response.content)
+
+    def test_expire_action_is_denied_without_access_to_the_product(self):
+        risk_acceptance = self.make_risk_acceptance()
+        outsider = User.objects.create(username="ra_outsider")
+        outsider_client = APIClient()
+        outsider_client.force_authenticate(user=outsider)
+
+        response = outsider_client.post(f"{self.url}{risk_acceptance.id}/expire/", {}, format="json")
+        self.assertIn(response.status_code, (403, 404), response.content)
+
+        risk_acceptance.refresh_from_db()
+        self.assertIsNone(risk_acceptance.expiration_date_handled, "an outsider must not be able to expire it")
 
     def test_risk_acceptance_created_filter(self):
         # 1. Create a baseline Risk Acceptance using the existing test setup


### PR DESCRIPTION
**Description**

A group of risk acceptance fixes, plus two new API actions. Bugfix branch: everything here is repairing existing behaviour, and the two new endpoints exist because expiring and reinstating were previously unreachable except by imitating them through `expiration_date`.

**Reinstating discarded the expiration date it was given.** `reinstate()` always overwrote `expiration_date` with today + the configured window, so extending an expired risk acceptance to a specific date produced a different date, and the only way to make one stick was to edit the risk acceptance a second time once it was active again. The documentation had to warn about this. It now keeps the requested date, and falls back to the configured window only when there is nothing to keep: the Reinstate action edits no date and passes back the one already stored, and expiry stamps `expiration_date` with the moment it lapsed. A date that is not in the future gets the same treatment, since the expiry job would immediately lapse it again.

**The default-window fallback never worked.** `get_system_setting(name, default)` substitutes its default only when the attribute is missing, so a null `risk_acceptance_form_default_days` column returned `None` and three call sites went on to compute `relativedelta(days=None)`. They now share `expiration_days()` / `default_expiration_date()`, whose fallback matches the column default of 180 rather than the 90 the code named.

**New: expire and reinstate over the API.**

- `POST /api/v2/risk_acceptance/{id}/expire/` — 400 if it has already expired.
- `POST /api/v2/risk_acceptance/{id}/reinstate/` — 400 if it has not expired. Optional `expiration_date`; without one the configured window applies.

Both accept an optional `reason`, recorded as a note on the risk acceptance together with the acting user, and both use the same authorization as editing the risk acceptance. `risk_unaccept()` gained matching `reason`/`source` arguments that flow into the note it leaves on the finding, and the reimporter now identifies itself: a finding that lost its acceptance because a scan stopped reporting it previously got a note saying only that "a risk exception" was removed, with no indication that a scan rather than a person had done it.

**Fixes to existing behaviour.**

- `get_view_risk_acceptance()` computed a URL and then returned `""` — the `return` was missing — so every audit note written when a finding was added to or removed from a risk acceptance read `... risk acceptance: "Name" ()` with nothing to click. It now also resolves an engagement through the accepted findings, so a risk acceptance that is only reachable that way gets a link instead of nothing.
- The Slack expiration template interpolated `risk_acceptance_url`, which is not in the notification context. The MS Teams one opened by reassigning `url` from a two-argument URL given a single argument — silently `""` under `as url` — discarding the correct URL the notification already passes. Both now use it, in the classic template tree as well.
- `Risk_Acceptance.get_breadcrumbs()` passed the product id where the URL takes an engagement id, so the crumb pointed at an unrelated engagement, and it raised `AttributeError` when the risk acceptance had no engagement.
- The SonarQube status sync called `ra_helper.remove_finding.from_any_risk_acceptance()`, which does not exist, so syncing an OPEN, CONFIRMED, FIXED or FALSE-POSITIVE issue raised `AttributeError` every time. Its WONTFIX branch also never set `risk_accepted` on the finding, and created an unnamed risk acceptance attached to no engagement — a row nobody could find, covering a finding that did not read as accepted.
- Downloading a proof that was never uploaded, or whose file has gone from storage, returned a 500 from `open()`; it is now a 404. Replacing a proof skipped extension validation entirely, unlike uploading one, and now shares the same accept list and `clean_path`.

**Test results**

New tests in `unittests/test_risk_acceptance.py`, `unittests/test_risk_acceptance_api.py`, and a new `unittests/test_api_sonarqube_updater_from_source.py` (the existing SonarQube test covers only transition mapping, not this updater). Each new test was re-run against unmodified source to confirm it fails without the fix — for example the reinstate date test fails with `datetime.date(2027, 1, 30) != datetime.date(2026, 9, 2)`, the audit-note test fails on `'(admin) (1) added this finding to the risk acceptance: "Accept: Unit test" ()'`, and the breadcrumb test fails with `/engagement/1/...` vs `/engagement/2/...`.

`ruff check` is clean, and `manage.py spectacular` emits both new paths with their request components and no new warnings.

The full `unittests` suite was run locally (5077 tests). It reports 269 failures and 1 error, and **all of them reproduce on unmodified `bugfix` in the same container against the same database**, so none are attributable to this PR — my local environment runs open-source settings inside a Pro image against a reused test database, which these particular suites are sensitive to. Accounted for individually rather than in aggregate: `test_parsers` (255, and the 1 error), `test_jira_config_product` (10), `test_filter_asset_tag_labels` (2), `test_product_endpoint_report_scoping` (2) and `test_notifications.test_auditlog_on` (1); re-running each module against a pristine `bugfix` worktree produced the same failures. The suites this PR touches are green: risk acceptance (3 suites), JIRA (2), import/reimport (132 tests), the API surface test, and SonarQube.

One thing worth noting for reviewers: an earlier draft of this change also guarded `reinstate()` against re-accepting findings that are mitigated, false positive or out of scope. That guard was removed, because `update_finding_status` already clears those flags whenever a finding is reactivated, so an active finding cannot carry them and `reinstate()` only touches active findings. The guard was unreachable.

**Documentation**

Both risk acceptance pages updated: the "your chosen date may be overridden / edit it a second time" warning is gone, since it described the bug, and the new endpoints are documented.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the docs as part of this PR.
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder. (No model changes.)
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.
