### PR TITLE
Fix two API v2 500s: non-string vulnerability_id values, and the endpoints prefetch on the test imports list

### DIFF
--- a/dojo/finding/api/serializer.py
+++ b/dojo/finding/api/serializer.py
@@ -340,7 +340,14 @@ class VulnerabilityIdsField(serializers.Field):
                 if "vulnerability_id" not in item:
                     msg = 'Each vulnerability id object requires a "vulnerability_id" key.'
                     raise serializers.ValidationError(msg)
-                parsed.append(item["vulnerability_id"])
+                value = item["vulnerability_id"]
+                if not isinstance(value, str):
+                    # Everything downstream (save_vulnerability_ids -> the entity store, and the
+                    # cve mirror) assumes strings, so a non-string here has to be a 400 rather
+                    # than an AttributeError 500 further down.
+                    msg = 'Each "vulnerability_id" value must be a string.'
+                    raise serializers.ValidationError(msg)
+                parsed.append(value)
             elif isinstance(item, str):
                 parsed.append(item)
             else:

--- a/dojo/test/api/views.py
+++ b/dojo/test/api/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.urls import reverse
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
@@ -291,12 +292,21 @@ class TestImportViewSet(
     )
 
     def get_queryset(self):
+        # Under V3 the Endpoint model is deprecated and its __init__ raises, so prefetching the
+        # endpoints m2m hydrates the legacy rows a migrated finding still carries and 500s the
+        # whole list response. Select the prefetch by the flag, as the finding viewset does.
+        # TODO: Delete the endpoints branch after the move to Locations
+        location_prefetch = (
+            "findings_affected__locations__location__url"
+            if settings.V3_FEATURE_LOCATIONS
+            else "findings_affected__endpoints"
+        )
         return get_authorized_test_imports(
             "view",
         ).prefetch_related(
             "test_import_finding_action_set",
             "findings_affected",
-            "findings_affected__endpoints",
+            location_prefetch,
             "findings_affected__status_finding",
             "findings_affected__finding_meta",
             "findings_affected__jira_issue",

--- a/unittests/test_endpoint_init_v3.py
+++ b/unittests/test_endpoint_init_v3.py
@@ -18,6 +18,7 @@ These tests cover the sites that were guarded/repaired for that:
   carries legacy endpoint rows must not crash.
 * API ``report_generate`` (Product/Engagement) -- ``get_endpoint_ids(Endpoint.objects...)``.
 * API ``metadata/batch`` -- the ``endpoint`` parent fetch.
+* API ``test_imports`` list -- the ``findings_affected__endpoints`` prefetch on the queryset.
 """
 import logging
 from io import BytesIO
@@ -36,6 +37,7 @@ from dojo.jira.helper import jira_description
 from dojo.location.models import LocationFindingReference, LocationProductReference
 from dojo.location.status import FindingLocationStatus, ProductLocationStatus
 from dojo.models import (
+    IMPORT_CREATED_FINDING,
     Endpoint,
     Endpoint_Status,
     Engagement,
@@ -43,6 +45,8 @@ from dojo.models import (
     Product,
     Product_Type,
     Test,
+    Test_Import,
+    Test_Import_Finding_Action,
     Test_Type,
     UserContactInfo,
 )
@@ -229,6 +233,39 @@ class TestEndpointInitV3(DojoTestCase):
         self.assertEqual(response.status_code, 200)
         hosts = [ep.get("host") for ep in response.json()["endpoints"]]
         self.assertIn("loc-engrpt.example.com", hosts)
+
+    # ------------------------------------------------------------------
+    # API test_imports list
+    # ------------------------------------------------------------------
+    def test_api_test_imports_list_with_legacy_endpoints_under_v3(self):
+        """
+        GET /test_imports/ must not 500 for a test import whose affected findings still carry
+        legacy Endpoint rows.
+
+        Regression: TestImportViewSet.get_queryset() prefetched
+        ``findings_affected__endpoints`` unconditionally. Under V3 the prefetch hydrates the
+        deprecated Endpoint model, so the paginator raised
+        ``NotImplementedError: Endpoint model is deprecated when V3_FEATURE_LOCATIONS is enabled``
+        for every caller of the endpoint.
+        """
+        tree = self._make_tree("test-import")
+        self._add_legacy_endpoint(tree, "legacy-testimport.example.com")
+        self._add_location(tree, "loc-testimport.example.com")
+
+        test_import = Test_Import.objects.create(test=tree.test, type=Test_Import.IMPORT_TYPE)
+        Test_Import_Finding_Action.objects.create(
+            test_import=test_import, finding=tree.finding, action=IMPORT_CREATED_FINDING,
+        )
+
+        response = self.api_client.get(
+            reverse("test_imports-list"), {"test": tree.test.id, "o": "-created", "limit": 1},
+        )
+
+        self.assertEqual(
+            response.status_code, 200,
+            msg=f"expected 200 listing test imports, got {response.status_code}: {response.content[:500]}",
+        )
+        self.assertEqual([row["id"] for row in response.json()["results"]], [test_import.id])
 
     # ------------------------------------------------------------------
     # API metadata batch

--- a/unittests/test_vulnerability_id.py
+++ b/unittests/test_vulnerability_id.py
@@ -12,8 +12,9 @@ import pathlib
 
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.utils.timezone import now
+from rest_framework import serializers
 
 from dojo.finding.api.serializer import VulnerabilityIdsField
 from dojo.finding.helper import save_vulnerability_ids
@@ -414,3 +415,61 @@ class TestEnumerableShapes(VulnerabilityEntityTestCase):
         duplicate = src.copy()
 
         self.assertEqual(Finding.objects.get(pk=duplicate.pk).get_vulnerability_ids(), "CVE-CP-1CVE-CP-2")
+
+
+# Regression: POST /api/v2/findings/ with a non-string vulnerability_id (e.g.
+# {"vulnerability_id": 407}) returned HTTP 500 -- VulnerabilityIdsField accepted the value
+# unchecked and it reached sanitize_vulnerability_ids, which calls .strip() on every entry:
+#   AttributeError: 'int' object has no attribute 'strip'
+class TestVulnerabilityIdsFieldInput(SimpleTestCase):
+
+    """
+    ``VulnerabilityIdsField.to_internal_value`` is the API's only validation boundary for
+    ``vulnerability_ids``. Everything downstream (save_vulnerability_ids -> the entity store,
+    and the ``cve`` mirror) assumes strings, so anything else has to be a 400 here rather than
+    a 500 further down.
+    """
+
+    ACCEPTED = [
+        ("bare string", ["CVE-2026-1"], ["CVE-2026-1"]),
+        ("object", [{"vulnerability_id": "CVE-2026-2"}], ["CVE-2026-2"]),
+        ("mixed", ["CVE-2026-3", {"vulnerability_id": "GHSA-aaaa-bbbb-cccc"}], ["CVE-2026-3", "GHSA-aaaa-bbbb-cccc"]),
+        ("empty list", [], []),
+        # Empty / whitespace strings stay accepted here; save_vulnerability_ids drops them.
+        ("blank string", ["", "   "], ["", "   "]),
+    ]
+
+    REJECTED = [
+        # The reported payload shape: the id nested in the object is an int, not a string.
+        ("int inside object", [{"vulnerability_id": 407}]),
+        ("null inside object", [{"vulnerability_id": None}]),
+        ("list inside object", [{"vulnerability_id": ["CVE-2026-4"]}]),
+        ("object inside object", [{"vulnerability_id": {"vulnerability_id": "CVE-2026-5"}}]),
+        # Already rejected before the fix -- kept as the control that bare non-strings and the
+        # nested form now behave identically.
+        ("bare int", [407]),
+        ("bare null", [None]),
+        ("missing key", [{"id": "CVE-2026-6"}]),
+        ("not a list", "CVE-2026-7"),
+    ]
+
+    def test_accepted_shapes_parse_to_strings(self):
+        for label, payload, expected in self.ACCEPTED:
+            with self.subTest(shape=label):
+                parsed = VulnerabilityIdsField().to_internal_value(payload)["parsed_vulnerability_ids"]
+                self.assertEqual(
+                    parsed, expected,
+                    msg=f"{label}: expected {expected}, parsed {parsed!r}",
+                )
+                self.assertTrue(
+                    all(isinstance(value, str) for value in parsed),
+                    msg=f"{label}: non-string survived parsing: {parsed!r}",
+                )
+
+    def test_rejected_shapes_raise_validation_error(self):
+        for label, payload in self.REJECTED:
+            with self.subTest(shape=label), self.assertRaises(
+                serializers.ValidationError,
+                msg=f"{label}: {payload!r} was accepted instead of raising ValidationError",
+            ):
+                VulnerabilityIdsField().to_internal_value(payload)


### PR DESCRIPTION
**Description**

Two unrelated HTTP 500s observed on production instances, both on API v2 read/write paths that a client hits in an ordinary loop. They are independent one-line-ish defects in different modules, so each has its own commit.

---

### 1. `POST /api/v2/findings/` — a non-string `vulnerability_id` returns 500

`VulnerabilityIdsField.to_internal_value` (`dojo/finding/api/serializer.py`) validates the *shape* of each list item — a dict or a bare string — but never the *type* of the value inside the dict:

```python
if isinstance(item, dict):
    if "vulnerability_id" not in item:
        raise serializers.ValidationError(msg)
    parsed.append(item["vulnerability_id"])   # <- whatever it is
elif isinstance(item, str):
    parsed.append(item)
else:
    raise serializers.ValidationError(msg)    # bare non-strings already 400
```

So `{"vulnerability_ids": [{"vulnerability_id": 407}]}` is accepted, and the int travels through `create()`/`update()` into `save_vulnerability_ids` → `sanitize_vulnerability_ids`, which calls `.strip()` on every entry:

```
File "dojo/finding/helper.py", line 1070, in sanitize_vulnerability_ids
    return [x for x in vulnerability_ids if x.strip()]
AttributeError: 'int' object has no attribute 'strip'
```

The result is a 500 for a payload the API should have rejected with a 400. `null`, a list and a nested object fail the same way. Note the asymmetry the fix removes: a *bare* non-string item (`[407]`) already raised a `ValidationError`, so only the nested form was unguarded.

The field is the API's only validation boundary for `vulnerability_ids`, and everything downstream — the entity store and the `cve` mirror — assumes strings, so the type check belongs here rather than as a defensive coercion in the shared helper (which would silently accept malformed client data and persist a meaningless id).

### 2. `GET /api/v2/test_imports/` — 500 whenever `V3_FEATURE_LOCATIONS` is enabled

`TestImportViewSet.get_queryset()` (`dojo/test/api/views.py`) prefetched `findings_affected__endpoints` unconditionally. Under V3 the `Endpoint` model is deprecated and `Endpoint.__init__` raises, so the prefetch hydrates the legacy `Endpoint` rows that findings migrated from V2 still carry (the migration keeps them as backup) and the paginator aborts the whole response:

```
File "/app/dojo/api_v2/prefetch/mixins.py", line 17, in list
    queryset = self.paginate_queryset(queryset)
...
File "/app/dojo/endpoint/models.py", line 140, in __init__
    raise NotImplementedError(msg)
NotImplementedError: Endpoint model is deprecated when V3_FEATURE_LOCATIONS is enabled
```

This is unconditional on a V3 deployment — the endpoint is unusable for every caller, including the single-row `?test=<id>&o=-created&limit=1` lookup a test view issues to show the latest import, which is where it was observed firing repeatedly.

The fix selects the prefetch by the flag, exactly as `FindingViewSet.get_queryset()` and the deduplication loaders already do:

```python
location_prefetch = (
    "findings_affected__locations__location__url"
    if settings.V3_FEATURE_LOCATIONS
    else "findings_affected__endpoints"
)
```

The V2 branch is byte-for-byte unchanged. This is the same crash class as the sibling call sites already repaired in `unittests/test_endpoint_init_v3.py`; this viewset was simply missed.

**Test results**

Both defects got a failing test first; each fails on `bugfix` and passes with its commit.

- `unittests/test_vulnerability_id.py::TestVulnerabilityIdsFieldInput` — parameterized over the accepted shapes (bare string, object, mixed, empty list, blank/whitespace string) and the rejected ones (int / `null` / list / object nested inside the object, plus the bare non-string and missing-key controls that already raised). Pure field-level, no DB. Pre-fix: 4 subtest failures, all of the form `ValidationError not raised : int inside object: [{'vulnerability_id': 407}] was accepted`.
- `unittests/test_endpoint_init_v3.py::TestEndpointInitV3::test_api_test_imports_list_with_legacy_endpoints_under_v3` — added to the existing regression suite for this crash class, reusing its `_make_tree` / `_add_legacy_endpoint` / `_add_location` fixtures so the affected finding carries both a legacy endpoint row and a V3 location, i.e. the exact shape of a migrated finding. Pre-fix: `AssertionError: 500 != 200`, with the `NotImplementedError` above in the captured request log.

Local runs (Python 3.13, PostgreSQL, `V3_FEATURE_LOCATIONS` on):

| Suite | Result |
|---|---|
| `unittests.test_endpoint_init_v3` (whole module) | 8 tests, OK |
| `unittests.test_vulnerability_id` + `test_apiv2_methods_and_endpoints` + `test_apiv2_prefetch_rbac` | 32 tests, OK |
| `test_rest_framework` `FindingsTest` + `FindingCreateUpdateMitigatedFieldsAPITest` + `FindingRequestResponseTest` | 33 tests, OK (8 skipped) |

`ruff check .` clean.

No expected-query-count updates are needed: no performance test exercises the test-imports viewset, and the V2 prefetch path is untouched.

**Documentation**

None. Both are internal defects with no new user-visible surface — the first turns a 500 into the 400 the field's documented contract already implied, the second restores an endpoint that was returning 500 unconditionally.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] Add applicable tests to the unit tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfJPZm71br9F4awmmaYMnk)_