### PR TITLE
ci: restore the migrated database instead of migrating it four times

### DIFF
--- a/.github/workflows/ci-warm-caches.yml
+++ b/.github/workflows/ci-warm-caches.yml
@@ -1,0 +1,132 @@
+name: "CI: Warm Caches"
+
+# Why this workflow exists at all.
+#
+# GitHub scopes every Actions cache entry to the ref that saved it. A run can
+# restore entries saved by its own ref, by its base branch (pull_request events
+# only), and by the repository's default branch -- nothing else. So a pull
+# request cannot leave behind a cache that any *other* pull request can use: it
+# saves into its own PR scope, and that scope dies with the PR.
+#
+# Without a workflow like this one, caching the migrated database would therefore
+# do nothing at all for the first push of a new branch, which is most branches
+# most of the time. Something has to save an entry into a scope pull requests are
+# allowed to read, and only a run triggered from a release line can do that.
+#
+# Note what is deliberately absent: a `schedule:` trigger. Scheduled workflows
+# only ever run against the default branch, so a cron here would run with ref
+# refs/heads/master and warm the master scope -- not the release-line scopes this
+# is for. Eviction is handled instead by reads: GitHub drops an entry it has not
+# seen used for 7 days, and every pull request based on a release line reads this
+# one, which keeps it alive without a timer.
+#
+# Warming the default-branch scope is worth doing too, since every run can read
+# it regardless of base, but that needs a workflow file on master and is a
+# separate change.
+
+on:
+  push:
+    branches:
+      - bugfix
+      - dev
+    # Exactly the paths the snapshot key hashes -- anything else leaves the key
+    # unchanged, so there would be nothing to warm.
+    paths:
+      - 'requirements.txt'
+      - 'dojo/db_migrations/**'
+      - 'dojo/models.py'
+      - 'dojo/base_models/**'
+      - 'dojo/pghistory_models.py'
+      - 'dojo/settings/settings.dist.py'
+      - 'docker-compose.yml'
+      - 'docker-compose.override.unit_tests_cicd.yml'
+      - 'docker/entrypoint-unit-tests.sh'
+      - '.github/workflows/ci-warm-caches.yml'
+  workflow_dispatch:
+
+concurrency:
+  # Two pushes in quick succession would warm the same key twice.
+  group: warm-caches-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warm-migrated-db:
+    name: Warm Migrated Database Snapshot
+    # A fork has its own cache scope and its own billing, so there is nothing
+    # here for it to warm. Same guard as release-nightly-dev.yml.
+    if: github.repository == 'DefectDojo/django-DefectDojo'
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_VERSION: debian
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # KEEP THIS KEY IN SYNC with the two copies in rest-framework-tests.yml.
+      # If they drift, this job warms an entry nothing reads and every pull
+      # request goes on paying the full migrate, with nothing failing to say so.
+      - name: Probe for an existing snapshot
+        id: probe
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migrated-db.dump
+          key: migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}
+          # Do not download it -- whether the key exists is the whole question,
+          # and on most runs the answer is usually yes.
+          lookup-only: true
+
+      - name: Set unit-test mode
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: docker/setEnv.sh unit_tests_cicd
+
+      # Built here rather than pulled from the build job's artifacts: this needs
+      # one image on one platform, and building it directly keeps the job
+      # self-contained instead of coupling it to that job's upload.
+      - name: Build the unit-test image
+        if: steps.probe.outputs.cache-hit != 'true'
+        timeout-minutes: 30
+        run: docker compose build uwsgi
+
+      - name: Start Postgres
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: docker compose up --no-deps -d postgres
+
+      - name: Wait for Postgres to accept connections
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: |
+          for _ in $(seq 1 60); do
+            if docker compose exec -T postgres pg_isready -q -U defectdojo -d test_defectdojo; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Postgres did not become ready in 120s" >&2
+          exit 1
+
+      - name: Migrate and dump
+        if: steps.probe.outputs.cache-hit != 'true'
+        timeout-minutes: 20
+        run: |
+          docker compose run --rm -T --no-deps uwsgi
+          docker compose exec -T postgres pg_dump \
+            --username defectdojo --dbname test_defectdojo --format=custom > migrated-db.dump
+          ls -lh migrated-db.dump
+        env:
+          DD_TEST_DB_MODE: prepare
+
+      - name: Save the snapshot
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migrated-db.dump
+          key: migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}
+
+      - name: Logs
+        if: failure()
+        run: docker compose logs --tail="2500"
+
+      - name: Shutdown
+        if: always()
+        run: docker compose down

--- a/.github/workflows/ci-warm-caches.yml
+++ b/.github/workflows/ci-warm-caches.yml
@@ -64,15 +64,25 @@ jobs:
         with:
           persist-credentials: false
 
-      # KEEP THIS KEY IN SYNC with the two copies in rest-framework-tests.yml.
-      # If they drift, this job warms an entry nothing reads and every pull
-      # request goes on paying the full migrate, with nothing failing to say so.
+      # Computed once, before anything runs Python, and referenced by both the
+      # probe and the save. Not written inline in both places: hashFiles is
+      # evaluated per step, and `dojo/db_migrations/**` picks up the
+      # __pycache__/*.pyc that migrating writes into the bind-mounted workspace,
+      # so the save would land under a key the probe will never ask for.
+      #
+      # KEEP IN SYNC with the same block in rest-framework-tests.yml. If they
+      # drift, this job warms an entry nothing reads and every pull request goes
+      # on paying the full migrate, with nothing failing to say so.
+      - name: Compute migrated database snapshot key
+        id: db-key
+        run: echo "key=migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}" >> "$GITHUB_OUTPUT"
+
       - name: Probe for an existing snapshot
         id: probe
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: migrated-db.dump
-          key: migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}
+          key: ${{ steps.db-key.outputs.key }}
           # Do not download it -- whether the key exists is the whole question,
           # and on most runs the answer is usually yes.
           lookup-only: true
@@ -121,7 +131,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: migrated-db.dump
-          key: migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}
+          key: ${{ steps.db-key.outputs.key }}
 
       - name: Logs
         if: failure()

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -31,6 +31,23 @@ jobs:
         with:
           persist-credentials: false
 
+      # Computed once, immediately after checkout, and referenced by both the
+      # restore and the save below.
+      #
+      # It has to be computed once rather than written inline in both places,
+      # because hashFiles is evaluated per step and these patterns do not hash to
+      # the same value all job long. `dojo/db_migrations/**` matches whatever is
+      # on disk when it runs, and migrating imports every migration module, which
+      # writes __pycache__/*.pyc into the workspace -- the repository is bind
+      # mounted into the container, so those land here. An inline key therefore
+      # saves under a different key than it restored with, and the entry is one
+      # nothing ever looks up again.
+      #
+      # KEEP IN SYNC with the same block in ci-warm-caches.yml.
+      - name: Compute migrated database snapshot key
+        id: db-key
+        run: echo "key=migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}" >> "$GITHUB_OUTPUT"
+
       # load docker images from build jobs
       - name: Load images from artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -70,14 +87,14 @@ jobs:
       # makes it safe for the entrypoint to skip its makemigrations guard on a
       # hit (see docker/entrypoint-unit-tests.sh).
       #
-      # KEEP THIS KEY IN SYNC with the one in ci-warm-caches.yml, which is what
-      # puts an entry in the base branch's cache scope for pull requests to find.
+      # ci-warm-caches.yml is what puts an entry in the base branch's cache scope
+      # for pull requests to find.
       - name: Restore migrated database snapshot
         id: db-snapshot
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: migrated-db.dump
-          key: migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}
+          key: ${{ steps.db-key.outputs.key }}
 
       # pg_restore runs inside the postgres container because it has to match the
       # server: this one is 18, and the runner's own client is not guaranteed to
@@ -114,7 +131,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: migrated-db.dump
-          key: migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}
+          key: ${{ steps.db-key.outputs.key }}
 
       # no celery or initializer needed for unit tests
       # The database is migrated by this point on both paths -- restored from the

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -53,13 +53,79 @@ jobs:
       - name: Start Postgres and webhook.endpoint
         run: docker compose up --no-deps -d postgres webhook.endpoint
 
+      - name: Wait for Postgres to accept connections
+        run: |
+          for _ in $(seq 1 60); do
+            if docker compose exec -T postgres pg_isready -q -U defectdojo -d test_defectdojo; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Postgres did not become ready in 120s" >&2
+          exit 1
+
+      # Applying 264 migrations takes ~100 seconds and produces the same schema
+      # every time, so restore that result instead of recomputing it. The key is
+      # the migration state: models included, not just migrations, which is what
+      # makes it safe for the entrypoint to skip its makemigrations guard on a
+      # hit (see docker/entrypoint-unit-tests.sh).
+      #
+      # KEEP THIS KEY IN SYNC with the one in ci-warm-caches.yml, which is what
+      # puts an entry in the base branch's cache scope for pull requests to find.
+      - name: Restore migrated database snapshot
+        id: db-snapshot
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migrated-db.dump
+          key: migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}
+
+      # pg_restore runs inside the postgres container because it has to match the
+      # server: this one is 18, and the runner's own client is not guaranteed to
+      # be. --single-transaction makes the restore atomic, so a failure leaves the
+      # database empty rather than half-populated, and the migrate below can then
+      # take over cleanly. That is why this step is allowed to fail.
+      - name: Restore snapshot into Postgres
+        id: db-restore
+        if: steps.db-snapshot.outputs.cache-hit == 'true'
+        continue-on-error: true
+        run: |
+          docker compose exec -T postgres pg_restore \
+            --username defectdojo --dbname test_defectdojo \
+            --no-owner --no-privileges --single-transaction < migrated-db.dump
+
+      - name: Migrate and snapshot the database
+        id: db-prepare
+        if: steps.db-snapshot.outputs.cache-hit != 'true' || steps.db-restore.outcome == 'failure'
+        run: |
+          docker compose run --rm -T --no-deps uwsgi
+          docker compose exec -T postgres pg_dump \
+            --username defectdojo --dbname test_defectdojo --format=custom > migrated-db.dump
+        env:
+          DJANGO_VERSION: ${{ matrix.os }}
+          DD_TEST_DB_MODE: prepare
+
+      # Saving here rather than in a post-job step means a snapshot survives a
+      # test failure: it is a function of the migration state, not of whether the
+      # suite passed. Four matrix jobs race for the same key and three of them
+      # lose, which the action reports as a warning, hence continue-on-error.
+      - name: Save migrated database snapshot
+        if: steps.db-prepare.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migrated-db.dump
+          key: migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}
+
       # no celery or initializer needed for unit tests
+      # The database is migrated by this point on both paths -- restored from the
+      # snapshot, or migrated by the step above -- so the entrypoint reuses it.
       - name: Unit tests
         timeout-minutes: 25
         run: docker compose up --no-deps --exit-code-from uwsgi uwsgi
         env:
           DJANGO_VERSION: ${{ matrix.os }}
           DD_V3_FEATURE_LOCATIONS: ${{ inputs.v3_feature_locations }}
+          DD_TEST_DB_MODE: reuse
 
       - name: Logs
         if: failure()

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -38,6 +38,9 @@ services:
       DD_CELERY_BROKER_PATH: ''
       DD_JIRA_EXTRA_ISSUE_TYPES: 'Vulnerability' # Shouldn't trigger a migration error
       DD_V3_FEATURE_LOCATIONS: ${DD_V3_FEATURE_LOCATIONS:-False}
+      # full | prepare | reuse -- see docker/entrypoint-unit-tests.sh. CI sets
+      # this to replace the migrate with restoring a snapshot of its result.
+      DD_TEST_DB_MODE: ${DD_TEST_DB_MODE:-full}
       # No Redis/valkey in unit tests -> default django cache is LocMemCache.
       DD_CACHE_URL: ''
       # In-process singleton cache (dojo/caching.py) stays ON: a singleton is read

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -24,6 +24,33 @@ unset DD_CELERY_BROKER_URL
 
 wait_for_database_to_be_reachable
 
+# What this script should do about the database before it runs anything.
+#
+#   full     (default) check the migration state, apply it, then run the tests.
+#   prepare  apply migrations and exit, leaving a migrated database behind for
+#            the caller to snapshot. Keeps the makemigrations guard.
+#   reuse    the database is already migrated -- restored from a snapshot by the
+#            caller -- so go straight to the tests.
+#
+# `reuse` skips the makemigrations guard along with the migrate, which is only
+# safe because the snapshot is keyed on the models as well as on the migrations:
+# a model change with no migration for it cannot happen without changing that
+# key, and a changed key means there is no snapshot to restore and therefore no
+# way to reach this branch. Do not key a snapshot on migrations alone.
+DD_TEST_DB_MODE="${DD_TEST_DB_MODE:-full}"
+
+case "${DD_TEST_DB_MODE}" in
+    full|prepare|reuse) ;;
+    *)
+        echo "DD_TEST_DB_MODE must be one of full, prepare, reuse (got '${DD_TEST_DB_MODE}')" >&2
+        exit 1
+        ;;
+esac
+
+# Nothing to do with the database: this checks the API schema, and it has to run
+# per test job because DD_V3_FEATURE_LOCATIONS changes the schema it produces.
+# Skipped only when preparing a database, which runs no tests.
+if [ "${DD_TEST_DB_MODE}" != "prepare" ]; then
 python3 manage.py spectacular --fail-on-warn > /dev/null || {
     cat <<-EOF
 
@@ -51,7 +78,12 @@ EOF
     python3 manage.py spectacular > /dev/null
     exit 1
 }
+fi  # DD_TEST_DB_MODE != prepare
 
+# The bodies below are deliberately left unindented: they contain `<<-EOF`
+# heredocs, which strip leading tabs but not spaces, so indenting them would
+# change the message text they print.
+if [ "${DD_TEST_DB_MODE}" != "reuse" ]; then
 python3 manage.py makemigrations --no-input --check --dry-run --verbosity 3 || {
     cat <<-EOF
 
@@ -72,6 +104,12 @@ EOF
 }
 
 python3 manage.py migrate
+fi  # DD_TEST_DB_MODE != reuse
+
+if [ "${DD_TEST_DB_MODE}" = "prepare" ]; then
+    echo "Database migrated; DD_TEST_DB_MODE=prepare, so not running any tests."
+    exit 0
+fi
 
 echo "Unit Tests"
 echo "------------------------------------------------------------"


### PR DESCRIPTION
## Description

> **Stacked on #15506.** This branch is #15506 plus one commit, because it adds a job to the `ci-warm-caches.yml` that #15506 introduces. It targets `bugfix` rather than #15506's branch so that the unit-test workflow actually runs against it — `unit-tests.yml` only triggers for pull requests into `master`, `dev`, `bugfix` and the release lines, and the mechanism here is the kind that has to be verified by CI rather than by reading. **Review the second commit only**; the first is #15506 unchanged. Merge #15506 first and this reduces to that one commit.

Every unit test job starts by applying all 264 migrations to an empty database. Measured on run [30873644826](https://github.com/DefectDojo/django-DefectDojo/actions/runs/30873644826) (job 91881121251) that is **98 seconds**, and it happens four times per pull request — amd64 and arm64, each with `DD_V3_FEATURE_LOCATIONS` on and off — for a result that is identical every time.

Snapshot it instead: `pg_dump --format=custom` after the migrate, cached under a key describing the migration state, and `pg_restore` on the way in.

This works because of something the entrypoint already does. It pre-migrates the database outside the test runner and passes `--keepdb`, so the runner logs `Using existing test database for alias 'default'` and does not migrate again. A restored schema satisfies it in exactly the same way.

## The key hashes models, not just migrations

`requirements.txt`, `dojo/db_migrations/**`, `dojo/models.py`, `dojo/base_models/**`, `dojo/pghistory_models.py`, `dojo/settings/settings.dist.py`, both compose files, and the entrypoint.

Including the **models** is what makes it safe for the entrypoint to skip its `makemigrations --check` guard on a hit: a model change that lacks a migration cannot exist without changing the key, and a changed key means there is no snapshot and the job takes the full guarded path. A snapshot keyed on migrations alone would quietly disable that guard, so the reasoning is written into the script where the skip happens.

`requirements.txt` is in there because third-party apps bring their own migrations.

## Failure modes, and what happens

| If | Then |
|---|---|
| The snapshot is bad or truncated | The restore runs `--single-transaction`, so it either applies completely or rolls back to an empty database, and the miss path takes over. No half-restored schema can reach the tests. |
| `pg_restore` version skew | Both dump and restore run inside the postgres container, whose client matches its own server. The runner's client is never involved — which matters, since the server is 18 and `pg_dump` refuses to dump a server newer than itself. |
| Four jobs race to save the same key | Three lose, which the action reports as a warning, so the step tolerates its own failure. |
| The tests fail | The snapshot is already saved: it is a function of the migration state, not of whether the suite passed. |

Both paths converge before the tests run — restored, or migrated by the prepare step — so the test step always runs with `DD_TEST_DB_MODE=reuse` and there is one code path through it rather than two.

## Why per-job rather than one shared prepare job

A dedicated `prepare-db` job would migrate once on a cold key instead of four times, saving ~5 runner-minutes — but every run, including the warm ones that are the common case, would wait for it before any test job could start. Doing it per job costs nothing on the warm path, which is the path that matters, and adds no cross-job dependency.

## Warming

Snapshots are warmed on the release lines for the same cache-scoping reason as #15506: a pull request cannot leave behind an entry another pull request can read, so without the warm job the first push of a branch always misses. The warm job probes with `lookup-only` first, so the daily run costs seconds unless a merge actually changed the migration state — in which case rebuilding the snapshot doubles as a check that the release line still migrates from empty.

## Expected effect

About 100 seconds off each of four jobs on a hit — roughly 6 runner-minutes per pull request, and rather less in wall clock since the four run concurrently.

Worth being straight about the ratio: this is a modest win next to what the same mechanism is worth on the integration-test matrix, where the initializer re-derives the same database **113 times** at 126 seconds each. I scoped this to the unit tests deliberately, as the smaller and safer place to prove the mechanism; the initializer version is the follow-up, and it needs the key to hash the fixtures too.

## Verification

Local: `docker compose config` confirms `DD_TEST_DB_MODE` reaches the container (`prepare` when set, `full` when unset, so existing behaviour is unchanged); all three modes take the intended branches; shellcheck v0.11.0 clean with the repo's `SHELLCHECK_OPTS`; all four copies of the cache key are byte-identical.

CI is what verifies the round trip. This run is a cold key: it should migrate, dump, and save. A second push should restore, log `Using existing test database`, and finish ~100 seconds faster. I will post both.
