### PR TITLE
ci(migrations): bring the migration graph check to dev

### DIFF
--- a/.github/workflows/migration-graph.yml
+++ b/.github/workflows/migration-graph.yml
@@ -1,0 +1,40 @@
+name: Migration Graph
+
+# Its own workflow rather than a job inside the lint workflow: this check goes
+# red for a reason that has nothing to do with code style, and it goes red on a
+# branch whose own commits are usually fine, so the name on the PR rollup needs
+# to say what actually broke.
+#
+# Both triggers are load-bearing, because there are two ways to fork the graph
+# and each trigger catches only one of them:
+#
+#   pull_request - actions/checkout resolves a pull_request event to the merge
+#     commit, so this sees the branch *combined with* its base. That is the only
+#     way to catch a migration written against a base branch that had already
+#     moved on: the branch on its own has a single leaf and looks fine.
+#
+#   push - catches the mirror case, where two PRs each add a migration on the
+#     same parent. Both are internally consistent so both go green pre-merge,
+#     and the fork exists only in their union. Nothing else re-derives the graph
+#     after a merge, since the test suite is per-PR.
+#
+# Without this check the failure mode is every container-based job dying at boot
+# with ~120 red checks, none of which says "migration graph" in its name.
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  migration-graph:
+    name: Migration Graph Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The script is stdlib-only (ast, no Django, no database, no settings), so
+      # it needs no setup beyond the checkout and finishes in well under a second.
+      - name: Check for multiple migration leaf nodes
+        run: python3 scripts/check_migration_leaves.py

--- a/ruff.toml
+++ b/ruff.toml
@@ -129,6 +129,10 @@ preview = true
 "dojo/filters.py" = [
     "A003",  # ruff upgrade to 0.13.3
 ]
+"scripts/check_migration_leaves.py" = [
+    "T201",   # print statements are fine for console output scripts
+    "EXE001", # git won't commit the executable flag I don't know why
+]
 "scripts/update_performance_test_counts.py" = [
     "S603",  # subprocess.run without shell=True is safe for this script
     "S604",  # subprocess.run without shell=True is safe for this script

--- a/scripts/check_migration_leaves.py
+++ b/scripts/check_migration_leaves.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""
+Fail when the Django migration graph has more than one leaf node in an app.
+
+``migrate`` refuses to apply *anything* while a graph has two leaves::
+
+    CommandError: Conflicting migrations detected; multiple leaf nodes in the
+    migration graph: (0281_fileupload_title_not_unique,
+    0288_backfill_vulnerability_id_entities in dojo).
+
+Every fresh install and every CI database build off the branch is blocked until
+someone re-parents one of them. There are two ways to arrive there, and the
+workflow that calls this script watches for both:
+
+* Two changes each add a migration on top of the same parent. Each is
+  internally consistent, so both go green pre-merge; the fork exists only in
+  their union, and nothing re-derives the graph after a merge.
+* One change adds a migration on top of a parent that is no longer the tip,
+  because the author's view of the base branch was stale. The branch alone
+  looks fine — the fork appears in the merge with the base.
+
+The failure is expensive out of proportion to the mistake: with no guard it
+surfaces as every container-based job dying at boot, ~120 red checks whose logs
+all have to be opened before one of them names the actual problem.
+
+The script is deliberately standalone: ``ast`` only, no Django import, no
+database, no settings module, no third-party package. That is what lets it run
+as a plain ``python3`` step with nothing but a checkout, in under a second.
+
+Usage::
+
+    python3 scripts/check_migration_leaves.py           # checks dojo
+    python3 scripts/check_migration_leaves.py DIR...    # checks DIRs
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# ``<repo>/scripts/`` -> ``<repo>/dojo/db_migrations``. ``dojo`` is the only
+# Django app in this repo that ships migrations, and its migration modules live
+# in ``db_migrations`` rather than the conventional ``migrations`` (see
+# MIGRATION_MODULES in dojo/settings/settings.dist.py).
+DEFAULT_MIGRATION_DIRS = (Path(__file__).resolve().parents[1] / "dojo" / "db_migrations",)
+
+# Django resolves these against another app's graph, never this one's.
+CROSS_APP_SENTINELS = frozenset({"__first__", "__latest__"})
+
+# ``migrations.swappable_dependency(settings.AUTH_USER_MODEL)`` resolves to whichever
+# app owns the user model — never ``dojo`` — so it cannot affect an intra-app leaf
+# count. It is common enough that reporting it as unreadable would be pure noise.
+KNOWN_CROSS_APP_CALLS = frozenset({"swappable_dependency"})
+
+
+class Reference(NamedTuple):
+
+    """An ``(app_label, migration_name)`` pair as written in a migration file."""
+
+    app_label: str
+    name: str
+
+
+class ParsedMigration(NamedTuple):
+
+    """The graph-relevant attributes of one migration module."""
+
+    name: str
+    path: Path
+    dependencies: tuple[Reference, ...]
+    run_before: tuple[Reference, ...]
+    replaces: tuple[Reference, ...]
+    # Entries we could not read as literal ``("app", "name")`` pairs — e.g.
+    # ``migrations.swappable_dependency(settings.AUTH_USER_MODEL)``, which is
+    # always cross-app and so never affects an intra-app leaf count. Reported
+    # only when the check fails, as context for an otherwise puzzling verdict.
+    opaque: tuple[str, ...]
+
+
+class AppGraph(NamedTuple):
+
+    """The intra-app migration graph derived from one migrations directory."""
+
+    app_label: str
+    directory: Path
+    migrations: dict[str, ParsedMigration]
+    children: dict[str, set[str]]
+    leaves: tuple[str, ...]
+    # ``("0281_x", "0280_missing")``: 0281 depends on a same-app migration that
+    # is not on disk. Django raises NodeNotFoundError for this, and it would
+    # also skew the leaf count here, so it is reported rather than ignored.
+    dangling: tuple[tuple[str, str], ...]
+    squashed_out: tuple[str, ...]
+
+
+def _is_known_cross_app_call(node: ast.AST) -> bool:
+    """True for calls that always resolve to some other app's graph."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+    return name in KNOWN_CROSS_APP_CALLS
+
+
+def _literal_references(value: ast.AST) -> tuple[list[Reference], list[str]]:
+    """
+    Read a ``[("app", "name"), ...]`` literal into references.
+
+    Returns the pairs it could read plus a source snippet for every entry it
+    could not, so a dynamically built dependency never silently vanishes.
+    """
+    if not isinstance(value, (ast.List, ast.Tuple, ast.Set)):
+        return [], [ast.unparse(value)]
+
+    references: list[Reference] = []
+    opaque: list[str] = []
+    for element in value.elts:
+        if (
+            isinstance(element, (ast.Tuple, ast.List))
+            and len(element.elts) == 2
+            and all(isinstance(part, ast.Constant) and isinstance(part.value, str) for part in element.elts)
+        ):
+            app_label, name = (part.value for part in element.elts)
+            references.append(Reference(app_label, name))
+        elif not _is_known_cross_app_call(element):
+            opaque.append(ast.unparse(element))
+    return references, opaque
+
+
+def parse_migration_file(path: Path) -> ParsedMigration:
+    """
+    Extract ``dependencies`` / ``run_before`` / ``replaces`` from one migration.
+
+    Only assignments inside ``class Migration`` count, which is the only place
+    Django reads them from. Anything not spelled as a literal pair of strings is
+    recorded as opaque rather than guessed at.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    collected: dict[str, list[Reference]] = {"dependencies": [], "run_before": [], "replaces": []}
+    opaque: list[str] = []
+
+    for class_node in tree.body:
+        if not isinstance(class_node, ast.ClassDef) or class_node.name != "Migration":
+            continue
+        for statement in class_node.body:
+            if isinstance(statement, ast.Assign):
+                targets = [t.id for t in statement.targets if isinstance(t, ast.Name)]
+            elif isinstance(statement, ast.AnnAssign) and isinstance(statement.target, ast.Name):
+                targets = [statement.target.id]
+            else:
+                continue
+            for target in targets:
+                if target not in collected or statement.value is None:
+                    continue
+                references, unreadable = _literal_references(statement.value)
+                collected[target].extend(references)
+                opaque.extend(f"{target}: {snippet}" for snippet in unreadable)
+
+    return ParsedMigration(
+        name=path.stem,
+        path=path,
+        dependencies=tuple(collected["dependencies"]),
+        run_before=tuple(collected["run_before"]),
+        replaces=tuple(collected["replaces"]),
+        opaque=tuple(opaque),
+    )
+
+
+def _same_app(references: Sequence[Reference], app_label: str) -> list[str]:
+    """Names from ``references`` that point at ``app_label`` itself."""
+    return [ref.name for ref in references if ref.app_label == app_label and ref.name not in CROSS_APP_SENTINELS]
+
+
+def build_app_graph(migrations_dir: Path, app_label: str | None = None) -> AppGraph:
+    """
+    Build the intra-app graph for one migrations directory.
+
+    Cross-app edges are dropped on purpose: they cannot change how many leaves
+    *this* app has, and following them would mean loading every other app.
+    """
+    if app_label is None:
+        # ``.../dojo/db_migrations`` -> ``dojo``, matching how Django labels the app.
+        app_label = migrations_dir.resolve().parent.name
+
+    migrations: dict[str, ParsedMigration] = {}
+    for path in sorted(migrations_dir.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        parsed = parse_migration_file(path)
+        migrations[parsed.name] = parsed
+
+    # A squashed migration takes the place of the ones it replaces, so the
+    # replaced nodes leave the graph and references to them land on the squash.
+    # This mirrors the fresh-install path, which is what the guard protects.
+    replaced_by: dict[str, str] = {}
+    for name, parsed in migrations.items():
+        for superseded in _same_app(parsed.replaces, app_label):
+            if superseded in migrations:
+                replaced_by[superseded] = name
+    for superseded in replaced_by:
+        migrations.pop(superseded, None)
+
+    def resolve(name: str) -> str:
+        return replaced_by.get(name, name)
+
+    children: dict[str, set[str]] = {name: set() for name in migrations}
+    dangling: list[tuple[str, str]] = []
+
+    for name, parsed in migrations.items():
+        # ``dependencies`` points at parents: the parent gains this node as a child.
+        for parent in map(resolve, _same_app(parsed.dependencies, app_label)):
+            if parent in children:
+                children[parent].add(name)
+            elif parent != name:
+                dangling.append((name, parent))
+        # ``run_before`` points the other way: this node becomes the target's parent.
+        for successor in map(resolve, _same_app(parsed.run_before, app_label)):
+            if successor in children:
+                children[name].add(successor)
+            elif successor != name:
+                dangling.append((name, successor))
+
+    leaves = tuple(sorted(name for name, kids in children.items() if not kids))
+    return AppGraph(
+        app_label=app_label,
+        directory=migrations_dir,
+        migrations=migrations,
+        children=children,
+        leaves=leaves,
+        dangling=tuple(sorted(set(dangling))),
+        squashed_out=tuple(sorted(replaced_by)),
+    )
+
+
+def describe_problems(graph: AppGraph) -> list[str]:
+    """Human-readable problems with ``graph``; empty when the graph is sound."""
+    problems: list[str] = []
+
+    if not graph.migrations:
+        problems.append(f"{graph.directory}: no migrations found (wrong path?)")
+        return problems
+
+    if len(graph.leaves) > 1:
+        joined = ", ".join(graph.leaves)
+        lines = [
+            (
+                "Conflicting migrations detected; multiple leaf nodes in the migration graph: "
+                f"({joined} in {graph.app_label})."
+            ),
+            "",
+            "  `migrate` refuses to apply anything at all in this state, so every fresh",
+            "  install and every CI database build off this branch is broken.",
+            "",
+            "  Either two changes added a migration on the same parent, or one was written",
+            "  against a base branch that had already moved on. Fix it by re-parenting the",
+            "  later migration onto the other leaf and renumbering it, or by adding an empty",
+            "  merge migration that depends on both leaves.",
+            "",
+            "  Before renumbering, confirm what the base branch actually holds: a stale",
+            "  remote-tracking ref is a common way to pick a number that is already taken.",
+            "",
+            "  Leaves and their declared parents:",
+        ]
+        for leaf in graph.leaves:
+            parents = _same_app(graph.migrations[leaf].dependencies, graph.app_label) or ["(none — root)"]
+            lines.append(f"    {leaf} <- {', '.join(parents)}")
+        problems.append("\n".join(lines))
+
+    for child, missing in graph.dangling:
+        problems.append(
+            f"{graph.app_label}.{child} depends on {graph.app_label}.{missing}, "
+            f"which is not in {graph.directory} (Django raises NodeNotFoundError).",
+        )
+
+    if problems:
+        opaque = [f"    {parsed.name}: {snippet}" for parsed in graph.migrations.values() for snippet in parsed.opaque]
+        if opaque:
+            problems.append(
+                'Note: these entries were not literal ("app", "name") pairs and were skipped.\n'
+                "They are normally cross-app (e.g. swappable_dependency) and harmless, but if a\n"
+                "verdict above looks wrong, start here:\n" + "\n".join(sorted(opaque)),
+            )
+
+    return problems
+
+
+def check_migration_dirs(directories: Sequence[Path]) -> list[str]:
+    """Collect problems across every directory; empty means everything is sound."""
+    problems: list[str] = []
+    for directory in directories:
+        if not directory.is_dir():
+            problems.append(f"{directory}: not a directory")
+            continue
+        problems.extend(describe_problems(build_app_graph(directory)))
+    return problems
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0], allow_abbrev=False)
+    parser.add_argument(
+        "migrations_dirs",
+        nargs="*",
+        type=Path,
+        help="migrations directories to check (default: the dojo app)",
+    )
+    args = parser.parse_args(argv)
+    directories = tuple(args.migrations_dirs) or DEFAULT_MIGRATION_DIRS
+
+    problems = check_migration_dirs(directories)
+    if problems:
+        print("Migration graph check FAILED\n", file=sys.stderr)
+        for problem in problems:
+            print(problem, file=sys.stderr)
+            print(file=sys.stderr)
+        return 1
+
+    for directory in directories:
+        graph = build_app_graph(directory)
+        squashed = f", {len(graph.squashed_out)} squashed out" if graph.squashed_out else ""
+        print(
+            f"{graph.app_label}: {len(graph.migrations)} migrations{squashed}, single leaf {graph.leaves[0]}",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/unittests/test_migration_leaves.py
+++ b/unittests/test_migration_leaves.py
@@ -1,0 +1,403 @@
+"""
+Tests for ``scripts/check_migration_leaves.py``, the migration-graph CI guard.
+
+The script under test is deliberately Django-free so it can run as a bare
+``python3`` step, so these tests import it by path and drive it with generated
+fixture apps rather than going through the Django test machinery. Only the last
+test touches the real ``dojo`` graph.
+"""
+
+import contextlib
+import importlib.util
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_migration_leaves.py"
+
+_spec = importlib.util.spec_from_file_location("check_migration_leaves", SCRIPT_PATH)
+check_migration_leaves = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_migration_leaves)
+
+MIGRATION_TEMPLATE = """\
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+{attributes}
+    operations = []
+"""
+
+
+class MigrationGraphFixtureMixin(unittest.TestCase):
+
+    """Builds throwaway ``<tmp>/<app_label>/db_migrations/`` trees to parse."""
+
+    def setUp(self):
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+
+    def make_app(self, migrations_spec, app_label="dojo", dir_name="db_migrations"):
+        """
+        Write one migration module per entry and return the migrations dir.
+
+        ``migrations_spec`` maps a migration name to the source of the class
+        attributes it declares, e.g.
+        ``{"0002_b": 'dependencies = [("dojo", "0001_a")]'}``.
+        """
+        migrations_dir = self.root / app_label / dir_name
+        migrations_dir.mkdir(parents=True, exist_ok=True)
+        (migrations_dir / "__init__.py").write_text("")
+        for name, attributes in migrations_spec.items():
+            body = "\n".join(f"    {line}" for line in attributes.splitlines()) + "\n" if attributes else ""
+            (migrations_dir / f"{name}.py").write_text(MIGRATION_TEMPLATE.format(attributes=body))
+        return migrations_dir
+
+
+class TestLeafDetection(MigrationGraphFixtureMixin):
+    def test_linear_chain_has_a_single_leaf(self):
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": "",
+                "0002_second": 'dependencies = [("dojo", "0001_initial")]',
+                "0003_third": 'dependencies = [("dojo", "0002_second")]',
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.app_label, "dojo")
+        self.assertEqual(graph.leaves, ("0003_third",))
+        self.assertEqual(check_migration_leaves.describe_problems(graph), [])
+
+    def test_two_changes_on_the_same_parent_report_both_leaves(self):
+        """One of the two ways to fork the graph: concurrent PRs off one parent."""
+        migrations_dir = self.make_app(
+            {
+                "0287_vulnerability_id_entity_tables": "",
+                "0288_left": 'dependencies = [("dojo", "0287_vulnerability_id_entity_tables")]',
+                "0288_right": 'dependencies = [("dojo", "0287_vulnerability_id_entity_tables")]',
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.leaves, ("0288_left", "0288_right"))
+        problems = check_migration_leaves.describe_problems(graph)
+        self.assertEqual(len(problems), 1)
+        # The offending node names must be in the message -- that is what makes
+        # the CI failure actionable without checking anything out.
+        self.assertIn("0288_left", problems[0])
+        self.assertIn("0288_right", problems[0])
+        self.assertIn("multiple leaf nodes", problems[0])
+
+    def test_migration_written_against_a_stale_base_is_caught(self):
+        """
+        The other way to fork it, and the case the pull_request trigger exists for.
+
+        A migration parented on what the author believed was the tip, while the
+        base had already advanced several migrations past it. Reproduces the real
+        instance from PR #15498, where 0281 was written on top of 0280 after
+        0281-0288 had already landed on the base branch.
+        """
+        spec = {"0280_vulnerability_id_upper_index": ""}
+        previous = "0280_vulnerability_id_upper_index"
+        for name in (
+            "0281_vulnerability_id_type",
+            "0282_backfill_vulnerability_id_type",
+            "0283_unique_finding_vulnerability_id",
+            "0284_finding_cwe",
+            "0285_backfill_finding_cwe",
+            "0286_cicd_infrastructure",
+            "0287_vulnerability_id_entity_tables",
+            "0288_backfill_vulnerability_id_entities",
+        ):
+            spec[name] = f'dependencies = [("dojo", "{previous}")]'
+            previous = name
+        # The stale-base migration: numbered 0281, parented on 0280.
+        spec["0281_fileupload_title_not_unique"] = 'dependencies = [("dojo", "0280_vulnerability_id_upper_index")]'
+
+        graph = check_migration_leaves.build_app_graph(self.make_app(spec))
+
+        self.assertEqual(
+            graph.leaves,
+            ("0281_fileupload_title_not_unique", "0288_backfill_vulnerability_id_entities"),
+        )
+        problems = check_migration_leaves.describe_problems(graph)
+        self.assertEqual(len(problems), 1)
+        # Each leaf is printed with its declared parent, which is what makes the
+        # "written against a stale base" shape recognisable at a glance.
+        self.assertIn("0281_fileupload_title_not_unique <- 0280_vulnerability_id_upper_index", problems[0])
+
+    def test_re_parenting_the_later_migration_resolves_the_fork(self):
+        """The fix applied to #15498: renumber onto the real tip."""
+        migrations_dir = self.make_app(
+            {
+                "0287_vulnerability_id_entity_tables": "",
+                "0288_backfill_vulnerability_id_entities": (
+                    'dependencies = [("dojo", "0287_vulnerability_id_entity_tables")]'
+                ),
+                "0289_fileupload_title_not_unique": (
+                    'dependencies = [("dojo", "0288_backfill_vulnerability_id_entities")]'
+                ),
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.leaves, ("0289_fileupload_title_not_unique",))
+        self.assertEqual(check_migration_leaves.describe_problems(graph), [])
+
+    def test_empty_merge_migration_resolves_the_fork(self):
+        """The other accepted fix."""
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": "",
+                "0002_left": 'dependencies = [("dojo", "0001_initial")]',
+                "0003_right": 'dependencies = [("dojo", "0001_initial")]',
+                "0004_merge": 'dependencies = [("dojo", "0002_left"), ("dojo", "0003_right")]',
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.leaves, ("0004_merge",))
+        self.assertEqual(check_migration_leaves.describe_problems(graph), [])
+
+    def test_three_way_fork_lists_every_leaf(self):
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": "",
+                "0002_a": 'dependencies = [("dojo", "0001_initial")]',
+                "0002_b": 'dependencies = [("dojo", "0001_initial")]',
+                "0002_c": 'dependencies = [("dojo", "0001_initial")]',
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.leaves, ("0002_a", "0002_b", "0002_c"))
+
+
+class TestGraphEdgeCases(MigrationGraphFixtureMixin):
+    def test_cross_app_dependencies_are_ignored(self):
+        """A dep on another app neither creates an edge nor counts as dangling."""
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": 'dependencies = [("auth", "0001_initial"), ("contenttypes", "0002_remove")]',
+                "0002_second": 'dependencies = [("dojo", "0001_initial"), ("pghistory", "0007_auto")]',
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.leaves, ("0002_second",))
+        self.assertEqual(graph.dangling, ())
+
+    def test_cross_app_sentinels_are_ignored(self):
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": 'dependencies = [("auth", "__first__")]',
+                "0002_second": 'dependencies = [("dojo", "0001_initial"), ("auth", "__latest__")]',
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.leaves, ("0002_second",))
+        self.assertEqual(graph.dangling, ())
+
+    def test_swappable_dependency_is_not_reported_as_unreadable(self):
+        """It is always cross-app, and flagging it would bury the real message."""
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": (
+                    "dependencies = [\n"
+                    '        ("contenttypes", "0002_remove"),\n'
+                    "        migrations.swappable_dependency(settings.AUTH_USER_MODEL),\n"
+                    "    ]"
+                ),
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.migrations["0001_initial"].opaque, ())
+        self.assertEqual(graph.leaves, ("0001_initial",))
+
+    def test_run_before_creates_a_forward_edge(self):
+        """``run_before`` points the opposite way to ``dependencies``."""
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": "",
+                "0002_early": ('dependencies = [("dojo", "0001_initial")]\nrun_before = [("dojo", "0003_late")]'),
+                "0003_late": 'dependencies = [("dojo", "0001_initial")]',
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        # Without the run_before edge this would look like a two-leaf fork.
+        self.assertEqual(graph.leaves, ("0003_late",))
+        self.assertEqual(check_migration_leaves.describe_problems(graph), [])
+
+    def test_squashed_migrations_leave_the_graph_and_references_rewire(self):
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": "",
+                "0002_old_a": 'dependencies = [("dojo", "0001_initial")]',
+                "0003_old_b": 'dependencies = [("dojo", "0002_old_a")]',
+                "0003_squashed": (
+                    'dependencies = [("dojo", "0001_initial")]\n'
+                    'replaces = [("dojo", "0002_old_a"), ("dojo", "0003_old_b")]'
+                ),
+                "0004_after": 'dependencies = [("dojo", "0003_old_b")]',
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.squashed_out, ("0002_old_a", "0003_old_b"))
+        self.assertNotIn("0002_old_a", graph.migrations)
+        # 0004's dep on the replaced 0003_old_b must land on the squash, not dangle.
+        self.assertEqual(graph.dangling, ())
+        self.assertEqual(graph.leaves, ("0004_after",))
+
+    def test_dependency_on_a_missing_same_app_migration_is_reported(self):
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": "",
+                "0002_second": 'dependencies = [("dojo", "0001_typo_never_existed")]',
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.dangling, (("0002_second", "0001_typo_never_existed"),))
+        problems = check_migration_leaves.describe_problems(graph)
+        self.assertTrue(any("0001_typo_never_existed" in problem for problem in problems))
+
+    def test_dynamically_built_dependencies_are_surfaced_not_silently_dropped(self):
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": "",
+                "0002_second": "dependencies = DEPENDENCIES_FROM_A_CONSTANT",
+            },
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.migrations["0002_second"].opaque, ("dependencies: DEPENDENCIES_FROM_A_CONSTANT",))
+        # It reads as a second root, so the guard fails loudly rather than
+        # quietly assuming the unparsed value was harmless.
+        self.assertEqual(graph.leaves, ("0001_initial", "0002_second"))
+        problems = check_migration_leaves.describe_problems(graph)
+        self.assertTrue(any("DEPENDENCIES_FROM_A_CONSTANT" in problem for problem in problems))
+
+    def test_attributes_outside_the_migration_class_are_ignored(self):
+        """Only ``class Migration`` counts -- prose and helpers must not create edges."""
+        migrations_dir = self.make_app(
+            {"0001_initial": "", "0002_second": 'dependencies = [("dojo", "0001_initial")]'},
+        )
+        (migrations_dir / "0003_third.py").write_text(
+            '"""A docstring that mentions dependencies and run_before."""\n'
+            "\n"
+            "from django.db import migrations\n"
+            "\n"
+            'dependencies = [("dojo", "0099_not_real")]\n'
+            "\n"
+            "\n"
+            "class NotTheMigration:\n"
+            '    dependencies = [("dojo", "0098_also_not_real")]\n'
+            "\n"
+            "\n"
+            "class Migration(migrations.Migration):\n"
+            '    dependencies = [("dojo", "0002_second")]\n'
+            "\n"
+            "    operations = []\n",
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.leaves, ("0003_third",))
+        self.assertEqual(graph.dangling, ())
+
+    def test_app_label_comes_from_the_parent_of_db_migrations(self):
+        """This repo keeps migrations in ``dojo/db_migrations``, not ``dojo/migrations``."""
+        migrations_dir = self.make_app(
+            {"0001_initial": "", "0002_second": 'dependencies = [("dojo", "0001_initial")]'},
+        )
+
+        self.assertEqual(migrations_dir.name, "db_migrations")
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+        self.assertEqual(graph.app_label, "dojo")
+        self.assertEqual(graph.leaves, ("0002_second",))
+
+    def test_app_label_is_derived_per_directory(self):
+        migrations_dir = self.make_app(
+            {"0001_initial": "", "0002_second": 'dependencies = [("otherapp", "0001_initial")]'},
+            app_label="otherapp",
+        )
+        graph = check_migration_leaves.build_app_graph(migrations_dir)
+
+        self.assertEqual(graph.app_label, "otherapp")
+        self.assertEqual(graph.leaves, ("0002_second",))
+
+
+class TestCommandLineInterface(MigrationGraphFixtureMixin):
+    def run_main(self, *argv):
+        """Invoke ``main`` with its output captured; returns (exit_code, stdout, stderr)."""
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            exit_code = check_migration_leaves.main(list(argv))
+        return exit_code, out.getvalue(), err.getvalue()
+
+    def test_exits_zero_on_a_sound_graph(self):
+        migrations_dir = self.make_app(
+            {"0001_initial": "", "0002_second": 'dependencies = [("dojo", "0001_initial")]'},
+        )
+        exit_code, stdout, _ = self.run_main(str(migrations_dir))
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("single leaf 0002_second", stdout)
+
+    def test_exits_non_zero_on_a_forked_graph(self):
+        migrations_dir = self.make_app(
+            {
+                "0001_initial": "",
+                "0002_a": 'dependencies = [("dojo", "0001_initial")]',
+                "0002_b": 'dependencies = [("dojo", "0001_initial")]',
+            },
+        )
+        exit_code, _, stderr = self.run_main(str(migrations_dir))
+
+        self.assertEqual(exit_code, 1)
+        # Failure detail belongs on stderr, and must name both offenders.
+        self.assertIn("0002_a", stderr)
+        self.assertIn("0002_b", stderr)
+
+    def test_exits_non_zero_when_the_directory_is_missing(self):
+        """A typo'd path must not read as a clean bill of health."""
+        exit_code, _, _ = self.run_main(str(self.root / "nope"))
+
+        self.assertEqual(exit_code, 1)
+
+    def test_exits_non_zero_on_an_empty_migrations_directory(self):
+        empty = self.root / "emptyapp" / "db_migrations"
+        empty.mkdir(parents=True)
+        (empty / "__init__.py").write_text("")
+        exit_code, _, _ = self.run_main(str(empty))
+
+        self.assertEqual(exit_code, 1)
+
+    def test_defaults_to_the_dojo_app_when_given_no_arguments(self):
+        """The bare invocation CI uses must resolve to dojo without a cwd assumption."""
+        self.assertEqual(
+            check_migration_leaves.DEFAULT_MIGRATION_DIRS,
+            (Path(check_migration_leaves.__file__).resolve().parents[1] / "dojo" / "db_migrations",),
+        )
+
+
+class TestRealDojoGraph(unittest.TestCase):
+
+    """The point of the whole exercise: this repo's own graph must be sound."""
+
+    def test_dojo_migrations_have_exactly_one_leaf(self):
+        graph = check_migration_leaves.build_app_graph(check_migration_leaves.DEFAULT_MIGRATION_DIRS[0])
+
+        self.assertEqual(graph.app_label, "dojo")
+        self.assertEqual(
+            len(graph.leaves), 1,
+            f"dojo has {len(graph.leaves)} migration leaves: {', '.join(graph.leaves)}",
+        )
+        self.assertEqual(check_migration_leaves.describe_problems(graph), [])


### PR DESCRIPTION
## Description

#15501 added a check that fails fast when a Django app has more than one migration leaf node. It landed on `bugfix`. This is the same commit, cherry-picked to `dev`.

`dev` is where this has actually bitten. Two changes that each add a migration on the same parent are individually consistent, so both go green before merge — the fork exists only in their union, and nothing re-derives the graph afterwards. Until a release merge-back carries #15501 across, the branch most exposed to that is the one without the check.

While the graph is forked, `migrate` refuses to apply anything at all, so every container-based job dies at boot. That surfaces as ~120 red checks, none of which mentions migrations.

Cherry-picked rather than reimplemented, so the two branches stay byte-identical and the next merge-back is a no-op.

## Test results

On this branch:

```
$ python3 scripts/check_migration_leaves.py
dojo: 199 migrations, 90 squashed out, single leaf 0288_backfill_vulnerability_id_entities
$ echo $?
0
```

```
$ python -m pytest unittests/test_migration_leaves.py -q
22 passed in 1.82s
```

`ruff check .` clean with the CI-pinned 0.16.0.

The script is stdlib-only — `ast`, no Django, no database, no settings — so the job is a checkout plus one `python3` call, well under a second.