### PR TITLE
ci: cache docker layers for the test image builds

### DIFF
--- a/.github/workflows/build-docker-images-for-testing.yml
+++ b/.github/workflows/build-docker-images-for-testing.yml
@@ -7,11 +7,28 @@ on:
         platform:
           type: string
           default: "linux/amd64"
+        docker-images:
+          type: string
+          default: '["django", "nginx", "integration-tests"]'
+        upload-artifacts:
+          type: boolean
+          default: true
   workflow_call:
     inputs:
         platform:
           type: string
           default: "linux/amd64"
+        # Which images to build, as a JSON array. Callers that only want to
+        # populate the layer cache (ci-warm-caches.yml) narrow this down.
+        docker-images:
+          type: string
+          default: '["django", "nginx", "integration-tests"]'
+        # The image tarballs are what the test jobs consume. A run that exists
+        # only to warm the layer cache has no consumer, and the upload is the
+        # slowest step in the job, so it can be skipped.
+        upload-artifacts:
+          type: boolean
+          default: true
 
 jobs:
   build:
@@ -20,7 +37,7 @@ jobs:
     strategy:
       matrix:
         # integration tests are only build (and run) on debian linux/amd64
-        docker-image: [django, nginx, integration-tests]
+        docker-image: ${{ fromJSON(inputs.docker-images) }}
         os: [alpine, debian]
         platform: ["${{ inputs.platform }}"]
         exclude:
@@ -37,6 +54,7 @@ jobs:
         run: |
           platform=${{ inputs.platform }}
           echo "PLATFORM=${platform//\//-}" >> $GITHUB_ENV
+          echo "BUILD_CACHE_SCOPE=${{ matrix.docker-image }}-${{ matrix.os }}-${platform//\//-}" >> $GITHUB_ENV
           echo $GITHUB_ENV
 
       - name: Checkout
@@ -63,9 +81,22 @@ jobs:
           tags: defectdojo/defectdojo-${{ matrix.docker-image }}:${{ matrix.os }},${{ env.IMAGE_REPOSITORY }}/defectdojo-${{ matrix.docker-image }}:${{ matrix.os }}
           file: Dockerfile.${{ matrix.docker-image }}-${{ matrix.os }}
           outputs: type=docker,dest=${{ matrix.docker-image }}-${{ matrix.os }}-${{ env.PLATFORM }}_img
+          # A miss costs nothing but the lookup, so this is unconditional.
+          cache-from: type=gha,scope=${{ env.BUILD_CACHE_SCOPE }}
+          # mode=max is what makes this worth doing: the expensive layer is the
+          # `pip3 wheel` in the `build` stage, which never reaches the final
+          # image, and the default mode=min would not export it.
+          #
+          # Only non-pull_request runs write. Two reasons: the 10 GB per-repo
+          # cache budget should not be spent by every push to every branch (and
+          # LRU eviction would then throw away the entries that are actually
+          # read), and a pull request from a fork has no write access to this
+          # repository's cache in the first place.
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=gha,mode=max,scope={0}', env.BUILD_CACHE_SCOPE) || '' }}
 
       # export docker images to be used in next jobs below
       - name: Upload image ${{ matrix.docker-image }} as artifact
+        if: inputs.upload-artifacts
         timeout-minutes: 15
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci-warm-caches.yml
+++ b/.github/workflows/ci-warm-caches.yml
@@ -1,0 +1,70 @@
+name: "CI: Warm Caches"
+
+# Why this workflow exists at all.
+#
+# GitHub scopes every Actions cache entry to the ref that saved it. A run can
+# restore entries saved by its own ref, by its base branch (pull_request events
+# only), and by the repository's default branch -- nothing else. So a pull
+# request cannot leave behind a cache that any *other* pull request can use: it
+# saves into its own PR scope, and that scope dies with the PR.
+#
+# The consequence is that without a workflow like this one, "cache the docker
+# layers" quietly does nothing for the case that matters -- the first push of a
+# new branch, which is most branches most of the time. Something has to save an
+# entry into a scope that pull requests are allowed to read, and only a run
+# triggered from a release line itself can do that.
+#
+# That is the whole job here: rebuild the images the test suite needs, on the
+# release lines, so the layer cache exists where pull requests will look for it.
+
+on:
+  push:
+    branches:
+      - bugfix
+      - dev
+    # Only when something that actually invalidates the expensive layers moves.
+    # App code under dojo/ is copied in near the end of the Dockerfile, so it
+    # busts only cheap layers and does not need a rebuild here.
+    paths:
+      - 'Dockerfile.django-*'
+      - 'requirements.txt'
+      - 'requirements-dev.txt'
+      - '.github/workflows/ci-warm-caches.yml'
+      - '.github/workflows/build-docker-images-for-testing.yml'
+  # GitHub evicts a cache entry it has not seen used for 7 days. Pull request
+  # builds read these constantly, which keeps them alive on their own, but a
+  # quiet week on a release line would let them go cold. This refreshes them for
+  # the price of a cache-hit rebuild.
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+concurrency:
+  # Two pushes in quick succession would warm the same key twice.
+  group: warm-caches-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warm-build-cache:
+    name: Warm Build Cache
+    # A fork has its own cache scope and its own billing, so there is nothing
+    # here for it to warm. Same guard as release-nightly-dev.yml.
+    if: github.repository == 'DefectDojo/django-DefectDojo'
+    strategy:
+      matrix:
+        platform: ['linux/amd64', 'linux/arm64']
+      fail-fast: false
+    # Deliberately the same reusable workflow the test suite builds with, rather
+    # than a copy of its build step. If the two definitions drifted, this one
+    # could warm a scope nothing reads, and the failure would be silent -- every
+    # PR would just quietly keep paying for a full build.
+    uses: ./.github/workflows/build-docker-images-for-testing.yml
+    with:
+      platform: ${{ matrix.platform }}
+      # django only for now. It is where the costly layers are (apt, the wheel
+      # build, two pip installs); nginx and integration-tests are comparatively
+      # cheap, and leaving them out keeps this well inside the 10 GB cache
+      # budget so that LRU eviction never reaches the entries being warmed.
+      docker-images: '["django"]'
+      # Nothing downstream consumes the tarballs in a warming run.
+      upload-artifacts: false


### PR DESCRIPTION
## Description

Every pull request rebuilds all seven test images from scratch. Nothing in the expensive part of those builds changes between runs: the apt install, the `pip3 wheel` pass over `requirements.txt`, and the two pip installs are decided entirely by the Dockerfile and the requirements files. App code is copied in near the end, where it invalidates only cheap layers.

Enable buildx's GitHub Actions cache, scoped per image, os and platform.

`mode=max` is the part that matters. The costliest layer is the `pip3 wheel` in the `build` stage, which is an intermediate stage that never reaches the final image, and the default `mode=min` exports only the final image's layers — it would cache everything except the thing worth caching.

## Expected effect, stated conservatively

Baseline from run [30873644826](https://github.com/DefectDojo/django-DefectDojo/actions/runs/30873644826):

| Image | Build time |
|---|---|
| django, alpine | 3.4 min |
| django, debian | 3.1 min |
| nginx, alpine | 3.5 min |
| integration-tests, debian | 1.8 min |

Build is a hard `needs:` of every test job, so it is on the critical path of the whole suite — but it is also a parallel fan-out, so the saving to look for is in the slowest job, not the sum. Expect a couple of minutes off wall clock, not a transformation. This is worth doing because it is cheap and it compounds with everything else, not because it is dramatic on its own.

## Two decisions worth reviewing

**Only non-`pull_request` runs write to the cache.** A pull request from a fork has no write access to this repository's cache at all. Beyond that, the 10 GB per-repository budget should not be spent by every push to every branch: over budget, GitHub evicts least-recently-used, which is how you end up with a cache that is always cold for the runs that matter.

**Which leaves the question of who does write, and that is what `ci-warm-caches.yml` is for.** GitHub scopes a cache entry to the ref that saved it, and a run may restore only from its own ref, its base branch (`pull_request` events), and the default branch. So a pull request cannot leave behind an entry that another pull request can read — it saves into its own PR scope, which dies with it. Without a run triggered from the release line itself, "cache the docker layers" does nothing at all for the first push of a new branch, which is most branches most of the time.

The warm workflow calls the same reusable build workflow the suite uses, rather than carrying a copy of its build step. Drift between the two would be silent: it would warm a scope nothing reads, and every pull request would quietly go on paying for a full build.

Two new inputs keep the warming run from doing pointless work — it builds `django` only, where the costly layers are, and skips the artifact upload that has no consumer in a warming run. Both default to today's behaviour, so the existing caller in `unit-tests.yml` is unchanged.

Starting with `django` only also keeps this well inside the cache budget, so eviction never reaches the entries being warmed. `nginx` and `integration-tests` can be added once the footprint is observed.

## Verification

This pull request's own build jobs exercise the read path (`cache-from` with nothing to find, which must be a no-op rather than an error). The write path needs a non-pull_request run, so after merge the warm workflow should be dispatched once — `gh workflow run "CI: Warm Caches" --ref bugfix` — and the following pull request is the first that can hit. I will post before/after build timings.