### PR TITLE
fix(dedupe): drop duplicate links whose original was deleted mid-batch

### DIFF
--- a/dojo/finding/deduplication.py
+++ b/dojo/finding/deduplication.py
@@ -4,6 +4,7 @@ from operator import attrgetter
 
 import hyperlink
 from django.conf import settings
+from django.db import transaction
 from django.db.models import Prefetch
 from django.db.models.query_utils import Q
 
@@ -754,15 +755,61 @@ def _flush_duplicate_changes(modified_new_findings):
     Bulk-updates all modified new findings in one round-trip instead of one
     save() call per finding.  Uses bulk_update to bypass Django signals.
 
-    Returns the list of modified findings so callers can perform any follow-up
-    processing (e.g. triggering prioritization) on the affected findings.
+    Originals are matched near the start of a batch and written at the end of it, so
+    one can be deleted in between -- the excess-duplicate delete task runs on its own
+    schedule. The duplicate_finding FK is DEFERRABLE INITIALLY DEFERRED, so such a link
+    is only rejected at COMMIT, which rolls back the whole batch: every other finding
+    in it loses its deduplication too, and the post-processing task fails. Links whose
+    original no longer exists are therefore dropped here, immediately before the write
+    and in the same transaction, leaving those findings exactly as they were for the
+    next import to match again.
+
+    Returns the list of findings actually written so callers perform follow-up
+    processing (e.g. triggering prioritization) only on findings that were persisted.
     """
-    if modified_new_findings:
-        Finding.objects.bulk_update(
-            modified_new_findings,
-            ["duplicate", "active", "verified", "duplicate_finding"],
-        )
-    return modified_new_findings
+    if not modified_new_findings:
+        return modified_new_findings
+
+    with transaction.atomic():
+        findings_to_write = _drop_links_to_deleted_originals(modified_new_findings)
+        if findings_to_write:
+            Finding.objects.bulk_update(
+                findings_to_write,
+                ["duplicate", "active", "verified", "duplicate_finding"],
+            )
+    return findings_to_write
+
+
+def _drop_links_to_deleted_originals(modified_new_findings):
+    """Return the subset of ``modified_new_findings`` whose duplicate_finding still exists."""
+    referenced_original_ids = {
+        finding.duplicate_finding_id
+        for finding in modified_new_findings
+        if finding.duplicate_finding_id
+    }
+    if not referenced_original_ids:
+        return modified_new_findings
+
+    live_original_ids = set(
+        Finding.objects.filter(id__in=referenced_original_ids).values_list("id", flat=True),
+    )
+    deleted_original_ids = referenced_original_ids - live_original_ids
+    if not deleted_original_ids:
+        return modified_new_findings
+
+    findings_to_write = [
+        finding
+        for finding in modified_new_findings
+        if finding.duplicate_finding_id not in deleted_original_ids
+    ]
+    deduplicationLogger.warning(
+        "dedupe: dropping %d duplicate link(s) to %d original(s) deleted while the batch "
+        "was being processed; %d finding(s) still written",
+        len(modified_new_findings) - len(findings_to_write),
+        len(deleted_original_ids),
+        len(findings_to_write),
+    )
+    return findings_to_write
 
 
 # ---------------------------------------------------------------------------

--- a/unittests/test_dedupe_flush_missing_original.py
+++ b/unittests/test_dedupe_flush_missing_original.py
@@ -1,0 +1,201 @@
+"""
+Tests for _flush_duplicate_changes() in dojo.finding.deduplication.
+
+Batch deduplication reads its candidate originals near the start of a batch and
+persists the resulting ``duplicate_finding`` links at the end of it. When an original
+is deleted in between -- the excess-duplicate delete task runs on its own schedule --
+the deferred self-FK rejects the whole write at COMMIT, so no finding in the batch
+gets deduplicated and the post-processing task fails.
+"""
+
+import logging
+
+from django.db import connection
+from django.utils import timezone
+
+from dojo.finding.deduplication import _flush_duplicate_changes  # noqa: PLC2701
+from dojo.models import (
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+    User,
+    UserContactInfo,
+)
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+# Regression: post-processing a batch of findings aborted at COMMIT with
+# "insert or update on table dojo_finding violates foreign key constraint
+# dojo_finding_duplicate_finding_id_... Key (duplicate_finding_id)=(N) is not
+# present in table dojo_finding" when the matched original was deleted while the
+# batch was being processed.
+class TestFlushDuplicateChangesMissingOriginal(DojoTestCase):
+
+    """A batch must not write a duplicate link to a finding that no longer exists."""
+
+    def setUp(self):
+        super().setUp()
+        self.testuser = User.objects.create(
+            username="dedupe_flush_user",
+            is_staff=True,
+            is_superuser=True,
+        )
+        UserContactInfo.objects.create(user=self.testuser, block_execution=True)
+        self.system_settings(enable_deduplication=False)
+        self.system_settings(enable_product_grade=False)
+
+        self.product_type = Product_Type.objects.create(name="Dedupe Flush PT")
+        self.product = Product.objects.create(
+            name="Dedupe Flush Product",
+            description="Test",
+            prod_type=self.product_type,
+        )
+        self.test_type = Test_Type.objects.get_or_create(name="Manual Test")[0]
+        self.engagement = Engagement.objects.create(
+            name="Dedupe Flush Engagement",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        self.test = Test.objects.create(
+            engagement=self.engagement,
+            test_type=self.test_type,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+
+    def _create_finding(self, title):
+        return Finding.objects.create(
+            test=self.test,
+            title=title,
+            severity="High",
+            description="Test",
+            mitigation="Test",
+            impact="Test",
+            reporter=self.testuser,
+            active=True,
+            verified=True,
+        )
+
+    @staticmethod
+    def _mark_as_duplicate_in_memory(new_finding, original):
+        """Apply what set_duplicate() applies, without persisting -- the batch's save=False path."""
+        new_finding.duplicate = True
+        new_finding.active = False
+        new_finding.verified = False
+        new_finding.duplicate_finding = original
+        return new_finding
+
+    def test_flush_skips_finding_whose_original_was_deleted(self):
+        """
+        A link to a vanished original is dropped instead of aborting the whole batch.
+
+        The self-FK is DEFERRABLE INITIALLY DEFERRED, so in production the bad row is
+        only rejected at COMMIT: the entire batch is rolled back and every other finding
+        in it loses its deduplication too. Dropping the one unusable link keeps the rest
+        of the batch.
+        """
+        surviving_original = self._create_finding("Flush surviving original")
+        doomed_original = self._create_finding("Flush doomed original")
+        keeps_its_link = self._create_finding("Flush duplicate with live original")
+        loses_its_link = self._create_finding("Flush duplicate with deleted original")
+
+        self._mark_as_duplicate_in_memory(keeps_its_link, surviving_original)
+        self._mark_as_duplicate_in_memory(loses_its_link, doomed_original)
+
+        # The excess-duplicate delete removes the original after the batch matched it.
+        doomed_original_id = doomed_original.id
+        Finding.objects.filter(id=doomed_original_id).delete()
+
+        flushed = _flush_duplicate_changes([keeps_its_link, loses_its_link])
+
+        keeps_its_link.refresh_from_db()
+        self.assertEqual(
+            keeps_its_link.duplicate_finding_id, surviving_original.id,
+            msg=(
+                "the rest of the batch must still be deduplicated, "
+                f"persisted duplicate_finding_id={keeps_its_link.duplicate_finding_id}"
+            ),
+        )
+        self.assertTrue(keeps_its_link.duplicate, "the usable link should have been persisted.")
+
+        loses_its_link.refresh_from_db()
+        self.assertIsNone(
+            loses_its_link.duplicate_finding_id,
+            msg=(
+                "a link to a deleted original must not be written, "
+                f"persisted duplicate_finding_id={loses_its_link.duplicate_finding_id}"
+            ),
+        )
+        self.assertFalse(
+            loses_its_link.duplicate,
+            "the finding stays as it was rather than being marked a duplicate of nothing.",
+        )
+        self.assertTrue(
+            loses_its_link.active,
+            "the finding keeps the status it had before the unusable match.",
+        )
+
+        self.assertEqual(
+            [finding.id for finding in flushed], [keeps_its_link.id],
+            "only persisted findings are returned for follow-up processing.",
+        )
+        # The check Postgres runs at COMMIT, where the dangling link is the
+        # IntegrityError that fails the batch in production.
+        connection.check_constraints()
+
+    def test_flush_persists_when_every_original_survives(self):
+        """Control: the ordinary path writes every link and returns every finding."""
+        original = self._create_finding("Flush control original")
+        first_duplicate = self._create_finding("Flush control duplicate A")
+        second_duplicate = self._create_finding("Flush control duplicate B")
+
+        self._mark_as_duplicate_in_memory(first_duplicate, original)
+        self._mark_as_duplicate_in_memory(second_duplicate, original)
+
+        flushed = _flush_duplicate_changes([first_duplicate, second_duplicate])
+
+        for duplicate in (first_duplicate, second_duplicate):
+            duplicate.refresh_from_db()
+            self.assertEqual(
+                duplicate.duplicate_finding_id, original.id,
+                msg=(
+                    "every link should have been persisted, "
+                    f"persisted duplicate_finding_id={duplicate.duplicate_finding_id}"
+                ),
+            )
+            self.assertTrue(duplicate.duplicate)
+            self.assertFalse(duplicate.active)
+
+        self.assertEqual(
+            sorted(finding.id for finding in flushed),
+            sorted([first_duplicate.id, second_duplicate.id]),
+            "all persisted findings are returned for follow-up processing.",
+        )
+        connection.check_constraints()
+
+    def test_flush_of_findings_without_a_link_is_unchanged(self):
+        """Findings promoted to originals carry a null link and must still be written."""
+        promoted = self._create_finding("Flush promoted finding")
+        promoted.duplicate = False
+        promoted.duplicate_finding = None
+        promoted.active = False
+
+        flushed = _flush_duplicate_changes([promoted])
+
+        promoted.refresh_from_db()
+        self.assertIsNone(promoted.duplicate_finding_id)
+        self.assertFalse(promoted.duplicate)
+        self.assertFalse(promoted.active, "the promoted finding's other fields are still written.")
+        self.assertEqual([finding.id for finding in flushed], [promoted.id])
+        connection.check_constraints()
+
+    def test_flush_of_an_empty_batch_is_a_no_op(self):
+        """Control: nothing to write, nothing returned."""
+        self.assertEqual(_flush_duplicate_changes([]), [])

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -549,7 +549,7 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self._deduplication_performance(
             expected_num_queries1=115,
             expected_num_async_tasks1=2,
-            expected_num_queries2=94,
+            expected_num_queries2=97,
             expected_num_async_tasks2=2,
         )
 
@@ -848,6 +848,6 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self._deduplication_performance(
             expected_num_queries1=123,
             expected_num_async_tasks1=2,
-            expected_num_queries2=204,
+            expected_num_queries2=207,
             expected_num_async_tasks2=2,
         )


### PR DESCRIPTION
**Description**

> **Scope narrowed.** This PR originally fixed both directions of one window on the `duplicate_finding` self-FK. The **delete side** has since landed independently as #15510, with a better ancestor walk than this branch carried, so that work has been dropped and #15510 is now the base. What remains is the **dedupe side**, which #15510 does not touch.

The `duplicate_finding` self-FK is `DEFERRABLE INITIALLY DEFERRED`. Batch deduplication matches its originals near the start of a batch and writes the links at the end of it, and the excess-duplicate delete task runs on its own schedule — so an original can be gone by the time the write lands. The bad link is then only rejected at COMMIT, which rolls back the entire batch:

```
django.db.utils.IntegrityError: insert or update on table "dojo_finding" violates foreign key
constraint "dojo_finding_duplicate_finding_id_..."
DETAIL:  Key (duplicate_finding_id)=(N) is not present in table "dojo_finding".
```

Every other finding in that batch loses its deduplication too, and `post_process_findings_batch` fails — all for one unusable link.

**The fix** (`dojo/finding/deduplication.py`)

`_flush_duplicate_changes` now verifies that each matched original still exists immediately before the write and in the same transaction, and drops only the links that cannot be written. Those findings are left exactly as they were, for the next import to match again. The return value narrows to what was actually persisted, so follow-up processing runs only on rows that were written.

**Why not row locks**

This narrows the window to a single transaction rather than closing it. Locking the originals would put a `select_for_update` on every import's dedupe write and create a lock-ordering cycle with the delete task — trading an occasional aborted batch for routine deadlocks on a hot path.

**Pro impact**

Pro calls `_flush_duplicate_changes` from all three of its dedupe branches via `FINDING_DEDUPE_BATCH_METHOD`, so the fix applies there unchanged with no companion PR. The narrowed return value is what Pro's post-flush prioritization consumes, so it now fires only for findings that were persisted.

**Test results**

`unittests/test_dedupe_flush_missing_original.py` — fails on the unfixed code with the production constraint error above. Covers the dropped link, the rest of the batch still persisting, findings carrying a null link, and an empty batch.

Suites run locally against this base, all green:

```
test_dedupe_flush_missing_original, test_bulk_delete_duplicate_references,
test_bulk_delete_findings_m2m, test_prepare_duplicates_for_delete,
test_duplication_loops, test_deduplication_logic, test_cascade_delete,
test_async_delete, test_importers_deduplication      Ran 222 tests — OK (skipped=2)

test_importers_performance                            Ran 11 tests — OK
```

`ruff check .` passes.

**Performance counts**

`expected_num_queries2` moves 94 → 97 and 204 → 207. Three queries per *batch*: the existence check, plus the savepoint pair for the transaction it now shares with the write. Measured by running the suite, not derived — and confirmed to come entirely from this change, since #15510's delete-side work leaves these counts untouched. The transaction also makes the batch write all-or-nothing, where `bulk_update`'s statements previously each committed on their own.

**Documentation**

No user-facing behaviour change: this removes a failure mode from a background task. No docs update needed.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.