### PR TITLE
fix(dedupe): resolve inbound duplicate references inside the delete transaction

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime
 from itertools import batched
@@ -901,6 +902,132 @@ def bulk_clear_finding_m2m(finding_qs):
         Notes.objects.filter(id__in=note_ids).delete()
 
 
+# A duplicate chain (A -> B -> C) is pathological; fix_loop_duplicates exists to repair
+# them. The walk below therefore stops after a level or two in practice -- this bound only
+# keeps a chain that loops entirely inside the delete set from looping here too.
+MAX_DUPLICATE_CHAIN_DEPTH = 10
+
+
+def _load_doomed_ancestors(chunk_ids, delete_scope_ids):
+    """
+    Map ``{doomed finding id: its duplicate_finding_id}`` for the chunk and its doomed ancestors.
+
+    Only findings this run will delete are included, so ``id in`` the returned mapping is
+    the test for "this ancestor is going away too" used by _resolve_surviving_root. The
+    chunk itself is one query; each further level costs one more, and levels beyond the
+    first only exist when a duplicate chain runs through the delete set.
+    """
+    parent_of_doomed = dict(
+        Finding.objects.filter(id__in=chunk_ids).values_list("id", "duplicate_finding_id"),
+    )
+    frontier = {
+        parent_id for parent_id in parent_of_doomed.values()
+        if parent_id and parent_id not in parent_of_doomed
+    }
+    for _ in range(MAX_DUPLICATE_CHAIN_DEPTH):
+        if not frontier:
+            break
+        next_level = dict(
+            Finding.objects
+            .filter(id__in=frontier)
+            .filter(id__in=delete_scope_ids)
+            .values_list("id", "duplicate_finding_id"),
+        )
+        if not next_level:
+            break
+        parent_of_doomed.update(next_level)
+        frontier = {
+            parent_id for parent_id in next_level.values()
+            if parent_id and parent_id not in parent_of_doomed
+        }
+    return parent_of_doomed
+
+
+def _resolve_surviving_root(start_id, parent_of_doomed):
+    """Walk up through doomed ancestors; return the first id that outlives the delete, or None."""
+    current = start_id
+    seen = set()
+    while current in parent_of_doomed:
+        if current in seen:
+            # Defensive: a reference loop entirely inside the delete set.
+            return None
+        seen.add(current)
+        current = parent_of_doomed[current]
+    return current  # A surviving finding id, or None when the chain dead-ends.
+
+
+def resolve_inbound_duplicate_references(chunk_ids, delete_scope_ids):
+    """
+    Resolve ``duplicate_finding`` references into ``chunk_ids`` held by findings that survive.
+
+    The duplicate_finding self-FK is ON DELETE DO_NOTHING and, like every Django FK on
+    Postgres, DEFERRABLE INITIALLY DEFERRED. A surviving finding still pointing at a
+    deleted one is therefore only rejected at COMMIT -- far from the code that wrote the
+    reference, as an opaque constraint error that takes the whole chunk with it.
+
+    Belongs inside the chunk's transaction for the same reason bulk_clear_finding_m2m
+    does. Resolving once up front leaves every chunk after the first exposed: each chunk
+    commits separately, so a reference written after that one pass -- deduplication of a
+    concurrent import landing on an original this run has selected but not yet reached --
+    survives into a later chunk's COMMIT. Run per chunk, no such window exists.
+
+    Only findings outside ``delete_scope_ids`` are touched: a reference from one doomed
+    finding to another goes away with the row that holds it.
+
+    Each survivor is re-pointed at its chain's first ancestor outside the delete set, and
+    promoted to an original (``duplicate_finding = None, duplicate = False``) when the
+    chain dead-ends inside it or circles back to the survivor -- mirroring how
+    fix_loop_duplicates treats parentless duplicates rather than fabricating a self-loop.
+
+    Returns the number of survivors whose reference was resolved.
+    """
+    survivors = list(
+        Finding.objects
+        .filter(duplicate_finding_id__in=chunk_ids)
+        .exclude(id__in=delete_scope_ids)
+        .values_list("id", "duplicate_finding_id"),
+    )
+    if not survivors:
+        return 0
+
+    parent_of_doomed = _load_doomed_ancestors(chunk_ids, delete_scope_ids)
+
+    repoint_groups = defaultdict(list)  # surviving root id -> [survivor ids]
+    promote_ids = []
+    for survivor_id, parent_id in survivors:
+        root_id = _resolve_surviving_root(parent_id, parent_of_doomed)
+        if root_id is None or root_id == survivor_id:
+            promote_ids.append(survivor_id)
+        else:
+            repoint_groups[root_id].append(survivor_id)
+
+    # The walk trusts the rows it read; confirm each root really is still there and out of
+    # scope before pointing anything at it, so an already-inconsistent graph degrades to a
+    # promote instead of a fresh dangling reference.
+    if repoint_groups:
+        live_root_ids = set(
+            Finding.objects
+            .filter(id__in=list(repoint_groups))
+            .exclude(id__in=delete_scope_ids)
+            .values_list("id", flat=True),
+        )
+        for root_id in list(repoint_groups):
+            if root_id not in live_root_ids:
+                promote_ids.extend(repoint_groups.pop(root_id))
+
+    deduplicationLogger.warning(
+        "bulk delete: resolving %d inbound duplicate reference(s) (%d re-pointed, %d promoted to original)",
+        len(survivors), len(survivors) - len(promote_ids), len(promote_ids),
+    )
+
+    for root_id, survivor_ids in repoint_groups.items():
+        Finding.objects.filter(id__in=survivor_ids).update(duplicate_finding_id=root_id)
+    if promote_ids:
+        Finding.objects.filter(id__in=promote_ids).update(duplicate_finding=None, duplicate=False)
+
+    return len(survivors)
+
+
 def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=False):
     """
     Delete findings and all related objects efficiently. Including any related object in Dojo-Pro
@@ -920,6 +1047,11 @@ def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=Fa
     constraint error naming an internal table. Per chunk, the through rows and the
     findings they point at go in one transaction and no such window exists.
 
+    Inbound duplicate_finding references are resolved the same way and for the same
+    reason -- see resolve_inbound_duplicate_references. Doing it here rather than in each
+    caller covers every entry point to the chunked delete, not just the one that first
+    hit the constraint.
+
     When order_desc is True, findings are processed highest id first (matches
     finding_delete: duplicate_cluster.order_by("-id").delete()) so self-FK
     duplicate chains delete children before parents.
@@ -932,6 +1064,9 @@ def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=Fa
 
     pre_bulk_delete_findings.send(sender=Finding, finding_qs=finding_qs)
     ordered_qs = finding_qs.order_by("-id") if order_desc else finding_qs.order_by("id")
+    # Kept as a subquery so the full delete scope never materializes in Python; it is only
+    # needed to tell a surviving finding from one this run is about to remove.
+    delete_scope_ids = finding_qs.order_by().values_list("id", flat=True)
     for chunk_num, chunk_ids in enumerate(
         batched(
             ordered_qs.values_list("id", flat=True).iterator(chunk_size=chunk_size),
@@ -943,6 +1078,7 @@ def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=Fa
         chunk_qs = Finding.objects.filter(id__in=chunk_ids)
         with transaction.atomic():
             bulk_clear_finding_m2m(chunk_qs)
+            resolve_inbound_duplicate_references(chunk_ids, delete_scope_ids)
             cascade_delete_related_objects(Finding, chunk_qs, skip_relations={Finding}, skip_m2m_for={Finding})
             execute_delete_sql(chunk_qs)
         logger.info(

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -1,5 +1,4 @@
 import logging
-from collections import defaultdict
 
 import pghistory
 from celery import Task
@@ -40,74 +39,6 @@ def async_dupe_delete(*args, **kwargs):
     # Wrap with pghistory context for audit trail
     with pghistory.context(source="dupe_delete_task"):
         _async_dupe_delete_impl()
-
-
-def _repoint_chained_duplicates(ids_to_delete):
-    """
-    Break inbound duplicate_finding references from findings that survive this run.
-
-    Chained duplicates (A -> B -> C, from past bugs or high parallel load - see
-    fix_loop_duplicates) can leave a SURVIVING finding pointing at an excess duplicate
-    that is about to be deleted. The duplicate_finding self-FK is ON DELETE DO_NOTHING,
-    so deleting while such references exist raises IntegrityError, rolls the chunk
-    back, and the task retries forever without ever making progress (observed in
-    production: the same finding id failing every run).
-
-    Survivors are re-pointed at their chain's root outside the delete set; when the
-    chain dead-ends or loops inside the delete set they are promoted to originals,
-    mirroring how fix_loop_duplicates handles parentless duplicates.
-    """
-    delete_set = set(ids_to_delete)
-
-    # Each deleted finding's own parent lets us walk chains that pass through the
-    # delete set: id -> duplicate_finding_id.
-    parent_of_deleted = dict(
-        Finding.objects.filter(id__in=delete_set).values_list("id", "duplicate_finding_id"),
-    )
-
-    def resolve_surviving_root(start_id):
-        seen = set()
-        current = start_id
-        while current in parent_of_deleted:
-            if current in seen:
-                # Defensive: a reference loop entirely inside the delete set.
-                return None
-            seen.add(current)
-            current = parent_of_deleted[current]
-        return current  # A surviving finding id, or None when the chain dead-ends.
-
-    survivors = (
-        Finding.objects
-        .filter(duplicate_finding_id__in=delete_set)
-        .exclude(id__in=delete_set)
-        .values_list("id", "duplicate_finding_id")
-    )
-
-    repoint_groups = defaultdict(list)  # surviving root id -> [survivor ids]
-    promote_ids = []
-
-    for survivor_id, parent_id in survivors:
-        root_id = resolve_surviving_root(parent_id)
-        if root_id is None or root_id == survivor_id:
-            # No surviving root (or the chain circles back to the survivor
-            # itself): promote to original rather than fabricate a self-loop.
-            promote_ids.append(survivor_id)
-        else:
-            repoint_groups[root_id].append(survivor_id)
-
-    if not repoint_groups and not promote_ids:
-        return
-
-    deduplicationLogger.warning(
-        "dupe delete: re-pointing %d chained duplicate reference(s) (promoting %d to original) before deleting %d findings",
-        sum(len(ids) for ids in repoint_groups.values()), len(promote_ids), len(delete_set),
-    )
-
-    for root_id, survivor_ids in repoint_groups.items():
-        Finding.objects.filter(id__in=survivor_ids).update(duplicate_finding_id=root_id)
-
-    if promote_ids:
-        Finding.objects.filter(id__in=promote_ids).update(duplicate_finding=None, duplicate=False)
 
 
 def _async_dupe_delete_impl():
@@ -184,8 +115,9 @@ def _async_dupe_delete_impl():
     logger.info("total number of excess duplicates to delete: %s", len(ids_to_delete))
 
     if ids_to_delete:
-        _repoint_chained_duplicates(ids_to_delete)
-
+        # Inbound duplicate_finding references from surviving findings are resolved inside
+        # each chunk's transaction by bulk_delete_findings itself -- see
+        # resolve_inbound_duplicate_references.
         # order_desc=True deletes higher ids before lower ids, consistent with how
         # finding_delete handles duplicate clusters (duplicate_cluster.order_by("-id").delete()).
         bulk_delete_findings(Finding.objects.filter(id__in=ids_to_delete), order_desc=True)

--- a/unittests/test_bulk_delete_duplicate_references.py
+++ b/unittests/test_bulk_delete_duplicate_references.py
@@ -1,0 +1,353 @@
+"""
+Unit tests for inbound ``duplicate_finding`` references in the chunked bulk finding delete.
+
+The duplicate_finding self-FK is ON DELETE DO_NOTHING and DEFERRABLE INITIALLY DEFERRED,
+so a surviving finding left pointing at a deleted one is only rejected at COMMIT -- as an
+opaque constraint error that takes the whole chunk down. Resolving those references is
+done by ``bulk_delete_findings`` itself, inside each chunk's transaction, so it covers
+every entry point and no window exists between resolving and committing.
+"""
+
+import logging
+from unittest.mock import patch
+
+from django.db import connection
+from django.utils import timezone
+
+from dojo import utils_cascade_delete
+from dojo.finding.helper import bulk_delete_findings
+from dojo.models import (
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+    User,
+    UserContactInfo,
+)
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+class TestBulkDeleteDuplicateReferences(DojoTestCase):
+
+    """No surviving finding may still point at a finding the delete removed."""
+
+    def setUp(self):
+        super().setUp()
+        self.testuser = User.objects.create(
+            username="bulk_delete_dupe_ref_user",
+            is_staff=True,
+            is_superuser=True,
+        )
+        UserContactInfo.objects.create(user=self.testuser, block_execution=True)
+        self.system_settings(enable_deduplication=False, enable_product_grade=False)
+
+        self.product_type = Product_Type.objects.create(name="Bulk Delete Dupe Ref PT")
+        self.product = Product.objects.create(
+            name="Bulk Delete Dupe Ref Product",
+            description="Test",
+            prod_type=self.product_type,
+        )
+        self.test_type = Test_Type.objects.get_or_create(name="Manual Test")[0]
+        self.engagement = Engagement.objects.create(
+            name="Bulk Delete Dupe Ref Engagement",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        self.test = self._create_test()
+
+    def _create_test(self):
+        return Test.objects.create(
+            engagement=self.engagement,
+            test_type=self.test_type,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+
+    def _create_finding(self, title, duplicate_of=None, test=None):
+        return Finding.objects.create(
+            test=test or self.test,
+            title=title,
+            severity="High",
+            description="Test",
+            mitigation="Test",
+            impact="Test",
+            reporter=self.testuser,
+            duplicate=duplicate_of is not None,
+            duplicate_finding=duplicate_of,
+        )
+
+    @staticmethod
+    def _point_at(finding, original):
+        """Wire a duplicate link directly, bypassing set_duplicate's chain normalization."""
+        Finding.objects.filter(id=finding.id).update(
+            duplicate=True,
+            duplicate_finding_id=original.id,
+        )
+
+    def _delete_with_reference_written_mid_delete(self, doomed, write_reference):
+        """
+        Delete ``doomed`` one finding per chunk, writing a duplicate reference partway through.
+
+        ``write_reference`` fires from inside the first chunk, once its findings are gone
+        and before any later chunk is reached. That is the interleaving a concurrent
+        import produces in production: dedupe points a finding at an original the running
+        delete has already selected but not yet removed.
+        """
+        real_execute_delete_sql = utils_cascade_delete.execute_delete_sql
+        state = {"calls": 0}
+
+        def execute_delete_sql_with_concurrent_write(queryset, *args, **kwargs):
+            result = real_execute_delete_sql(queryset, *args, **kwargs)
+            state["calls"] += 1
+            if state["calls"] == 1:
+                write_reference()
+            return result
+
+        # bulk_delete_findings imports execute_delete_sql at call time, so the patch has
+        # to land on the defining module rather than on dojo.finding.helper.
+        with patch.object(
+            utils_cascade_delete,
+            "execute_delete_sql",
+            execute_delete_sql_with_concurrent_write,
+        ):
+            bulk_delete_findings(
+                Finding.objects.filter(id__in=[finding.id for finding in doomed]),
+                chunk_size=1,
+                order_desc=True,
+            )
+        return state["calls"]
+
+    def test_chained_reference_is_repointed_for_any_caller(self):
+        """
+        A chained duplicate must be resolved by the delete primitive, not by one caller.
+
+        This goes straight through bulk_delete_findings rather than the excess-duplicate
+        task, which is the only caller that used to resolve these references itself.
+        """
+        root = self._create_finding("Chain root")
+        doomed = self._create_finding("Chain doomed", duplicate_of=root)
+        survivor = self._create_finding("Chain survivor")
+        self._point_at(survivor, doomed)
+
+        bulk_delete_findings(Finding.objects.filter(id=doomed.id), order_desc=True)
+
+        self.assertFalse(
+            Finding.objects.filter(id=doomed.id).exists(),
+            "The doomed duplicate should have been deleted despite the chained reference.",
+        )
+        survivor.refresh_from_db()
+        self.assertEqual(
+            survivor.duplicate_finding_id, root.id,
+            msg=(
+                "the survivor should have been re-pointed at the chain's surviving root, "
+                f"persisted duplicate_finding_id={survivor.duplicate_finding_id}"
+            ),
+        )
+        self.assertTrue(survivor.duplicate, "re-pointing at a surviving root keeps it a duplicate.")
+        connection.check_constraints()
+
+    def test_scoped_delete_without_order_desc_resolves_inbound_references(self):
+        """
+        The ascending, scope-filtered shape used when a Test/Engagement/Product cascades.
+
+        That caller reconciles duplicates before calling in, so nothing here should have
+        been left over -- which is exactly why the gap went unnoticed. The delete itself
+        has to hold the invariant.
+        """
+        other_test = self._create_test()
+        root = self._create_finding("Scoped root", test=other_test)
+        doomed = self._create_finding("Scoped doomed", duplicate_of=root)
+        survivor = self._create_finding("Scoped survivor", test=other_test)
+        self._point_at(survivor, doomed)
+
+        bulk_delete_findings(Finding.objects.filter(test=self.test))
+
+        self.assertFalse(
+            Finding.objects.filter(id=doomed.id).exists(),
+            "The in-scope finding should have been deleted.",
+        )
+        survivor.refresh_from_db()
+        self.assertEqual(
+            survivor.duplicate_finding_id, root.id,
+            msg=(
+                "an out-of-scope survivor should have been re-pointed, "
+                f"persisted duplicate_finding_id={survivor.duplicate_finding_id}"
+            ),
+        )
+        connection.check_constraints()
+
+    def test_chain_is_walked_through_several_doomed_ancestors(self):
+        """
+        A chain running through more than one doomed finding resolves to the surviving root.
+
+        Stopping at the first ancestor would find another doomed finding and promote the
+        survivor to an original, silently breaking a cluster that has a perfectly good
+        root still standing.
+        """
+        root = self._create_finding("Deep chain root")
+        doomed_lower = self._create_finding("Deep chain doomed lower", duplicate_of=root)
+        doomed_upper = self._create_finding("Deep chain doomed upper")
+        self._point_at(doomed_upper, doomed_lower)
+        survivor = self._create_finding("Deep chain survivor")
+        self._point_at(survivor, doomed_upper)
+
+        bulk_delete_findings(
+            Finding.objects.filter(id__in=[doomed_lower.id, doomed_upper.id]),
+            chunk_size=1,
+            order_desc=True,
+        )
+
+        self.assertFalse(
+            Finding.objects.filter(id__in=[doomed_lower.id, doomed_upper.id]).exists(),
+            "Both findings in the chain should have been deleted.",
+        )
+        survivor.refresh_from_db()
+        self.assertEqual(
+            survivor.duplicate_finding_id, root.id,
+            msg=(
+                "the survivor should have been re-pointed past both doomed ancestors, "
+                f"persisted duplicate_finding_id={survivor.duplicate_finding_id}"
+            ),
+        )
+        self.assertTrue(survivor.duplicate, "the survivor is still a duplicate, now of the root.")
+        connection.check_constraints()
+
+    def test_reference_written_mid_delete_is_repointed(self):
+        """
+        A reference that lands mid-delete must be resolved in its chunk's transaction.
+
+        Resolving once up front cannot see this write: it happens after that pass and
+        before the chunk holding its target commits.
+        """
+        original = self._create_finding("Mid-delete original")
+        doomed_first = self._create_finding("Mid-delete doomed A", duplicate_of=original)
+        doomed_second = self._create_finding("Mid-delete doomed B", duplicate_of=original)
+        survivor = self._create_finding("Mid-delete survivor")
+
+        # order_desc deletes the higher id first, so doomed_first is still present when the
+        # reference is written and is removed by a later chunk.
+        self._delete_with_reference_written_mid_delete(
+            [doomed_first, doomed_second],
+            lambda: self._point_at(survivor, doomed_first),
+        )
+
+        self.assertFalse(
+            Finding.objects.filter(id__in=[doomed_first.id, doomed_second.id]).exists(),
+            "Both findings should have been deleted.",
+        )
+        survivor.refresh_from_db()
+        self.assertEqual(
+            survivor.duplicate_finding_id, original.id,
+            msg=(
+                "the survivor should have been re-pointed at the surviving original, "
+                f"persisted duplicate_finding_id={survivor.duplicate_finding_id}"
+            ),
+        )
+        # The check Postgres runs at COMMIT, where a leftover reference is the
+        # IntegrityError that fails the delete in production.
+        connection.check_constraints()
+
+    def test_survivor_is_promoted_when_no_root_survives(self):
+        """Same window, but the doomed finding has no surviving ancestor to inherit."""
+        doomed_first = self._create_finding("Orphan doomed A")
+        doomed_second = self._create_finding("Orphan doomed B")
+        survivor = self._create_finding("Orphan survivor")
+
+        self._delete_with_reference_written_mid_delete(
+            [doomed_first, doomed_second],
+            lambda: self._point_at(survivor, doomed_first),
+        )
+
+        self.assertFalse(
+            Finding.objects.filter(id__in=[doomed_first.id, doomed_second.id]).exists(),
+            "Both findings should have been deleted.",
+        )
+        survivor.refresh_from_db()
+        self.assertIsNone(
+            survivor.duplicate_finding_id,
+            msg=(
+                "with no surviving root the survivor should be promoted, "
+                f"persisted duplicate_finding_id={survivor.duplicate_finding_id}"
+            ),
+        )
+        self.assertFalse(survivor.duplicate, "a promoted finding is no longer flagged as a duplicate.")
+        connection.check_constraints()
+
+    def test_only_references_into_the_delete_are_touched(self):
+        """
+        Resolving inbound references must not disturb anything else.
+
+        A duplicate that already points at the surviving original is not part of this
+        delete and has to come through it untouched -- re-pointing or promoting it would
+        silently rewrite duplicate clusters on every delete.
+        """
+        original = self._create_finding("Scoping original")
+        doomed_first = self._create_finding("Scoping doomed A", duplicate_of=original)
+        doomed_second = self._create_finding("Scoping doomed B", duplicate_of=original)
+        survivor_of_doomed = self._create_finding("Scoping survivor of doomed")
+        survivor_of_original = self._create_finding(
+            "Scoping survivor of original", duplicate_of=original,
+        )
+
+        self._delete_with_reference_written_mid_delete(
+            [doomed_first, doomed_second],
+            lambda: self._point_at(survivor_of_doomed, doomed_first),
+        )
+
+        survivor_of_doomed.refresh_from_db()
+        self.assertEqual(
+            survivor_of_doomed.duplicate_finding_id, original.id,
+            "the reference into the delete should have been resolved.",
+        )
+
+        survivor_of_original.refresh_from_db()
+        self.assertEqual(
+            survivor_of_original.duplicate_finding_id, original.id,
+            msg=(
+                "a duplicate of the surviving original is out of scope and must be left as-is, "
+                f"persisted duplicate_finding_id={survivor_of_original.duplicate_finding_id}"
+            ),
+        )
+        self.assertTrue(
+            survivor_of_original.duplicate,
+            "an out-of-scope duplicate must not be promoted to an original.",
+        )
+
+        original.refresh_from_db()
+        self.assertIsNone(
+            original.duplicate_finding_id,
+            "the surviving original must not be touched by the delete.",
+        )
+        self.assertFalse(original.duplicate, "the surviving original must stay an original.")
+        connection.check_constraints()
+
+    def test_ordinary_delete_is_unchanged(self):
+        """Control: with no inbound references the ordinary path behaves as before."""
+        original = self._create_finding("Control original")
+        doomed_first = self._create_finding("Control doomed A", duplicate_of=original)
+        doomed_second = self._create_finding("Control doomed B", duplicate_of=original)
+        survivor = self._create_finding("Control survivor", duplicate_of=original)
+
+        bulk_delete_findings(
+            Finding.objects.filter(id__in=[doomed_first.id, doomed_second.id]),
+            chunk_size=1,
+            order_desc=True,
+        )
+
+        self.assertFalse(
+            Finding.objects.filter(id__in=[doomed_first.id, doomed_second.id]).exists(),
+            "Both excess duplicates should have been deleted.",
+        )
+        survivor.refresh_from_db()
+        self.assertEqual(
+            survivor.duplicate_finding_id, original.id,
+            "an untouched duplicate keeps pointing at its original.",
+        )
+        self.assertTrue(survivor.duplicate, "an untouched duplicate stays a duplicate.")
+        connection.check_constraints()


### PR DESCRIPTION
since recent prs we now have multiple ways to fix/correct duplicate chains/clusters. this pr harmonizes this to reduce future maintenance costs. and make the code easier to understand and more consistent.

**Summary**

- Moves resolution of inbound `duplicate_finding` references into `_bulk_delete_findings_internal`, inside each chunk's `transaction.atomic()`, next to the `bulk_clear_finding_m2m` call that already exists there for exactly the same reason.

- Closes a coverage gap. #15383 fixed the `IntegrityError` below by re-pointing chained duplicates in `dojo/tasks.py`, immediately before the excess-duplicate task's own call to `bulk_delete_findings`. That protected one of four entry points to the chunked delete — `dojo/utils.py` `async_delete_task`, `prepare_duplicates_for_delete`'s outside-scope cascade, and any other caller stayed exposed. The invariant belongs to the delete primitive, not to one of its callers.

  ```
  django.db.utils.IntegrityError: update or delete on table "dojo_finding" violates foreign key
  constraint "dojo_finding_duplicate_finding_id_..." on table "dojo_finding"
  DETAIL:  Key (id)=(N) is still referenced from table "dojo_finding".
  ```

- Closes the window that remained even for the protected caller. Resolving once up front cannot cover a chunked delete: each chunk commits separately, so a reference written after that pass — deduplication of a concurrent import landing on an original the delete has selected but not yet reached — survives into a later chunk's COMMIT. The self-FK is `DEFERRABLE INITIALLY DEFERRED`, so it is rejected there rather than at the write, as an opaque error that takes the whole chunk down. Run per chunk, inside the transaction, no such window exists. This is the same argument the docstring for the M2M clear already makes.

- Keeps #15383's algorithm rather than writing a second one. A survivor is re-pointed at its chain's first ancestor outside the delete set, and promoted to an original when the chain dead-ends inside it or circles back to the survivor — mirroring how `fix_loop_duplicates` treats parentless duplicates rather than fabricating a self-loop. `_repoint_chained_duplicates` and its call site are removed; `resolve_inbound_duplicate_references` replaces them.

- Two adaptations were needed for the per-chunk position. The delete set is now `(chunk_ids, delete_scope_ids)` instead of one materialized `set`, with the scope kept as a subquery so it never lands in Python. Chain ancestors are loaded a level at a time — the chunk itself, then any ancestor also in scope — bounded by `MAX_DUPLICATE_CHAIN_DEPTH`, since a chain can now run out of the chunk into the rest of the delete. Resolved roots are confirmed live and out of scope before anything is pointed at them, so an already-inconsistent graph degrades to a promote instead of a fresh dangling reference.

- `reconfigure_duplicate_cluster` is deliberately untouched. It handles the other direction — deleting an *original*, where no ancestor exists and a new one has to be elected from the cluster with the old one's status copied onto it. Deleting a mid-chain duplicate has a root already standing, so inheriting it is correct and electing would not be.

- Query cost is one indexed lookup per chunk in the common case, served by the existing `[duplicate_finding, id]` index. The scope anti-join and the ancestor walk only execute when that lookup returns inbound references, which after a caller's own reconciliation means only when the race actually happened.

- `unittests/test_duplication_loops.py::test_delete_duplicate_excess_with_chained_reference` from #15383 is unchanged and still passes, now exercising the relocated code through the same task.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.
