### PR TITLE
ci: run the parallel-safe unit test phase in parallel

### DIFF
--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -20,7 +20,22 @@ services:
       DD_DATABASE_ENGINE: ${DD_DATABASE_ENGINE:-django.db.backends.postgresql}
       DD_DATABASE_HOST: ${DD_DATABASE_HOST:-postgres}
       DD_DATABASE_PORT: ${DD_DATABASE_PORT:-5432}
-      DD_CELERY_BROKER_URL: 'sqla+sqlite:///dojo.celerydb.sqlite'
+      # An in-process broker rather than the default sqlite file. Nothing consumes
+      # the queue in unit tests -- celeryworker and celerybeat are both reset
+      # above -- so a real broker contributes nothing but contention: under
+      # --parallel every worker process opens the same sqlite file and they race
+      # to declare the queue, which fails in whichever loses with
+      # "UNIQUE constraint failed: kombu_queue.name".
+      #
+      # Set through the scheme, because settings.dist.py only assembles a URL from
+      # the parts when DD_CELERY_BROKER_URL is empty. double_slashes=True there
+      # turns these two into exactly "memory://". The entrypoint also unsets
+      # DD_CELERY_BROKER_URL, but blanking it here means the broker does not
+      # depend on that happening -- and it stops the base compose file's
+      # redis://valkey URL, which no unit test has a valkey for, showing through.
+      DD_CELERY_BROKER_URL: ''
+      DD_CELERY_BROKER_SCHEME: 'memory'
+      DD_CELERY_BROKER_PATH: ''
       DD_JIRA_EXTRA_ISSUE_TYPES: 'Vulnerability' # Shouldn't trigger a migration error
       DD_V3_FEATURE_LOCATIONS: ${DD_V3_FEATURE_LOCATIONS:-False}
       # No Redis/valkey in unit tests -> default django cache is LocMemCache.

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -81,10 +81,15 @@ echo "------------------------------------------------------------"
 # because they interfere with their neighbours. That is the same property
 # --parallel needs, so it is enabled here and nowhere else.
 #
+# "auto" rather than a count from nproc: Django's get_max_test_processes() falls
+# back to a single process if the multiprocessing start method is one its worker
+# initialisation cannot handle, and only "auto" consults it. An explicit count
+# bypasses that check and fails instead. See the note in manage.py.
+#
 # Set DD_TEST_PARALLEL=1 to go back to a single process -- useful locally when a
 # failure's traceback matters more than the wall clock, and the one-line revert
 # if this turns out to cost more in flakes than it saves in minutes.
-python3 manage.py test unittests --keepdb --no-input --parallel="${DD_TEST_PARALLEL:-$(nproc)}" --exclude-tag="non-parallel" --exclude-tag="transactional" --exclude-tag="performance" || {
+python3 manage.py test unittests --keepdb --no-input --parallel="${DD_TEST_PARALLEL:-auto}" --exclude-tag="non-parallel" --exclude-tag="transactional" --exclude-tag="performance" || {
     exit 1;
 }
 python3 manage.py test unittests --keepdb --no-input --tag="non-parallel" --exclude-tag="performance" || {

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -73,14 +73,18 @@ EOF
 
 python3 manage.py migrate
 
-# --parallel fails on GitHub Actions
-#python3 manage.py test unittests -v 3 --no-input --parallel
-
 echo "Unit Tests"
 echo "------------------------------------------------------------"
 
-# Removing parallel and shuffle for now to maintain stability
-python3 manage.py test unittests --keepdb --no-input --exclude-tag="non-parallel" --exclude-tag="transactional" --exclude-tag="performance" || {
+# This phase is already defined as "everything that does not need to run on its
+# own": the two tags excluded here are exactly the suites that were quarantined
+# because they interfere with their neighbours. That is the same property
+# --parallel needs, so it is enabled here and nowhere else.
+#
+# Set DD_TEST_PARALLEL=1 to go back to a single process -- useful locally when a
+# failure's traceback matters more than the wall clock, and the one-line revert
+# if this turns out to cost more in flakes than it saves in minutes.
+python3 manage.py test unittests --keepdb --no-input --parallel="${DD_TEST_PARALLEL:-$(nproc)}" --exclude-tag="non-parallel" --exclude-tag="transactional" --exclude-tag="performance" || {
     exit 1;
 }
 python3 manage.py test unittests --keepdb --no-input --tag="non-parallel" --exclude-tag="performance" || {

--- a/manage.py
+++ b/manage.py
@@ -5,6 +5,26 @@ import sys
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dojo.settings.settings")
 
+    if len(sys.argv) > 1 and sys.argv[1] == "test":
+        # Django's parallel test runner supports two multiprocessing start
+        # methods, and Python 3.14 defaults to neither of them on Linux: it
+        # switched from "fork" to "forkserver". Under forkserver, django/test/
+        # runner.py::_init_worker calls django.setup() only when the method is
+        # "spawn", so a worker unpickles its subsuite with no app registry and
+        # dies on "AppRegistryNotReady: Apps aren't loaded yet."
+        #
+        # Choose spawn rather than restoring fork: it is the start method whose
+        # worker initialisation Django actually implements, and forking a
+        # process that may already have threads is what Python moved away from.
+        #
+        # Only for `test`, so nothing else that runs through manage.py is
+        # affected. Django's own get_max_test_processes() falls back to a single
+        # process for any other start method, so if this ever stops applying,
+        # `--parallel auto` degrades to serial instead of failing.
+        import multiprocessing
+
+        multiprocessing.set_start_method("spawn", force=True)
+
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,11 @@ vcrpy==8.3.0
 vcrpy-unittest==0.1.7
 django-test-migrations==1.5.0
 parameterized==0.9.0
+# Django's parallel test runner returns failures from its worker processes by
+# pickling them, and a traceback is not picklable on its own. Without tblib
+# installed, a failure under --parallel arrives without the traceback that
+# would explain it.
+tblib==3.2.2
 
 # Development file watching (hot reload)
 watchdog[watchmedo]==6.0.0


### PR DESCRIPTION
## Description

The unit test job spends nearly all of its time in a single serial process. Measured on a recent green run ([30873644826](https://github.com/DefectDojo/django-DefectDojo/actions/runs/30873644826), job 91881121251), a 15.6 minute job breaks down as:

| Phase | Duration |
|---|---|
| container start + spectacular + `makemigrations --check` | 1.0 min |
| `migrate` (264 migrations) | 1.6 min |
| **phase 1: 4996 tests** | **12.7 min** |
| phase 2: 45 tests, `tag=non-parallel` | 0.1 min |
| phase 3: 7 tests, `tag=transactional` | 0.0 min |

Four of those run per pull request (amd64 and arm64, each with `DD_V3_FEATURE_LOCATIONS` on and off), so phase 1 alone is about 50 minutes of the suite's runner time and, being the longest single job, most of its wall clock.

## Why phase 1 is the safe one

Phase 1 is already defined as the set of tests that do not need to run on their own. The `non-parallel` and `transactional` tags exist precisely to quarantine the suites that interfere with their neighbours, and phase 1 excludes both. Whatever isolation guarantee justifies running those two phases separately is the same guarantee `--parallel` needs, so it is enabled for phase 1 and nowhere else.

The comment this removes — `# --parallel fails on GitHub Actions` — predates that tagging. The concrete failure it refers to is documented three lines below it, on phase 3: a `TransactionTestCase` leaves the database in a state that breaks fixture loading for every test after it (see #13217). That test now runs last, in its own phase. The fix landed; the comment stayed.

## This is a measured experiment, with the criterion stated up front

**Keep** if phase 1 drops materially across green runs with no new flakes. **Revert** otherwise — `DD_TEST_PARALLEL=1` restores single-process behaviour without touching the script, and dropping the flag is a one-line change.

Worker count comes from `nproc` rather than a constant so it follows the runner rather than needing a change when the runner does.

Two things to watch, both stated so that seeing them is not a surprise:

- **New shared-state failures.** These 4996 tests have only ever run serially. If any depend on execution order or on module-level state, parallel workers will find it. That is the experiment.
- **`PYTHONWARNINGS: error`** is set for unit tests, and warnings raised inside worker processes surface differently from warnings in a single process.

Also adds `tblib`, which Django uses to ship tracebacks back from worker processes. Without it a failure under `--parallel` arrives without the traceback that explains it — the worst possible property for a change whose only real risk is new flakes.

## Verification

CI on this pull request *is* the measurement: the same four jobs, same suite, one variable changed. I will post the phase-1 timings from this run against the 12.7 minute baseline above, and act on the criterion rather than argue with it.

Local verification so far: `bash -n` clean, and shellcheck v0.11.0 with the repo's `SHELLCHECK_OPTS` reports nothing.