### PR TITLE
fix(notifications): don't send an empty webhook header name

### DIFF
--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -527,7 +527,10 @@ class WebhookNotificationManger(NotificationManagerHelpers):
             "X-DefectDojo-Instance": settings.SITE_URL,
             "Accept": "application/json",
         }
-        if endpoint.header_name is not None:
+        # The model default for header_name is "" (not None), so endpoints created
+        # without a custom header via the API/ORM would add a header with an empty
+        # name here, which requests rejects with InvalidHeader.
+        if endpoint.header_name:
             headers[endpoint.header_name] = endpoint.header_value
         yaml_data = self._create_notification_message(
             event,


### PR DESCRIPTION
## Summary

- `Notification_Webhooks.header_name` has a model default of `""` (with `null=True`), and the API serializer exposes the field as-is, so an endpoint created through the API or the ORM without a custom header stores an empty string instead of `NULL`.
- `_generate_request_details` checked `if endpoint.header_name is not None`, so that empty string was added to the outgoing headers as a header with an empty name. `requests` rejects it with `InvalidHeader` before the request leaves the process.
- The generic `except Exception` handler in `send_webhooks_notification` classifies that as a permanent error, so the endpoint is immediately moved to `inactive_permanent` with `Exception: Invalid leading whitespace, reserved character(s), or return character(s) in header name: ''` in its `note`, and no notification is ever delivered — the first send silently kills the endpoint.
- Fixed by testing truthiness instead, so a blank header name is skipped exactly like a `NULL` one.
- Endpoints created through the UI or the Django admin are not affected: Django's `CharField.formfield()` sets `empty_value=None` for nullable char fields, so a blank input is stored as `NULL` there.
